### PR TITLE
Use a path prefixed folder for assets and use CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .rvmrc
 .rbenv-version
 /doc/
+/public/finder-frontend/

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,8 @@ module FinderFrontend
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    # Path within public/ where assets are compiled to
+    config.assets.prefix = '/finder-frontend'
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,6 +35,8 @@ FinderFrontend::Application.configure do
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 
+  config.action_controller.asset_host = Plek.current.find('assets')
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx


### PR DESCRIPTION
Use the `public/finder-frontend` to compile assets into. Then use the
CDN to serve these assets in a production environment.
