### PR TITLE
Use header-footer-only slimmer template

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -7,6 +7,30 @@
 @import "design-patterns/buttons";
 
 
+#wrapper {
+  display: block;
+  text-align: center;
+  padding-bottom: $gutter;
+  
+  @include media(desktop) {
+    padding-bottom: $gutter*2;
+  }
+
+  #content {
+    text-align: left;
+    display: block;
+    position: relative;
+    margin: 0 auto;
+    width: auto;
+    max-width: 960 + $gutter*2;
+    @extend %contain-floats;
+
+    @include ie-lte(8){
+      width: 960px;
+    }
+  }
+}
+
 #finder-frontend {
   @extend %contain-floats;
   margin-bottom: $gutter*2;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
+  include Slimmer::Headers
+  before_filter :set_slimmer_headers
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   helper :application
+
+  def set_slimmer_headers
+    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
+  end
 end


### PR DESCRIPTION
So that we don't include lots of JavaScript and CSS which we don't use
or need.

The only obvious thing which needed fixing as a result of this was that
the wrapper wasn't given a width.
