### PR TITLE
Fix empty metadata

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -24,7 +24,7 @@ private
 
   def date_metadata
     keys = ['opened_date', 'closed_date'].select do |key|
-      @attrs.has_key?(key)
+      @attrs.fetch(key, false).present?
     end
 
     keys.map do |key|
@@ -38,7 +38,7 @@ private
 
   def tag_metadata
     keys = ['case_type', 'case_state', 'market_sector', 'outcome_type'].select do |key|
-      @attrs.has_key?(key)
+      @attrs.fetch(key, {}).fetch('label', false).present?
     end
 
     keys.map do |key|

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,5 +1,165 @@
 require 'spec_helper'
 
 describe Document do
+  subject { Document.new(document_attributes) }
+  let(:opened_date) { 1.year.ago.to_date }
+  let(:closed_date) { 3.months.ago.to_date }
+  let(:document_attributes) { {} }
 
+  describe '#metadata' do
+    context 'with all attributes' do
+      let(:document_attributes) do
+        {
+          'case_type' => {
+            'key' => 'mergers',
+            'label' => 'Mergers',
+          },
+          'case_state' => {
+            'key' => 'closed',
+            'label' => 'Closed',
+          },
+          'market_sector' => {
+            'key' => 'energy',
+            'label' => 'Energy',
+          },
+          'outcome_type' => {
+            'key' => 'mergers-phase-1-clearance',
+            'label' => 'Mergers - phase 1 clearance',
+          },
+          'opened_date' => opened_date,
+          'closed_date' => closed_date,
+        }
+      end
+
+      specify do
+        subject.metadata.should == [
+          {
+            name: 'Case type',
+            value: 'Mergers',
+            type: 'text',
+          },
+          {
+            name: 'Case state',
+            value: 'Closed',
+            type: 'text',
+          },
+          {
+            name: 'Market sector',
+            value: 'Energy',
+            type: 'text',
+          },
+          {
+            name: 'Outcome type',
+            value: 'Mergers - phase 1 clearance',
+            type: 'text',
+          },
+          {
+            name: 'Opened date',
+            value: opened_date,
+            type: 'date',
+          },
+          {
+            name: 'Closed date',
+            value: closed_date,
+            type: 'date',
+          },
+        ]
+      end
+    end
+
+    context 'with missing attributes' do
+      let(:document_attributes) do
+        {
+          'case_type' => {
+            'key' => 'mergers',
+            'label' => 'Mergers',
+          },
+          'case_state' => {
+            'key' => 'open',
+            'label' => 'Open',
+          },
+          'market_sector' => {
+            'key' => 'energy',
+            'label' => 'Energy',
+          },
+          'opened_date' => opened_date,
+        }
+      end
+
+      specify do
+        subject.metadata.should == [
+          {
+            name: 'Case type',
+            value: 'Mergers',
+            type: 'text',
+          },
+          {
+            name: 'Case state',
+            value: 'Open',
+            type: 'text',
+          },
+          {
+            name: 'Market sector',
+            value: 'Energy',
+            type: 'text',
+          },
+          {
+            name: 'Opened date',
+            value: opened_date,
+            type: 'date',
+          },
+        ]
+      end
+    end
+
+    context 'with empty attributes' do
+      let(:document_attributes) do
+        {
+          'case_type' => {
+            'key' => 'mergers',
+            'label' => 'Mergers',
+          },
+          'case_state' => {
+            'key' => 'open',
+            'label' => 'Open',
+          },
+          'market_sector' => {
+            'key' => 'energy',
+            'label' => 'Energy',
+          },
+          'outcome_type' => {
+            'key' => '',
+            'label' => nil,
+          },
+          'opened_date' => opened_date,
+          'closed_date' => nil,
+        }
+      end
+
+      specify do
+        subject.metadata.should == [
+          {
+            name: 'Case type',
+            value: 'Mergers',
+            type: 'text',
+          },
+          {
+            name: 'Case state',
+            value: 'Open',
+            type: 'text',
+          },
+          {
+            name: 'Market sector',
+            value: 'Energy',
+            type: 'text',
+          },
+          {
+            name: 'Opened date',
+            value: opened_date,
+            type: 'date',
+          },
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
This stops the view choking on bad data being passed back by the finder-api. We should probably stop that happening at the root, but this is a quick fix which will become a nice belt-and-braces backup once finder-api is sorted.
