### PR TITLE
Remove word-wrap break-all

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -165,6 +165,7 @@
         background-color: $white;
         height:200px;
         overflow-y:scroll;
+        overflow-x:hidden;
 
         ul {
           margin:0;
@@ -179,17 +180,6 @@
           label {
             @include inline-block;
             margin-left:20px;
-
-            /* if the label is long break it with a hypen if the browser allows this behaviour */
-            -ms-word-break: break-all;
-            word-break: break-all;
-
-            /* Non standard for webkit */
-            word-break: break-word;
-
-            -webkit-hyphens: auto;
-            -moz-hyphens: auto;
-            hyphens: auto;
           }
           /* IE6 doesn't support psuedo selectors so scoping to checkbox-container instead of using a psuedo selector */
           input {


### PR DESCRIPTION
At screen widths of between 645 and 750px long labels such as "case type: telecommunications" are too wide to fit in the checkbox container causing it to horizontally scroll.

The current solution to this works in chrome but not in firefox or safari, so reverting back letting the long words overflow and be hidden at narrow-but-not-narrow-enough-to-be-tablet browser widths. 
