### PR TITLE
Fix bold styling on result count

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -33,6 +33,10 @@
   }
 }
 
+strong {
+  font-weight: 600;
+}
+
 #finder-frontend {
   @extend %contain-floats;
   margin-bottom: $gutter*2;


### PR DESCRIPTION
After adding the reset to fix spacing issues, it also removed the font-weight from `<strong>`. This commit styles the strong element with the same font-weight as is coming from the govuk_template.
