### PR TITLE
Fix rspec.rake so it doesn't fail

### DIFF
--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,7 +1,8 @@
-if Gem.loaded_specs.include?("rspec")
+begin
   require 'rspec/core/rake_task'
 
   RSpec::Core::RakeTask.new(:spec)
 
   task :default => :spec
+rescue LoadError
 end


### PR DESCRIPTION
This project uses rspec-rails not rspec so the check for the rspec gem always failed. I've switched this code to try and then catch if the dependencies are not loaded. This approach has been used in specialist-frontend.
