### PR TITLE
Scope strong style to .result-info

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -33,10 +33,6 @@
   }
 }
 
-strong {
-  font-weight: 600;
-}
-
 #finder-frontend {
   @extend %contain-floats;
   margin-bottom: $gutter*2;
@@ -284,6 +280,9 @@ strong {
         font-weight: normal;
         position: relative;
         top: 1px;
+      }
+      strong {
+        font-weight: 600;
       }
     }
 


### PR DESCRIPTION
In 90a8325b0ba3d0cfb91356fe19d81635c313869d I added a declaration for strong which was global. Although this repo doesn't have govspeak, it may have in future, so this commit scopes the declaration to the relevant place.
