### PR TITLE
Display multiple metadata values

### DIFF
--- a/app/models/abstract_document.rb
+++ b/app/models/abstract_document.rb
@@ -47,10 +47,24 @@ private
       .select(&method(:metadata_value_present?))
   end
 
+  def tag_labels_for(key)
+    Array(attrs.fetch(key, []))
+      .map { |tag| tag.fetch("label") }
+     .select(&:present?)
+  end
+
   def build_tag_metadata(key)
+    labels = tag_labels_for(key)
+
+    if labels.count > 1
+      value = "#{labels.first} and #{labels.count - 1} others"
+    else
+      value = labels.first
+    end
+
     {
       name: key,
-      value: attrs.fetch(key, {})["label"],
+      value: value,
       type: "text",
     }
   end

--- a/features/support/case_helper.rb
+++ b/features/support/case_helper.rb
@@ -59,22 +59,22 @@ module CaseHelper
           "closed_date": "2010-10-05",
           "summary": "Inquiry into making CMA cases keyword saerchable",
 
-          "market_sector": {
+          "market_sector": [{
             "value": "pharmaceuticals",
             "label": "Pharmaceuticals"
-          },
-          "case_type": {
+          }],
+          "case_type": [{
             "value": "mergers",
             "label": "Mergers"
-          },
-          "outcome_type": {
+          }],
+          "outcome_type": [{
             "value": "ca98-infringement-chapter-i",
             "label": "CA98 - infringement Chapter I"
-          },
-          "case_state": {
+          }],
+          "case_state": [{
             "value": "closed",
             "label": "Closed"
-          }
+          }]
         }
       ]
     }|
@@ -91,22 +91,22 @@ module CaseHelper
           "closed_date": "2004-03-01",
           "summary": "Inquiry into the HealthCorp / DrugInc merger",
 
-          "market_sector": {
+          "market_sector": [{
             "value": "pharmaceuticals",
             "label": "Pharmaceuticals"
-          },
-          "case_type": {
+          }],
+          "case_type": [{
             "value": "mergers",
             "label": "Mergers"
-          },
-          "outcome_type": {
+          }],
+          "outcome_type": [{
             "value": "ca98-infringement-chapter-i",
             "label": "CA98 - infringement Chapter I"
-          },
-          "case_state": {
+          }],
+          "case_state": [{
             "value": "closed",
             "label": "Closed"
-          }
+          }]
         },
         {
           "title": "Private healthcare market investigation",
@@ -116,22 +116,22 @@ module CaseHelper
           "closed_date": "2008-03-01",
           "summary": "Inquiry into the private healthcare market",
 
-          "market_sector": {
+          "market_sector": [{
             "value": "pharmaceuticals",
             "label": "Pharmaceuticals"
-          },
-          "case_type": {
+          }],
+          "case_type": [{
             "value": "markets",
             "label": "Markets"
-          },
-          "outcome_type": {
+          }],
+          "outcome_type": [{
             "value": "ca98-infringement-chapter-i",
             "label": "CA98 - infringement Chapter I"
-          },
-          "case_state": {
+          }],
+          "case_state": [{
             "value": "closed",
             "label": "Closed"
-          }
+          }]
         }
       ]
     }|
@@ -148,22 +148,22 @@ module CaseHelper
           "closed_date": "2004-03-01",
           "summary": "Inquiry into the HealthCorp / DrugInc merger",
 
-          "market_sector": {
+          "market_sector": [{
             "value": "pharmaceuticals",
             "label": "Pharmaceuticals"
-          },
-          "case_type": {
+          }],
+          "case_type": [{
             "value": "mergers",
             "label": "Mergers"
-          },
-          "outcome_type": {
+          }],
+          "outcome_type": [{
             "value": "ca98-infringement-chapter-i",
             "label": "CA98 - infringement Chapter I"
-          },
-          "case_state": {
+          }],
+          "case_state": [{
             "value": "closed",
             "label": "Closed"
-          }
+          }]
         }
       ]
     }|

--- a/spec/models/aaib_report_spec.rb
+++ b/spec/models/aaib_report_spec.rb
@@ -9,14 +9,14 @@ describe AaibReport do
     context 'with all attributes' do
       let(:document_attributes) do
         {
-          'aircraft_category' => {
-            'key' => 'commercial-fixed-wing',
+          'aircraft_category' => [{
+            'value' => 'commercial-fixed-wing',
             'label' => 'Commercial - fixed wing',
-          },
-          'report_type' => {
-            'key' => 'annual-safety-reports',
+          }],
+          'report_type' => [{
+            'value' => 'annual-safety-reports',
             'label' => 'Annual safety reports',
-          },
+          }],
           'date_of_occurrence' => date_of_occurrence,
         }
       end
@@ -45,10 +45,10 @@ describe AaibReport do
     context 'with missing attributes' do
       let(:document_attributes) do
         {
-          'aircraft_category' => {
-            'key' => 'commercial-fixed-wing',
+          'aircraft_category' => [{
+            'value' => 'commercial-fixed-wing',
             'label' => 'Commercial - fixed wing',
-          },
+          }],
           'date_of_occurrence' => date_of_occurrence,
         }
       end
@@ -72,14 +72,14 @@ describe AaibReport do
     context 'with empty attributes' do
       let(:document_attributes) do
         {
-          'aircraft_category' => {
-            'key' => 'commercial-fixed-wing',
+          'aircraft_category' => [{
+            'value' => 'commercial-fixed-wing',
             'label' => 'Commercial - fixed wing',
-          },
-          'report_type' => {
-            'key' => '',
+          }],
+          'report_type' => [{
+            'value' => nil,
             'label' => nil,
-          },
+          }],
           'date_of_occurrence' => nil,
         }
       end

--- a/spec/models/cma_case_spec.rb
+++ b/spec/models/cma_case_spec.rb
@@ -10,22 +10,22 @@ describe CmaCase do
     context 'with all attributes' do
       let(:document_attributes) do
         {
-          'case_type' => {
-            'key' => 'mergers',
+          'case_type' => [{
+            'value' => 'mergers',
             'label' => 'Mergers',
-          },
-          'case_state' => {
-            'key' => 'closed',
+          }],
+          'case_state' => [{
+            'value' => 'closed',
             'label' => 'Closed',
-          },
-          'market_sector' => {
-            'key' => 'energy',
+          }],
+          'market_sector' => [{
+            'value' => 'energy',
             'label' => 'Energy',
-          },
-          'outcome_type' => {
-            'key' => 'mergers-phase-1-clearance',
+          }],
+          'outcome_type' => [{
+            'value' => 'mergers-phase-1-clearance',
             'label' => 'Mergers - phase 1 clearance',
-          },
+          }],
           'opened_date' => opened_date,
           'closed_date' => closed_date,
         }
@@ -70,18 +70,18 @@ describe CmaCase do
     context 'with missing attributes' do
       let(:document_attributes) do
         {
-          'case_type' => {
-            'key' => 'mergers',
+          'case_type' => [{
+            'value' => 'mergers',
             'label' => 'Mergers',
-          },
-          'case_state' => {
-            'key' => 'open',
+          }],
+          'case_state' => [{
+            'value' => 'open',
             'label' => 'Open',
-          },
-          'market_sector' => {
-            'key' => 'energy',
+          }],
+          'market_sector' => [{
+            'value' => 'energy',
             'label' => 'Energy',
-          },
+          }],
           'opened_date' => opened_date,
         }
       end
@@ -115,22 +115,22 @@ describe CmaCase do
     context 'with empty attributes' do
       let(:document_attributes) do
         {
-          'case_type' => {
-            'key' => 'mergers',
+          'case_type' => [{
+            'value' => 'mergers',
             'label' => 'Mergers',
-          },
-          'case_state' => {
-            'key' => 'open',
+          }],
+          'case_state' => [{
+            'value' => 'open',
             'label' => 'Open',
-          },
-          'market_sector' => {
-            'key' => 'energy',
+          }],
+          'market_sector' => [{
+            'value' => 'energy',
             'label' => 'Energy',
-          },
-          'outcome_type' => {
-            'key' => '',
+          }],
+          'outcome_type' => [{
+            'value' => nil,
             'label' => nil,
-          },
+          }],
           'opened_date' => opened_date,
           'closed_date' => nil,
         }

--- a/spec/parsers/document_parser_spec.rb
+++ b/spec/parsers/document_parser_spec.rb
@@ -11,22 +11,22 @@ describe DocumentParser do
         "closed_date" => "2008-03-01",
         "summary" => "Inquiry into the private healthcare market",
 
-        "market_sector" => {
+        "market_sector" => [{
           "value" => "pharmaceuticals",
           "label" => "Pharmaceuticals"
-        },
-        "case_type" => {
+        }],
+        "case_type" => [{
           "value" => "markets",
           "label" => "Markets"
-        },
-        "outcome_type" => {
+        }],
+        "outcome_type" => [{
           "value" => "ca98-infringement-chapter-i",
           "label" => "CA98 - infringement Chapter I"
-        },
-        "case_state" => {
+        }],
+        "case_state" => [{
           "value" => "closed",
           "label" => "Closed"
-        }
+        }]
       }
     }
     subject { DocumentParser.parse(document_hash) }


### PR DESCRIPTION
In order for documents to have metadata values with multiple options present, this commit does the following:
- in `abstract_document` map over all the values and find the label for each, then pass them through as "Item 1 + N others"
- refactors the tests to reflect that tag metadata is now always in Arrays
