### PR TITLE
Always parse radio facets as Arrays

### DIFF
--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -8,7 +8,9 @@ class RadioFacet < Facet
   end
 
   def value
-    @value if allowed_values.map(&:value).include?(@value)
+    Array(@value).find { |value|
+      allowed_values.map(&:value).include?(value)
+    }
   end
 
   def values_for_select
@@ -16,7 +18,7 @@ class RadioFacet < Facet
   end
 
   def selected_values
-    allowed_values.select { |option| option.value == @value && option.described }
+    allowed_values.select { |option| option.value == value && option.described }
   end
 
 private

--- a/spec/models/radio_facet_spec.rb
+++ b/spec/models/radio_facet_spec.rb
@@ -17,9 +17,9 @@ describe RadioFacet do
       specify { subject.value.should == "allowed-value-1" }
     end
 
-    context "multiple values disallowed" do
+    context "multiple values parsed as one" do
       let(:value) { ["allowed-value-1", "allowed-value-2"] }
-      specify { subject.value.should == nil }
+      specify { subject.value.should == "allowed-value-1" }
     end
 
     context "single disallowed value" do


### PR DESCRIPTION
In order to link back to the pre filtered Finders, we need to have a started way of linking backing to select and radio facets. To do this, we turn the radio facet values into an array and take the first value when we check it against the allowed_values. This also means we should remove the test which was safeguarding against this.
