### PR TITLE
Add "format" to blacklist

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -4,7 +4,7 @@ class FindersController < ApplicationController
 
   def show
     @results = ResultSetPresenter.new(finder, facet_params)
-    
+
     respond_to do |format|
       format.html
       format.json do
@@ -32,6 +32,7 @@ private
       :controller,
       :action,
       :slug,
+      :format,
     )
   end
 


### PR DESCRIPTION
So that when we build urls for the list of selected categories they don't include the json format
