### PR TITLE
Auto-open the first checkbox filter

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,9 +20,13 @@
 
 
 jQuery(function($) {
-  $('.js-openable-filter').each(function(){
-    new GOVUK.CheckboxFilter({el:$(this)});
+  var filters = $('.js-openable-filter').map(function(){
+    return new GOVUK.CheckboxFilter({el:$(this)});
   });
+
+  if (filters.length > 0 && $('.js-openable-filter').not('.closed').size() == 0) {
+    filters[0].open();
+  }
 
   var $form = $('.js-live-search-form'),
       $results = $('.js-live-search-results-block');


### PR DESCRIPTION
User research has shown that users aren't seeing the filter options down the left hand side. This commit opens the top filter on page load unless any of the other filters are already open (this would happen if any of them had selected options)
