### PR TITLE
Use assertive not polite here

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -18,7 +18,7 @@
 <div class='js-live-search-results-block'>
   <div class="filtered-results">
     <div class="inner-block">
-      <p class="result-info" aria-live='polite' id='js-search-results-info'>
+      <p class="result-info" aria-live='assertive' id='js-search-results-info'>
         <%= render_mustache('result_count', @results.to_hash)%>
       </p>
       <div id='js-results'>


### PR DESCRIPTION
So the new result count is announced immediately after the box is checked rather than waiting for the user to move focus off of the checkbox they've just selected.
