### PR TITLE
Swap space for nbsp

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -34,7 +34,7 @@ class ResultSetPresenter
     values = facet.selected_values.map do |option|
       query_string = link_params_without_facet_value(facet.key, option.value).to_query
       href = CGI.escapeHTML("?#{query_string}")
-      "<strong>#{option.label} <a href='#{href}'>×</a></strong>"
+      "<strong>#{option.label}&nbsp;<a href='#{href}'>×</a></strong>"
     end
     values.to_sentence(last_word_connector: ' and ')
   end


### PR DESCRIPTION
So that the 'x' doesn't end up an orphan on a newline

before:
![screen shot 2014-08-19 at 15 04 08](https://cloud.githubusercontent.com/assets/68009/3968848/5b8e0c88-27ba-11e4-8eee-963869692549.png)

after:

![screen shot 2014-08-19 at 15 30 28](https://cloud.githubusercontent.com/assets/68009/3968846/5a0f033a-27ba-11e4-97a6-b00d162050be.png)
