### PR TITLE
Make labels in scrolly checks wider

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -228,6 +228,7 @@
           label {
             @include inline-block;
             margin-left:20px;
+            width: 91%;
           }
           /* IE6 doesn't support psuedo selectors so scoping to checkbox-container instead of using a psuedo selector */
           input {


### PR DESCRIPTION
So that they have a wider click target make the labels 91% width. This is a best approximation of a full width as different browsers do different things with scroll-bars which means that any wider can lead to text being hidden under scroll bars in some cases
