### PR TITLE
Add medical safety alert

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -50,6 +50,7 @@ private
     [
       'aaib-reports',
       'drug-safety-update',
+      'drug-device-alerts',
     ]
   end
 end

--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -1,0 +1,21 @@
+class MedicalSafetyAlert < AbstractDocument
+private
+  def date_metadata_keys
+    %w(
+      published_at
+    )
+  end
+
+  def tag_metadata_keys
+    %w(
+      alert_type
+      medical_specialism
+    )
+  end
+
+  def metadata_name_mappings
+    {
+      "published_at" => "Published",
+    }
+  end
+end

--- a/app/parsers/document_parser.rb
+++ b/app/parsers/document_parser.rb
@@ -11,6 +11,8 @@ module DocumentParser
       InternationalDevelopmentFund.new(document_hash)
     when "drug_safety_update"
       DrugSafetyUpdate.new(document_hash)
+    when "medical_safety_alert"
+      MedicalSafetyAlert.new(document_hash)
     end
   end
 end

--- a/spec/models/medical_safety_alert.rb
+++ b/spec/models/medical_safety_alert.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe MedicalSafetyAlert do
+  subject { MedicalSafetyAlert.new(document_attributes) }
+  let(:published_at) { 1.year.ago.to_date }
+  let(:document_attributes) { {} }
+
+  describe '#metadata' do
+    context 'with all attributes' do
+      let(:document_attributes) do
+        {
+          'alert_type' => [{
+            'value' => 'drugs',
+            'label' => 'Drugs',
+          }],
+          'medical_specialism' => [{
+            'value' => 'dentistry',
+            'label' => 'Dentistry',
+          }],
+          'published_at' => published_at,
+        }
+      end
+
+      specify do
+        subject.metadata.should == [
+          {
+            name: 'Alert type',
+            value: 'Drugs',
+            type: 'text',
+          },
+          {
+            name: 'Medical specialism',
+            value: 'Dentistry',
+            type: 'text',
+          },
+          {
+            name: 'Published',
+            value: published_at,
+            type: 'date',
+          },
+        ]
+      end
+    end
+
+    context 'with missing attributes' do
+      let(:document_attributes) do
+        {}
+      end
+
+      specify do
+        subject.metadata.should == []
+      end
+    end
+
+    context 'with empty attributes' do
+      let(:document_attributes) do
+        {
+          'alert_type' => [{
+            'value' => nil,
+            'label' => nil,
+          }],
+          'medical_specialism' => [{
+            'value' => nil,
+            'label' => nil,
+          }],
+          'published_at' => nil,
+        }
+      end
+
+      specify do
+        subject.metadata.should == []
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding a model for MSA along with a test. Also excluding the MSA finder from google for now. [Ticket](https://trello.com/c/LN4aLOOW/283-alerts-finder-add-support-to-finder-frontend-for-registering-and-rendering-the-alerts-and-recalls-for-drugs-and-medical-devices-).
