### PR TITLE
Remove empty related links div

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,7 +2,7 @@
 
 <header>
   <h1><%= raw(finder.name) %></h1>
-  <% if finder.related %>
+  <% if finder.related.any? %>
     <div class='related-links'>
       <ul>
         <% finder.related.each do |link| %>


### PR DESCRIPTION
With related links, the array was empty but wasn't nil, so the empty tags were being rendered.
