### PR TITLE
Implement metadata component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.0.9'
-gem 'slimmer'
+gem 'slimmer', '4.2.2'
 gem 'gds-api-adapters', '10.4.0'
 gem 'exception_notification', '4.0.1'
 gem 'aws-ses', require: 'aws/ses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,9 +165,9 @@ GEM
     shared_mustache (0.1.3)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
-    slimmer (3.25.0)
+    slimmer (4.2.2)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
       plek (>= 0.1.8)
@@ -225,7 +225,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.2)
   sdoc
   shared_mustache (= 0.1.3)
-  slimmer
+  slimmer (= 4.2.2)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.1)
   webmock

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -78,28 +78,6 @@
         }
       }
     }
-    .metadata {
-      @include core-14;
-      @extend %contain-floats;
-      width: 100%;
-
-      dt {
-        float: left;
-        clear: left;
-        width: auto;
-        min-width: 120px;
-        @include media(tablet) {
-          padding-right: $gutter-one-third;
-        }
-      }
-      dd {
-        float: left;
-        width: 57%;
-        @include media(tablet) {
-          width: 70%;
-        }
-      }
-    }
   }
 
   .filter-form,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
+  include Slimmer::SharedTemplates
   before_filter :set_slimmer_headers
 
   # Prevent CSRF attacks by raising an exception.

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -13,12 +13,11 @@
   <% end %>
   <% if finder.primary_organisation %>
     <div class="metadata">
-      <dl class="inner-block">
-        <dt>From:</dt>
-        <dd>
-          <%= link_to finder.primary_organisation.title, finder.primary_organisation.web_url %>
-        </dd>
-      </dl>
+      <div class="inner-block">
+        <%= render partial: 'govuk_component/metadata', locals: {
+          from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
+        } %>
+      </div>
     </div>
   <% end %>
 </header>

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -7,8 +7,8 @@ Then(/^I can get a list of all merger inquiries$/) do
   stub_finder_artefact_api_request
   visit finder_path('cma-cases')
   page.should_not have_content('2 cases')
-  page.should have_css('a', text: 'Competition and Markets Authority')
   page.should have_css('.filtered-results .document', count: 2)
+  page.should have_css(shared_component_selector('metadata'))
 
   within '.filtered-results .document:nth-child(1)' do
     page.should have_link('HealthCorp / DrugInc merger inquiry')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,6 +8,10 @@ require 'cucumber/rails'
 require 'webmock/cucumber'
 require 'slimmer/test'
 
+require 'slimmer/test_helpers/shared_templates'
+World(Slimmer::TestHelpers::SharedTemplates)
+
+
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.


### PR DESCRIPTION
- Bump slimmer to a version with shared templates
- Remove bespoke metadata Sass
- Use shared template partial for metadata
- Update test to ensure shared metadata element it used
### Prerequisites:
- [x] Static to be deployed: https://github.com/alphagov/static/commits/release_2038
