### PR TITLE
Make keywords show up in search results

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -24,10 +24,22 @@ class ResultSetPresenter
   end
 
   def describe_filters_in_sentence
-    selections = finder.facets.with_selected_values.map do |facet|
+    keywords_description.concat(selected_filter_descriptions).to_sentence
+  end
+
+  def keywords_description
+    if finder.keywords.present?
+      href = "TODO: This should be a thing that works, otherwise you two are clowns."
+      ['containing '+ "<strong>#{finder.keywords}&nbsp;<a href='#{href}'>×</a></strong>"]
+    else
+      []
+    end
+  end
+
+  def selected_filter_descriptions
+    finder.facets.with_selected_values.map do |facet|
       "#{facet.preposition} #{facet_values_sentence(facet)}"
     end
-    selections.to_sentence
   end
 
   def facet_values_sentence(facet)
@@ -36,6 +48,7 @@ class ResultSetPresenter
       href = CGI.escapeHTML("?#{query_string}")
       "<strong>#{option.label}&nbsp;<a href='#{href}'>×</a></strong>"
     end
+
     values.to_sentence(last_word_connector: ' and ')
   end
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe ResultSetPresenter do
     OpenStruct.new({
       results: result_set,
       document_noun: document_noun,
-      facets: facets
+      facets: facets,
+      keywords: keywords,
     })
   end
 
+  let(:keywords){ '' }
   let(:document_noun){ 'case' }
   let(:count) { 2 }
   let(:facets) {[ :facet_1, :facet_2 ]}
@@ -116,6 +118,14 @@ RSpec.describe ResultSetPresenter do
       sentence = presenter.describe_filters_in_sentence
       facets.each do | facet |
         sentence.include?(facet[:preposition]).should == true
+      end
+    end
+
+    context 'when keywords have been searched for' do
+      let(:keywords) { "my search term" }
+
+      it 'should include the keywords' do
+        presenter.describe_filters_in_sentence.should include("my search term")
       end
     end
   end


### PR DESCRIPTION
Before, the search summary didn't show up keywords. This commit adds keywords to the summary and adds tests.
