### PR TITLE
Order by last_update when not searching by keyword

### DIFF
--- a/features/support/case_helper.rb
+++ b/features/support/case_helper.rb
@@ -57,12 +57,17 @@ module CaseHelper
   end
 
   def rummager_all_cases_url
-    "#{Plek.current.find('search')}/unified_search.json?#{search_params}"
+    params = {
+      "order" => "-last_update",
+    }
+
+    "#{Plek.current.find('search')}/unified_search.json?#{search_params(params)}"
   end
 
   def rummager_merger_inquiry_cases_url
     params = {
       "filter_case_type[]" => "mergers",
+      "order" => "-last_update",
     }
 
     "#{Plek.current.find('search')}/unified_search.json?#{search_params(params)}"

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -85,6 +85,7 @@ module FinderFrontend
       keyword_param
         .merge(filter_params)
         .merge(document_type_param)
+        .merge(order_param)
     end
 
   private
@@ -95,6 +96,14 @@ module FinderFrontend
         {"q" => params.fetch("keywords")}
       else
         {}
+      end
+    end
+
+    def order_param
+      if params.has_key?("keywords")
+        {}
+      else
+        {"order" => "-last_update"}
       end
     end
 


### PR DESCRIPTION
In order to match the finder-api behaviour that rummager is taking over,
we want to order results when filtering by the date they were last
updated.

This last_update field, once added to rummager in the schema and
permitted sort fields, and provided by the publishing applications, will
allow this behaviour to be maintained.

See alphagov/rummager#294 and alphagov/specialist-publisher#250
