### PR TITLE
Allow each finder to have a 'signup' page

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -44,9 +44,32 @@
     }
   }
 
+  .signup-content {
+    a.button {
+      @include button($button-colour);
+      width: auto;
+      @include bold-24;
+    }
+
+    p {
+      @include core-19;
+      margin: $gutter-half 0;
+
+      &.quiet {
+        color: $grey-1;
+        width: $two-thirds;
+      }
+    }
+
+    strong {
+      font-weight: bold;
+    }
+  }
+
   header {
     width: $full-width;
     margin-bottom: $gutter;
+    clear: both;
 
     h1 {
       @include heading-48;
@@ -59,6 +82,9 @@
         float:left;
       }
     }
+
+    &.signups h1 { float: inherit; }
+
     .related-links {
       @include core-16;
       margin: $gutter-one-third $gutter-half;

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -13,6 +13,11 @@ class FindersController < ApplicationController
     end
   end
 
+  def signup
+    schema_attributes = Finder.schema_attributes_hash(finder_slug)
+    @signup = SignupPresenter.new(schema_attributes)
+  end
+
 private
   def finder
     @finder ||= Finder.get(finder_slug).tap { |finder|

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -7,18 +7,22 @@ class Finder
   attr_accessor :keywords
 
   def self.get(slug)
-    schema_attributes = FinderFrontend.get_schema(slug)
+    schema_attributes = schema_attributes_hash(slug)
     artefact_attributes = content_api.artefact(slug)
     organisation_tags = artefact_attributes.tags.select { |t| t.details.type == "organisation" }
     related_artefacts = artefact_attributes.related
 
     FinderParser.parse(
-      schema_attributes.send(:schema_hash).merge(
+      schema_attributes.merge(
         "name" => artefact_attributes['title'],
         "organisations" => organisation_tags,
         "related"=> related_artefacts,
       )
     )
+  end
+
+  def self.schema_attributes_hash(slug)
+    FinderFrontend.get_schema(slug).send(:schema_hash)
   end
 
   def initialize(attrs = {})

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,0 +1,21 @@
+class SignupPresenter < Struct.new(:schema_attributes)
+  def page_title
+    "#{name} emails"
+  end
+
+  def title
+    "#{name} email alert subscription"
+  end
+
+  def name
+    schema_attributes.fetch("name")
+  end
+
+  def body
+    schema_attributes.fetch("email_signup_copy")
+  end
+
+  def target
+    schema_attributes.fetch("email_signup_url")
+  end
+end

--- a/app/views/finders/signup.html.erb
+++ b/app/views/finders/signup.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, raw(@signup.page_title) %>
+
+<header class="signups">
+  <h1><%= raw @signup.title %></h1>
+</header>
+
+<div class="outer-block">
+  <div class="inner-block signup-content">
+    <p>You're signing up for e-mail alerts for <strong><%= @signup.name %></strong>.</p>
+
+    <p><%= raw(@signup.body) %></p>
+
+    <%= link_to "Create subscription", @signup.target, class: "button" %>
+
+    <p class="quiet">
+      You can enter your email address on the next page to complete
+      the subscription
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ FinderFrontend::Application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
 
   get '/:slug' => 'finders#show', as: :finder
+  get '/:slug/signup' => 'finders#signup', as: :signup
 end


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/2KUtZWCp/322-email-sign-up-page-for-a-finder-document-format-3)

Route: `/:finder_slug/signup`

Users visiting this page see copy which comes from several attributes in
the schema:
- name: used for page title and initial summary paragraph.
- email_signup_copy: Used for the second paragraph, free-form.
- email_signup_url: The target for the button displayed on the page.

This allows users to sign up for alerts, using details present in the
schema for display.

Screenshot:

![Finder frontend screenshot](https://dl.dropboxusercontent.com/u/39836361/Screenshot%202014-09-11%2019.00.01.png)

TODO:
- [ ] Merge alphagov/finder-api#52
