### PR TITLE
Disable CSRF protection for email signup creation

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -3,6 +3,7 @@ require 'gds_api/helpers'
 
 class EmailAlertSubscriptionsController < ApplicationController
   include GdsApi::Helpers
+  protect_from_forgery except: :create
 
   def new
     # So using request.env["PATH_INFO"] has a leading slash which would need


### PR DESCRIPTION
CSRF can't work on GOV.UK frontend applications because cookies are stripped before the request is served to the user.

Hence we need to disable protection for this method. We may need to reconsider this when we pull the provision of the users e-mail address out of gov delivery and back into finder-frontend (it may be that we move where this code 'lives' at this point).
