### PR TITLE
Fix width of result count

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -44,7 +44,7 @@
     }
   }
 
-  p {
+  .signup-content p {
     margin: $gutter-half 0;
     @include core-19;
 


### PR DESCRIPTION
After b207dd9, the result count was mistakingly being applied a max-width of 66% from the core. This commit correctly nests it inside `.signup-content`.
