### PR TITLE
Parse six digit dates correctly

### DIFF
--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -74,7 +74,15 @@ private
     end
 
     def date
-      @date ||= Date.parse(original_input) rescue nil
+      @date ||= parse_date(original_input)
+    end
+
+    def parse_date(original_input)
+      if original_input =~ /(\d{2})\/(\d{2})\/(\d{2})$/
+        Date.new("20#{$3}".to_i, $2.to_i, $1.to_i)
+      else
+        Date.parse(original_input) rescue nil
+      end
     end
 
     def to_param

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -65,6 +65,16 @@ describe DateFacet do
       }
     end
 
+    context "6 digit date value" do
+      let(:value) { { to: "22/09/14" } }
+      specify {
+        subject.sentence_fragment.preposition.should == "occurred before"
+        subject.sentence_fragment.values.first.label == "22 September 2014"
+        subject.sentence_fragment.values.first.parameter_key == "date_of_occurrence[to]"
+        subject.sentence_fragment.values.first.other_params == []
+      }
+    end
+
     context "multiple date values" do
       let(:value) {
         {


### PR DESCRIPTION
With the new Date Facet added in 3376192, Ruby's `Date.parse` method was parsing six digit dates the wrong way round, so 25/09/14 would be parsed as 14th September 2025. This commit fixes that by checking if it's a 6 digit date and then building the correct Date, if it doesn't match it hands the input to `Date.parse`.
