### PR TITLE
Parse six digit dates correctly

### DIFF
--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -74,7 +74,7 @@ private
     end
 
     def date
-      @date ||= Date.parse(original_input) rescue nil
+      @date ||= DateParser.parse(original_input)
     end
 
     def to_param

--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -1,0 +1,8 @@
+class DateParser
+  def self.parse(date_string)
+    # Line below has been added to fix Ruby's parsing of 6 digits
+    # This will be break in the year 2100 
+    massaged_date = date_string.sub(/\A(\d{1,2})\/(\d{1,2})\/(\d{2})\z/, '\1/\2/20\3')
+    Date.parse(massaged_date) rescue nil
+  end
+end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -65,6 +65,16 @@ describe DateFacet do
       }
     end
 
+    context "6 digit date value" do
+      let(:value) { { to: "22/09/14" } }
+      specify {
+        subject.sentence_fragment.preposition.should == "occurred before"
+        subject.sentence_fragment.values.first.label == "22 September 2014"
+        subject.sentence_fragment.values.first.parameter_key == "date_of_occurrence[to]"
+        subject.sentence_fragment.values.first.other_params == []
+      }
+    end
+
     context "multiple date values" do
       let(:value) {
         {

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+describe DateParser do
+
+  context "8 digit date" do
+    let(:date_string) { "22/09/2014" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "6 digit date" do
+    let(:date_string) { "22/09/14" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "5 digit date" do
+    let(:date_string) { "22/9/14" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "non-numeric long date" do
+    let(:date_string) { "22nd September 2014" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "non-numeric short date" do
+    let(:date_string) { "22 Sept 2014" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "false date value" do
+    let(:date_string) { "31/15/14" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.should == nil
+    }
+  end
+
+  context "reverse date" do
+    let(:date_string) { "2014/09/22" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2014
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+end


### PR DESCRIPTION
With the new Date Facet added in 3376192, Ruby's `Date.parse` method was parsing six digit dates the wrong way round, so 25/09/14 would be parsed as 14th September 2025. This commit fixes that by checking if it's a 6 digit date and then building the correct Date, if it doesn't match it hands the input to `Date.parse`.
