### PR TITLE
Close <dd> tag properly

### DIFF
--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -9,12 +9,12 @@
         {{#metadata}}
           {{#is_text}}
             <dt class='metadata-text-label'>{{label}}:</dt>
-            <dd class='metadata-text-value'>{{value}}<dd>
+            <dd class='metadata-text-value'>{{value}}</dd>
           {{/is_text}}
 
           {{#is_date}}
             <dt class='metadata-date-label'>{{label}}:</dt>
-            <dd class='metadata-date-value'><time datetime='{{machine_date}}'>{{human_date}}</time><dd>
+            <dd class='metadata-date-value'><time datetime='{{machine_date}}'>{{human_date}}</time></dd>
           {{/is_date}}
         {{/metadata}}
       </dl>


### PR DESCRIPTION
The `<dd>` tag previously wasn't being closed properly. This was causing the browser to close it and place an empty `<dd>` and `</dd>` pair after it. This commit closes the `<dd>` tag in the correct place, removing the empty pair generated by the browser.
