### PR TITLE
Handle Rummager not returning description

### DIFF
--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -1,7 +1,7 @@
 class DrugSafetyUpdate < AbstractDocument
 
   def summary
-    attrs.fetch(:description)
+    attrs.fetch(:description, nil)
   end
 
   def self.tag_metadata_keys


### PR DESCRIPTION
If a record in Rummager's search index doesn't have a description then it will omit the field completely rather than returning a blank value. That causes the `fetch` to blow up, so this change defaults it to `nil`.
