### PR TITLE
Swap 'and' for 'or'

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -55,7 +55,7 @@ class ResultSetPresenter
   def fragment_values_to_s(values)
     values.map { |value|
       fragment_to_link(value)
-    }.to_sentence(last_word_connector: ' and ')
+    }.to_sentence(last_word_connector: ' or ')
   end
 
   def fragment_to_link(value)


### PR DESCRIPTION
(Bofore) ![screen shot 2014-10-03 at 15 10 02](https://cloud.githubusercontent.com/assets/68009/4506953/11d32a9e-4b08-11e4-89e4-92b682a8a265.png)
So that search result descriptors make sense i.e.

3 cases that are open and closed

becomes

3 cases that are open or closed
