### PR TITLE
Fix for Facet Changes

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -5,7 +5,7 @@ class Facet
   def initialize(attrs = {})
     @key = attrs[:key]
     @name = attrs[:name]
-    @value = attrs[:value].presence
+    self.value = attrs[:value].presence
     @preposition = attrs[:preposition]
   end
 

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -8,10 +8,14 @@ class SelectFacet < Facet
   end
 
   def value
-    return nil if @value.nil?
+    return nil if @value.blank?
 
     permitted_values = allowed_values.map(&:value)
     @value.select {|v| permitted_values.include?(v) }
+  end
+
+  def value=(new_value)
+    @value = Array(new_value)
   end
 
   def values_for_select


### PR DESCRIPTION
After the change in Finder API that changed Radio Facets to Select Facets old URLs with preselected options were broken. This fixes it by using a setter method to cast the value to an array for select facets. This allows the name of the old radio facet in the URL to be correctly parsed as a select facet.
