### PR TITLE
Add issued date to medical safety alerts

### DIFF
--- a/app/models/medical_safety_alert.rb
+++ b/app/models/medical_safety_alert.rb
@@ -5,4 +5,16 @@ class MedicalSafetyAlert < AbstractDocument
       medical_specialism
     )
   end
+
+  def self.date_metadata_keys
+    %w(
+      issued_date
+    )
+  end
+
+  def self.metadata_name_mappings
+    {
+      "issued_date" => "Issued",
+    }
+  end
 end


### PR DESCRIPTION
Add the issued date attribute to the medical safety alert date metadata in the model so that it can be shown in the frontend. This corresponds to this commit in specialist publisher:
alphagov/specialist-publisher#281

The trello ticket can be found here:
https://trello.com/c/QFE3nYlc/361-add-issued-date-to-medical-safety-alerts-2
