### PR TITLE
Display published_at as a metadata field on a finder

### DIFF
--- a/app/models/drug_safety_update.rb
+++ b/app/models/drug_safety_update.rb
@@ -12,13 +12,13 @@ class DrugSafetyUpdate < AbstractDocument
 
   def self.date_metadata_keys
     %w(
-      published_date
+      first_published_at
     )
   end
 
   def self.metadata_name_mappings
     {
-      "published_date" => "Published",
+      "first_published_at" => "Published",
     }
   end
 end


### PR DESCRIPTION
DO NOT MERGE: Dependant on merging of:
https://github.com/alphagov/rummager/pull/301 and
https://github.com/alphagov/finder-api/pull/68
for index generation and facet generation

This pull request allows published_at metadata for Drug Safety Update documents to be viewed and searched by on finder-frontend.

Trello ticket: https://trello.com/c/ZW0i6nya/362-add-first-published-date-to-the-dsu-finder-3-1
