### PR TITLE
Add MAIB Finder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ private
       'aaib-reports',
       'drug-safety-update',
       'drug-device-alerts',
+      'maib-reports',
     ]
   end
 

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -57,6 +57,7 @@ private
       "international-development-funding" => "international_development_fund",
       "drug-device-alerts" => "medical_safety_alert",
       "drug-safety-update" => "drug_safety_update",
+      "maib-reports" => "maib_report",
     }.fetch(@slug)
   end
 

--- a/app/models/maib_report.rb
+++ b/app/models/maib_report.rb
@@ -1,0 +1,21 @@
+class MaibReport < AbstractDocument
+private
+  def self.date_metadata_keys
+    %w(
+      date_of_occurrence
+    )
+  end
+
+  def self.tag_metadata_keys
+    %w(
+      vessel_type
+      report_type
+    )
+  end
+
+  def self.metadata_name_mappings
+    {
+      "date_of_occurrence" => "Occurred",
+    }
+  end
+end

--- a/app/parsers/document_parser.rb
+++ b/app/parsers/document_parser.rb
@@ -11,6 +11,8 @@ module DocumentParser
       InternationalDevelopmentFund.new(document_hash)
     when "drug_safety_update"
       DrugSafetyUpdate.new(document_hash)
+    when "maib_report"
+      MaibReport.new(document_hash)
     when "medical_safety_alert"
       MedicalSafetyAlert.new(document_hash)
     end

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -59,6 +59,7 @@ module FinderFrontend
         "drug_safety_update" => DrugSafetyUpdate,
         "international_development_fund" => InternationalDevelopmentFund,
         "medical_safety_alert" => MedicalSafetyAlert,
+        "maib_report" => MaibReport,
       }.fetch(document_type) { |type| raise "Unknown document type #{type}" }
     end
 


### PR DESCRIPTION
This commit adds the ability for Finder Frontend to present MAIB results.

[Ticket](https://trello.com/c/t240dCwY/370-maib-finder-add-support-to-finder-frontend-for-registering-and-rendering-maib-reports-2).
