### PR TITLE
Add RAIB Finder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,7 @@ private
       'drug-safety-update',
       'drug-device-alerts',
       'maib-reports',
+      'raib-reports',
     ]
   end
 

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -68,6 +68,7 @@ private
       "drug-device-alerts" => "medical_safety_alert",
       "drug-safety-update" => "drug_safety_update",
       "maib-reports" => "maib_report",
+      "raib-reports" => "raib_report",
     }.fetch(@slug)
   end
 

--- a/app/models/raib_report.rb
+++ b/app/models/raib_report.rb
@@ -1,0 +1,21 @@
+class RaibReport < AbstractDocument
+private
+  def self.date_metadata_keys
+    %w(
+      date_of_occurrence
+    )
+  end
+
+  def self.tag_metadata_keys
+    %w(
+      railway_type
+      report_type
+    )
+  end
+
+  def self.metadata_name_mappings
+    {
+      "date_of_occurrence" => "Occurred",
+    }
+  end
+end

--- a/app/parsers/document_parser.rb
+++ b/app/parsers/document_parser.rb
@@ -15,6 +15,8 @@ module DocumentParser
       MaibReport.new(document_hash)
     when "medical_safety_alert"
       MedicalSafetyAlert.new(document_hash)
+    when "raib_report"
+      RaibReport.new(document_hash)
     end
   end
 end

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -60,6 +60,7 @@ module FinderFrontend
         "international_development_fund" => InternationalDevelopmentFund,
         "medical_safety_alert" => MedicalSafetyAlert,
         "maib_report" => MaibReport,
+        "raib_report" => RaibReport,
       }.fetch(document_type) { |type| raise "Unknown document type #{type}" }
     end
 


### PR DESCRIPTION
This commit adds the ability for Finder Frontend to present RAIB results.

[Ticket](https://trello.com/c/wwrCuXqI/372-raib-finder-add-support-to-finder-frontend-for-registering-and-rendering-raib-reports-2).
