### PR TITLE
Remove email signup link in view

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -20,13 +20,6 @@
       </div>
     </div>
   <% end %>
-  <% if finder.email_alert_signup %>
-    <div class='inner-block'>
-      <p class='email-link'>
-        <%= link_to "Subscribe to email alerts", finder.email_alert_signup.web_url %>
-      </p>
-    </div>
-  <% end %>
 </header>
 
 <%= render finder.facets %>


### PR DESCRIPTION
As we want to be able to access the pages for the email signup pages but don't want to expose these to Users we want to remove the link until we're ready for these to go 'live'.
