### PR TITLE
Add keyword search placeholder option for Finders

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -3,7 +3,7 @@ require 'gds_api/helpers'
 class Finder
   include GdsApi::Helpers
 
-  attr_reader :slug, :name, :document_noun, :facets, :related, :email_alert_signup
+  attr_reader :slug, :name, :document_noun, :facets, :related, :email_alert_signup, :keyword_search_placeholder
   attr_accessor :keywords
 
   def self.get(slug)
@@ -38,6 +38,10 @@ class Finder
     @organisations = attrs[:organisations]
     @related = attrs[:related]
     @email_alert_signup = attrs[:email_alert_signup]
+    @keyword_search_placeholder = attrs.fetch(
+      :keyword_search_placeholder,
+      "eg #{document_noun} title"
+    )
   end
 
   def results

--- a/app/parsers/finder_parser.rb
+++ b/app/parsers/finder_parser.rb
@@ -8,6 +8,7 @@ module FinderParser
       organisations: finder_hash['organisations'],
       related: finder_hash['related'],
       email_alert_signup: finder_hash['email_alert_signup'],
+      keyword_search_placeholder: finder_hash['keyword_search_placeholder'],
     )
   end
 end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -5,7 +5,7 @@
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
         <label class="legend" for="search">Search</label>
-        <input value="<%= params[:keywords] %>" placeholder="eg <%= finder.document_noun %> title" type="text" name="keywords" id="search" aria-controls="js-search-results-info"/>
+        <input value="<%= params[:keywords] %>" placeholder="<%= finder.keyword_search_placeholder %>" type="text" name="keywords" id="search" aria-controls="js-search-results-info"/>
       </div>
       <%= render facet_collection.facets %>
       <input type="submit" value="Filter results" class="button js-live-search-fallback"/>

--- a/spec/parsers/finder_parser_spec.rb
+++ b/spec/parsers/finder_parser_spec.rb
@@ -6,7 +6,8 @@ describe FinderParser do
       "name" => "CMA Cases",
       "slug" => "finder-slug",
       "document_noun" => "case",
-      "facets" => :facet_hashes
+      "facets" => :facet_hashes,
+      "keyword_search_placeholder" => "eg Case name",
     } }
     before {
       FacetCollectionParser.stub(:parse).with(:facet_hashes).and_return(:a_facet_collection)
@@ -17,5 +18,6 @@ describe FinderParser do
     specify { subject.slug.should == "finder-slug" }
     specify { subject.document_noun.should == "case" }
     specify { subject.facets.should == :a_facet_collection }
+    specify { subject.keyword_search_placeholder.should == "eg Case name"}
   end
 end


### PR DESCRIPTION
For some Finders "eg `document.noun` title" doesn't make sense. This commit allows us to specify a keyword_search_placeholder in the schema and have it used for the keyword facet. It default to using
document.noun if this isn't present.

Related to https://github.com/alphagov/finder-api/pull/78.
