### PR TITLE
Use "document noun title" if no placeholder

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -38,10 +38,7 @@ class Finder
     @organisations = attrs[:organisations]
     @related = attrs[:related]
     @email_alert_signup = attrs[:email_alert_signup]
-    @keyword_search_placeholder = attrs.fetch(
-      :keyword_search_placeholder,
-      "eg #{document_noun} title"
-    )
+    @keyword_search_placeholder = attrs[:keyword_search_placeholder]
   end
 
   def results

--- a/app/parsers/finder_parser.rb
+++ b/app/parsers/finder_parser.rb
@@ -8,7 +8,10 @@ module FinderParser
       organisations: finder_hash['organisations'],
       related: finder_hash['related'],
       email_alert_signup: finder_hash['email_alert_signup'],
-      keyword_search_placeholder: finder_hash['keyword_search_placeholder'],
+      keyword_search_placeholder: finder_hash.fetch(
+        'keyword_search_placeholder',
+        "eg #{finder_hash['document_noun']} title"
+      ),
     )
   end
 end


### PR DESCRIPTION
After the work in b223db47d4e4b291f88959fb9ef88a302a58f3ed, Finders without a placeholder specified used nil. This commit correctly uses the fetch to return document_noun title if no placeholder is provided.
