### PR TITLE
Display 1000+ if there's more than 1000 results

### DIFF
--- a/app/models/result_set.rb
+++ b/app/models/result_set.rb
@@ -1,13 +1,12 @@
 class ResultSet
-  attr_reader :documents
-
-  delegate :count, to: :documents
+  attr_reader :documents, :total
 
   def self.get(finder_slug, document_type, params)
     ResultSetParser.parse(FinderFrontend.get_documents(finder_slug, document_type, params))
   end
 
-  def initialize(attrs)
-    @documents = attrs[:documents]
+  def initialize(documents, total)
+    @documents = documents
+    @total = total
   end
 end

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,11 +1,12 @@
 module ResultSetParser
-  def self.parse(results)
+  def self.parse(response)
 
-    documents = results
+    documents = response['results']
       .map { |document_hash| DocumentParser.parse(document_hash) }
 
     ResultSet.new(
-      documents: documents
+      documents,
+      response['total']
     )
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -1,19 +1,20 @@
 class ResultSetPresenter
   include ERB::Util
 
-  attr_reader :finder, :documents_noun, :params, :result_set
+  attr_reader :finder, :documents_noun, :params, :results, :total
 
   def initialize(finder, facet_params)
     @finder = finder
-    @result_set = finder.results
+    @results = finder.results.documents
+    @total = finder.results.total
     @documents_noun = finder.document_noun
     @params = facet_params
   end
 
   def to_hash
     {
-      count: result_set.count,
-      pluralised_document_noun: documents_noun.pluralize(result_set.count),
+      total: total > 1000 ? "1,000+" : total,
+      pluralised_document_noun: documents_noun.pluralize(total),
       applied_filters: describe_filters_in_sentence,
       documents: documents,
       any_filters_applied: any_filters_applied?,
@@ -75,7 +76,7 @@ class ResultSetPresenter
   end
 
   def documents
-    result_set.documents.map do |result|
+    results.map do |result|
       SearchResultPresenter.new(result).to_hash
     end
   end

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,7 +1,7 @@
 {{#any_filters_applied}}
 <p class="result-info">
   <span class="result-count">
-    {{count}}
+    {{total}}
   </span>
   {{{pluralised_document_noun}}}
   {{{applied_filters}}}

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -26,7 +26,6 @@ module FinderFrontend
     def call
       rummager_api.unified_search(default_params.merge(massaged_params))
         .to_hash
-        .fetch("results")
     end
 
   private

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -1,7 +1,7 @@
 describe("liveSearch", function(){
   var $form, $results, _supportHistory, liveSearch;
   var dummyResponse = {
-    "count":1,
+    "total":1,
     "pluralised_document_noun":"reports",
     "applied_filters":" \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026keywords='\u003E×\u003C/a\u003E\u003C/strong\u003E",
     "any_filters_applied":true,

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -8,8 +8,14 @@ describe ResultSetParser do
         :another_document_hash
       ]
     }
+    let(:response) {
+      {
+        total: 2,
+        results: results,
+      }.with_indifferent_access
+    }
 
-    subject { ResultSetParser.parse(results) }
+    subject { ResultSetParser.parse(response) }
 
     before do
       DocumentParser.stub(:parse).with(:a_document_hash).and_return(:a_document_instance)

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe ResultSetPresenter do
 
   let(:finder) do
     OpenStruct.new({
-      results: result_set,
+      results: results,
       document_noun: document_noun,
+      total: 2,
       facets: [ a_facet, another_facet ],
       keywords: keywords,
     })
@@ -72,10 +73,10 @@ RSpec.describe ResultSetPresenter do
 
   let(:keywords){ '' }
   let(:document_noun){ 'case' }
-  let(:count) { 2 }
+  let(:total) { 2 }
 
-  let(:result_set) do
-    OpenStruct.new({ count: count, documents: [ document ] })
+  let(:results) do
+    OpenStruct.new({ total: total, documents: [ document ] })
   end
 
   let(:document) do
@@ -99,7 +100,7 @@ RSpec.describe ResultSetPresenter do
     end
 
     it 'returns an appropriate hash' do
-      presenter.to_hash[:count].should == count
+      presenter.to_hash[:total].should == total
       presenter.to_hash[:pluralised_document_noun].present?.should == true
       presenter.to_hash[:documents].present?.should == true
       presenter.to_hash[:applied_filters].present?.should == true
@@ -109,7 +110,7 @@ RSpec.describe ResultSetPresenter do
     it 'calls pluralize on the document noun with the results_count' do
       allow(document_noun).to receive(:pluralize)
       presenter.to_hash
-      document_noun.should have_received(:pluralize).with(count)
+      document_noun.should have_received(:pluralize).with(total)
     end
 
     it 'calls describe_filters_in_sentence' do
@@ -221,8 +222,8 @@ RSpec.describe ResultSetPresenter do
 
   describe '#documents' do
     context "has one document" do
-      let(:result_set) do
-        OpenStruct.new({ count: count, documents: [ document ] })
+      let(:results) do
+        OpenStruct.new({ total: total, documents: [ document ] })
       end
       it 'creates a new search_result_presenter hash for each result' do
         search_result_objects = presenter.documents
@@ -232,8 +233,8 @@ RSpec.describe ResultSetPresenter do
     end
 
     context "has 3 documents" do
-      let(:result_set) do
-        OpenStruct.new({ count: count, documents: [ document, document, document ] })
+      let(:results) do
+        OpenStruct.new({ total: total, documents: [ document, document, document ] })
       end
       it 'creates a new document for each result' do
         search_result_objects = presenter.documents


### PR DESCRIPTION
For Finders with a large number of documents, such as AAIB Reports, telling the User that there's more results that we display helps them to narrow their search.

As we use `total` from the response, it also made sense to change this in the code.
