### PR TITLE
2 digit years that can be in the past

### DIFF
--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -3,6 +3,11 @@ class DateParser
     # Line below has been added to fix Ruby's parsing of 6 digits
     # This will be break in the year 2100 
     massaged_date = date_string.sub(/\A(\d{1,2})\/(\d{1,2})\/(\d{2})\z/, '\1/\2/20\3')
-    Date.parse(massaged_date) rescue nil
+    if date = Date.parse(massaged_date) rescue nil
+      if date.year > (DateTime.now + 50.years).year
+        date = date - 100.years
+      end
+      date
+    end
   end
 end

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -77,4 +77,26 @@ describe DateParser do
     }
   end
 
+  context "date far in the past" do
+    let(:date_string) { "22/09/80" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 1980
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
+  context "date in the future" do
+    let(:date_string) { "22/09/25" }
+
+    subject(:parsed_date) { DateParser.parse(date_string) }
+    specify {
+      parsed_date.year.should == 2025
+      parsed_date.month.should == 9
+      parsed_date.day.should == 22
+    }
+  end
+
 end


### PR DESCRIPTION
With the fix for Ruby's bananas YY/MM/DD date format guess, any 2 digit year would be assumed to be in the 21st century. This commit allows Users to give 2 digits and get a year in the 20th century by checking if the year given is in any of the next 50 and if not, assumes it's in the previous 50.
