### PR TITLE
Remove FRONTEND_TOOLKIT_DEV flag handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,7 @@ gem 'pry'
 gem 'airbrake', '4.0.0'
 
 group :assets do
-  if ENV['FRONTEND_TOOLKIT_DEV']
-    gem 'govuk_frontend_toolkit', path: '../govuk_frontend_toolkit_gem'
-  else
-    gem 'govuk_frontend_toolkit', '0.43.0'
-  end
+  gem 'govuk_frontend_toolkit', '0.43.0'
   gem 'sass-rails', '~> 4.0.2'
   gem 'uglifier', '>= 1.3.0'
 end


### PR DESCRIPTION
Nobody on this project is using this flag at the moment (or has ever used it, for that matter), so removing it from the Gemfile as it kind of threw me earlier when I was trying to debug my project not using the right version of the frontend toolkit gem
