### PR TITLE
Replace proxy with bind

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,6 @@
 //= require live_search
 //= require govuk_toolkit
 
-
 jQuery(function($) {
   var filters = $('.js-openable-filter').map(function(){
     return new GOVUK.CheckboxFilter({el:$(this)});

--- a/app/assets/javascripts/checkbox_filter.js
+++ b/app/assets/javascripts/checkbox_filter.js
@@ -10,10 +10,10 @@
     this.$checkboxResetter = this.$filter.find('.clear-selected');
     this.$checkboxes = this.$filter.find("input[type='checkbox']");
 
-    this.$checkboxResetter.on('click', $.proxy(this.resetCheckboxes, this));
+    this.$checkboxResetter.on('click', this.resetCheckboxes.bind(this));
 
-    this.$checkboxes.on('click', $.proxy(this.updateCheckboxes, this));
-    this.$checkboxes.on('focus', $.proxy(this.ensureFinderIsOpen, this));
+    this.$checkboxes.on('click', this.updateCheckboxes.bind(this));
+    this.$checkboxes.on('focus', this.ensureFinderIsOpen.bind(this));
 
     // setupHeight is called on open, but filters containing checked checkboxes will already be open
     if (this.isOpen() || !allowCollapsible) {
@@ -22,9 +22,9 @@
 
     if(allowCollapsible){
       // set up open/close listeners
-      this.$filter.find('.head').on('click', $.proxy(this.toggleFinder, this));
-      this.$filter.on('focus', $.proxy(this.listenForKeys, this));
-      this.$filter.on('blur', $.proxy(this.stopListeningForKeys, this));
+      this.$filter.find('.head').on('click', this.toggleFinder.bind(this));
+      this.$filter.on('focus', this.listenForKeys.bind(this));
+      this.$filter.on('blur', this.stopListeningForKeys.bind(this));
     }
   }
 
@@ -58,7 +58,7 @@
   };
 
   CheckboxFilter.prototype.listenForKeys = function listenForKeys(){
-    this.$filter.keypress($.proxy(this.checkForSpecialKeys, this));
+    this.$filter.keypress(this.checkForSpecialKeys.bind(this));
   };
 
   CheckboxFilter.prototype.checkForSpecialKeys = function checkForSpecialKeys(e){

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -15,20 +15,19 @@
 
     if(GOVUK.support.history()){
       this.saveState();
-      this.$form.on('change', 'input[type=checkbox], input[type=text], input[type=radio]', $.proxy(this.formChange, this));
+      this.$form.on('change', 'input[type=checkbox], input[type=text], input[type=radio]', this.formChange.bind(this));
 
-      var liveSearch = this;
       this.$form.find('input[type=text]').keypress(
         function(e){
           if(e.keyCode == 13) {
             // 13 is the return key
-            liveSearch.formChange();
+            this.formChange();
             e.preventDefault();
           }
-        }
+        }.bind(this)
       );
 
-      $(window).on('popstate', $.proxy(this.popState, this));
+      $(window).on('popstate', this.popState.bind(this));
     } else {
       this.$form.find('.js-live-search-fallback').show();
     }
@@ -57,11 +56,9 @@
       this.saveState();
       pageUpdated = this.updateResults();
       pageUpdated.done(
-        $.proxy(
-          function(){
-            history.pushState(this.state, '', window.location.pathname + "?" + $.param(this.state));
-          },
-          this)
+        function(){
+          history.pushState(this.state, '', window.location.pathname + "?" + $.param(this.state));
+        }.bind(this)
       );
     }
   };


### PR DESCRIPTION
As per https://github.com/alphagov/finder-frontend/issues/49, the frontend toolkit now has a bind shim for older browsers, so we can use bind instead of $.proxy to pass `this` context into functions. Hurrah!
