### PR TITLE
Remove link underlines from finder item headings

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -346,6 +346,10 @@
       h3 {
         @include bold-19;
         margin: 0;
+
+        a {
+          text-decoration:none;
+        }
       }
 
       dl {


### PR DESCRIPTION
In long lists of links, underlines add a lot of visual clutter to headings, making them really hard to read, as they are here. 

This follows the example seen in [Search](https://www.gov.uk/search?q=tax), [Browse](https://www.gov.uk/browse/tax/income-tax), [Manuals](https://www.gov.uk/guidance/content-design), [Policies](https://www.gov.uk/government/policies) and many other lists where the link is implicit by its context.

![no_underlines](https://cloud.githubusercontent.com/assets/265403/4996404/47a039f2-69bf-11e4-85de-299b75de06a3.png)
