### PR TITLE
Remove instruction text above finder filters

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,7 +1,5 @@
 <div class="filter-form">
   <div class="inner-block">
-    <p>You can use the filters to show only <%= finder.document_noun.pluralize %> that match your interests</p>
-
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
         <label class="legend" for="search">Search</label>


### PR DESCRIPTION
We shouldn't have to describe how the UI works like this.
If it's not clear in and of itself, we're doing something wrong.
Let's see how users get on without this instruction.
