### PR TITLE
Auto check checboxes

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -17,7 +17,7 @@
           </legend>
           <% @signup.choices.each do |choice| %>
             <%= label_tag "choices[#{@signup.choice_key}][#{choice.key}]", class: 'block-label' do %>
-              <%= check_box_tag "choices[#{@signup.choice_key}][#{choice.key}]", 1, false, class: 'checkbox' %>
+              <%= check_box_tag "choices[#{@signup.choice_key}][#{choice.key}]", 1, true, class: 'checkbox' %>
               <%= choice.name %>
             <% end %>
           <% end %>


### PR DESCRIPTION
[yes this is a dark-pattern] We have decided to auto check checkboxes because we know from research that most users want to subscribe to both types of alert for the MHRA medical device alerts and drug alerts.
