### PR TITLE
Use format instead of slug for finding govdelivery url

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -27,6 +27,10 @@ private
     Finder.get(finder_slug)
   end
 
+  def finder_format
+    finder.document_type
+  end
+
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       email_alert_api: email_alert_api,
@@ -36,7 +40,7 @@ private
 
   def email_signup_attributes
     {
-      "format" => [finder_slug],
+      "format" => [finder_format],
     }.merge(choices)
   end
 

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -58,9 +58,6 @@ class Finder
     facets.map { |facet| facet.sentence_fragment }.compact
   end
 
-private
-  attr_reader :organisations
-
   def document_type
     # TODO: get this from the content api respose
     {
@@ -73,6 +70,9 @@ private
       "raib-reports" => "raib_report",
     }.fetch(@slug)
   end
+
+private
+  attr_reader :organisations
 
   def search_params
     facet_search_params.merge(keyword_search_params)

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -8,7 +8,8 @@ describe EmailAlertSubscriptionsController do
     let(:delivery_api) { double(:delivery_api) }
     let(:finder) {
       double(:finder,
-        name: alert_name
+        name: alert_name,
+        document_type: 'cma_case'
       )
     }
     let(:signup_api_wrapper) {


### PR DESCRIPTION
In 5a107b7373cdc4e8fdf923b62b21d71027098016 we started using format
instead of slugs for the tags on email-alert-api.

This updates the getting of the subscription url to use format instead
of slug.
