### PR TITLE
Remove placeholder from search

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -3,7 +3,7 @@ require 'gds_api/helpers'
 class Finder
   include GdsApi::Helpers
 
-  attr_reader :slug, :name, :document_noun, :facets, :related, :email_alert_signup, :keyword_search_placeholder, :beta
+  attr_reader :slug, :name, :document_noun, :facets, :related, :email_alert_signup, :beta
   attr_accessor :keywords
 
   def self.get(slug)
@@ -39,7 +39,6 @@ class Finder
     @organisations = attrs[:organisations]
     @related = attrs[:related]
     @email_alert_signup = attrs[:email_alert_signup]
-    @keyword_search_placeholder = attrs[:keyword_search_placeholder]
   end
 
   def results

--- a/app/parsers/finder_parser.rb
+++ b/app/parsers/finder_parser.rb
@@ -9,10 +9,6 @@ module FinderParser
       organisations: finder_hash['organisations'],
       related: finder_hash['related'],
       email_alert_signup: finder_hash['email_alert_signup'],
-      keyword_search_placeholder: finder_hash.fetch(
-        'keyword_search_placeholder',
-        "eg #{finder_hash['document_noun']} title"
-      ),
     )
   end
 end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -3,7 +3,7 @@
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
         <label class="legend" for="search">Search</label>
-        <input value="<%= params[:keywords] %>" placeholder="<%= finder.keyword_search_placeholder %>" type="text" name="keywords" id="search" aria-controls="js-search-results-info" class='text'/>
+        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="search" aria-controls="js-search-results-info" class='text'/>
       </div>
       <%= render facet_collection.facets %>
       <input type="submit" value="Filter results" class="button js-live-search-fallback"/>

--- a/spec/parsers/finder_parser_spec.rb
+++ b/spec/parsers/finder_parser_spec.rb
@@ -9,7 +9,6 @@ describe FinderParser do
       "slug" => "finder-slug",
       "document_noun" => "case",
       "facets" => :facet_hashes,
-      "keyword_search_placeholder" => "eg Case name",
     } }
 
     let(:cma_cases_content_item) { {
@@ -42,6 +41,5 @@ describe FinderParser do
     specify { subject.slug.should == "finder-slug" }
     specify { subject.document_noun.should == "case" }
     specify { subject.facets.should == :a_facet_collection }
-    specify { subject.keyword_search_placeholder.should == "eg Case name"}
   end
 end


### PR DESCRIPTION
User research has showed us that users were seeing the placeholder text and assuming they could only put in strings of those types. A specific example; users needed to search by device manufacturer in the search field, but didn't because the placeholder was 'eg drug or device name'

This commit removes the placeholder handling for keyword field.
