### PR TITLE
Move date suggestion text out of placeholder

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -159,6 +159,15 @@
     }
   }
 
+  .help-text {
+    @include core-14;
+    display:block;
+    padding: $gutter-one-third/2 0;
+    @include media(tablet) {
+      padding: $gutter-one-third 0;
+    }
+  }
+
   .filter {
     margin-bottom: $gutter;
     background-color:$grey-3;

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -1,7 +1,8 @@
 <div class="filter text-filter">
   <label class="legend" for="<%= date_facet.key %>[from]"><%= date_facet.name %> after</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('from', nil) %>" placeholder="eg <%= Date.today.strftime("%e/%m/%Y") %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" class="text" />
+  <input value="<%= params.fetch(date_facet.key, {}).fetch('from', nil) %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" aria-describedby="date-help-text" class="text" />
 
   <label class="legend" for="<%= date_facet.key %>[to]"><%= date_facet.name %> before</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('to', nil) %>" placeholder="eg <%= Date.today.strftime("%e/%m/%Y") %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" />
+  <input value="<%= params.fetch(date_facet.key, {}).fetch('to', nil) %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" aria-describedby="date-help-text"/>
+  <span id='date-help-text' class='help-text'>For example, 2005 or 21/11/2014<span>
 </div>


### PR DESCRIPTION
_before_
![screen shot 2014-11-18 at 14 29 56](https://cloud.githubusercontent.com/assets/68009/5088947/63090622-6f2f-11e4-95a2-2e743092635f.png)

_after_
![screen shot 2014-11-18 at 14 30 32](https://cloud.githubusercontent.com/assets/68009/5088956/7d6291f0-6f2f-11e4-9e19-0f4b5118db0d.png)

Multiple functional changes here:
- The date filters are now way more flexible than they were, so I've changed the suggestions to show two accepted date formats as examples.
- Use "for example" instead of eg because in previous filters, users seemed to treat eg as ie, meaning they would only use the search box with the suggested format types. Since we can fit "for example" in this placeholder text we should use it instead.
- To avoid replication of the same text, and because the date fields are already visually linked by the grey box, have one help text at the bottom of the box, rather than one for each input.
