### PR TITLE
Use default prechecked state on page load

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -20,7 +20,7 @@
           </legend>
           <% @signup.choices.each do |choice| %>
             <%= label_tag "choices[#{@signup.choice_key}][#{choice.key}]", class: 'block-label' do %>
-              <%= check_box_tag "choices[#{@signup.choice_key}][#{choice.key}]", 1, true, class: 'checkbox' %>
+              <%= check_box_tag "choices[#{@signup.choice_key}][#{choice.key}]", 1, choice.prechecked, class: 'checkbox' %>
               <%= choice.name %>
             <% end %>
           <% end %>


### PR DESCRIPTION
DO NOT MERGE: 
Depends on https://github.com/alphagov/finder-api/pull/92
Without the above change this will not break finder frontend but it will remove the default preselection for drug-device-alerts

Rather than always prechecking select boxes, use the prechecked state from the metadata about an email signup currently pulled from finder-api.

Ticket: https://trello.com/c/DzJdcftL/431-checkbox-email-signup-for-other-finders-3
