### PR TITLE
Allow Beta message to be passed in

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,6 +1,6 @@
 class FinderPresenter
 
-  attr_reader :name, :slug, :document_noun, :document_type, :organisations, :keywords
+  attr_reader :name, :slug, :document_noun, :document_type, :organisations, :keywords, :beta_message
 
   def initialize(content_item, values = {}, keywords = nil)
     @content_item = content_item
@@ -11,6 +11,7 @@ class FinderPresenter
     @organisations = content_item.links.organisations
     facets.values = values
     @keywords = keywords
+    @beta_message = content_item.details.beta_message
   end
 
   def beta?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,7 +2,11 @@
 
 <header>
   <% if finder.beta? %>
-    <%= render partial: 'govuk_component/beta_label' %>
+    <% if finder.beta_message %>
+      <%= render partial: 'govuk_component/beta_label', locals: { message: finder.beta_message } %>
+    <% else %>
+      <%= render partial: 'govuk_component/beta_label' %>
+    <% end %>
   <% end %>
   <h1><%= raw(finder.name) %></h1>
   <% if finder.related.any? %>


### PR DESCRIPTION
With some Finders, the default beta message doesn't quite work for us. This commit allows the beta message to be passed in as an optional argument.
