### PR TITLE
Make finder#show more agnostic

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,6 +1,6 @@
 class FinderPresenter
 
-  attr_reader :name, :slug, :document_noun, :document_type, :organisations, :keywords, :beta_message
+  attr_reader :name, :slug, :document_noun, :document_type, :organisations, :keywords
 
   def initialize(content_item, values = {}, keywords = nil)
     @content_item = content_item
@@ -11,15 +11,18 @@ class FinderPresenter
     @organisations = content_item.links.organisations
     facets.values = values
     @keywords = keywords
-    @beta_message = content_item.details.beta_message
   end
 
   def beta?
-    content_item.details.beta
+    content_item.details.beta || false
+  end
+
+  def beta_message
+    content_item.details.beta_message || false
   end
 
   def email_alert_signup_enabled?
-    content_item.details.email_signup_enabled
+    content_item.details.email_signup_enabled || false
   end
 
   def email_alert_signup

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, raw(finder.name) %>
+<% content_for :title, finder.name %>
 
 <header>
   <% if finder.beta? %>
@@ -8,7 +8,7 @@
       <%= render partial: 'govuk_component/beta_label' %>
     <% end %>
   <% end %>
-  <h1><%= raw(finder.name) %></h1>
+  <h1><%= finder.name %></h1>
   <% if finder.related.any? %>
     <div class='related-links'>
       <ul>


### PR DESCRIPTION
As we move Finders to being published by multiple Apps we want to make the Frontend more agnostic to what information it receives. This commit does that by specifying that if a value isn't returned in the response it is false. This happens for the beta flag, beta message and email signup flag.