### PR TITLE
Don't use raw for page title and Finder name

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, raw(finder.name) %>
+<% content_for :title, finder.name %>
 
 <header>
   <% if finder.beta? %>
@@ -8,7 +8,7 @@
       <%= render partial: 'govuk_component/beta_label' %>
     <% end %>
   <% end %>
-  <h1><%= raw(finder.name) %></h1>
+  <h1><%= finder.name %></h1>
   <% if finder.related.any? %>
     <div class='related-links'>
       <ul>


### PR DESCRIPTION
With Orgs like HMRC, they have `&` in their name. We don't want to use raw in these instances as we want to escape the HTML entities.

Doing this again because I have no idea how `git` works.

![](http://s.mlkshk-cdn.com/r/97VP)