### PR TITLE
Contacts finder

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,13 @@
+class Contact < AbstractDocument
+  def self.tag_metadata_keys
+    %w(
+      contact_group
+    )
+  end
+
+  def self.metadata_name_mappings
+    {
+      "contact_group" => "Topic",
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 FinderFrontend::Application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
 
-  get '/:slug' => 'finders#show', as: :finder
+  get '/*slug/email-signup' => 'email_alert_subscriptions#new', as: :new_email_alert_subscriptions
+  post '/*slug/email-signup' => 'email_alert_subscriptions#create', as: :email_alert_subscriptions
 
-  get '/:slug/email-signup' => 'email_alert_subscriptions#new', as: :new_email_alert_subscriptions
-  post '/:slug/email-signup' => 'email_alert_subscriptions#create', as: :email_alert_subscriptions
+  get '/*slug' => 'finders#show', as: :finder
 end

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -44,6 +44,7 @@ module FinderFrontend
       {
         "aaib_report" => AaibReport,
         "cma_case" => CmaCase,
+        "contact" => Contact,
         "drug_safety_update" => DrugSafetyUpdate,
         "international_development_fund" => InternationalDevelopmentFund,
         "medical_safety_alert" => MedicalSafetyAlert,


### PR DESCRIPTION
This PR contains the first load of work to render a Contacts Finder. The PR contains the following:

- **Accept routes not at root**: Other Finders will live at other URLs apart from root. This commit adds
a catchall glob and moves it after any that match email-signup.

- **Add Contact Document format**: Add a Contact document type. The only metadata this format has is ContactGroups which is labelled as Topics. These will be fetched from Rummager (when they are in there).
