### PR TITLE
Add validation for email signup checkboxes

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -320,6 +320,20 @@
       max-width: $full-width;
     }
 
+    fieldset.invalid {
+      border-left: solid 4px $error-colour;
+      padding-left: $gutter-half;
+      margin-left: -$gutter-half - 4;
+    }
+
+    .validation-message {
+      color: $error-colour;
+      font-weight: bold;
+      padding: $gutter-half;
+      margin-left: -$gutter-half - 4;
+      border-left: solid 4px $error-colour;
+    }
+
     .block-label {
       display: block;
       clear: left;

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -7,17 +7,31 @@ class EmailAlertSubscriptionsController < ApplicationController
 
   def new
     if content
-      @signup = SignupPresenter.new(content)
+      @signup = signup_presenter
     else
       error_not_found
     end
   end
 
   def create
-    redirect_to email_alert_signup_api.signup_url
+    if valid_choices?
+      redirect_to email_alert_signup_api.signup_url
+    else
+      @signup = signup_presenter
+      @error_message = "Please choose an email alert"
+      render action: :new
+    end
   end
 
 private
+
+  def valid_choices?
+    available_choices.blank? || chosen_options.present?
+  end
+
+  def signup_presenter
+    @signup_presenter ||= SignupPresenter.new(content)
+  end
 
   def content
     @content ||= content_store.content_item(request.path)
@@ -35,20 +49,28 @@ private
     finder.document_type
   end
 
+  def available_choices
+    content.details.email_signup_choice
+  end
+
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       email_alert_api: email_alert_api,
       attributes: email_signup_attributes,
       subscription_list_title_prefix: content.details.subscription_list_title_prefix,
-      available_choices: content.details.email_signup_choice,
+      available_choices: available_choices,
       filter_key: content.details.email_filter_by,
     )
+  end
+
+  def chosen_options
+    params["filter"]
   end
 
   def email_signup_attributes
     {
       "format" => [finder_format],
-      "filter" => params["filter"],
+      "filter" => chosen_options,
     }
   end
 

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -14,10 +14,10 @@
   <div class="inner-block signup-content">
     <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
       <% if @signup.choices? %>
-        <fieldset>
-          <legend>
+        <fieldset<%= ' class="invalid"'.html_safe if @error_message.present? %> aria-labelledby="fieldset-title">
+          <p id="fieldset-title">
             Select the email alerts you need
-          </legend>
+          </p>
           <% @signup.choices.each do |choice| %>
             <%= label_tag "filter_#{choice.key}", class: 'block-label' do %>
               <%= check_box_tag "filter[]", choice.key, choice.prechecked, class: 'checkbox', id: "filter_#{choice.key}" %>
@@ -25,6 +25,9 @@
             <% end %>
           <% end %>
         </fieldset>
+        <% if @error_message.present? %>
+          <p class="validation-message"><%= @error_message %></p>
+        <% end %>
       <% end %>
 
       <p><%= @signup.body %></p>


### PR DESCRIPTION
Provides an error to the user if there are checkboxes and they select
none of them on email signup

Testable by going to http://finder-frontend.dev.gov.uk/aaib-reports/email-signup and hitting submit with no checkboxes checked.

![screenshot 2015-01-16 16 14 25](https://cloud.githubusercontent.com/assets/425/5779485/f2db3920-9d9a-11e4-834c-b3ebbc0a36d6.png)