### PR TITLE
Enable signup link override

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -30,6 +30,14 @@ class FinderPresenter
     end
   end
 
+  def email_alert_signup_url
+    if content_item.details.signup_link.present?
+      content_item.details.signup_link
+    else
+      email_alert_signup.web_url
+    end
+  end
+
   def facets
     @facets ||= FacetCollection.new(
       content_item.details.facets.map { |facet|

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -30,7 +30,7 @@
 <% if finder.email_alert_signup_enabled? %>
   <div class='inner-block'>
     <p class='email-link'>
-      <%= link_to "Subscribe to email alerts", finder.email_alert_signup.web_url %>
+      <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
     </p>
   </div>
 <% end %>


### PR DESCRIPTION
Use manual signup link if specified in content store. As specified in
specialist-publisher#0897e8cd8b55cd2f0efa62da9fa0ad64a18ffc5d