### PR TITLE
Use "or" for two options

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -56,7 +56,7 @@ class ResultSetPresenter
   def fragment_values_to_s(values)
     values.map { |value|
       "<strong>#{html_escape(value.label)}</strong>"
-    }.to_sentence(last_word_connector: ' or ')
+    }.to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
   end
 
   def documents


### PR DESCRIPTION
When selecting 2 options, the search description was "a and b". When selecting 3 options, it was "a, b, or c".

This commit adds the two_word_connector option to the fragment_values_to_s method to correctly make the 2 option description "a or b".