### PR TITLE
Result count spacing

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -397,7 +397,7 @@
       @include core-16;
       vertical-align: baseline;
       border-bottom: solid 1px $border-colour;
-      margin: $gutter-half 0;
+      margin: 0 0 $gutter-half 0;
       padding-bottom: $gutter-half;
 
       .result-count {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -402,7 +402,7 @@
 
       .result-count {
         @include bold-48;
-        margin-right: $gutter-one-third;
+        margin-right: $gutter-one-third / 2;
       }
     }
 


### PR DESCRIPTION
A couple of tiny presentational changes:

* Remove margin at top of result count so it's positioned in the same way an unfiltered result set is.
* Bring result count and type closer together.

Like this:

![finder](https://cloud.githubusercontent.com/assets/265403/5856263/7708e25e-a239-11e4-8117-b1e503b452ac.png)

I should really have included them in this [previously merged PR](https://github.com/alphagov/finder-frontend/pull/143) but hey ¯\_(ツ)_/¯