### PR TITLE
Allow robots to crawl MHRA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,6 @@ private
   def finders_excluded_from_robots
     [
       'aaib-reports',
-      'drug-safety-update',
-      'drug-device-alerts',
       'maib-reports',
       'raib-reports',
     ]


### PR DESCRIPTION
MHRA are setting up redirects for their content on Tuesday 27th Jan 2015 at 2.30pm (UTC). Since GOV.UK is going to become the official home for this content at that point, we should make sure search engines are allowed to index it.

This commit had a false start in #146 and #147, but we're confident it's really happening this time.