### PR TITLE
Make facet parser accept text facets

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -7,6 +7,7 @@ class Facet
     @name = facet.name
     self.value = facet.value.presence
     @preposition = facet.preposition
+    @filterable = facet.filterable.nil? ? true : facet.filterable
   end
 
   def to_partial_path
@@ -15,5 +16,9 @@ class Facet
 
   def selected_values
     []
+  end
+
+  def filterable?
+    @filterable
   end
 end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -1,7 +1,7 @@
 module FacetParser
   def self.parse(facet)
     case facet.type
-    when 'multi-select'
+    when 'multi-select', 'text'
       SelectFacet.new(facet)
     when 'date'
       DateFacet.new(facet)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -42,7 +42,7 @@ class FinderPresenter
     @facets ||= FacetCollection.new(
       content_item.details.facets.map { |facet|
         FacetParser.parse(facet)
-      }
+      }.select(&:filterable?)
     )
   end
 

--- a/features/fixtures/cma_cases_content_item.json
+++ b/features/fixtures/cma_cases_content_item.json
@@ -14,6 +14,7 @@
           "type": "multi-select",
           "include_blank": "All case types",
           "preposition": "of type",
+          "filterable": true,
           "allowed_values": [
             {"label": "CA98 and civil cartels", "value": "ca98-and-civil-cartels"},
             {"label": "Criminal cartels", "value": "criminal-cartels"},
@@ -28,6 +29,7 @@
         "type": "multi-select",
         "include_blank": false,
         "preposition": "which are",
+        "filterable": true,
         "allowed_values": [
           {"label": "Open", "value": "open"},
           {"label": "Closed", "value": "closed"}
@@ -40,6 +42,7 @@
         "type": "multi-select",
         "include_blank": false,
         "preposition": "about",
+        "filterable": true,
         "allowed_values": [
           {"label": "Agriculture, environment and natural resources", "value": "agriculture-environment-and-natural-resources"},
           {"label": "Aerospace", "value": "aerospace"},
@@ -57,6 +60,7 @@
         "type": "multi-select",
         "include_blank": false,
         "preposition": "with outcome",
+        "filterable": true,
         "allowed_values": [
           {"label": "CA98 - no grounds for action/non-infringement", "value": "ca98-no-grounds-for-action-non-infringement"},
           {"label": "CA98 - infringement Chapter I", "value": "ca98-infringement-chapter-i"},

--- a/spec/parsers/facet_parser_spec.rb
+++ b/spec/parsers/facet_parser_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe FacetParser do
   context "with a select facet OpenStruct" do
-    let(:facet) { 
+    let(:facet) {
       OpenStruct.new(
         type: "multi-select",
         name: "Case type",
         key: "case_type",
         value: ["market-investigations"],
         preposition: "of type",
+        filterable: true,
         allowed_values: [
            OpenStruct.new(
             label: "Airport price control reviews",
@@ -16,7 +17,7 @@ describe FacetParser do
           ),
            OpenStruct.new(
             label: "Market investigations",
-            value: "market-investigations" 
+            value: "market-investigations"
           ),
            OpenStruct.new(
             label: "Remittals",


### PR DESCRIPTION
With the changes in 04fcb52d we need to make this App work with both `text` and `multi-select` while we deploy them.