### PR TITLE
Handle non existent content items gracefully

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   helper :application
+  rescue_from GdsApi::HTTPNotFound, with: :error_not_found
 
 private
   def set_slimmer_headers
@@ -31,4 +32,7 @@ private
     raise NotImplementedError
   end
 
+  def error_not_found
+    render status: :not_found, text: "404 error not found"
+  end
 end

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -6,11 +6,7 @@ class EmailAlertSubscriptionsController < ApplicationController
   protect_from_forgery except: :create
 
   def new
-    if content
-      @signup = signup_presenter
-    else
-      error_not_found
-    end
+    @signup = signup_presenter
   end
 
   def create
@@ -34,7 +30,7 @@ private
   end
 
   def content
-    @content ||= content_store.content_item(request.path)
+    @content ||= content_store.content_item!(request.path)
   end
 
   def finder_slug
@@ -42,7 +38,7 @@ private
   end
 
   def finder
-    FinderPresenter.new(content_store.content_item("/#{finder_slug}"))
+    FinderPresenter.new(content_store.content_item!("/#{finder_slug}"))
   end
 
   def finder_format
@@ -73,10 +69,4 @@ private
       "filter" => chosen_options,
     }
   end
-
-  def error_not_found
-    render status: :not_found, text: "404 error not found"
-  end
-
 end
-

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -17,7 +17,7 @@ class FindersController < ApplicationController
 private
   def finder
     @finder ||= FinderPresenter.new(
-      content_store.content_item("/#{finder_slug}"),
+      content_store.content_item!("/#{finder_slug}"),
       facet_params,
       keywords,
     )

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -5,6 +5,17 @@ include FixturesHelper
 
 describe EmailAlertSubscriptionsController do
 
+  describe 'GET #new' do
+    describe "finder email signup item doesn't exist" do
+      it 'returns a 404, rather than 5xx' do
+        content_store_does_not_have_item('/does-not-exist/email-signup')
+
+        get :new, slug: 'does-not-exist'
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   describe 'POST "#create"' do
     let(:alert_name) { double(:alert_name) }
     let(:alert_identifier) { double(:alert_identifier) }

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+include GdsApi::TestHelpers::ContentStore
+include FixturesHelper
+
+describe FindersController do
+  describe "GET show" do
+    describe "finder item doesn't exist" do
+      it 'returns a 404, rather than 5xx' do
+        content_store_does_not_have_item('/does-not-exist')
+
+        get :show, slug: 'does-not-exist'
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was piecemeal support for this before but no test coverage.

In theory, requests for non-existent finders shouldn't be routed to this app,
but they could be. Additionally, the nil-pointer error that happened instead
was confusing in development.