### PR TITLE
Make keyword search label/input ID unique

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -2,8 +2,8 @@
   <div class="inner-block">
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
-        <label class="legend" for="search">Search</label>
-        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="search" aria-controls="js-search-results-info" class='text'/>
+        <label class="legend" for="finder-keyword-search">Search</label>
+        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
       </div>
       <%= render facet_collection.facets %>
       <input type="submit" value="Filter results" class="button js-live-search-fallback"/>


### PR DESCRIPTION
The ID of #search was clashing with form#search in the base template.

Make it unique to make the label behaviour work as expected, and make
it specific to finders to avoid similar clashes in the future (as
`govuk_template`  and/or static can change underneath the app without
warning)
