### PR TITLE
Explain facets and links in Content Item

### DIFF
--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -56,6 +56,82 @@ A boolean. Required.
 
 Used to decide if the summaries for Documents should be displayed in the results list. It will truncate the summary at the end of the first sentence.
 
-## facets
+## `facets`
 
-__TO DO__
+An array of hashes. Optional.
+
+Facets describe the metadata that the Finder deals with. They can contain several keys:
+
+### `key`
+
+A string. Required.
+
+`snake_case` string which matches to the field being searched in Rummager.
+
+### `filterable`
+
+A boolean. Required.
+
+Specifies if the facet should have a matching Filter for the results.
+
+### `display_as_result_metadata`
+
+A boolean. Required.
+
+Specifies if the facet should be returned as metadata underneath each result.
+
+### `name`
+
+A string. Required.
+
+Used to label the filter panel for the facet.
+
+For date facets, it may be used to label the metadata shown for each result. (See also short_name)
+
+### `preposition`
+
+A string. Required if `filterable` is set to `true`.
+
+Is prepended to the name of the Filter when constructing the `sentence_fragment` for that Filter.
+
+### `type`
+
+A string set to `date` or `text`. Required.
+
+If `filterable` is `true`, this generates a `date` or `multi-select` Filter respectively. If `display_as_result_metadata` is ` true` and this is set to `date`, it will present the date as `DD Month YYYY` under the result.
+
+### `short_name`
+
+A string. Optional.
+
+For dates, the name of the Filter may be too long, such as `Date of occurrence`. The field lets you specify a short name. For the `Date of occurrence` example, the `short_name` would be `Occurred`.
+
+### `allowed_values`
+
+An array of hashes. Required if `filterable` is set to `true` and `type` is set to `text`.
+
+The `allowed_values` array contains hashes with the following keys and values:
+
+#### `label`
+
+A string. Required.
+
+Displayed as the label for the option in the `multi-select` Filter and as the label in the `sentence_fragment`.
+
+#### `value`
+
+A string. Required.
+
+Appended to the URL when the option is select. Usually a paramterized slug of the label, but it doesn't need to be a direct 1:1.
+
+# Outside of the details hash
+
+## `links`
+
+### `organisations`
+
+Currently, only the first Organisation is displayed as metadata on the Finder.
+
+### `email_alert_signup`
+
+This is the Content Item for the email-signup for the Finder. Most of these live at `#{base_path}/email-signup` but there's no reason this couldn't point anywhere else.


### PR DESCRIPTION
This commit adds an explanation for what keys should be in the facets and what they do. It also explains what this App does with the `links` provided by the Content Item.