### PR TITLE
Use new grid layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :assets do
   if ENV['FRONTEND_TOOLKIT_DEV']
     gem 'govuk_frontend_toolkit', path: '../govuk_frontend_toolkit_gem'
   else
-    gem 'govuk_frontend_toolkit', '2.0.1'
+    gem 'govuk_frontend_toolkit', '3.1.0'
   end
   gem 'sass-rails', '~> 4.0.2'
   gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       rest-client (~> 1.6.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    govuk_frontend_toolkit (2.0.1)
+    govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -232,7 +232,7 @@ DEPENDENCIES
   cucumber-rails
   exception_notification (= 4.0.1)
   gds-api-adapters (= 16.1.0)
-  govuk_frontend_toolkit (= 2.0.1)
+  govuk_frontend_toolkit (= 3.1.0)
   jasmine-rails
   launchy
   logstasher (= 0.4.8)

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -57,26 +57,11 @@
   }
 
   header {
-    width: $full-width;
-    margin-bottom: $gutter;
-    clear: both;
+    margin: $gutter 0;
 
-    h1 {
-      @include heading-48;
-      font-weight: bold;
-      margin: $gutter-half 0;
-
-      .aside {
-        @include heading-27;
-        display: block;
-        color: $grey-1;
-      }
-
-      @include media(tablet) {
-        margin: $gutter 0;
-        width: $two-thirds;
-        float:left;
-      }
+    @include media(tablet) {
+      width: $two-thirds;
+      float: left;
     }
 
     .email-link {
@@ -115,6 +100,7 @@
   }
 
   .filtering {
+    clear: both; // Clear `header` float for max-width
     @extend %grid-row;
   }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -52,16 +52,12 @@
     @include bold-24;
   }
 
-  .govuk-beta-label {
-    margin: 0 $gutter;
-  }
-
   header {
-    margin: $gutter 0;
+    @extend %grid-row;
+    margin-bottom: $gutter;
 
-    @include media(tablet) {
-      width: $two-thirds;
-      float: left;
+    .title-and-metadata {
+      @include grid-column(2/3);
     }
 
     .email-link {
@@ -79,16 +75,10 @@
     }
 
     .related-links {
+      @include grid-column(1/3);
       @include core-16;
-      margin: $gutter-one-third $gutter-half;
+      margin: $gutter 0;
       list-style:none;
-
-      @include media(tablet) {
-        padding-top: 7px;
-        margin-left: 0;
-        float:right;
-        width: 20%;
-      }
 
       li {
         margin-bottom:4px;
@@ -100,7 +90,6 @@
   }
 
   .filtering {
-    clear: both; // Clear `header` float for max-width
     @extend %grid-row;
   }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,6 +1,7 @@
 // govuk_frontend_toolkit helpers
 @import "typography";
 @import "measurements";
+@import "grid_layout";
 @import "colours";
 @import "shims";
 @import "css3";
@@ -11,37 +12,17 @@
 
 #wrapper {
   display: block;
+  @extend %site-width-container;
+
   padding-bottom: $gutter;
 
   @include media(desktop) {
     padding-bottom: $gutter*2;
   }
-
-  #content {
-    text-align: left;
-    display: block;
-    position: relative;
-    margin: 0 auto;
-    width: auto;
-    max-width: 960 + $gutter*2;
-    @extend %contain-floats;
-
-    @include ie-lte(8){
-      width: 960px;
-    }
-  }
 }
 
 #finder-frontend {
-  @extend %contain-floats;
   margin-bottom: $gutter*2;
-
-  .inner-block {
-    margin: 0 $gutter-half;
-    @include media(tablet) {
-      margin: 0 $gutter;
-    }
-  }
 
   .signup-content p {
     margin: $gutter-half 0;
@@ -83,7 +64,7 @@
     h1 {
       @include heading-48;
       font-weight: bold;
-      margin: $gutter-half;
+      margin: $gutter-half 0;
 
       .aside {
         @include heading-27;
@@ -92,7 +73,7 @@
       }
 
       @include media(tablet) {
-        margin: $gutter;
+        margin: $gutter 0;
         width: $two-thirds;
         float:left;
       }
@@ -133,17 +114,15 @@
     }
   }
 
-  .filter-form,
-  .filtered-results {
-    @include media(tablet) {
-      float: left;
-      width: $one-third;
-    }
+  .filtering {
+    @extend %grid-row;
+  }
+
+  .filter-form {
+    @include grid-column(1/3);
   }
   .filtered-results {
-    @include media(tablet) {
-      width: $two-thirds;
-    }
+    @include grid-column(2/3);
   }
 
   .filter-form {

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for :title, @signup.page_title %>
 
-<header class="signups">
-  <% if @signup.beta? %>
-    <%= render partial: 'govuk_component/beta_label' %>
-  <% end %>
-  <div class="inner-block">
+<% if @signup.beta? %>
+  <%= render partial: 'govuk_component/beta_label' %>
+<% end %>
+<header>
+ <div class="title-and-metadata">
     <%= render partial: 'govuk_component/title', locals: {
       title: @signup.name,
       context: "Email alert subscription"

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -11,7 +11,7 @@
 </header>
 
 <div class="outer-block">
-  <div class="inner-block signup-content">
+  <div class="signup-content">
     <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
       <% if @signup.choices? %>
         <fieldset<%= ' class="invalid"'.html_safe if @error_message.present? %> aria-labelledby="fieldset-title">

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -4,10 +4,12 @@
   <% if @signup.beta? %>
     <%= render partial: 'govuk_component/beta_label' %>
   <% end %>
-  <h1>
-    <span class="aside">Email alert subscription</span>
-    <%= @signup.name %>
-  </h1>
+  <div class="inner-block">
+    <%= render partial: 'govuk_component/title', locals: {
+      title: @signup.name,
+      context: "Email alert subscription"
+    } %>
+  </div>
 </header>
 
 <div class="outer-block">

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,12 +1,10 @@
 <div class="filter-form">
-  <div class="inner-block">
-    <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
-      <div class="filter text-filter">
-        <label class="legend" for="finder-keyword-search">Search</label>
-        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
-      </div>
-      <%= render facet_collection.facets %>
-      <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
-    </form>
-  </div>
+  <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
+    <div class="filter text-filter">
+      <label class="legend" for="finder-keyword-search">Search</label>
+      <input value="<%= params[:keywords] %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
+    </div>
+    <%= render facet_collection.facets %>
+    <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
+  </form>
 </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,16 +1,32 @@
 <% content_for :title, finder.name %>
 
-<header>
-  <% if finder.beta? %>
-    <% if finder.beta_message %>
-      <%= render partial: 'govuk_component/beta_label', locals: { message: finder.beta_message } %>
-    <% else %>
-      <%= render partial: 'govuk_component/beta_label' %>
-    <% end %>
+<% if finder.beta? %>
+  <% if finder.beta_message %>
+    <%= render partial: 'govuk_component/beta_label', locals: { message: finder.beta_message } %>
+  <% else %>
+    <%= render partial: 'govuk_component/beta_label' %>
   <% end %>
-  <%= render partial: 'govuk_component/title', locals: {
-    title: finder.name
-  } %>
+<% end %>
+
+<header>
+  <div class="title-and-metadata">
+    <%= render partial: 'govuk_component/title', locals: {
+      title: finder.name
+    } %>
+    <% if finder.primary_organisation %>
+      <div class="metadata">
+        <%= render partial: 'govuk_component/metadata', locals: {
+          from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
+        } %>
+      </div>
+    <% end %>
+    <% if finder.email_alert_signup_enabled? %>
+      <p class='email-link'>
+        <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
+      </p>
+    <% end %>
+  </div>
+
   <% if finder.related.any? %>
     <div class='related-links'>
       <ul>
@@ -20,18 +36,6 @@
       </ul>
     </div>
   <% end %>
-  <% if finder.primary_organisation %>
-    <div class="metadata">
-      <%= render partial: 'govuk_component/metadata', locals: {
-        from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
-      } %>
-    </div>
-  <% end %>
-<% if finder.email_alert_signup_enabled? %>
-  <p class='email-link'>
-    <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
-  </p>
-<% end %>
 </header>
 
 <div class="filtering">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -8,7 +8,9 @@
       <%= render partial: 'govuk_component/beta_label' %>
     <% end %>
   <% end %>
-  <h1><%= finder.name %></h1>
+  <%= render partial: 'govuk_component/title', locals: {
+    title: finder.name
+  } %>
   <% if finder.related.any? %>
     <div class='related-links'>
       <ul>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -31,7 +31,7 @@
     <div class='related-links'>
       <ul>
         <% finder.related.each do |link| %>
-          <li><%= link_to "View #{link[:title]}", link[:web_url] %></li>
+          <li><%= link_to link[:title], link[:web_url] %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -20,26 +20,22 @@
   <% end %>
   <% if finder.primary_organisation %>
     <div class="metadata">
-      <div class="inner-block">
-        <%= render partial: 'govuk_component/metadata', locals: {
-          from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
-        } %>
-      </div>
+      <%= render partial: 'govuk_component/metadata', locals: {
+        from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
+      } %>
     </div>
   <% end %>
 <% if finder.email_alert_signup_enabled? %>
-  <div class='inner-block'>
-    <p class='email-link'>
-      <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
-    </p>
-  </div>
+  <p class='email-link'>
+    <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
+  </p>
 <% end %>
 </header>
 
-<%= render finder.facets %>
-<div class='js-live-search-results-block'>
-  <div class="filtered-results">
-    <div class="inner-block">
+<div class="filtering">
+  <%= render finder.facets %>
+  <div class='js-live-search-results-block'>
+    <div class="filtered-results">
       <div aria-live='assertive' id='js-search-results-info'>
         <%= render_mustache('result_count', @results.to_hash)%>
       </div>


### PR DESCRIPTION
There a significant visual difference, so i'm not sure this is ready to merge, but I think theres enough to be worth discussion. I'd recommend looking at the commits (and their messages) in isolation, rather than the whole diff.

Mostly this converted fine, there were some sticking points around:
- Needing an element to wrap the filters and results columns, acting as a grid row - basically not the `header`. I chose `.filtering` as a not-awful start, but I think we could do better.
- Continuing to enforce the max-width of the `header`, to ensure the line length doesn't go beyond `2/3`rds, is done in a fiddly way. It requires floating 
 - One option would be to it in a row/column, but that would add quite a bit of markup just for CSS hooks.
 - Another would be using max-width 
- Finally, the show stopper; the gutters between columns is significantly smaller, `30px` in the new vs `60px` in the old. As the screenshots show, it's a hefty change.

The first point is semantic flddling, while the other two are a class of problem we'll see on other applications when trying to use modern grids and so are worth proper discussion.

Screenshots!


| Before | After |
| ---------| ------- |
| ![finder-before](https://cloud.githubusercontent.com/assets/63201/6026775/527b5b24-abd5-11e4-86e8-7344585397cd.png) | ![finder-after](https://cloud.githubusercontent.com/assets/63201/6026774/527abb7e-abd5-11e4-959d-c0233483828c.png) | 
| ![finder-desktop-before](https://cloud.githubusercontent.com/assets/63201/6026779/52806506-abd5-11e4-81e9-1e3184906a13.png) | ![screenshot 2015-02-04 10 18 56](https://cloud.githubusercontent.com/assets/63201/6038709/60f32d3a-ac57-11e4-977b-26991b4ac8c5.png) | 
| ![finder-email-before](https://cloud.githubusercontent.com/assets/63201/6026776/527c8788-abd5-11e4-96f7-c4fec4d9a298.png) | ![finder-email-after](https://cloud.githubusercontent.com/assets/63201/6026778/527f6282-abd5-11e4-8a70-3fb996a3f356.png) | 
| ![finder-email-desktop-before](https://cloud.githubusercontent.com/assets/63201/6026780/528e7f6a-abd5-11e4-8304-ec6839482cdc.png) | ![finder-email-desktop-after](https://cloud.githubusercontent.com/assets/63201/6026781/528ee450-abd5-11e4-812f-4952bb55ce29.png) |