### PR TITLE
Get the filter restriction from the Content Item

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def finder_format
-    finder.document_type
+    finder.filter.filter_document_type
   end
 
   def available_choices

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,13 +1,13 @@
 class FinderPresenter
 
-  attr_reader :name, :slug, :document_noun, :document_type, :organisations, :keywords, :beta_message
+  attr_reader :name, :slug, :document_noun, :filter, :organisations, :keywords, :beta_message
 
   def initialize(content_item, values = {}, keywords = nil)
     @content_item = content_item
     @name = content_item.title
     @slug = content_item.base_path
     @document_noun = content_item.details.document_noun
-    @document_type = content_item.details.document_type
+    @filter = content_item.details.filter
     @organisations = content_item.links.organisations
     facets.values = values
     @keywords = keywords

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -24,11 +24,22 @@ A string. Required.
 
 The lowercase singular version of whatever format the Finder is using. For example: [`/cma-cases`](https://www.gov.uk/cma-cases) has a `document_noun` of `case`, [`/aaib-report`](https://www.gov.uk/aaib-reports) has a `document_noun` of `report`. This is used to construct the sentence descriving the current search by the user.
 
-## `document_type`
+## `filter`
 
-A string. Required.
+A hash. Required.
 
-[snake_case](http://en.wikipedia.org/wiki/Snake_case) string which tells Finder Frontend what doctype to limit the search to in Rummager. It must match the name of the file describing the doctype [in Rummager](https://github.com/alphagov/rummager/tree/master/config/schema/default/doctypes).
+Used to restrict the base search in Rummager. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in Rummager](https://github.com/alphagov/rummager/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16) and prepended with `filter_`.
+
+For example filtering all documents with a `contact` format from HM Revenue & Customs would need a hash like:
+
+```
+{
+  "filter_document_type": "contact",
+  "filter_organisations": [
+    "hm-revenue-customs"
+  ]
+}
+```
 
 ## `email_signup_enabled`
 

--- a/features/fixtures/cma_cases_content_item.json
+++ b/features/fixtures/cma_cases_content_item.json
@@ -16,6 +16,9 @@
     "format_name":"Competition and Markets Authority case",
     "signup_link":null,
     "summaries":false,
+    "filter": {
+      "filter_document_type": "cma_case"
+    },
     "facets":[
       {
         "key":"case_type",

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -8,7 +8,6 @@ module FinderFrontend
   class FindDocuments
     def initialize(finder, params)
       @finder = finder
-      @document_type = finder.document_type
       @params = params
     end
 
@@ -19,7 +18,7 @@ module FinderFrontend
 
   private
 
-    attr_reader :document_type, :params, :finder
+    attr_reader :params, :finder
 
     def default_params
       {
@@ -45,7 +44,7 @@ module FinderFrontend
     end
 
     def massaged_params
-      ParamsMassager.new(params, document_type).to_h
+      ParamsMassager.new(params, finder).to_h
     end
 
     def rummager_api
@@ -54,20 +53,20 @@ module FinderFrontend
   end
 
   class ParamsMassager
-    def initialize(params, document_type)
+    def initialize(params, finder)
       @params = params
-      @document_type = document_type
+      @finder = finder
     end
 
     def to_h
       keyword_param
         .merge(filter_params)
-        .merge(document_type_param)
+        .merge(base_filter)
         .merge(order_param)
     end
 
   private
-    attr_reader :params, :document_type
+    attr_reader :params, :finder
 
     def keyword_param
       if params.has_key?("keywords")
@@ -93,10 +92,8 @@ module FinderFrontend
         }
     end
 
-    def document_type_param
-      {
-        "filter_document_type" => document_type,
-      }
+    def base_filter
+      finder.filter.to_h
     end
   end
 end


### PR DESCRIPTION
As we now want Finders not restricted by the document type we can move this default restriction into the Content Item and call it from the Finder Presenter. We also need to use the document_type for the email alert subs controller as it passes this to the EmailAlertAPI.