### PR TITLE
Allow Finders to have a summary

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -60,6 +60,10 @@
       @include grid-column(2/3);
     }
 
+    .summary {
+      margin-top: $gutter;
+    }
+
     .email-link {
       margin-top: $gutter;
       a {

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -5,6 +5,7 @@ class FinderPresenter
   delegate :beta_message,
            :document_noun,
            :filter,
+           :summary,
            to: :"content_item.details"
 
   def initialize(content_item, values = {}, keywords = nil)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,17 +1,19 @@
 class FinderPresenter
 
-  attr_reader :name, :slug, :document_noun, :filter, :organisations, :keywords, :beta_message
+  attr_reader :name, :slug, :organisations, :keywords
+
+  delegate :beta_message,
+           :document_noun,
+           :filter,
+           to: :"content_item.details"
 
   def initialize(content_item, values = {}, keywords = nil)
     @content_item = content_item
     @name = content_item.title
     @slug = content_item.base_path
-    @document_noun = content_item.details.document_noun
-    @filter = content_item.details.filter
     @organisations = content_item.links.organisations
     facets.values = values
     @keywords = keywords
-    @beta_message = content_item.details.beta_message
   end
 
   def beta?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -20,6 +20,15 @@
         } %>
       </div>
     <% end %>
+
+    <% if finder.summary %>
+      <div class="summary">
+        <%= render partial: 'govuk_component/govspeak', locals: {
+            content: finder.summary
+          } %>
+      </div>
+    <% end %>
+
     <% if finder.email_alert_signup_enabled? %>
       <p class='email-link'>
         <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -67,6 +67,12 @@ A boolean. Required.
 
 Used to decide if the summaries for Documents should be displayed in the results list. It will truncate the summary at the end of the first sentence.
 
+## `summary`
+
+A string. Optional.
+
+Rendered in the header after the metadata. Can contain Govspeak and is rendered using the [Govspeak component](http://govuk-component-guide.herokuapp.com/component/govspeak).
+
 ## `facets`
 
 An array of hashes. Optional.

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe FinderPresenter do
+
+  subject(:presenter) { FinderPresenter.new(finder) }
+
+  let(:finder) {
+    OpenStruct.new(
+      base_path: "/mosw-reports",
+      title: "Ministry of Silly Walks reports",
+      details: OpenStruct.new(
+        facets: [
+          OpenStruct.new(
+            key: "walk-type",
+            name: "Walk type",
+            preposition: "of type",
+            type: "text",
+            filterable: true,
+            display_as_result_metadata: true,
+            allowed_values: [
+              OpenStruct.new(
+                key: "backwards",
+                label: "Backwards",
+              ),
+              OpenStruct.new(
+                key: "hopscotch",
+                label: "Hopscotch",
+              ),
+              OpenStruct.new(
+                key: "start-and-stop",
+                label: "Start-and-stop",
+              ),
+            ]
+          ),
+          OpenStruct.new(
+            key: "place-of-origin",
+            name: "Place of origin",
+            preposition: "which originated in",
+            type: "text",
+            filterable: true,
+            display_as_result_metadata: true,
+            allowed_values: [
+              OpenStruct.new(
+                key: "england",
+                label: "England",
+              ),
+              OpenStruct.new(
+                key: "northern-ireland",
+                label: "Northern Ireland",
+              ),
+              OpenStruct.new(
+                key: "scotland",
+                label: "Scotland",
+              ),
+              OpenStruct.new(
+                key: "wales",
+                label: "Wales",
+              ),
+            ]
+          ),
+          OpenStruct.new(
+            key: "date-of-introduction",
+            name: "Date of introduction",
+            short_name: "Introduced",
+            type: "date",
+            filterable: false,
+            display_as_result_metadata: true,
+          ),
+          OpenStruct.new(
+            key: "creator",
+            name: "Creator",
+            type: "text",
+            filterable: false,
+            display_as_result_metadata: false,
+          )
+        ]
+      ),
+      links: OpenStruct.new(
+        organisations: [
+          OpenStruct.new(
+            title: "Ministry of Silly Walks",
+            base_path: "/government/organisations/ministry-of-silly-walks",
+          )
+        ],
+      )
+    )
+  }
+
+  describe "facets" do
+    it "returns the correct facets" do
+      subject.facets.to_a.select{ |f| f.type == "date" }.length.should == 1
+      subject.facets.to_a.select{ |f| f.type == "text" }.length.should == 3
+      subject.facet_keys.should =~ %w{place-of-origin date-of-introduction walk-type creator}
+    end
+
+    it "returns the correct filters" do
+      subject.filters.length.should == 2
+    end
+
+    it "returns the correct metadata" do
+      subject.metadata.length.should == 3
+    end
+
+    it "returns correct keys for each facet type" do
+      subject.date_metadata_keys.should =~ %w{date-of-introduction}
+      subject.text_metadata_keys.should =~ %w{place-of-origin walk-type}
+    end
+  end
+
+  describe "#label_for_metadata_key" do
+    it "finds the correct key" do
+      subject.label_for_metadata_key("date-of-introduction").should == "Introduced"
+    end
+  end
+
+end


### PR DESCRIPTION
For the Policies as a Finder, we want to be able to have a bit of text to explain what the Finder is. This commit adds the ability for the Content Item to have a summary and for it to be rendered.

![screen shot 2015-02-09 at 17 35 47](https://cloud.githubusercontent.com/assets/449004/6111637/547fbfc6-b082-11e4-8233-b18a1a37daaa.png)
