### PR TITLE
Use namespaced filter keys

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -38,7 +38,7 @@ private
   end
 
   def finder_format
-    finder.filter.filter_document_type
+    finder.filter.document_type
   end
 
   def available_choices

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -28,14 +28,14 @@ The lowercase singular version of whatever format the Finder is using. For examp
 
 A hash. Required.
 
-Used to restrict the base search in Rummager. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in Rummager](https://github.com/alphagov/rummager/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16) and prepended with `filter_`.
+Used to restrict the base search in Rummager. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in Rummager](https://github.com/alphagov/rummager/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16).
 
 For example filtering all documents with a `contact` format from HM Revenue & Customs would need a hash like:
 
 ```
 {
-  "filter_document_type": "contact",
-  "filter_organisations": [
+  "document_type": "contact",
+  "organisations": [
     "hm-revenue-customs"
   ]
 }

--- a/features/fixtures/cma_cases_content_item.json
+++ b/features/fixtures/cma_cases_content_item.json
@@ -17,7 +17,7 @@
     "signup_link":null,
     "summaries":false,
     "filter": {
-      "filter_document_type": "cma_case"
+      "document_type": "cma_case"
     },
     "facets":[
       {

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -61,7 +61,6 @@ module FinderFrontend
     def to_h
       keyword_param
         .merge(filter_params)
-        .merge(base_filter)
         .merge(order_param)
     end
 
@@ -87,6 +86,7 @@ module FinderFrontend
     def filter_params
       params
         .except("keywords")
+        .merge(base_filter)
         .reduce({}) { |memo, (k,v)|
           memo.merge("filter_#{k}" => v)
         }


### PR DESCRIPTION
As we don't want to have to prefix all filter keys with `filter_`, this commit makes this happening programmatically in `lib/finderfrontend.rb`. This also changes the readme to reflect the changes and the `email_alert_subscriptions_controller.rb` to call the document_type.