### PR TITLE
Display `part_of` as metadata

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -81,6 +81,10 @@ class FinderPresenter
     content_item.links.organisations
   end
 
+  def part_of
+    @part_of = content_item.links.part_of || []
+  end
+
   def primary_organisation
     organisations.first
   end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -17,6 +17,9 @@
       <div class="metadata">
         <%= render partial: 'govuk_component/metadata', locals: {
           from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
+          part_of: finder.part_of.map { |link|
+            link_to(link.title, link.web_url)
+          },
         } %>
       </div>
     <% end %>


### PR DESCRIPTION
With the policy area Finders, we want to display the part of tag using the metadata pattern. This commit adds it to the presenter and view, passing an empty array if the Finder has no `part_of` links.