### PR TITLE
Pass a context to the title component

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -4,6 +4,7 @@ class FinderPresenter
 
   delegate :beta_message,
            :document_noun,
+           :human_readable_finder_format,
            :filter,
            :summary,
            to: :"content_item.details"

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -11,6 +11,7 @@
 <header>
   <div class="title-and-metadata">
     <%= render partial: 'govuk_component/title', locals: {
+      context: finder.human_readable_finder_format,
       title: finder.name
     } %>
     <% if finder.primary_organisation %>

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -55,6 +55,12 @@ Not specifically used by the Finder, but used by [Specialist Frontend](https://g
 Usually a singularised version of the title of the Finder - `"Competition and Markets Authority case"` for [`/cma-cases`](https://www.gov.uk/cma-cases) for example.
 However there are edge cases where it's not the same such as `"Medical safety alert"` for [Alerts and recalls for drugs and medical devices](https://www.gov.uk/drug-device-alerts).
 
+## `human_readable_finder_format`
+
+A string. Optional.
+
+Human readable version of the content format. Passed as the context to the [title](http://govuk-component-guide.herokuapp.com/component/title) component.
+
 ## `signup_link`
 
 A string. Optional.


### PR DESCRIPTION
As we now have Finders which may act as a format, we want to be able to display the context in the title. This is passed as a `human_readable_finder_format` in the Content Item.