### PR TITLE
Better Atom entry id

### DIFF
--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -9,11 +9,13 @@ class AtomPresenter
   end
 
   def entries
-    finder.results.documents
+    finder.results.documents.map { |d|
+      EntryPresenter.new(d)
+    }
   end
 
   def updated_at
-    DateTime.parse(entries.first.last_update)
+    entries.first.updated_at
   end
 
 private

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -1,0 +1,31 @@
+class EntryPresenter
+
+  delegate :title,
+           :summary,
+           :path,
+           to: :entry
+
+  def initialize(entry)
+    @entry = entry
+  end
+
+  def tag(schema)
+    "tag:#{website_root},#{schema_date(schema)}:#{entry.path}"
+  end
+
+  def updated_at
+    DateTime.parse(entry.last_update)
+  end
+
+private
+  attr_reader :entry
+
+  def website_root
+    Plek.current.website_root.gsub(/https?:\/\//, '')
+  end
+
+  def schema_date(schema)
+    schema.instance_variable_get(:@feed_options)[:schema_date]
+  end
+
+end

--- a/app/views/finders/show.atom.builder
+++ b/app/views/finders/show.atom.builder
@@ -8,7 +8,7 @@ atom_feed do |feed|
   end
 
   @feed.entries.each do |result|
-    feed.entry(result, id: result.path, url: absolute_url_for(result.path), updated: DateTime.parse(result.last_update)) do |entry|
+    feed.entry(result, id: result.tag(feed), url: absolute_url_for(result.path), updated: result.updated_at) do |entry|
       entry.title(result.title)
       entry.summary(result.summary, type: 'html')
     end


### PR DESCRIPTION
This commit adds an EntryPresenter class and updates the `id` of the entry to follow the tag paradigm. It also uses the `schema_date` from the Builder to specify the year of the spec which it follows.

The work in this commit comes from the information [here](http://web.archive.org/web/20110514113830/http://diveintomark.org/archives/2004/05/28/howto-atom-id).