### PR TITLE
Government navigation for government finders

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -54,6 +54,14 @@ class FinderPresenter
     facets.filters
   end
 
+  def government?
+    slug.starts_with?("/government")
+  end
+
+  def government_content_section
+    slug.split('/')[2]
+  end
+
   def metadata
     facets.metadata
   end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -9,6 +9,10 @@
   <% end %>
 <% end %>
 
+<% if finder.government? %>
+  <%= render partial: 'govuk_component/government_navigation', locals: { active: finder.government_content_section } %>
+<% end %>
+
 <header>
   <div class="title-and-metadata">
     <%= render partial: 'govuk_component/title', locals: {

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -11,3 +11,7 @@ Feature: Filtering documents
     Given a collection of documents exist
     When I search documents by keyword
     Then I see all documents which contain the keywords
+
+  Scenario: Visit a government finder
+    Given a government finder exists
+    Then I can see the government header

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -39,3 +39,13 @@ Then(/^I see all documents which contain the keywords$/) do
     expect(page).to have_css("a", text: @keyword_search)
   end
 end
+
+Given(/^a government finder exists$/) do
+  content_store_has_government_finder
+  stub_rummager_api_request
+end
+
+Then(/^I can see the government header$/) do
+  visit finder_path('government/policies/benefits-reform')
+  page.should have_css(shared_component_selector('government_navigation'))
+end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -4,7 +4,6 @@ Given(/^a collection of documents exist$/) do
 end
 
 Then(/^I can get a list of all documents with matching metadata$/) do
-  content_store_has_mosw_reports_finder
   visit finder_path('mosw-reports')
   page.should_not have_content('2 reports')
   page.should have_css('.filtered-results .document', count: 2)
@@ -26,7 +25,6 @@ Then(/^I can get a list of all documents with matching metadata$/) do
 end
 
 When(/^I search documents by keyword$/) do
-  content_store_has_mosw_reports_finder
   stub_keyword_search_api_request
 
   visit finder_path('mosw-reports')

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -23,6 +23,13 @@ module DocumentHelper
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
 
+  def content_store_has_government_finder
+    base_path = '/government/policies/benefits-reform'
+    content_store_has_item(base_path,
+      govuk_content_schema_example('finder').merge('base_path' => base_path).to_json
+    )
+  end
+
   def search_params(params = {})
     default_search_params.merge(params).to_a.map { |tuple|
       tuple.join("=")

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,8 +1,6 @@
-require 'gds_api/test_helpers/content_store'
 require_relative '../../lib/govuk_content_schema_examples'
 
 module DocumentHelper
-  include GdsApi::TestHelpers::ContentStore
   include GovukContentSchemaExamples
 
   def stub_rummager_api_request

--- a/lib/govuk_content_schema_examples.rb
+++ b/lib/govuk_content_schema_examples.rb
@@ -7,6 +7,8 @@
 #
 #   $ GOVUK_CONTENT_SCHEMAS_PATH=/some/dir/govuk-content-schemas bundle exec rake
 #
+require 'gds_api/test_helpers/content_store'
+
 module GovukContentSchemaExamples
   extend ActiveSupport::Concern
 

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -5,10 +5,21 @@ RSpec.describe FinderPresenter do
 
   subject(:presenter) { described_class.new(content_item) }
 
+  let(:government_presenter) { described_class.new(government_finder_content_item) }
+
   let(:content_item) {
     dummy_http_response = double("net http response",
       code: 200,
       body: govuk_content_schema_example('finder').to_json,
+      headers: {}
+    )
+    GdsApi::Response.new(dummy_http_response).to_ostruct
+  }
+
+  let(:government_finder_content_item) {
+    dummy_http_response = double("net http response",
+      code: 200,
+      body: govuk_content_schema_example('finder').merge("base_path" => "/government/policies/a-finder").to_json,
       headers: {}
     )
     GdsApi::Response.new(dummy_http_response).to_ostruct
@@ -38,6 +49,16 @@ RSpec.describe FinderPresenter do
   describe "#label_for_metadata_key" do
     it "finds the correct key" do
       subject.label_for_metadata_key("date_of_introduction").should == "Introduced"
+    end
+  end
+
+  describe "a government finder" do
+    it "sets the government flag" do
+      government_presenter.government?.should == true
+    end
+
+    it "exposes the government_content_section" do
+      government_presenter.government_content_section.should == "policies"
     end
   end
 


### PR DESCRIPTION
This PR adds a render call for the `government_navigation` component in static which is added in https://github.com/alphagov/static/pull/553. This is only called if the Finder's `base_path` begins with `/government`. If it does, it also then extracts the second part of the `base_path` and uses this to decide which link should get a class of active added.

It also addresses some require weirdness with the `govuk_content_schemas_example` file.