### PR TITLE
Refactor metadata

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,10 @@ module ApplicationHelper
   def absolute_url_for(path)
     URI.join(Plek.current.website_root, path)
   end
+
+  def arr_to_links(arr)
+    arr.map { |link|
+      link_to(link.title, link.web_url)
+    }
+  end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -87,15 +87,11 @@ class FinderPresenter
   end
 
   def organisations
-    content_item.links.organisations
+    content_item.links.organisations || []
   end
 
   def part_of
-    @part_of = content_item.links.part_of || []
-  end
-
-  def primary_organisation
-    organisations.first
+    content_item.links.part_of || []
   end
 
   def related

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -19,13 +19,12 @@
       context: finder.human_readable_finder_format,
       title: finder.name
     } %>
-    <% if finder.primary_organisation %>
+
+    <% if finder.organisations.any? || finder.part_of.any? %>
       <div class="metadata">
         <%= render partial: 'govuk_component/metadata', locals: {
-          from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
-          part_of: finder.part_of.map { |link|
-            link_to(link.title, link.web_url)
-          },
+          from:  arr_to_links(finder.organisations),
+          part_of: arr_to_links(finder.part_of),
         } %>
       </div>
     <% end %>


### PR DESCRIPTION
This PR cleans up some of the code around displaying metadata. Specially, it adds a helper to turn an array of links in a content item into an array of appropriate `<a>` tags. It also removes `#primary_organisation` and just uses the `#organisations` method.