### PR TITLE
Add people to metadata

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,12 @@ module ApplicationHelper
     URI.join(Plek.current.website_root, path)
   end
 
+  def page_metadata_links(metadata)
+    metadata.inject({}) do |memo, (type, links)|
+      memo.merge(type => arr_to_links(links))
+    end
+  end
+
   def arr_to_links(arr)
     arr.map { |link|
       link_to(link.title, link.web_url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,10 @@ module ApplicationHelper
   def absolute_url_for(path)
     URI.join(Plek.current.website_root, path)
   end
+
+  def arr_to_links(arr)
+    arr.map { |link|
+      link_to(link.title, link.web_url)
+    }
+  end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -87,15 +87,11 @@ class FinderPresenter
   end
 
   def organisations
-    content_item.links.organisations
+    content_item.links.organisations || []
   end
 
   def part_of
-    @part_of = content_item.links.part_of || []
-  end
-
-  def primary_organisation
-    organisations.first
+    content_item.links.part_of || []
   end
 
   def related

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -86,12 +86,13 @@ class FinderPresenter
     content_item.details.show_summaries
   end
 
-  def organisations
-    content_item.links.organisations || []
-  end
+  def page_metadata
+    metadata = {
+      part_of: part_of,
+      from: from,
+    }
 
-  def part_of
-    content_item.links.part_of || []
+    metadata.reject { |_, links| links.empty? }
   end
 
   def related
@@ -113,6 +114,22 @@ class FinderPresenter
 
 private
   attr_reader :content_item, :values
+
+  def part_of
+    content_item.links.part_of || []
+  end
+
+  def organisations
+    content_item.links.organisations || []
+  end
+
+  def people
+    content_item.links.people || []
+  end
+
+  def from
+    organisations + people
+  end
 
   def facet_search_params
     facets.values

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -19,13 +19,12 @@
       context: finder.human_readable_finder_format,
       title: finder.name
     } %>
-    <% if finder.primary_organisation %>
+
+    <% if finder.organisations.any? || finder.part_of.any? %>
       <div class="metadata">
         <%= render partial: 'govuk_component/metadata', locals: {
-          from: link_to(finder.primary_organisation.title, finder.primary_organisation.web_url),
-          part_of: finder.part_of.map { |link|
-            link_to(link.title, link.web_url)
-          },
+          from:  arr_to_links(finder.organisations),
+          part_of: arr_to_links(finder.part_of),
         } %>
       </div>
     <% end %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -19,13 +19,10 @@
       context: finder.human_readable_finder_format,
       title: finder.name
     } %>
-
-    <% if finder.organisations.any? || finder.part_of.any? %>
+    <% if finder.page_metadata.any? %>
       <div class="metadata">
-        <%= render partial: 'govuk_component/metadata', locals: {
-          from:  arr_to_links(finder.organisations),
-          part_of: arr_to_links(finder.part_of),
-        } %>
+        <%= render partial: 'govuk_component/metadata',
+          locals: page_metadata_links(finder.page_metadata) %>
       </div>
     <% end %>
 

--- a/lib/govuk_content_schema_examples.rb
+++ b/lib/govuk_content_schema_examples.rb
@@ -21,8 +21,8 @@ module GovukContentSchemaExamples
     include GdsApi::TestHelpers::ContentStore
 
     # Returns a hash representing an finder content item from govuk-content-schemas
-    def govuk_content_schema_example(name)
-      string = GovukContentSchemaTestHelpers::Examples.new.get('finder', name)
+    def govuk_content_schema_example(name, format='finder')
+      string = GovukContentSchemaTestHelpers::Examples.new.get(format, name)
       JSON.parse(string)
     end
   end

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe FinderPresenter do
 
   let(:government_presenter) { described_class.new(government_finder_content_item) }
 
+  let(:minimal_policy_presenter) { described_class.new(minimal_policy_content_item) }
+
   let(:content_item) {
     dummy_http_response = double("net http response",
       code: 200,
@@ -19,7 +21,16 @@ RSpec.describe FinderPresenter do
   let(:government_finder_content_item) {
     dummy_http_response = double("net http response",
       code: 200,
-      body: govuk_content_schema_example('finder').merge("base_path" => "/government/policies/a-finder").to_json,
+      body: govuk_content_schema_example('policy_programme', 'policy').to_json,
+      headers: {}
+    )
+    GdsApi::Response.new(dummy_http_response).to_ostruct
+  }
+
+  let(:minimal_policy_content_item) {
+    dummy_http_response = double("net http response",
+      code: 200,
+      body: govuk_content_schema_example('minimal_policy_area', 'policy').to_json,
       headers: {}
     )
     GdsApi::Response.new(dummy_http_response).to_ostruct
@@ -60,6 +71,20 @@ RSpec.describe FinderPresenter do
     it "exposes the government_content_section" do
       government_presenter.government_content_section.should == "policies"
     end
+
+    it "has metadata" do
+      expect(government_presenter.page_metadata.any?).to be true
+    end
+
+    it "has people and organisations in the from metadata" do
+      from = government_presenter.page_metadata[:from].map(&:title)
+      expect(from).to include("George Dough", "Department for Work and Pensions")
+    end
   end
 
+  describe "a minimal policy content item" do
+    it "doesn't have any page meta data" do
+      expect(minimal_policy_presenter.page_metadata.any?).to be false
+    end
+  end
 end


### PR DESCRIPTION
This includes the work from #178 which had the following description:

This PR cleans up some of the code around displaying metadata. Specially, it adds a helper to turn an array of links in a content item into an array of appropriate <a> tags. It also removes #primary_organisation and just uses the #organisations method.

It also adds in people into the metadata list.

Relies upon https://github.com/alphagov/govuk-content-schemas/pull/36 being merged for the tests to pass.