### PR TITLE
Update finder to order with public_timestamp

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,14 +1,14 @@
 class Document
-  attr_reader :title, :last_update
+  attr_reader :title, :public_timestamp
 
   def initialize(attrs, finder)
     attrs = attrs.with_indifferent_access
     @title = attrs.fetch(:title)
     @link = attrs.fetch(:link)
     @description = attrs.fetch(:description, nil)
-    @last_update = attrs.fetch(:last_update)
+    @public_timestamp = attrs.fetch(:public_timestamp)
 
-    @attrs = attrs.except(:title, :link, :description, :last_update)
+    @attrs = attrs.except(:title, :link, :description, :public_timestamp)
     @finder = finder
   end
 

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -14,7 +14,7 @@ class EntryPresenter
   end
 
   def updated_at
-    DateTime.parse(entry.last_update)
+    DateTime.parse(entry.public_timestamp)
   end
 
 private

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -49,7 +49,7 @@ module DocumentHelper
       title
       link
       description
-      last_update
+      public_timestamp
       walk_type
       place_of_origin
       date_of_introduction
@@ -59,7 +59,7 @@ module DocumentHelper
 
   def rummager_all_documents_url
     params = {
-      "order" => "-last_update",
+      "order" => "-public_timestamp",
     }
 
     "#{Plek.current.find('search')}/unified_search.json?#{search_params(params)}"
@@ -68,7 +68,7 @@ module DocumentHelper
   def rummager_hopscotch_walks_url
     params = {
       "filter_walk_type[]" => "hopscotch",
-      "order" => "-last_update",
+      "order" => "-public_timestamp",
     }
 
     "#{Plek.current.find('search')}/unified_search.json?#{search_params(params)}"
@@ -87,7 +87,7 @@ module DocumentHelper
       "results": [
         {
           "title": "Acme keyword searchable walk",
-          "last_update": "2010-10-06",
+          "public_timestamp": "2010-10-06",
           "summary": "ACME researched a new type of silly walk",
           "document_type": "mosw_report",
           "walk_type": [{
@@ -116,7 +116,7 @@ module DocumentHelper
       "results": [
         {
           "title": "West London wobbley walk",
-          "last_update": "2014-11-25",
+          "public_timestamp": "2014-11-25",
           "summary": "MOSW researched a new type of silly walk",
           "document_type": "mosw_report",
           "walk_type": [{
@@ -134,7 +134,7 @@ module DocumentHelper
         },
         {
           "title": "The Gerry Anderson",
-          "last_update": "2010-10-06",
+          "public_timestamp": "2010-10-06",
           "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
           "document_type": "mosw_report",
           "walk_type": [{
@@ -163,7 +163,7 @@ module DocumentHelper
       "results": [
         {
           "title": "The Gerry Anderson",
-          "last_update": "2010-10-06",
+          "public_timestamp": "2010-10-06",
           "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
           "document_type": "mosw_report",
           "walk_type": [{

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -32,7 +32,7 @@ module FinderFrontend
         title
         link
         description
-        last_update
+        public_timestamp
       )
     end
 
@@ -80,7 +80,7 @@ module FinderFrontend
       if params.has_key?("keywords")
         {}
       else
-        {"order" => "-last_update"}
+        {"order" => "-public_timestamp"}
       end
     end
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -29,7 +29,7 @@ describe FindersController do
             "suggested_queries": []
           }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,last_update&order=-last_update").to_return(:status => 200, :body => rummager_response, :headers => {})
+        stub_request(:get, "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp&order=-public_timestamp").to_return(:status => 200, :body => rummager_response, :headers => {})
       end
 
       it "correctly renders a finder page" do


### PR DESCRIPTION
All existing specialist content should now include a "public_timestamp" in the search index, which is semantically identical to last_update. This change will make it possible for finders to work with non-specialist content, which sets a public_timestamp, but not last_update.

Trello: https://trello.com/c/oMo0JVPx/159-update-finder-frontend-to-order-by-public-timestamp-and-not-last-update

/cc @tommyp 

- [x] dependent rummager changes deployed
- [x] rummager index rebuilt
- [x] code review
- [ ] product owner signoff