### PR TITLE
Applicable nations

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -60,6 +60,13 @@
       @include grid-column(2/3);
     }
 
+    a[rel="external"] {
+      @include external-link-12;
+      @include media(tablet) {
+        @include external-link-14;
+      }
+    }
+
     .summary {
       margin-top: $gutter;
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,9 +17,11 @@ module ApplicationHelper
     URI.join(Plek.current.website_root, path)
   end
 
-  def page_metadata_links(metadata)
-    metadata.inject({}) do |memo, (type, links)|
-      memo.merge(type => arr_to_links(links))
+  def page_metadata(metadata)
+    metadata.inject({}) do |memo, (type, data)|
+      memo.merge(type =>
+        data.is_a?(Array) ? arr_to_links(data) : data
+      )
     end
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -22,7 +22,7 @@
     <% if finder.page_metadata.any? %>
       <div class="metadata">
         <%= render partial: 'govuk_component/metadata',
-          locals: page_metadata_links(finder.page_metadata) %>
+          locals: page_metadata(finder.page_metadata) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
This PR allows policies to display which nations they apply to and link to the alternative policies for the inapplicable nations. To do this I've modified the existing helpers for displaying page metadata to handle strings and renamed them to reflect this.

The Finder Presenter generates the sentences. This will contain the links to the alternative policies if there are any alternative policies, which should only be there if there isn't all 4 nations in the `applies_to` array. Note that these don't need to be present and a Policy can apply to certain nations without having alternative policies. [Ticket](https://trello.com/c/01iC4gHk/82-add-ability-to-set-inapplicable-nations-on-policies).

Screenshot:

![screen shot 2015-04-07 at 16 12 57](https://cloud.githubusercontent.com/assets/449004/7026326/01fbb070-dd41-11e4-8638-2e00085621c6.png)
