### PR TITLE
Handle nil metadata gracefully

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -74,7 +74,7 @@ private
 
   def tag_labels_for(key)
     Array(attrs.fetch(key, []))
-      .map { |tag| tag.fetch("label") }
+      .map(&method(:get_metadata_label))
      .select(&:present?)
   end
 
@@ -102,5 +102,12 @@ private
     metadata_hash.merge(
       name: finder.label_for_metadata_key(metadata_hash.fetch(:name))
     )
+  end
+
+  def get_metadata_label(tag)
+    tag.fetch("label")
+  rescue => error
+    Airbrake.notify(error)
+    nil
   end
 end

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -16,3 +16,7 @@ Feature: Filtering documents
     Given a government finder exists
     Then I can see the government header
     And I can see documents which have government metadata
+
+  Scenario: Filters document with bad metadata
+    Given a collection of documents with bad metadata exist
+    Then I can get a list of all documents with good metadata

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -54,3 +54,23 @@ Then(/^I can see documents which have government metadata$/) do
   page.should have_css('p.historic', count: 1)
   page.should have_content("2005 to 2010 Labour government")
 end
+
+Given(/^a collection of documents with bad metadata exist$/) do
+  content_store_has_mosw_reports_finder
+  stub_rummager_api_request_with_bad_data
+end
+
+Then(/^I can get a list of all documents with good metadata$/) do
+  visit finder_path('mosw-reports')
+  page.should have_css('.filtered-results .document', count: 2)
+
+  within '.filtered-results .document:nth-child(1)' do
+    page.should have_content('Backward')
+    page.should_not have_content('England')
+  end
+
+  within '.filtered-results .document:nth-child(2)' do
+    page.should have_content('Northern Ireland')
+    page.should_not have_content('Hopscotch')
+  end
+end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -25,6 +25,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_bad_data
+    stub_request(:get, rummager_all_documents_url).to_return(
+      body: documents_with_bad_data_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
@@ -188,6 +194,47 @@ module DocumentHelper
           "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
           "link": "/government/policies/education/an-extra-bank-holiday-per-year",
           "_id": "/government/policies/education/an-extra-bank-holiday-per-year"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {},
+      "suggested_queries": []
+    }|
+  end
+
+  def documents_with_bad_data_json
+    %|{
+      "results": [
+        {
+          "title": "West London wobbley walk",
+          "public_timestamp": "2014-11-25",
+          "summary": "MOSW researched a new type of silly walk",
+          "document_type": "mosw_report",
+          "walk_type": [{
+            "value": "backward",
+            "label": "Backward"
+          }],
+          "place_of_origin": [null],
+          "creator": "Road Runner",
+          "date_of_introduction": "2003-12-30",
+          "link": "mosw-reports/west-london-wobbley-walk",
+          "_id": "mosw-reports/west-london-wobbley-walk"
+        },
+        {
+          "title": "The Gerry Anderson",
+          "public_timestamp": "2010-10-06",
+          "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
+          "document_type": "mosw_report",
+          "walk_type": [null],
+          "place_of_origin": [{
+            "value": "northern-ireland",
+            "label": "Northern Ireland"
+          }],
+          "creator": "",
+          "date_of_introduction": "1914-08-28",
+          "link": "mosw-reports/the-gerry-anderson",
+          "_id": "mosw-reports/the-gerry-anderson"
         }
       ],
       "total": 2,


### PR DESCRIPTION
Finder frontend currently has a bug which means that if it gets a metadata field returned which is nil then the app will 500. This commit makes the document model handle this by not including the nil metadata and silently triggering an Airbrake notification.