### PR TITLE
History mode in results

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -423,6 +423,12 @@
           @include inline-block;
         }
       }
+
+      p.historic {
+        @include core-14;
+        padding: 0 0 3px;
+        color: $secondary-text-colour;
+      }
     }
   }
 }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document
-  attr_reader :title, :public_timestamp
+  attr_reader :title, :public_timestamp, :is_historic, :government_name
 
   def initialize(attrs, finder)
     attrs = attrs.with_indifferent_access
@@ -7,8 +7,18 @@ class Document
     @link = attrs.fetch(:link)
     @description = attrs.fetch(:description, nil)
     @public_timestamp = attrs.fetch(:public_timestamp)
+    @is_historic = attrs.fetch(:is_historic, false)
+    @government_name = attrs.fetch(:government_name, nil)
 
-    @attrs = attrs.except(:title, :link, :description, :public_timestamp)
+    @attrs = attrs.except(
+      :title,
+      :link,
+      :description,
+      :public_timestamp,
+      :is_historic,
+      :government_name,
+    )
+
     @finder = finder
   end
 

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -1,6 +1,11 @@
 class SearchResultPresenter
 
-  attr_reader :title, :link, :raw_metadata, :summary
+  attr_reader :title,
+              :link,
+              :raw_metadata,
+              :summary,
+              :is_historic,
+              :government_name,
 
   def initialize(search_result)
     @title = search_result.title
@@ -8,6 +13,8 @@ class SearchResultPresenter
     @summary = search_result.summary
 
     @raw_metadata = search_result.metadata
+    @is_historic = search_result.is_historic
+    @government_name = search_result.government_name
   end
 
   def to_hash
@@ -15,6 +22,8 @@ class SearchResultPresenter
       title: title,
       link: link,
       summary: summary,
+      is_historic: is_historic,
+      government_name: government_name,
       metadata: metadata,
     }
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -1,20 +1,13 @@
 class SearchResultPresenter
 
-  attr_reader :title,
-              :link,
-              :raw_metadata,
-              :summary,
-              :is_historic,
-              :government_name,
+  delegate :title,
+           :summary,
+           :is_historic,
+           :government_name,
+           to: :search_result
 
   def initialize(search_result)
-    @title = search_result.title
-    @link = search_result.path
-    @summary = search_result.summary
-
-    @raw_metadata = search_result.metadata
-    @is_historic = search_result.is_historic
-    @government_name = search_result.government_name
+    @search_result = search_result
   end
 
   def to_hash
@@ -26,6 +19,10 @@ class SearchResultPresenter
       government_name: government_name,
       metadata: metadata,
     }
+  end
+
+  def link
+    search_result.path
   end
 
   def metadata
@@ -55,5 +52,12 @@ class SearchResultPresenter
       machine_date: date.iso8601,
       human_date: date.strftime("%-d %B %Y"),
     }
+  end
+
+private
+  attr_reader :search_result
+
+  def raw_metadata
+    search_result.metadata
   end
 end

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -23,6 +23,9 @@
           {{/is_date}}
         {{/metadata}}
       </dl>
+      {{#is_historic}}
+        <p class="historic">First published during the {{government_name}}</p>
+      {{/is_historic}}
     </li>
   {{/documents}}
 </ul>

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -15,3 +15,4 @@ Feature: Filtering documents
   Scenario: Visit a government finder
     Given a government finder exists
     Then I can see the government header
+    And I can see documents which have government metadata

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -42,10 +42,15 @@ end
 
 Given(/^a government finder exists$/) do
   content_store_has_government_finder
-  stub_rummager_api_request
+  stub_rummager_api_request_with_government_results
 end
 
 Then(/^I can see the government header$/) do
   visit finder_path('government/policies/benefits-reform')
   page.should have_css(shared_component_selector('government_navigation'))
+end
+
+Then(/^I can see documents which have government metadata$/) do
+  page.should have_css('p.historic', count: 1)
+  page.should have_content("2005 to 2010 Labour government")
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -19,6 +19,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_government_results
+    stub_request(:get, rummager_all_documents_url).to_return(
+      body: government_documents_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
@@ -149,6 +155,39 @@ module DocumentHelper
           "date_of_introduction": "1914-08-28",
           "link": "mosw-reports/the-gerry-anderson",
           "_id": "mosw-reports/the-gerry-anderson"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {},
+      "suggested_queries": []
+    }|
+  end
+
+  def government_documents_json
+    %|{
+      "results": [
+        {
+          "title": "Free computers for schools",
+          "summary": "Giving all children access to a computer",
+          "format": "news_article",
+          "creator": "Dale Cooper",
+          "public_timestamp": "2007-02-14T00:00:00.000+01:00",
+          "is_historic": true,
+          "government_name": "2005 to 2010 Labour government",
+          "link": "/government/policies/education/free-computers-for-schools",
+          "_id": "/government/policies/education/free-computers-for-schools"
+        },
+        {
+          "title": "An extra bank holiday per year",
+          "public_timestamp": "2015-03-14T00:00:00.000+01:00",
+          "summary": "We lost a day and found it again so everyone can get it off",
+          "format": "news_article",
+          "creator": "Dale Cooper",
+          "is_historic": false,
+          "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
+          "link": "/government/policies/education/an-extra-bank-holiday-per-year",
+          "_id": "/government/policies/education/an-extra-bank-holiday-per-year"
         }
       ],
       "total": 2,


### PR DESCRIPTION
This PR contains the work needed in order to display history mode on results if they were published under a previous government. [Ticket](https://trello.com/c/uw3FYUyO/119-implement-visual-presentation-of-history-mode-appearance-in-policy-finder).

I have modified the `Document` model to get `is_historic` and `government_name` from the document attrs. These two bits of metadata are extracted from the normal metadata pattern because we only want to display `government_name` if `is_historic` is true and it needs to be displayed on a newline (and not inline with other metadata).

Screenshot:
![screen shot 2015-04-10 at 14 57 35](https://cloud.githubusercontent.com/assets/449004/7089215/22b2e7b8-df92-11e4-8c8d-b258d7158cdc.png)

This PR also refactors the `SearchResultPresenter` to use delegation.
