### PR TITLE
Update styling of related links

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -87,7 +87,7 @@
 
     .related-links {
       @include grid-column(1/3);
-      @include core-16;
+      @include bold-16;
       margin: $gutter 0;
       list-style:none;
 
@@ -95,6 +95,14 @@
         margin-bottom:4px;
         @include media(tablet) {
           margin-bottom:8px;
+        }
+
+        a:link,
+        a:visited {
+          text-decoration: none;
+        }
+        a:hover {
+          text-decoration: underline;
         }
       }
     }


### PR DESCRIPTION
To make them match other related links on GOV.UK

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tr><td>
<img src="https://cloud.githubusercontent.com/assets/35035/7116837/9da37a12-e1ec-11e4-8328-867af2deccb4.png">
</td>
<td>
<img src="https://cloud.githubusercontent.com/assets/35035/7116847/b17afbc8-e1ec-11e4-9992-38a7d8dbccb0.png">
</td>
</tr></table>