### PR TITLE
Allow robots to index AAIB, MAIB and RAIB reports

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::SharedTemplates
-  before_filter :set_slimmer_headers, :set_robots_headers
+  before_filter :set_slimmer_headers
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -12,20 +12,6 @@ class ApplicationController < ActionController::Base
 private
   def set_slimmer_headers
     response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
-  end
-
-  def set_robots_headers
-    if finders_excluded_from_robots.include?(finder_slug)
-      response.headers["X-Robots-Tag"] = "none"
-    end
-  end
-
-  def finders_excluded_from_robots
-    [
-      'aaib-reports',
-      'maib-reports',
-      'raib-reports',
-    ]
   end
 
   def finder_slug


### PR DESCRIPTION
AAIB, MAIB and RAIB have now transitioned (as of today). We now want these reports to appear in Google so they can be found by users.