### PR TITLE
Add quiet assets gem to reduce console noise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "quiet_assets"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -267,6 +269,7 @@ DEPENDENCIES
   launchy
   logstasher (= 0.4.8)
   pry
+  quiet_assets
   rails (= 4.2.0)
   rspec-rails
   sass-rails (~> 4.0.2)


### PR DESCRIPTION
Requests for static assets were obscuring request details
and console logging for the app itself.