### PR TITLE
Add the possibility to add a logo on a finder

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -85,6 +85,15 @@
       }
     }
 
+    .logo {
+      @include grid-column(1/3);
+      margin: $gutter 0;
+    }
+
+    #logo-image{
+      max-width: 100%
+    }
+
     .related-links {
       @include grid-column(1/3);
       @include bold-16;

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -7,6 +7,7 @@ class FinderPresenter
            :document_noun,
            :human_readable_finder_format,
            :filter,
+           :logo_path,
            :summary,
            to: :"content_item.details"
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -41,6 +41,12 @@
     <% end %>
   </div>
 
+  <% if finder.logo_path %>
+    <div class="logo">
+      <%= image_tag finder.logo_path, id: "logo-image" %>
+    </div>
+  <% end %>
+
   <% if finder.related.any? %>
     <div class='related-links'>
       <ul>


### PR DESCRIPTION
European Structural and Investment funds must comply with EU legislations and they therefore need to display the EU logo.

Quote from the legislation: "the Union emblem and the reference to the Union shall be visible, when landing on the website, inside the viewing area of a digital device, without requiring a user to scroll down the page".

- Why is this not a GOV.UK Component? Because we might receive different logos, with different text and with different styles.

