### PR TITLE
Remove email_alert_signup_enabled flag

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -23,10 +23,6 @@ class FinderPresenter
     content_item.details.beta
   end
 
-  def email_alert_signup_enabled?
-    content_item.details.email_signup_enabled
-  end
-
   def email_alert_signup
     if content_item.links.email_alert_signup
       content_item.links.email_alert_signup.first
@@ -39,7 +35,9 @@ class FinderPresenter
     if content_item.details.signup_link.present?
       content_item.details.signup_link
     else
-      email_alert_signup.web_url
+      if email_alert_signup
+        email_alert_signup.web_url
+      end
     end
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -34,7 +34,7 @@
       </div>
     <% end %>
 
-    <% if finder.email_alert_signup_enabled? %>
+    <% if finder.email_alert_signup_url %>
       <p class='email-link'>
         <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
       </p>


### PR DESCRIPTION
As all Finders which now want a signup page have it live, we no longer
need to hide the link to the page. This commit removes the code for this
and changes it to be displayed based on the presence of the link in the
`email_alert_signup` array.