### PR TITLE
Add support for policy metadata fields

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -70,7 +70,7 @@ private
 
   def tag_labels_for(key)
     Array(attrs.fetch(key, []))
-      .map(&method(:get_metadata_label))
+      .map { |label| get_metadata_label(key, label) }
      .select(&:present?)
   end
 
@@ -100,9 +100,9 @@ private
     )
   end
 
-  def get_metadata_label(tag)
+  def get_metadata_label(key, tag)
     if tag.respond_to? :fetch
-      tag.fetch("label")
+      tag.fetch(finder.display_key_for_metadata_key(key))
     else
       tag
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,16 +10,8 @@ class Document
     @is_historic = attrs.fetch(:is_historic, false)
     @government_name = attrs.fetch(:government_name, nil)
 
-    @attrs = attrs.except(
-      :title,
-      :link,
-      :description,
-      :public_timestamp,
-      :is_historic,
-      :government_name,
-    )
-
     @finder = finder
+    @attrs = attrs.slice(*metadata_keys)
   end
 
   def metadata
@@ -39,6 +31,10 @@ class Document
 
 private
   attr_reader :link, :attrs, :finder, :description
+
+  def metadata_keys
+    date_metadata_keys + tag_metadata_keys
+  end
 
   def date_metadata_keys
     finder.date_metadata_keys

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -101,7 +101,11 @@ private
   end
 
   def get_metadata_label(tag)
-    tag.fetch("label")
+    if tag.respond_to? :fetch
+      tag.fetch("label")
+    else
+      tag
+    end
   rescue => error
     Airbrake.notify(error)
     nil

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -114,6 +114,15 @@ class FinderPresenter
     facet.short_name || facet.key.humanize
   end
 
+  def display_key_for_metadata_key(key)
+    case key
+    when 'organisations'
+      'title'
+    else
+      'label'
+    end
+  end
+
 private
   attr_reader :content_item, :values
 

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -145,7 +145,6 @@ A string. Required.
 
 Appended to the URL when the option is select. Usually a paramterized slug of the label, but it doesn't need to be a direct 1:1.
 
-
 # `routes`
 
 In order for a Finder to work as intended, the routes array needs to have 3 entries. One for the page, one for `.json` which is used to update the results and one for `.atom` which is used for the Atom feed. Example:

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -15,7 +15,7 @@ Feature: Filtering documents
   Scenario: Visit a government finder
     Given a government finder exists
     Then I can see the government header
-    And I can see documents which have government metadata
+    And I can see documents which are marked as being in history mode
 
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -17,6 +17,12 @@ Feature: Filtering documents
     Then I can see the government header
     And I can see documents which are marked as being in history mode
 
+  Scenario: Visit a policy finder
+    Given a policy finder exists
+    Then I can see the government header
+    And I can see documents which are marked as being in history mode
+    And I can see documents which have government metadata
+
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist
     Then I can get a list of all documents with good metadata

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -50,7 +50,7 @@ Then(/^I can see the government header$/) do
   page.should have_css(shared_component_selector('government_navigation'))
 end
 
-Then(/^I can see documents which have government metadata$/) do
+Then(/^I can see documents which are marked as being in history mode$/) do
   page.should have_css('p.historic', count: 1)
   page.should have_content("2005 to 2010 Labour government")
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -55,6 +55,14 @@ Then(/^I can see documents which are marked as being in history mode$/) do
   page.should have_content("2005 to 2010 Labour government")
 end
 
+
+Then(/^I can see documents which have government metadata$/) do
+  within '.filtered-results .document:nth-child(1)' do
+    page.should have_content('Updated:')
+    page.should have_css('dl time[datetime="2007-02-14"]')
+  end
+end
+
 Given(/^a collection of documents with bad metadata exist$/) do
   content_store_has_mosw_reports_finder
   stub_rummager_api_request_with_bad_data
@@ -73,4 +81,9 @@ Then(/^I can get a list of all documents with good metadata$/) do
     page.should have_content('Northern Ireland')
     page.should_not have_content('Hopscotch')
   end
+end
+
+Given(/^a policy finder exists$/) do
+  content_store_has_policy_finder
+  stub_rummager_api_request_with_policy_results
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -62,6 +62,8 @@ Then(/^I can see documents which have government metadata$/) do
     page.should have_css('dl time[datetime="2007-02-14"]')
 
     page.should have_content('News Story')
+
+    page.should have_content('Ministry of Justice')
   end
 end
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -60,6 +60,8 @@ Then(/^I can see documents which have government metadata$/) do
   within '.filtered-results .document:nth-child(1)' do
     page.should have_content('Updated:')
     page.should have_css('dl time[datetime="2007-02-14"]')
+
+    page.should have_content('News Story')
   end
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -110,7 +110,7 @@ module DocumentHelper
   def rummager_policy_search_url
     # This is manual for now, as the stub URL helpers are deeply tied to mosw examples
     # @TODO: Refactor the search_params/search_fields methods to be generic
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,display_type&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
   end
 
   def keyword_search_results
@@ -199,6 +199,7 @@ module DocumentHelper
           "creator": "Dale Cooper",
           "public_timestamp": "2007-02-14T00:00:00.000+01:00",
           "is_historic": true,
+          "display_type": "News Story",
           "government_name": "2005 to 2010 Labour government",
           "link": "/government/policies/education/free-computers-for-schools",
           "_id": "/government/policies/education/free-computers-for-schools"
@@ -210,6 +211,7 @@ module DocumentHelper
           "format": "news_article",
           "creator": "Dale Cooper",
           "is_historic": false,
+          "display_type": "News Story",
           "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
           "link": "/government/policies/education/an-extra-bank-holiday-per-year",
           "_id": "/government/policies/education/an-extra-bank-holiday-per-year"

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -31,6 +31,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_policy_results
+    stub_request(:get, rummager_policy_search_url).to_return(
+      body: government_documents_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
@@ -39,6 +45,13 @@ module DocumentHelper
     base_path = '/government/policies/benefits-reform'
     content_store_has_item(base_path,
       govuk_content_schema_example('finder').merge('base_path' => base_path).to_json
+    )
+  end
+
+  def content_store_has_policy_finder
+    base_path = '/government/policies/benefits-reform'
+    content_store_has_item(base_path,
+      govuk_content_schema_example('policy_area', 'policy').to_json
     )
   end
 
@@ -92,6 +105,12 @@ module DocumentHelper
     }
 
     "#{Plek.current.find('search')}/unified_search.json?#{search_params(params)}"
+  end
+
+  def rummager_policy_search_url
+    # This is manual for now, as the stub URL helpers are deeply tied to mosw examples
+    # @TODO: Refactor the search_params/search_fields methods to be generic
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
   end
 
   def keyword_search_results

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -110,7 +110,7 @@ module DocumentHelper
   def rummager_policy_search_url
     # This is manual for now, as the stub URL helpers are deeply tied to mosw examples
     # @TODO: Refactor the search_params/search_fields methods to be generic
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,display_type&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,organisations,display_type&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
   end
 
   def keyword_search_results
@@ -200,6 +200,13 @@ module DocumentHelper
           "public_timestamp": "2007-02-14T00:00:00.000+01:00",
           "is_historic": true,
           "display_type": "News Story",
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
           "government_name": "2005 to 2010 Labour government",
           "link": "/government/policies/education/free-computers-for-schools",
           "_id": "/government/policies/education/free-computers-for-schools"
@@ -211,6 +218,13 @@ module DocumentHelper
           "format": "news_article",
           "creator": "Dale Cooper",
           "is_historic": false,
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
           "display_type": "News Story",
           "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
           "link": "/government/policies/education/an-extra-bank-holiday-per-year",

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -37,7 +37,7 @@ module FinderFrontend
     end
 
     def return_fields
-      base_return_fields.concat(metadata_fields)
+      base_return_fields.concat(metadata_fields).uniq
     end
 
     def metadata_fields


### PR DESCRIPTION
> As a user filtering a policy area or programme I need the results to contain metadata so that I don't have to click through to every document to find out who it's from, when it was last edited and what type of content it is.

- https://trello.com/c/KfLCMS6V/175-add-more-metadata-to-documents-on-policy-filter-pages

Matching schema PR: https://github.com/alphagov/govuk-content-schemas/pull/55 (tests will fail until this is merged as the tests are using an example from the schema repo).

The [first commit](https://github.com/alphagov/finder-frontend/commit/68410a8b1979536243b9611b97b77709741cdbcd) does some refactoring to make the testing clearer.

1. Allow `public_timstamp` to be a metadata field, for "Updated at" (https://github.com/alphagov/finder-frontend/commit/00546ffb31eeb899796edcc5dc89484ed4a5fc63)
2. Allow a field to be a string or an object, for `display_type` (https://github.com/alphagov/finder-frontend/commit/69731211faeb0ed8c8077c1bb6d825f298df57dc)
3. Allow object fields to use a different key for the value, suporting organisations (https://github.com/alphagov/finder-frontend/commit/9f1cc923ce6eacc74157617fe77b170dde3406b6)

Each of those commits only allow those fields to work correctly, they're actually be implemented by changes to the schema generated by policy-publisher (PR forthcoming), to match https://github.com/alphagov/govuk-content-schemas/pull/55

![benefits reform gov uk](https://cloud.githubusercontent.com/assets/63201/7324697/874771ca-eab0-11e4-8408-4c221ffadd33.png)