### PR TITLE
Short-term hack to set default policy date filter

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -2,6 +2,7 @@ require 'gds_api/helpers'
 
 class FindersController < ApplicationController
   include GdsApi::Helpers
+  before_filter :apply_policy_finder_default_date
 
   def show
     @results = ResultSetPresenter.new(finder, facet_params)
@@ -39,5 +40,27 @@ private
 
   def keywords
     params[:keywords] unless params[:keywords].blank?
+  end
+
+  def apply_policy_finder_default_date
+    # SHORT-TERM HACK AHOY
+    # This this will be used for a few weeks post-election and should be
+    # completely removed afterewards. It only applies to a policy finders, (eg
+    # /government/policies/benefits-reform, but not the finder of policies, eg
+    # /government/policies nor any other finders, eg, /cma-cases)
+
+    # This will not show documents-related-to-policy published under the previous
+    # government, though they can been seen by removing/changing the published
+    # after date in the finder UI.
+
+    # Needs updating if the government is not formed the day after polling
+    date_new_government_formed = "08/05/2015"
+
+    is_policy_finder = finder_slug.starts_with?("government/policies/")
+    has_date_param = params[:public_timestamp]
+
+    if is_policy_finder && !has_date_param
+      params[:public_timestamp] = {from: date_new_government_formed}
+    end
   end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -110,7 +110,7 @@ module DocumentHelper
   def rummager_policy_search_url
     # This is manual for now, as the stub URL helpers are deeply tied to mosw examples
     # @TODO: Refactor the search_params/search_fields methods to be generic
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,organisations,display_type&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,organisations,display_type&filter_policies%5B0%5D=benefits-reform&filter_public_timestamp=from%3A2015-05-08&order=-public_timestamp"
   end
 
   def keyword_search_results


### PR DESCRIPTION
> As a user looking at a policy finder
> I need to initially see information from the current government only
> So that I am not confused by old content that won't be as relevant

- https://trello.com/c/sRi6RXKd/118-default-date-view-on-finder-frontend-policy-frontend

This this will be used for a few weeks post-election and should be
completely removed afterwards. It only applies to a policy finders, (eg
`/government/policies/benefits-reform`, but not the finder of policies, eg
`/government/policies` nor any other finders, eg, `/cma-cases`)

This will not show documents-related-to-policy published under the previous
government, though they can been seen by removing/changing the published
after date in the finder UI.

This can be removed once there are documents-related-to-policy published
by the new government. It's intended to be reverted and entirely removed
at that point, including the test that needed to be modified (stubbing rummager
request URLs is a bit manual, doubly so for non-MOSW finders - improving
that is on our tech debt list)

`date_new_government_formed` will need updating to be the day the new
government forms, if it is not the day after polling day.

Longer term it would be nice to support this properly through the finder schema, allowing a filter facet to set a default value. That required more time than we had to do/test properly, so we're going with this hacky-but-isolated short term approach.

CC @evilstreak and @tommyp 

![screenshot 2015-04-28 15 31 22](https://cloud.githubusercontent.com/assets/63201/7371932/b4a5d3ce-edbb-11e4-901a-9dca2832450c.png)
