### PR TITLE
Disable hacked default policy date fillter

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -54,12 +54,13 @@ private
     # after date in the finder UI.
 
     # Needs updating if the government is not formed the day after polling
-    date_new_government_formed = "08/05/2015"
+    # set in the format of 'DD/MM/YYYY'
+    date_new_government_formed = nil
 
     is_policy_finder = finder_slug.starts_with?("government/policies/")
     has_date_param = params[:public_timestamp]
 
-    if is_policy_finder && !has_date_param
+    if date_new_government_formed && is_policy_finder && !has_date_param
       params[:public_timestamp] = {from: date_new_government_formed}
     end
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -110,7 +110,7 @@ module DocumentHelper
   def rummager_policy_search_url
     # This is manual for now, as the stub URL helpers are deeply tied to mosw examples
     # @TODO: Refactor the search_params/search_fields methods to be generic
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,organisations,display_type&filter_policies%5B0%5D=benefits-reform&filter_public_timestamp=from%3A2015-05-08&order=-public_timestamp"
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp,is_historic,government_name,organisations,display_type&filter_policies%5B0%5D=benefits-reform&order=-public_timestamp"
   end
 
   def keyword_search_results


### PR DESCRIPTION
But leave the code in place, so we can use it if we want to.

We were going to set this to the date the government is formed, but
have decided to show all content together for now, and if there is
confusion we can use this.

Regardless of whether we use it or not, it will be removed as part
of the election cleanup work.

Original PR:
https://github.com/alphagov/finder-frontend/pull/192

CC @evilstreak / @tommyp 