### PR TITLE
Increase summary font size

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -69,6 +69,7 @@
 
     .summary {
       margin-top: $gutter;
+      @include core-19;
     }
 
     .email-link {


### PR DESCRIPTION
The size of the intro text on the policy finders is currently too small.
This change uses the standard GOV.UK body copy size.