### PR TITLE
Add keyline beneath finder summary

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -118,6 +118,13 @@
     }
   }
 
+  .keyline {
+    height:1px;
+    line-height:1px;
+    background-color:$grey-3;
+    margin: 0 0 $gutter 0;
+  }
+
   .filtering {
     @extend %grid-row;
   }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -121,7 +121,7 @@
   .keyline {
     height:1px;
     line-height:1px;
-    background-color:$grey-3;
+    background-color:$border-colour;
     margin: 0 0 $gutter 0;
   }
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -58,6 +58,10 @@
   <% end %>
 </header>
 
+<% if finder.summary %>
+  <div class="keyline"><!-- --></div>
+<% end %>
+
 <div class="filtering">
   <%= render finder.facets %>
   <div class='js-live-search-results-block'>


### PR DESCRIPTION
For finders that feature a summary a keyline is needed to add visual structure to the page. 
This clearly marks where the summary ends and where the finder begins.

# Before

![without](https://cloud.githubusercontent.com/assets/265403/7494826/f518d6bc-f401-11e4-9f0e-36272d382d1b.png)


# After

![with](https://cloud.githubusercontent.com/assets/265403/7494886/6195c96c-f402-11e4-9145-00800a1ab520.png)

