### PR TITLE
Handle nil input in DateParser.parse

### DIFF
--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -1,7 +1,7 @@
 class DateParser
   def self.parse(date_string)
 
-    date_string = date_string.strip
+    date_string = date_string.to_s.strip
 
     # Catches if user inputs just year which Chronic would parse as a time. e.g. "2008" as "8:08pm"
     if date_string.match(/^\d{4}$/)

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -44,6 +44,10 @@ describe DateParser do
 
             # Future date
             '22/09/25' => Date.new(2025,9,22),
+
+            # Blank dates
+            "" => nil,
+            nil => nil,
           }
 
   dates.each_pair do | input, expected |


### PR DESCRIPTION
When a request is made with parameters like `?date[from]&date[to]` Rails
converts that into

    "date" => {
      "from" => nil,
      "to" => nil,
    }

That ends up getting passed down to `DateParser.parse` which blows up
when calling `#strip` on the `nil` input.

This fixes a recurring error reported in errbit, eg https://errbit.production.alphagov.co.uk/apps/54088bad0da1152a9f001417/problems/5542817b65786364ce010100