### PR TITLE
Pass base_path to Airbrake when triggering

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -107,7 +107,15 @@ private
       tag
     end
   rescue => error
-    Airbrake.notify(error)
+    # TODO Pass the whole Rack env to Airbrake
+    # It would be nice to pass the entire Rack env to Airbrake but we don't
+    # have access to it here and it would require a lot of refactoring for
+    # this to happen so instead passing it at least the base_path of the
+    # Finder at least allows us to know which Finder this is happening on
+    Airbrake.notify(
+      error,
+      url: finder.base_path,
+    )
     nil
   end
 end


### PR DESCRIPTION
When Rummager returns data which doesn't have the key that we need,
Finder Frontend triggers an error with Airbrake. Because this happens in
the model it doesn't have access to the Rack env. In order to get more
information, like what page this is happening on, I've changed this to
pass the `base_path` of the Finder to Airbrake so we at least know what
page this is happening on, but it would be good to refactor it to get
the whole Rack env in future.