### PR TITLE
Stop collapsed checkbox container using 100% width

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -211,6 +211,7 @@
           .checkbox-container {
             position:absolute;
             left:-9999px;
+            width: 10px;
             padding:0;
             margin:0;
           }


### PR DESCRIPTION
For some reason sometimes the collapsed checkbox container takes 100%
width which causes some very weird behavior. It is most strange because
of the absolute positioning it appears over all the other content in the
finder. This forces it to have a small width when it is positioned off
the page and stops it interfering with the content a user can see.

<table>
<tr><th>before</th><th>after</th></tr>
<tr>
<td>

<img src="https://cloud.githubusercontent.com/assets/35035/7631716/b8753eac-fa3d-11e4-9fbd-ab0ef90263f4.png" alt="before" style="max-width:100%;">

</td>
<td>

<img src="https://cloud.githubusercontent.com/assets/35035/7631710/ac981a1e-fa3d-11e4-9ea8-bc2770e8b931.png" alt="after" style="max-width:100%;">

</td>
</tr>
</table>
