### PR TITLE
Remove policy default date filter

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -2,7 +2,6 @@ require 'gds_api/helpers'
 
 class FindersController < ApplicationController
   include GdsApi::Helpers
-  before_filter :apply_policy_finder_default_date
 
   def show
     @results = ResultSetPresenter.new(finder, facet_params)
@@ -40,28 +39,5 @@ private
 
   def keywords
     params[:keywords] unless params[:keywords].blank?
-  end
-
-  def apply_policy_finder_default_date
-    # SHORT-TERM HACK AHOY
-    # This this will be used for a few weeks post-election and should be
-    # completely removed afterewards. It only applies to a policy finders, (eg
-    # /government/policies/benefits-reform, but not the finder of policies, eg
-    # /government/policies nor any other finders, eg, /cma-cases)
-
-    # This will not show documents-related-to-policy published under the previous
-    # government, though they can been seen by removing/changing the published
-    # after date in the finder UI.
-
-    # Needs updating if the government is not formed the day after polling
-    # set in the format of 'DD/MM/YYYY'
-    date_new_government_formed = nil
-
-    is_policy_finder = finder_slug.starts_with?("government/policies/")
-    has_date_param = params[:public_timestamp]
-
-    if date_new_government_formed && is_policy_finder && !has_date_param
-      params[:public_timestamp] = {from: date_new_government_formed}
-    end
   end
 end


### PR DESCRIPTION
This is no longer needed and wasn't used when the new Policies went
live.