### PR TITLE
Use default_order if present

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -4,6 +4,7 @@ class FinderPresenter
   attr_reader :name, :slug, :organisations, :keywords
 
   delegate :beta_message,
+           :default_order,
            :document_noun,
            :human_readable_finder_format,
            :filter,

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -80,7 +80,11 @@ module FinderFrontend
       if params.has_key?("keywords")
         {}
       else
-        {"order" => "-public_timestamp"}
+        if finder.default_order
+          {"order" => finder.default_order}
+        else
+          {"order" => "-public_timestamp"}
+        end
       end
     end
 


### PR DESCRIPTION
For some Finders, it makes sense to have them ordered by something other
than `public_timestamp`. This commit delegates it to the content_item in
the Finder and uses it when querying Rummager is there is no keyword.