### PR TITLE
Allow disabling of atom feed

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -55,6 +55,10 @@ class FinderPresenter
     facets.filters
   end
 
+  def feed_disabled?
+    content_item.details.feed_disabled || false
+  end
+
   def government?
     slug.starts_with?("/government")
   end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -18,7 +18,7 @@ class ResultSetPresenter
       applied_filters: describe_filters_in_sentence,
       documents: documents,
       any_filters_applied: any_filters_applied?,
-      atom_url: atom_url
+      atom_url: finder.feed_disabled? ? nil : atom_url,
     }
   end
 

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -1,7 +1,9 @@
-<div class="feed">
-  <span>Get updates to this list</span>
-  <a href="{{atom_url}}">feed</a>
-</div>
+{{#atom_url}}
+  <div class="feed">
+    <span>Get updates to this list</span>
+    <a href="{{atom_url}}">feed</a>
+  </div>
+{{/atom_url}}
 
 <ul>
   {{#documents}}

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ResultSetPresenter do
       total: 2,
       facets: [ a_facet, another_facet ],
       keywords: keywords,
+      feed_disabled: false,
     })
   end
 
@@ -125,6 +126,11 @@ RSpec.describe ResultSetPresenter do
       allow(presenter).to receive(:documents)
       presenter.to_hash
       presenter.should have_received(:documents)
+    end
+
+    it 'returns no atom_url if it is disabled' do
+      finder.stub(:feed_disabled?).and_return(true)
+      presenter.to_hash[:atom_url].should == nil
     end
   end
 


### PR DESCRIPTION
For Finders which aren't sorted by a date, it doesn't make sense to have
the atom feed still be present. This commit allows the feed to be
disabled through a boolean in the content item.