### PR TITLE
Finders have a slug, not a base_path

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -114,7 +114,7 @@ private
     # Finder at least allows us to know which Finder this is happening on
     Airbrake.notify(
       error,
-      url: finder.base_path,
+      url: finder.slug,
     )
     nil
   end


### PR DESCRIPTION
When reporting the error to Airbrake we need to pass the slug to find
out what page this happened on as we're triggering the error from a
model and not the controller. Previously this was incorrectly calling
base_path. This commit sets it to correctly use slug instead.