### PR TITLE
Disable atom feed if finder has a default order

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -11,8 +11,10 @@ class FindersController < ApplicationController
       format.json do
         render json: @results
       end
-      format.atom do
-        @feed = AtomPresenter.new(finder)
+      if finder.atom_feed_enabled?
+        format.atom do
+          @feed = AtomPresenter.new(finder)
+        end
       end
     end
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -124,8 +124,12 @@ class FinderPresenter
     end
   end
 
+  def atom_feed_enabled?
+    !default_order.present?
+  end
+
   def atom_url
-    ["#{slug}.atom", values.to_query].reject(&:blank?).join("?")
+    ["#{slug}.atom", values.to_query].reject(&:blank?).join("?") if atom_feed_enabled?
   end
 
 private

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -1,7 +1,9 @@
-<div class="feed">
-  <span>Get updates to this list</span>
-  <a href="{{atom_url}}">feed</a>
-</div>
+{{#atom_url}}
+  <div class="feed">
+    <span>Get updates to this list</span>
+    <a href="{{atom_url}}">feed</a>
+  </div>
+{{/atom_url}}
 
 <ul>
   {{#documents}}

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe FinderPresenter do
 
   let(:national_applicability_with_internal_policies_presenter) { described_class.new(national_applicability_with_internal_policies_content_item) }
 
+  let(:policies_presenter) { described_class.new(policies_finder_content_item) }
+
   let(:content_item) {
     dummy_http_response = double("net http response",
       code: 200,
@@ -46,6 +48,15 @@ RSpec.describe FinderPresenter do
     dummy_http_response = double("net http response",
       code: 200,
       body: govuk_content_schema_example('policy_with_inapplicable_nations', 'policy').to_json,
+      headers: {}
+    )
+    GdsApi::Response.new(dummy_http_response).to_ostruct
+  }
+
+  let(:policies_finder_content_item) {
+    dummy_http_response = double("net http response",
+      code: 200,
+      body: govuk_content_schema_example('policies_finder', 'finder').to_json,
       headers: {}
     )
     GdsApi::Response.new(dummy_http_response).to_ostruct
@@ -132,6 +143,12 @@ RSpec.describe FinderPresenter do
 
       it "returns the finder URL appended with .atom and query params" do
         presenter.atom_url.should == "/mosw-reports.atom?format=publication&keyword=legal&state=open"
+      end
+    end
+
+    context "when the finder is ordered by title" do
+      it "atom_url is disabled" do
+        policies_presenter.atom_feed_enabled?.should == false
       end
     end
   end


### PR DESCRIPTION
When a Finder has a default_order we want to disable the atom feed from
appearing. The current behaviour of a Finder having an atom feed is
unchanged unless the Finder has a default_order. This commit changes the
atom_url method to return nil if the Finder has a default order, hides
the atom_url link if that is nil in the hash and only responds to the
atom format if the atom_url method isn't nil.