### PR TITLE
Facet options from Rummager

### DIFF
--- a/app/models/facet_collection.rb
+++ b/app/models/facet_collection.rb
@@ -20,6 +20,12 @@ class FacetCollection
     end
   end
 
+  def options=(options_hash)
+    filters.each do |facet|
+      facet.options = options_hash[facet.key] if options_hash[facet.key]
+    end
+  end
+
   def with_selected_values
     filters.select { |f| f.selected_values.present? }
   end

--- a/app/models/result_set.rb
+++ b/app/models/result_set.rb
@@ -1,15 +1,15 @@
 class ResultSet
-  attr_reader :documents, :total
+  attr_reader :documents, :total, :facets
 
   def self.get(finder, params)
-    ResultSetParser.parse(
-      FinderFrontend.get_documents(finder, params),
-      finder,
+    ResultSetParser.new(finder).parse(
+      FinderFrontend.get_documents(finder, params)
     )
   end
 
-  def initialize(documents, total)
+  def initialize(documents, total, facets)
     @documents = documents
     @total = total
+    @facets = facets
   end
 end

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -36,7 +36,7 @@ class SelectFacet < FilterableFacet
   def selected_values
     return [] if @value.nil?
     options.select { |option|
-      @value.include?(option.value)
+      @value.include?(option['value'])
     }
   end
 
@@ -53,7 +53,7 @@ private
   def value_fragments
     selected_values.map { |v|
       OpenStruct.new(
-        label: v.label,
+        label: v['label'],
         parameter_key: key,
         other_params: other_params(v),
       )
@@ -62,7 +62,7 @@ private
 
   def other_params(v)
     selected_values
-      .map(&:value)
-      .reject { |selected_value|  selected_value == v.value }
+      .map { |selected_value| selected_value['value'] }
+      .reject { |selected_value|  selected_value == v['value'] }
   end
 end

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -1,25 +1,26 @@
 class SelectFacet < FilterableFacet
-  attr_reader :allowed_values
+  attr_reader :allowed_values, :options
 
   def initialize(facet)
     super
     @allowed_values = facet.allowed_values
+    @options = @allowed_values || []
   end
 
   def options
-    allowed_values.map do | allowed_value |
+    @options.map do | option |
       {
-        "value" => allowed_value.value,
-        "label" => allowed_value.label,
-        "id" => allowed_value.value,
-        "checked" => value.include?(allowed_value.value),
+        "value" => option.value,
+        "label" => option.label,
+        "id" => option.value,
+        "checked" => value.include?(option.value),
       }
     end
   end
 
   def value
     return [] if @value.blank?
-
+    return @value if allowed_values.nil?
     permitted_values = allowed_values.map(&:value)
     @value.select {|v| permitted_values.include?(v) }
   end
@@ -28,9 +29,13 @@ class SelectFacet < FilterableFacet
     @value = Array(new_value)
   end
 
+  def options=(new_options)
+    @options = Array(new_options)
+  end
+
   def selected_values
     return [] if @value.nil?
-    allowed_values.select { |option|
+    options.select { |option|
       @value.include?(option.value)
     }
   end

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,12 +1,34 @@
-module ResultSetParser
-  def self.parse(response, finder)
+class ResultSetParser
+  def initialize(finder)
+    @finder = finder
+  end
+
+  def parse(response)
 
     documents = response['results']
-      .map { |document| Document.new(document, finder) }
+      .map { |document| Document.new(document, @finder) }
 
     ResultSet.new(
       documents,
-      response['total']
+      response['total'],
+      parse_dynamic_facets(response['facets'])
     )
+  end
+
+private
+
+  def parse_dynamic_facets(response_facets)
+    response_facets.map { |key, facet|
+      [key, build_dynamic_facet_options(key, facet)]
+    }.to_h
+  end
+
+  def build_dynamic_facet_options(key, facet)
+    facet['options'].map { |option|
+      label_key = @finder.display_key_for_metadata_key(key)
+      label = option['value'].fetch(label_key, option['value']['slug'])
+      value = option['value']['slug']
+      OpenStruct.new(label: label, value: value)
+    }
   end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -56,6 +56,12 @@ class FinderPresenter
     facets.filters
   end
 
+  def faceted_filters
+    filters.select { |filter|
+      filter.type == 'text' && filter.allowed_values.nil?
+    }
+  end
+
   def government?
     slug.starts_with?("/government")
   end
@@ -107,6 +113,10 @@ class FinderPresenter
       self,
       search_params,
     )
+
+    facets.options = @results.facets
+
+    @results
   end
 
   def label_for_metadata_key(key)

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -31,3 +31,7 @@ Feature: Filtering documents
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist
     Then I can get a list of all documents with good metadata
+
+  Scenario: Visit a finder with dynamic filter
+    Given a finder with a dynamic filter exists
+    Then I can see filters based on the results

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -105,3 +105,15 @@ end
 Then(/^I only see documents with matching dates$/) do
   assert_cma_cases_are_filtered_by_date
 end
+
+Given(/^a finder with a dynamic filter exists$/) do
+  content_store_has_policies_finder
+  stub_rummager_api_request_with_policies_finder_results
+end
+
+Then(/^I can see filters based on the results$/) do
+  visit finder_path('government/policies')
+  within '.filtering .filter:nth-child(2)' do
+    page.should have_content('Ministry of Justice')
+  end
+end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -113,7 +113,9 @@ end
 
 Then(/^I can see filters based on the results$/) do
   visit finder_path('government/policies')
-  within '.filtering .filter:nth-child(2)' do
+
+  within shared_component_selector('option_select') do
+    page.should have_content('ministry-of-justice')
     page.should have_content('Ministry of Justice')
   end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -37,6 +37,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_policies_finder_results
+    stub_request(:get, rummager_policies_finder_search_url).to_return(
+      body: policies_documents_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
@@ -53,6 +59,19 @@ module DocumentHelper
     content_store_has_item(base_path,
       govuk_content_schema_example('policy_area', 'policy').to_json
     )
+  end
+
+  def content_store_has_policies_finder
+    base_path = '/government/policies'
+    content_store_has_item(base_path,
+      govuk_content_schema_example('policies_finder').to_json
+    )
+  end
+
+  def search_params(params = {})
+    default_search_params.merge(params).to_a.map { |tuple|
+      tuple.join("=")
+    }.join("&")
   end
 
   def stub_content_store_with_cma_cases_finder
@@ -122,6 +141,10 @@ module DocumentHelper
         "order" => "-public_timestamp",
       )
     )
+  end
+
+  def rummager_policies_finder_search_url
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&facet_organisations=1000,order:value.title&fields=title,link,description,public_timestamp,organisations&filter_document_type=policy&order=-public_timestamp"
   end
 
   def keyword_search_results
@@ -245,6 +268,61 @@ module DocumentHelper
       "total": 2,
       "start": 0,
       "facets": {},
+      "suggested_queries": []
+    }|
+  end
+
+  def policies_documents_json
+        %|{
+      "results": [
+        {
+          "title": "Education",
+          "summary": "Education",
+          "format": "policy",
+          "creator": "Dale Cooper",
+          "public_timestamp": "2007-02-14T00:00:00.000+01:00",
+          "is_historic": true,
+          "display_type": "Policy",
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
+          "government_name": "2005 to 2010 Labour government",
+          "link": "/government/policies/education",
+          "_id": "/government/policies/education"
+        },
+        {
+          "title": "Afghanistan",
+          "public_timestamp": "2015-03-14T00:00:00.000+01:00",
+          "summary": "What the government is doing about Afghanistan",
+          "format": "policy",
+          "creator": "Dale Cooper",
+          "is_historic": false,
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
+          "display_type": "Policy",
+          "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
+          "link": "/government/policies/afghanistan",
+          "_id": "/government/policies/afghanistan"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {
+        "organisations": {
+          "options": [
+              {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}}
+          ]
+        }
+      },
       "suggested_queries": []
     }|
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -144,7 +144,7 @@ module DocumentHelper
   end
 
   def rummager_policies_finder_search_url
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&facet_organisations=1000,order:value.title&fields=title,link,description,public_timestamp,organisations&filter_document_type=policy&order=-public_timestamp"
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&facet_organisations=1000,order:value.title&fields=title,link,description,public_timestamp,organisations&filter_document_type=policy&order=title"
   end
 
   def keyword_search_results

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -7,17 +7,18 @@ module FinderFrontend
       metadata_fields: finder.facet_keys,
       default_order: finder.default_order,
       params: params,
-      facets: finder.faceted_filters
+      finder: finder,
     ).call
   end
 
   class FindDocuments
-    def initialize(base_filter:, metadata_fields:, default_order:, params:, facets:)
+    def initialize(base_filter:, metadata_fields:, default_order:, params:, finder:)
       @base_filter = base_filter
       @metadata_fields = metadata_fields
       @default_order = default_order || "-public_timestamp"
       @params = params
-      @facets = facets
+      @finder = finder
+      @facets = finder.faceted_filters
     end
 
     def call
@@ -27,7 +28,7 @@ module FinderFrontend
 
   private
 
-    attr_reader :base_filter, :metadata_fields, :default_order, :params, :facets
+    attr_reader :base_filter, :metadata_fields, :default_order, :params, :finder, :facets
 
     def rummager_api
       @rummager_api ||= GdsApi::Rummager.new(Plek.new.find('search'))
@@ -87,7 +88,7 @@ module FinderFrontend
 
     def facet_params
       facets.reduce({}) { |memo, (facet)|
-        memo.merge("facet_#{facet.key}" => "1000,order:value.title")
+        memo.merge("facet_#{facet.key}" => "1000,order:value.#{finder.display_key_for_metadata_key(facet.key)}")
       }
     end
   end

--- a/lib/finder_frontend.rb
+++ b/lib/finder_frontend.rb
@@ -7,15 +7,17 @@ module FinderFrontend
       metadata_fields: finder.facet_keys,
       default_order: finder.default_order,
       params: params,
+      facets: finder.faceted_filters
     ).call
   end
 
   class FindDocuments
-    def initialize(base_filter:, metadata_fields:, default_order:, params:)
+    def initialize(base_filter:, metadata_fields:, default_order:, params:, facets:)
       @base_filter = base_filter
       @metadata_fields = metadata_fields
       @default_order = default_order || "-public_timestamp"
       @params = params
+      @facets = facets
     end
 
     def call
@@ -25,7 +27,7 @@ module FinderFrontend
 
   private
 
-    attr_reader :base_filter, :metadata_fields, :default_order, :params
+    attr_reader :base_filter, :metadata_fields, :default_order, :params, :facets
 
     def rummager_api
       @rummager_api ||= GdsApi::Rummager.new(Plek.new.find('search'))
@@ -55,6 +57,7 @@ module FinderFrontend
       keyword_param
         .merge(filter_params)
         .merge(order_param)
+        .merge(facet_params)
     end
 
     def keyword_param
@@ -80,6 +83,12 @@ module FinderFrontend
         .reduce({}) { |memo, (k,v)|
           memo.merge("filter_#{k}" => v)
         }
+    end
+
+    def facet_params
+      facets.reduce({}) { |memo, (facet)|
+        memo.merge("facet_#{facet.key}" => "1000,order:value.title")
+      }
     end
   end
 end

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -7,11 +7,11 @@ describe SelectFacet do
         label: "Airport price control reviews",
         value: "allowed-value-1"
       ),
-       OpenStruct.new(
+      OpenStruct.new(
         label: "Market investigations",
-        value: "allowed-value-2" 
+        value: "allowed-value-2"
       ),
-       OpenStruct.new(
+      OpenStruct.new(
         label: "Remittals",
         value: "remittals"
       )
@@ -60,10 +60,11 @@ describe SelectFacet do
   describe "#selected_values" do
     context "permitted value" do
       let(:value) { ["allowed-value-1"] }
-      
+
       it "should return selected value object" do
         subject.selected_values.length.should == 1
-        subject.selected_values[0].should == allowed_values[0]
+        subject.selected_values[0]["label"].should == allowed_values[0].label
+        subject.selected_values[0]["value"].should == allowed_values[0].value
       end
     end
 
@@ -72,8 +73,10 @@ describe SelectFacet do
 
       it "should return selected value object" do
         subject.selected_values.length.should == 2
-        subject.selected_values[0].should == allowed_values[0]
-        subject.selected_values[1].should == allowed_values[1]
+        subject.selected_values[0]["label"].should == allowed_values[0].label
+        subject.selected_values[0]["value"].should == allowed_values[0].value
+        subject.selected_values[1]["label"].should == allowed_values[1].label
+        subject.selected_values[1]["value"].should == allowed_values[1].value
       end
     end
 

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe ResultSetParser do
+
+  let(:finder) { double(:finder) }
+  subject { ResultSetParser.new(finder) }
+
   context "with a result set hash with some documents" do
     let(:results) {
       [
@@ -12,18 +16,17 @@ describe ResultSetParser do
       {
         total: 2,
         results: results,
+        facets: {}
       }.with_indifferent_access
     }
-
-    let(:finder) { double(:finder) }
-
-    subject { ResultSetParser.parse(response, finder) }
 
     before do
       Document.stub(:new).with(:a_document_hash, finder).and_return(:a_document_instance)
       Document.stub(:new).with(:another_document_hash, finder).and_return(:another_document_instance)
     end
 
-    specify { subject.documents.should == [:a_document_instance, :another_document_instance] }
+    specify {
+      subject.parse(response).documents.should == [:a_document_instance, :another_document_instance]
+    }
   end
 end


### PR DESCRIPTION
This PR allows Finder Frontend to pull the facet options from Rummager when they are no `allowed_values` for a facet. It also modifies some code in the `SelectFacet` to use hashes as we are now using the component for the option_select which expects a hash instead of an object.

Work mostly completed by @dsingleton. I only swooped in at the end in an attempt to steal all the credit.

[Ticket](https://trello.com/c/dw31ZV0Y/231-add-filter-options-to-finder-of-finders).

Relies on https://github.com/alphagov/govuk-content-schemas/pull/78 being merged first to pass.