### PR TITLE
Bump slimmer for new rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.0'
-gem 'slimmer', '8.2.0'
+gem 'slimmer', '8.2.1'
 gem 'gds-api-adapters', '16.1.0'
 gem 'exception_notification', '4.0.1'
 gem 'aws-ses', require: 'aws/ses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    slimmer (8.2.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -276,7 +276,7 @@ DEPENDENCIES
   sdoc
   shared_mustache (= 0.1.3)
   simplecov
-  slimmer (= 8.2.0)
+  slimmer (= 8.2.1)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.1)
   webmock


### PR DESCRIPTION
This now uses the GOVUK_APP_NAME env variable rather than the
application class name so it can be cross referenced to other things in
the stack.

This contains https://github.com/alphagov/slimmer/pull/128