### PR TITLE
Get facet options from rummager

### DIFF
--- a/app/lib/facet_query_builder.rb
+++ b/app/lib/facet_query_builder.rb
@@ -1,0 +1,32 @@
+class FacetQueryBuilder
+  def initialize(facets:)
+    @facets = facets
+  end
+
+  def call
+    dynamic_facets.reduce({}) { |query, facet|
+      # TODO title will only work for Orgs, this key will need changed for
+      # other dynamic facets
+      #
+      # "1000,order:value.title" is specifying that we want 1000 results back
+      # which are ordered by the title attribute of each value (option)
+      # that is returned
+      query.merge(facet.key => "1000,order:value.title")
+    }
+  end
+
+private
+  attr_reader :facets
+
+  def dynamic_facets
+    text_facets.select { |f| f.allowed_values.blank? }
+  end
+
+  def text_facets
+    filterable_facets.select { |f| f.type == "text" }
+  end
+
+  def filterable_facets
+    facets.select(&:filterable)
+  end
+end

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -81,15 +81,6 @@ private
 
   class TextFilter < Filter
     def value
-      allowed_values & user_values
-    end
-
-  private
-    def allowed_values
-      facet.allowed_values.map(&:value)
-    end
-
-    def user_values
       Array(params)
     end
   end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -8,11 +8,11 @@ class FinderApi
 
   def fetch(base_path, params)
     content_item = fetch_content_item(base_path)
-    results = fetch_search_results(content_item, params)
+    search_response = fetch_search_response(content_item, params)
 
-    ResultsDecorator.new(
+    augment_content_item_with_results(
       content_item,
-      results,
+      search_response,
     )
   end
 
@@ -23,9 +23,10 @@ private
     content_store_api.content_item!(base_path)
   end
 
-  def fetch_search_results(content_item, params)
+  def fetch_search_response(content_item, params)
     query = SearchQueryBuilder.new(
       filter_query_builder: filter_query_builder,
+      facet_query_builder: facet_query_builder,
       finder_content_item: content_item,
       params: params,
     ).call
@@ -37,12 +38,30 @@ private
     ->(**args) { FilterQueryBuilder.new(args).call }
   end
 
-  class ResultsDecorator < SimpleDelegator
-    attr_reader :results
+  def facet_query_builder
+    ->(**args) { FacetQueryBuilder.new(args).call }
+  end
 
-    def initialize(finder, results)
-      super(finder)
-      @results = results
+  def augment_content_item_with_results(content_item, search_response)
+    content_item.details.results = search_response.fetch("results")
+    content_item.details.total_result_count = search_response.fetch("total")
+
+    search_response.fetch("facets", {}).each do |facet_key, facet_details|
+      facet = content_item.details.facets.find { |f| f.key == facet_key }
+      facet.allowed_values = allowed_values_for_facet_details(facet_details) if facet
     end
+
+    content_item
+  end
+
+  def allowed_values_for_facet_details(facet_details)
+    values = facet_details.fetch("options", {}).map { |f| f.fetch("value", {}) }
+
+    values.map { |value|
+      OpenStruct.new(
+        label: value.fetch("title", ""),
+        value: value.fetch("slug", ""),
+      )
+    }
   end
 end

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -1,6 +1,7 @@
 class SearchQueryBuilder
-  def initialize(filter_query_builder:, finder_content_item:, params: {})
+  def initialize(filter_query_builder:, facet_query_builder:, finder_content_item:, params: {})
     @filter_query_builder = filter_query_builder
+    @facet_query_builder = facet_query_builder
     @finder_content_item = finder_content_item
     @params = params
   end
@@ -12,12 +13,13 @@ class SearchQueryBuilder
       keyword_query,
       filter_query,
       order_query,
+      facet_query,
     ].reduce(&:merge)
   end
 
 private
-  attr_reader :filter_query_builder, :finder_content_item, :params
-  
+  attr_reader :filter_query_builder, :facet_query_builder, :finder_content_item, :params
+
   def base_query
     {
       "count" => "1000",
@@ -88,5 +90,17 @@ private
 
   def base_filter
     finder_content_item.details.filter.to_h
+  end
+
+  def facet_query
+    facet_params.reduce({}) { |query, (k, v)|
+      query.merge("facet_#{k}" => v)
+    }
+  end
+
+  def facet_params
+    @facet_params ||= facet_query_builder.call(
+      facets: finder_content_item.details.facets,
+    )
   end
 end

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,12 +1,11 @@
 module ResultSetParser
-  def self.parse(response, finder)
+  def self.parse(results, total, finder)
 
-    documents = response['results']
-      .map { |document| Document.new(document, finder) }
+    documents = results.map { |document| Document.new(document, finder) }
 
     ResultSet.new(
       documents,
-      response['total']
+      total,
     )
   end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -100,7 +100,8 @@ class FinderPresenter
 
   def results
     @results ||= ResultSetParser.parse(
-      content_item.results,
+      content_item.details.results,
+      content_item.details.total_result_count,
       self,
     )
   end

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -31,3 +31,7 @@ Feature: Filtering documents
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist
     Then I can get a list of all documents with good metadata
+
+  Scenario: Visit a finder with dynamic filter
+    Given a finder with a dynamic filter exists
+    Then I can see filters based on the results

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -105,3 +105,15 @@ end
 Then(/^I only see documents with matching dates$/) do
   assert_cma_cases_are_filtered_by_date
 end
+
+Given(/^a finder with a dynamic filter exists$/) do
+  content_store_has_policies_finder
+  stub_rummager_api_request_with_policies_finder_results
+end
+
+Then(/^I can see filters based on the results$/) do
+  visit finder_path('government/policies')
+  within '.filtering .filter:nth-child(2)' do
+    page.should have_content('Ministry of Justice')
+  end
+end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -113,7 +113,9 @@ end
 
 Then(/^I can see filters based on the results$/) do
   visit finder_path('government/policies')
-  within '.filtering .filter:nth-child(2)' do
+
+  within shared_component_selector('option_select') do
+    page.should have_content('ministry-of-justice')
     page.should have_content('Ministry of Justice')
   end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -144,7 +144,12 @@ module DocumentHelper
   end
 
   def rummager_policies_finder_search_url
-    "#{Plek.current.find('search')}/unified_search.json?count=1000&facet_organisations=1000,order:value.title&fields=title,link,description,public_timestamp,organisations&filter_document_type=policy&order=-public_timestamp"
+    rummager_url(
+      policies_search_params.merge(
+        "facet_organisations" => "1000,order:value.title",
+        "order" => "title",
+      )
+    )
   end
 
   def keyword_search_results

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -37,6 +37,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_policies_finder_results
+    stub_request(:get, rummager_policies_finder_search_url).to_return(
+      body: policies_documents_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
@@ -53,6 +59,19 @@ module DocumentHelper
     content_store_has_item(base_path,
       govuk_content_schema_example('policy_area', 'policy').to_json
     )
+  end
+
+  def content_store_has_policies_finder
+    base_path = '/government/policies'
+    content_store_has_item(base_path,
+      govuk_content_schema_example('policies_finder').to_json
+    )
+  end
+
+  def search_params(params = {})
+    default_search_params.merge(params).to_a.map { |tuple|
+      tuple.join("=")
+    }.join("&")
   end
 
   def stub_content_store_with_cma_cases_finder
@@ -122,6 +141,10 @@ module DocumentHelper
         "order" => "-public_timestamp",
       )
     )
+  end
+
+  def rummager_policies_finder_search_url
+    "#{Plek.current.find('search')}/unified_search.json?count=1000&facet_organisations=1000,order:value.title&fields=title,link,description,public_timestamp,organisations&filter_document_type=policy&order=-public_timestamp"
   end
 
   def keyword_search_results
@@ -245,6 +268,61 @@ module DocumentHelper
       "total": 2,
       "start": 0,
       "facets": {},
+      "suggested_queries": []
+    }|
+  end
+
+  def policies_documents_json
+    %|{
+      "results": [
+        {
+          "title": "Education",
+          "summary": "Education",
+          "format": "policy",
+          "creator": "Dale Cooper",
+          "public_timestamp": "2007-02-14T00:00:00.000+01:00",
+          "is_historic": true,
+          "display_type": "Policy",
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
+          "government_name": "2005 to 2010 Labour government",
+          "link": "/government/policies/education",
+          "_id": "/government/policies/education"
+        },
+        {
+          "title": "Afghanistan",
+          "public_timestamp": "2015-03-14T00:00:00.000+01:00",
+          "summary": "What the government is doing about Afghanistan",
+          "format": "policy",
+          "creator": "Dale Cooper",
+          "is_historic": false,
+          "organisations": [{
+            "slug": "ministry-of-justice",
+            "link": "/government/organisations/ministry-of-justice",
+            "title": "Ministry of Justice",
+            "acronym": "MoJ",
+            "organisation_state": "live"
+          }],
+          "display_type": "Policy",
+          "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
+          "link": "/government/policies/afghanistan",
+          "_id": "/government/policies/afghanistan"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {
+        "organisations": {
+          "options": [
+              {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}}
+          ]
+        }
+      },
       "suggested_queries": []
     }|
   end

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -53,6 +53,19 @@ module RummagerUrlHelper
     )
   end
 
+  def policies_search_params
+    base_search_params.merge(
+      "fields" => policies_search_fields.join(","),
+      "filter_document_type" => "policy",
+    )
+  end
+
+  def policies_search_fields
+    base_search_fields + %w(
+      organisations
+    )
+  end
+
   def base_search_params
     {
       "count" => "1000",

--- a/spec/lib/filter_query_builder_spec.rb
+++ b/spec/lib/filter_query_builder_spec.rb
@@ -75,13 +75,7 @@ describe FilterQueryBuilder::TextFilter do
     FilterQueryBuilder::TextFilter.new(facet, params)
   }
 
-  let(:facet) {
-    double(
-      allowed_values: allowed_values,
-    )
-  }
-
-  let(:allowed_values) { [] }
+  let(:facet) { double }
   let(:params) { nil }
 
   describe "#active?" do
@@ -91,41 +85,8 @@ describe FilterQueryBuilder::TextFilter do
       end
     end
 
-    context "when both params and allowed values are empty" do
+    context "when params is empty" do
       let(:params) { [] }
-
-      it "should be false" do
-        expect(text_filter).not_to be_active
-      end
-    end
-
-    context "when allowed_values is not empty and params is empty" do
-      let(:allowed_values) {
-        [
-          double(value: :alpha),
-        ]
-      }
-
-      it "should be false" do
-        expect(text_filter).not_to be_active
-      end
-    end
-
-    context "when params is not empty and allowed_values is empty" do
-      let(:params) { [:alpha] }
-
-      it "should be false" do
-        expect(text_filter).not_to be_active
-      end
-    end
-
-    context "when params and allowed_values do not intersect" do
-      let(:params) { [:alpha] }
-      let(:allowed_values) {
-        [
-          double(value: :beta),
-        ]
-      }
 
       it "should be false" do
         expect(text_filter).not_to be_active
@@ -134,30 +95,11 @@ describe FilterQueryBuilder::TextFilter do
   end
 
   describe "#value" do
-    context "when params and allowed_values completely intersect" do
+    context "when params is present" do
       let(:params) { [:alpha] }
-      let(:allowed_values) {
-        [
-          double(value: :alpha),
-        ]
-      }
 
       it "should contain all values" do
         expect(text_filter.value).to eq([:alpha])
-      end
-    end
-
-    context "when params and allowed_values partially intersect" do
-      let(:params) { [:alpha, :beta] }
-      let(:allowed_values) {
-        [
-          double(value: :beta),
-          double(value: :gamma),
-        ]
-      }
-
-      it "should contain only common values" do
-        expect(text_filter.value).to eq([:beta])
       end
     end
   end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -5,6 +5,7 @@ describe SearchQueryBuilder do
   subject(:query) {
     SearchQueryBuilder.new(
       filter_query_builder: filter_query_builder,
+      facet_query_builder: facet_query_builder,
       finder_content_item: finder_content_item,
       params: params,
     ).call
@@ -13,6 +14,8 @@ describe SearchQueryBuilder do
   # TODO assert the correct arguments are passed to this and that the response
   # is merged into the returned query
   let(:filter_query_builder) { double(call: {}) }
+
+  let(:facet_query_builder) { double(call: {}) }
 
   let(:finder_content_item) {
     double(

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -8,16 +8,11 @@ describe ResultSetParser do
         :another_document_hash
       ]
     }
-    let(:response) {
-      {
-        total: 2,
-        results: results,
-      }.with_indifferent_access
-    }
+    let(:total) { 2 }
 
     let(:finder) { double(:finder) }
 
-    subject { ResultSetParser.parse(response, finder) }
+    subject { ResultSetParser.parse(results, total, finder) }
 
     before do
       Document.stub(:new).with(:a_document_hash, finder).and_return(:a_document_instance)


### PR DESCRIPTION
If a facet of type `text` has no `allowed_values` and is `filterable` then we want to query Rummager for the options for that facet. 

This PR adds a `FacetQueryBuiler` which takes a list of facets and decides if they need to be dynamic and returns a hash of the keys with the value of `"1000,order:value.title"`. This is then used in the `SearchQueryBuilder` with all the other params to build the query for Rummager.

The result which is returned then modifies the Content Item before passing it to the `FinderPresenter` which then constructs all of the facets through `FacetCollection`.

This PR also does a little refactoring with how the total is passed around. Interesting stuff is mostly 35bfce9 and 966e362. [Ticket](https://trello.com/c/dw31ZV0Y/231-add-filter-options-to-finder-of-finders).

Spiritual successor to https://github.com/alphagov/finder-frontend/pull/212 so shout out to @dsingleton for the first commit in this and doing most of the work on that previous PR.