### PR TITLE
Use symbols, not strings, for component object keys

### DIFF
--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -4,10 +4,10 @@ class SelectFacet < FilterableFacet
   def options
     allowed_values.map do | allowed_value |
       {
-        "value" => allowed_value.value,
-        "label" => allowed_value.label,
-        "id" => allowed_value.value,
-        "checked" => selected_values.include?(allowed_value),
+        value: allowed_value.value,
+        label: allowed_value.label,
+        id: allowed_value.value,
+        checked: selected_values.include?(allowed_value),
       }
     end
   end


### PR DESCRIPTION
**This shouldn't be merged until https://github.com/alphagov/static/pull/601 is merged and deployed**

We should only use one style of keys for objects used in components,
to avoid reduce confusion when using components. Consistency is good.

After discussion with @edds we agreed to use symbols as this makes
more sense in a ruby/rails environment.

The first step was to support both, as clients of those components
will still be sending string key'd objects and can't be updated
at the time as this app, so we have to;

1. Support both kinds of keys on components that expect strings
2. Update clients sending string keys to use symbols instead
3. Remove support for string keys from those components

This PR is step 2. for `options_select`, but also needs doing in
`manuals-frontend` for `previous_and_next_navigation`.

Step 1 is: https://github.com/alphagov/static/pull/601