### PR TITLE
Add print styles so finders look better printed

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,50 @@
+@import "colours";
+@import "shims";
+
+.filter-form,
+.email-link,
+.feed {
+  display: none;
+}
+header {
+  @extend %contain-floats;
+
+  dt {
+    float: left;
+    clear: left;
+    width: auto;
+    min-width: 40px;
+    padding-right: 10px;
+  }
+  dd {
+    float: left;
+    width: 70%;
+  }
+}
+.filtered-results {
+  margin-top: 20px;
+  clear: both;
+
+  h3, dl, dd, ul, li {
+    margin: 0;
+  }
+  ul {
+    padding: 0;
+  }
+  .document {
+    margin: 10px 0;
+    padding-bottom: 10px;
+    border-bottom: 1px solid $border-colour;
+    list-style: none;
+  }
+  h3 {
+    margin-bottom: 5px;
+  }
+  dt {
+    display: none;
+  }
+  dd {
+    margin-right: 10px;
+    display: inline-block;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
   <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
   <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
+  <%= stylesheet_link_tag "print", media: "print" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :head %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,7 @@ FinderFrontend::Application.configure do
     application-ie6.css
     application-ie7.css
     application-ie8.css
+    print.css
   )
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
Hide the sidebar navigation as it isn't any use when printed, replicate
the visual presentation for the metadata and for the document rows.

Before/After:
![screen shot 2015-06-25 at 12 08 35](https://cloud.githubusercontent.com/assets/35035/8357391/9fbc230e-1b52-11e5-9418-4e325de33a19.png)
