### PR TITLE
Ensure date-help-text id is unique

### DIFF
--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -1,8 +1,8 @@
 <div class="filter text-filter">
   <label class="legend" for="<%= date_facet.key %>[from]"><%= date_facet.name %> after</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('from', nil) %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" aria-describedby="date-help-text" class="text" />
+  <input value="<%= params.fetch(date_facet.key, {}).fetch('from', nil) %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" aria-describedby="date-help-text-<%= date_facet.key %>" class="text" />
 
   <label class="legend" for="<%= date_facet.key %>[to]"><%= date_facet.name %> before</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('to', nil) %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" aria-describedby="date-help-text"/>
-  <span id='date-help-text' class='help-text'>For example, 2005 or 21/11/2014<span>
+  <input value="<%= params.fetch(date_facet.key, {}).fetch('to', nil) %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" aria-describedby="date-help-text-<%= date_facet.key %>"/>
+  <span id='date-help-text-<%= date_facet.key %>' class='help-text'>For example, 2005 or 21/11/2014<span>
 </div>


### PR DESCRIPTION
* Ensure unique date-help-text id is created when `_date_facet` is used more than once in a finder.
* Without this `slimmer` raises exception that id has been used more than once.