### PR TITLE
Track filtering

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -58,7 +58,11 @@
       pageUpdated = this.updateResults();
       pageUpdated.done(
         function(){
-          history.pushState(this.state, '', window.location.pathname + "?" + $.param(this.state));
+          var newPath = window.location.pathname + "?" + $.param(this.state);
+          history.pushState(this.state, '', newPath);
+          if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
+            GOVUK.analytics.trackPageview(newPath);
+          }
         }.bind(this)
       );
     }

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -39,6 +39,7 @@ describe("liveSearch", function(){
 
     _supportHistory = GOVUK.support.history;
     GOVUK.support.history = function(){ return true; };
+    GOVUK.analytics = { trackPageview: function (){ } };
 
     liveSearch = new GOVUK.LiveSearch({$form: $form, $results: $results, $atomAutodiscoveryLink:$atomAutodiscoveryLink});
   });
@@ -175,6 +176,20 @@ describe("liveSearch", function(){
       expect(liveSearch.updateResults).toHaveBeenCalled();
       promise.done.calls.mostRecent().args[0]();
       //expect(liveSearch.pageTrack).toHaveBeenCalled();
+    });
+
+    it("should trigger analytics trackpage when checkbox is changed", function(){
+      var promise = jasmine.createSpyObj('promise', ['done']);
+      spyOn(liveSearch, 'updateResults').and.returnValue(promise);
+      spyOn(GOVUK.analytics, 'trackPageview');
+      liveSearch.state = [];
+
+      liveSearch.formChange();
+      promise.done.calls.mostRecent().args[0]();
+
+      expect(GOVUK.analytics.trackPageview).toHaveBeenCalled();
+      var trackArgs = GOVUK.analytics.trackPageview.calls.first().args[0];
+      expect(trackArgs.split('?')[1], 'field=sheep');
     });
 
     it("should do nothing if state hasn't changed when a checkbox is changed", function(){


### PR DESCRIPTION
So that we know how people use the filters on finder pages add a page
track event after we have updated the URL.