### PR TITLE
Pagination

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -342,5 +342,10 @@
         color: $secondary-text-colour;
       }
     }
+
+    .govuk-previous-and-next-navigation {
+      margin-top: $gutter;
+    }
+
   }
 }

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -4,7 +4,7 @@ class FindersController < ApplicationController
   include GdsApi::Helpers
 
   def show
-    @results = ResultSetPresenter.new(finder)
+    @results = ResultSetPresenter.new(finder, view_context)
 
     respond_to do |format|
       format.html

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -46,6 +46,12 @@ private
     content_item.details.results = search_response.fetch("results")
     content_item.details.total_result_count = search_response.fetch("total")
 
+    content_item.details.pagination = build_pagination(
+      content_item.details.documents_per_page,
+      search_response.fetch('start'),
+      search_response.fetch('total')
+    )
+
     search_response.fetch("facets", {}).each do |facet_key, facet_details|
       facet = content_item.details.facets.find { |f| f.key == facet_key }
       facet.allowed_values = allowed_values_for_facet_details(facet_details) if facet
@@ -63,5 +69,14 @@ private
         value: value.fetch("slug", ""),
       )
     }
+  end
+
+  def build_pagination(documents_per_page, start_offset, total_results)
+    if documents_per_page
+      OpenStruct.new(
+        current_page: (start_offset / documents_per_page) + 1,
+        total_pages: (total_results / documents_per_page.to_f).ceil,
+      )
+    end
   end
 end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -47,7 +47,7 @@ private
     content_item.details.total_result_count = search_response.fetch("total")
 
     content_item.details.pagination = build_pagination(
-      content_item.details.documents_per_page,
+      content_item.details.default_documents_per_page,
       search_response.fetch('start'),
       search_response.fetch('total')
     )

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -8,7 +8,7 @@ class SearchQueryBuilder
 
   def call
     [
-      base_query,
+      pagination_query,
       return_fields_query,
       keyword_query,
       filter_query,
@@ -20,11 +20,23 @@ class SearchQueryBuilder
 private
   attr_reader :filter_query_builder, :facet_query_builder, :finder_content_item, :params
 
-  def base_query
+  def pagination_query
     {
-      "count" => "1000",
-      "start" => "0",
+      "count" => documents_per_page,
+      "start" => pagination_start,
     }
+  end
+
+  def pagination_start
+    documents_per_page * (current_page - 1) || 0
+  end
+
+  def current_page
+    params.fetch("page", 1).to_i
+  end
+
+  def documents_per_page
+    finder_content_item.details.documents_per_page || 1000
   end
 
   def return_fields_query

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -23,6 +23,7 @@ private
   def base_query
     {
       "count" => "1000",
+      "start" => "0",
     }
   end
 

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -36,7 +36,7 @@ private
   end
 
   def documents_per_page
-    finder_content_item.details.documents_per_page || 1000
+    finder_content_item.details.default_documents_per_page || 1000
   end
 
   def return_fields_query

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,6 +1,5 @@
 module ResultSetParser
   def self.parse(results, total, finder)
-
     documents = results.map { |document| Document.new(document, finder) }
 
     ResultSet.new(

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -129,6 +129,31 @@ class FinderPresenter
     ["#{slug}.atom", values.to_query].reject(&:blank?).join("?") if atom_feed_enabled?
   end
 
+  def pagination
+    return unless content_item.details.pagination
+
+    current_page = content_item.details.pagination.current_page
+    previous_page = current_page - 1 if current_page > 1
+    next_page = current_page + 1 if current_page < content_item.details.pagination.total_pages
+    results = {}
+    if previous_page
+      results[:previous_page] = {
+        url: [slug, values.merge({page: previous_page}).to_query].reject(&:blank?).join("?"),
+        title: "Previous page",
+        label: "#{previous_page} of #{content_item.details.pagination.total_pages}"
+      }
+    end
+
+    if next_page
+      results[:next_page] = {
+        url: [slug, values.merge({page: next_page}).to_query].reject(&:blank?).join("?"),
+        title: "Next page",
+        label: "#{next_page} of #{content_item.details.pagination.total_pages}"
+      }
+    end
+    results
+  end
+
 private
   attr_reader :content_item, :values
 

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,7 +1,7 @@
 class FinderPresenter
   include ActionView::Helpers::UrlHelper
 
-  attr_reader :name, :slug, :organisations, :keywords
+  attr_reader :name, :slug, :organisations, :keywords, :values
 
   delegate :beta_message,
            :default_order,
@@ -10,6 +10,7 @@ class FinderPresenter
            :filter,
            :logo_path,
            :summary,
+           :pagination,
            to: :"content_item.details"
 
   def initialize(content_item, values = {})
@@ -129,33 +130,8 @@ class FinderPresenter
     ["#{slug}.atom", values.to_query].reject(&:blank?).join("?") if atom_feed_enabled?
   end
 
-  def pagination
-    return unless content_item.details.pagination
-
-    current_page = content_item.details.pagination.current_page
-    previous_page = current_page - 1 if current_page > 1
-    next_page = current_page + 1 if current_page < content_item.details.pagination.total_pages
-    results = {}
-    if previous_page
-      results[:previous_page] = {
-        url: [slug, values.merge({page: previous_page}).to_query].reject(&:blank?).join("?"),
-        title: "Previous page",
-        label: "#{previous_page} of #{content_item.details.pagination.total_pages}"
-      }
-    end
-
-    if next_page
-      results[:next_page] = {
-        url: [slug, values.merge({page: next_page}).to_query].reject(&:blank?).join("?"),
-        title: "Next page",
-        label: "#{next_page} of #{content_item.details.pagination.total_pages}"
-      }
-    end
-    results
-  end
-
 private
-  attr_reader :content_item, :values
+  attr_reader :content_item
 
   def part_of
     content_item.links.part_of || []

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -31,3 +31,5 @@
     </li>
   {{/documents}}
 </ul>
+
+{{{next_and_prev_links}}}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -68,6 +68,8 @@
       <div id='js-results'>
         <%= render_mustache('results', @results.to_hash) %>
       </div>
+
+      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: finder.pagination if finder.pagination %>
     </div>
   </div>
 </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -68,8 +68,6 @@
       <div id='js-results'>
         <%= render_mustache('results', @results.to_hash) %>
       </div>
-
-      <%= render partial: 'govuk_component/previous_and_next_navigation', locals: finder.pagination if finder.pagination %>
     </div>
   </div>
 </div>

--- a/features/filtering.feature
+++ b/features/filtering.feature
@@ -35,3 +35,8 @@ Feature: Filtering documents
   Scenario: Visit a finder with dynamic filter
     Given a finder with a dynamic filter exists
     Then I can see filters based on the results
+
+  Scenario: Visit a finder with paginated results
+    Given a finder with paginated results exists
+    Then I can see pagination
+    And I can browse to the next page

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -119,3 +119,27 @@ Then(/^I can see filters based on the results$/) do
     page.should have_content('Ministry of Justice')
   end
 end
+
+Given(/^a finder with paginated results exists$/) do
+  content_store_has_policy_finder
+  stub_rummager_api_request_with_policy_results
+end
+
+Then(/^I can see pagination$/) do
+  visit finder_path('government/policies/benefits-reform')
+
+  within shared_component_selector('previous_and_next_navigation') do
+    page.should_not have_content('Previous page')
+    page.should have_content('Next page')
+  end
+end
+
+Then(/^I can browse to the next page$/) do
+  stub_rummager_api_request_with_page_2_policy_results
+  visit finder_path('government/policies/benefits-reform',  page: 2)
+
+  within shared_component_selector('previous_and_next_navigation') do
+    page.should have_content('Previous page')
+    page.should_not have_content('Next page')
+  end
+end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -51,7 +51,7 @@ Then(/^I can see the government header$/) do
 end
 
 Then(/^I can see documents which are marked as being in history mode$/) do
-  page.should have_css('p.historic', count: 1)
+  page.should have_css('p.historic', count: 5)
   page.should have_content("2005 to 2010 Labour government")
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -37,6 +37,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_page_2_policy_results
+    stub_request(:get, rummager_policy_page_2_search_url).to_return(
+      body: government_documents_page_2_json,
+    )
+  end
+
   def stub_rummager_api_request_with_policies_finder_results
     stub_request(:get, rummager_policies_finder_search_url).to_return(
       body: policies_documents_json,
@@ -122,6 +128,18 @@ module DocumentHelper
     rummager_url(
       policy_search_params.merge(
         "order" => "-public_timestamp",
+        "count" => 10,
+        "start" => 0,
+      )
+    )
+  end
+
+  def rummager_policy_page_2_search_url
+    rummager_url(
+      policy_search_params.merge(
+        "order" => "-public_timestamp",
+        "count" => 10,
+        "start" => 10,
       )
     )
   end
@@ -230,51 +248,71 @@ module DocumentHelper
 
   def government_documents_json
     %|{
-      "results": [
-        {
-          "title": "Free computers for schools",
-          "summary": "Giving all children access to a computer",
-          "format": "news_article",
-          "creator": "Dale Cooper",
-          "public_timestamp": "2007-02-14T00:00:00.000+01:00",
-          "is_historic": true,
-          "display_type": "News Story",
-          "organisations": [{
-            "slug": "ministry-of-justice",
-            "link": "/government/organisations/ministry-of-justice",
-            "title": "Ministry of Justice",
-            "acronym": "MoJ",
-            "organisation_state": "live"
-          }],
-          "government_name": "2005 to 2010 Labour government",
-          "link": "/government/policies/education/free-computers-for-schools",
-          "_id": "/government/policies/education/free-computers-for-schools"
-        },
-        {
-          "title": "An extra bank holiday per year",
-          "public_timestamp": "2015-03-14T00:00:00.000+01:00",
-          "summary": "We lost a day and found it again so everyone can get it off",
-          "format": "news_article",
-          "creator": "Dale Cooper",
-          "is_historic": false,
-          "organisations": [{
-            "slug": "ministry-of-justice",
-            "link": "/government/organisations/ministry-of-justice",
-            "title": "Ministry of Justice",
-            "acronym": "MoJ",
-            "organisation_state": "live"
-          }],
-          "display_type": "News Story",
-          "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
-          "link": "/government/policies/education/an-extra-bank-holiday-per-year",
-          "_id": "/government/policies/education/an-extra-bank-holiday-per-year"
-        }
-      ],
-      "total": 2,
+      "results": #{government_document_results_json.to_s},
+      "total": 20,
       "start": 0,
       "facets": {},
       "suggested_queries": []
     }|
+  end
+
+  def government_documents_page_2_json
+    %|{
+      "results": #{government_document_results_json(5).to_s},
+      "total": 20,
+      "start": 10,
+      "facets": {},
+      "suggested_queries": []
+    }|
+  end
+
+  def government_document_results_json(start_at = 0)
+    results = []
+
+    5.times do |n|
+      results << [
+        {
+          "title" => "Document #{n+start_at}",
+          "summary" => "Giving all children access to a computer",
+          "format" => "news_article",
+          "creator" => "Dale Cooper",
+          "public_timestamp" => "2007-02-14T00:00:00.000+01:00",
+          "is_historic" => true,
+          "display_type" => "News Story",
+          "organisations" => [{
+            "slug" => "ministry-of-justice",
+            "link" => "/government/organisations/ministry-of-justice",
+            "title" => "Ministry of Justice",
+            "acronym" => "MoJ",
+            "organisation_state" => "live"
+          }],
+          "government_name" => "2005 to 2010 Labour government",
+          "link" => "/government/policies/education/free-computers-for-schools",
+          "_id" => "/government/policies/education/free-computers-for-schools"
+        },
+        {
+          "title" => "Document #{n+1+start_at}",
+          "public_timestamp" => "2015-03-14T00:00:00.000+01:00",
+          "summary" => "We lost a day and found it again so everyone can get it off",
+          "format" => "news_article",
+          "creator" => "Dale Cooper",
+          "is_historic" => false,
+          "display_type" => "News Story",
+          "organisations" => [{
+            "slug" => "ministry-of-justice",
+            "link" => "/government/organisations/ministry-of-justice",
+            "title" => "Ministry of Justice",
+            "acronym" => "MoJ",
+            "organisation_state" => "live"
+          }],
+          "government_name" => "2010 to 2015 Conservative and Liberal Democrat Coalition government",
+          "link" => "/government/policies/education/an-extra-bank-holiday-per-year",
+          "_id" => "/government/policies/education/an-extra-bank-holiday-per-year"
+        }
+      ]
+    end
+
+    results.flatten.to_json
   end
 
   def policies_documents_json

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -69,6 +69,7 @@ module RummagerUrlHelper
   def base_search_params
     {
       "count" => "1000",
+      "start" => "0",
     }
   end
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -29,7 +29,7 @@ describe FindersController do
             "suggested_queries": []
           }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp&order=-public_timestamp").to_return(:status => 200, :body => rummager_response, :headers => {})
+        stub_request(:get, "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp&order=-public_timestamp&start=0").to_return(:status => 200, :body => rummager_response, :headers => {})
       end
 
       it "correctly renders a finder page" do

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -23,7 +23,7 @@ describe SearchQueryBuilder do
         facets: facets,
         filter: double(to_h: filter),
         default_order: default_order,
-        documents_per_page: nil,
+        default_documents_per_page: nil,
       ),
     )
   }
@@ -45,7 +45,7 @@ describe SearchQueryBuilder do
           facets: facets,
           filter: double(to_h: filter),
           default_order: default_order,
-          documents_per_page: 10
+          default_documents_per_page: 10
         ),
       )
     }

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -23,6 +23,7 @@ describe SearchQueryBuilder do
         facets: facets,
         filter: double(to_h: filter),
         default_order: default_order,
+        documents_per_page: nil,
       ),
     )
   }
@@ -34,7 +35,27 @@ describe SearchQueryBuilder do
   let(:params) { {} }
 
   it "should include a count" do
-    expect(query).to include("count" => "1000")
+    expect(query).to include("count" => 1000)
+  end
+
+  context "with pagination" do
+    let(:finder_content_item) {
+      double(
+        details: double(
+          facets: facets,
+          filter: double(to_h: filter),
+          default_order: default_order,
+          documents_per_page: 10
+        ),
+      )
+    }
+
+    it "should use documents_per_page from content item" do
+      expect(query).to include({
+          "count" => 10,
+          "start" => 0
+        })
+    end
   end
 
   context "without any facets" do


### PR DESCRIPTION
Within certain Finders, we don't want the documents per page to be all of them (or 1000). This PR allows us to specify a `default_documents_per_page` as part of the content item and have Finder Frontend build the pagination query within the `SearchQueryBuilder` and render the Previous and Next component. [Ticket](https://trello.com/c/NfxTcDci/273-paginate-finder-frontend).

Now with AJAX! This happens by returning the partial as part of the hash and having mustache render it which means it respects the query being added.

Screenshot:
![screen shot 2015-06-30 at 12 42 15](https://cloud.githubusercontent.com/assets/449004/8430073/7e3d7738-1f25-11e5-82c3-d68c4d8bb796.png)