### PR TITLE
Allow reject queries

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -12,6 +12,7 @@ class SearchQueryBuilder
       return_fields_query,
       keyword_query,
       filter_query,
+      reject_query,
       order_query,
       facet_query,
     ].reduce(&:merge)
@@ -94,6 +95,12 @@ private
       }
   end
 
+  def reject_query
+    base_reject.reduce({}) { |query, (k, v)|
+      query.merge("reject_#{k}" => v)
+    }
+  end
+
   def filter_params
     @filter_params ||= filter_query_builder.call(
       facets: finder_content_item.details.facets,
@@ -103,6 +110,10 @@ private
 
   def base_filter
     finder_content_item.details.filter.to_h
+  end
+
+  def base_reject
+    finder_content_item.details.reject.to_h
   end
 
   def facet_query

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -22,6 +22,7 @@ describe SearchQueryBuilder do
       details: double(
         facets: facets,
         filter: double(to_h: filter),
+        reject: double(to_h: reject),
         default_order: default_order,
         default_documents_per_page: nil,
       ),
@@ -30,6 +31,7 @@ describe SearchQueryBuilder do
 
   let(:facets) { [] }
   let(:filter) { {} }
+  let(:reject) { {} }
   let(:default_order) { nil }
 
   let(:params) { {} }
@@ -44,6 +46,7 @@ describe SearchQueryBuilder do
         details: double(
           facets: facets,
           filter: double(to_h: filter),
+          reject: double(to_h: reject),
           default_order: default_order,
           default_documents_per_page: 10
         ),
@@ -80,9 +83,22 @@ describe SearchQueryBuilder do
       ]
     }
 
+    let(:reject) {
+      {
+        alpha: "value"
+      }
+    }
+
     it "should include base and extra return fields" do
       expect(query).to include(
         "fields" => "title,link,description,public_timestamp,alpha,beta",
+      )
+    end
+
+    it "should include reject fields prefixed with reject_" do
+
+      expect(query).to include(
+        "reject_alpha" => "value",
       )
     end
 


### PR DESCRIPTION
In order to filter documents on say, all policies, chaining the slug
runs over the max length for a URL. This commit adds the ability for a
content item to specify a `reject` hash which allows us to exclude
certain values from a base query.