### PR TITLE
Allow Finders to display Alpha Banner

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -3,7 +3,8 @@ class FinderPresenter
 
   attr_reader :name, :slug, :organisations, :keywords, :values
 
-  delegate :beta_message,
+  delegate :alpha_message,
+           :beta_message,
            :default_order,
            :document_noun,
            :human_readable_finder_format,
@@ -21,6 +22,10 @@ class FinderPresenter
     @values = values
     facets.values = values
     @keywords = values["keywords"].presence
+  end
+
+  def alpha?
+    content_item.details.alpha
   end
 
   def beta?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,7 +1,13 @@
 <% content_for :title, finder.name %>
 <% content_for :head, auto_discovery_link_tag(:atom, @results.atom_url) %>
 
-<% if finder.beta? %>
+<% if finder.alpha? %>
+  <% if finder.alpha_message %>
+    <%= render partial: 'govuk_component/alpha_label', locals: { message: finder.alpha_message } %>
+  <% else %>
+    <%= render partial: 'govuk_component/alpha_label' %>
+  <% end %>
+<% elsif finder.beta? %>
   <% if finder.beta_message %>
     <%= render partial: 'govuk_component/beta_label', locals: { message: finder.beta_message } %>
   <% else %>


### PR DESCRIPTION
This commit allows `finders#show` to be displayed with the Alpha banner
in the same way we can currently display the Beta banner.