### PR TITLE
If an atom feed isn't enabled return 404

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -11,9 +11,11 @@ class FindersController < ApplicationController
       format.json do
         render json: @results
       end
-      if finder.atom_feed_enabled?
-        format.atom do
+      format.atom do
+        if finder.atom_feed_enabled?
           @feed = AtomPresenter.new(finder)
+        else
+          render text: 'Not found', status: 404
         end
       end
     end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -46,6 +46,39 @@ describe FindersController do
       end
     end
 
+    describe "a finder content item with a default order exists" do
+      before do
+        content_store_has_item('/lunch-finder',
+          {
+            base_path: '/lunch-finder',
+            title: 'Lunch Finder',
+            details: {
+              default_order: "-closing_date",
+              facets: [],
+            },
+            links: {
+              organisations: [],
+            },
+          }
+        )
+
+        rummager_response = %|{
+            "results": [],
+            "total": 0,
+            "start": 0,
+            "facets": {},
+            "suggested_queries": []
+          }|
+
+        stub_request(:get, "#{Plek.current.find('search')}/unified_search.json?count=1000&fields=title,link,description,public_timestamp&order=-closing_date&start=0").to_return(:status => 200, :body => rummager_response, :headers => {})
+      end
+
+      it "returns a 404 when requesting an atom feed, rather than a 500" do
+        get :show, format: :atom, slug: 'lunch-finder'
+        expect(response.status).to eq(404)
+      end
+    end
+
     describe "finder item doesn't exist" do
       it 'returns a 404, rather than 5xx' do
         content_store_does_not_have_item('/does-not-exist')


### PR DESCRIPTION
Currently we are just not responding to the format if the atom feed is
disabled. This raises an exception. Instead we should raise an
appropriate 404.