### PR TITLE
Remove unused notification gems and actionmailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.3'
 gem 'slimmer', '~> 8.2.1'
 gem 'gds-api-adapters', '~> 20.1.1'
-gem 'exception_notification', '~> 4.0.1'
-gem 'aws-ses', '~> 0.5.0', require: 'aws/ses'
 gem 'unicorn', '~> 4.8.1'
 
 gem 'logstasher', '~> 0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,11 +43,6 @@ GEM
       multi_json
     arel (6.0.3)
     awesome_print (1.6.1)
-    aws-ses (0.5.0)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -84,9 +79,6 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    exception_notification (4.0.1)
-      actionmailer (>= 3.0.4)
-      activesupport (>= 3.0.4)
     execjs (2.6.0)
     gds-api-adapters (20.1.2)
       link_header
@@ -252,7 +244,6 @@ GEM
     webmock (1.17.4)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -262,13 +253,11 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.0.0)
   awesome_print
-  aws-ses (~> 0.5.0)
   better_errors
   binding_of_caller
   byebug
   chronic (~> 0.10.2)
   cucumber-rails (~> 1.4.0)
-  exception_notification (~> 4.0.1)
   gds-api-adapters (~> 20.1.1)
   govuk-content-schema-test-helpers (~> 1.0.1)
   govuk_frontend_toolkit (~> 3.1.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 # Pick the frameworks you want:
 # require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,9 +13,6 @@ FinderFrontend::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,10 +71,6 @@ FinderFrontend::Application.configure do
     print.css
   )
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,11 +26,6 @@ FinderFrontend::Application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 end


### PR DESCRIPTION
This PR removes the `exception_notification` and `aws-ses` gems, as they are not needed anymore.