### PR TITLE
Configure asset host in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,4 +21,8 @@ FinderFrontend::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.debug = true
+
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 end


### PR DESCRIPTION
When run under `govuk_setenv`, this configures the asset host to point
at the assets-origin on the dev VM.  This will give us better dev-prod
parity, and enable running this behind the router in dev.

See equiv on `finder`:

https://github.com/alphagov/frontend/commit/77bb2cb3a05a8a87b23008f6fcc8b7f5ff9b88c5

Tested by @robmckinnon, who encountered the problem.

There are quite a few apps missing this config, that will have the same problem. We should look at cleaning them all up / adding this config to the template rails apps, but in the mean time this unblocks @robmckinnon 