### PR TITLE
Fix date values joining

### DIFF
--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -3,6 +3,7 @@ class DateFacet < FilterableFacet
     return nil unless present_values.any?
 
     OpenStruct.new(
+      type: "date",
       preposition: [preposition, additional_preposition].compact.join(' '),
       values: value_fragments,
     )

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -20,6 +20,7 @@ class SelectFacet < FilterableFacet
     return nil unless selected_values.any?
 
     OpenStruct.new(
+      type: "text",
       preposition: preposition,
       values: value_fragments,
     )

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -56,14 +56,20 @@ class ResultSetPresenter
   def fragment_description(fragment)
     [
       fragment.preposition,
-      fragment_values_to_s(fragment.values)
+      fragment_to_s(fragment),
     ]
   end
 
-  def fragment_values_to_s(values)
-    values.map { |value|
+  def fragment_to_s(fragment)
+    values = fragment.values.map { |value|
       "<strong>#{html_escape(value.label)}</strong>"
-    }.to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
+    }
+
+    if fragment.type == "text"
+      values.to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
+    elsif fragment.type == "date"
+      values.to_sentence(two_words_connector: ' and ')
+    end
   end
 
   def documents

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -184,25 +184,6 @@ RSpec.describe ResultSetPresenter do
       finder.stub(:filter_sentence_fragments).and_return( [a_facet, another_facet].flat_map { |f| f.sentence_fragment }.compact )
     end
 
-    let(:a_facet) do
-      OpenStruct.new(
-        sentence_fragment: OpenStruct.new(
-          preposition: 'about',
-          values: [
-            OpenStruct.new(
-              label: 'Farming',
-              parameter_key: 'key_1',
-              other_params: ['chemicals'],
-            ),
-            OpenStruct.new(
-              label: 'Chemicals',
-              parameter_key: 'key_1',
-              other_params: ['farming'],
-            ),
-          ]
-        )
-      )
-    end
 
     it 'returns a string with all the facets passed to it in strong tags' do
       presenter.stub(:link_params_without_facet_value).and_return({param_1: 'one'})

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ResultSetPresenter do
       ],
       sentence_fragment: [
         OpenStruct.new(
+        type: 'text',
           preposition: 'of type',
           values: [
             OpenStruct.new(
@@ -63,6 +64,7 @@ RSpec.describe ResultSetPresenter do
       ],
       sentence_fragment: [
         OpenStruct.new(
+          type: 'text',
           preposition: 'about',
           values: [
             OpenStruct.new(

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ResultSetPresenter do
       results: results,
       document_noun: document_noun,
       total: 20,
-      facets: [ a_facet, another_facet ],
+      facets: [ a_facet, another_facet, a_date_facet ],
       keywords: keywords,
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
@@ -83,6 +83,37 @@ RSpec.describe ResultSetPresenter do
     )
   end
 
+  let(:a_date_facet) do
+    OpenStruct.new(
+      sentence_fragment: OpenStruct.new(
+        type: "date",
+        preposition: "closed between",
+        values: [
+          OpenStruct.new(
+            label: "22 June 1990",
+            parameter_key: "closed_date",
+            other_params: {
+              "to"=> OpenStruct.new(
+                original_input: "22 June 1994",
+                date: Date.new,
+              )
+            },
+          ),
+          OpenStruct.new(
+            label: "22 June 1994",
+            parameter_key: "closed_date",
+            other_params: {
+              "from" => OpenStruct.new(
+                original_input: "22 June 1990",
+                date: Date.new,
+              )
+            }
+          )
+        ]
+      )
+    )
+  end
+
   let(:keywords){ '' }
   let(:document_noun){ 'case' }
   let(:total) { 20 }
@@ -145,7 +176,7 @@ RSpec.describe ResultSetPresenter do
 
     before(:each) do
       presenter.stub(:link_without_facet_value)
-      finder.stub(:filter_sentence_fragments).and_return( [a_facet, another_facet].flat_map { |f| f.sentence_fragment }.compact )
+      finder.stub(:filter_sentence_fragments).and_return( [a_facet, another_facet, a_date_facet].flat_map { |f| f.sentence_fragment }.compact )
     end
 
     it 'calls selected_filter_descriptions' do
@@ -182,16 +213,13 @@ RSpec.describe ResultSetPresenter do
   describe '#facet_values_sentence' do
 
     before(:each) do
-      presenter.stub(:link_params_without_facet_value).and_return({})
-      finder.stub(:filter_sentence_fragments).and_return( [a_facet, another_facet].flat_map { |f| f.sentence_fragment }.compact )
+      finder.stub(:filter_sentence_fragments).and_return( [a_facet, another_facet, a_date_facet].flat_map { |f| f.sentence_fragment }.compact )
     end
 
+    let(:sentence) { presenter.selected_filter_descriptions }
 
     it 'returns a string with all the facets passed to it in strong tags' do
-      presenter.stub(:link_params_without_facet_value).and_return({param_1: 'one'})
-
-      sentence = presenter.selected_filter_descriptions
-      a_facet.sentence_fragment.values.each do | value |
+      finder.facets.flat_map(&:sentence_fragment).flat_map(&:values).flatten.each do | value |
         sentence.include?("<strong>#{value.label}").should == true
       end
     end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -223,6 +223,14 @@ RSpec.describe ResultSetPresenter do
         sentence.include?("<strong>#{value.label}").should == true
       end
     end
+
+    it 'returns a string with the facet values joined correctly' do
+      text_values = another_facet.selected_values
+      sentence.include?("<strong>#{text_values.first.label}</strong> or <strong>#{text_values.last.label}</strong>").should == true
+
+      date_fragment = a_date_facet.sentence_fragment
+      sentence.include?("<strong>#{date_fragment.values.first.label}</strong> and <strong>#{date_fragment.values.last.label}</strong>").should == true
+    end
   end
 
   describe '#documents' do


### PR DESCRIPTION
This PR fixes an issue with this Application where it would join a date based search with 2 values or like this: ` 1 January 2015 or 1 September 2015`. In this PR I've added a `type` attribute of `text|date` and I use this to switch the `.to_sentence` call with different arguments, so that we join Date values with `and`.

Within this PR I've also removed some duplicated and unnecessary stubbing that I found within the `ResultSetPresenter` spec. This commits for cleaning this up are a bit mixed because git had difficulty separating the diff out.