### PR TITLE
Send document URL as params when can't find key

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -115,6 +115,9 @@ private
     Airbrake.notify(
       error,
       url: finder.slug,
+      parameters: {
+        document: link,
+      },
     )
     nil
   end


### PR DESCRIPTION
When a document is returned from Rummager missing a key
`Document#get_metadata_label` will raise an error and send an Airbrake
notification. Previously we added the URL of the Finder to this
information which is useful, but the real useful information is the
document which has caused the error.

This commit modifies this `Airbrake#notify` method to send the document
link (aka: the id in Rummager) as part of the parameters which would
then make debugging which document is missing the metadata easier.

An example of one of these errors can be found
[here](https://errbit.production.alphagov.co.uk/apps/54088bad0da1152a9f001417/problems/55f1f437657863344fed0500).