### PR TITLE
Default to `start=0` for invalid `page` input

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -33,7 +33,7 @@ private
   end
 
   def current_page
-    params.fetch("page", 1).to_i
+    [params["page"].to_i, 1].max
   end
 
   def documents_per_page

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -159,4 +159,45 @@ describe SearchQueryBuilder do
       expect(query).to include("filter_document_type" => "news_story")
     end
   end
+
+  describe '#start' do
+    it 'starts at zero by default' do
+      query = query_with_params({})
+
+      expect(query['start']).to eql(0)
+    end
+
+    it 'starts at zero when page param is zero' do
+      query = query_with_params({ "page" => 0 })
+
+      expect(query['start']).to eql(0)
+    end
+
+    it 'starts at zero when page param is nil' do
+      query = query_with_params({ "page" => nil })
+
+      expect(query['start']).to eql(0)
+    end
+
+    it 'starts at zero when page param is empty' do
+      query = query_with_params({ "page" => "" })
+
+      expect(query['start']).to eql(0)
+    end
+
+    it 'is paginated' do
+      query = query_with_params({ "page" => "10" })
+
+      expect(query['start']).to eql(9000)
+    end
+
+    def query_with_params(params)
+      SearchQueryBuilder.new(
+        filter_query_builder: filter_query_builder,
+        facet_query_builder: facet_query_builder,
+        finder_content_item: finder_content_item,
+        params: params
+      ).call
+    end
+  end
 end


### PR DESCRIPTION
Currently when the user sets the `page` parameter to `0` or leaves it empty, finder-frontend will ask rummager for results starting at a negative index:

`https://www.gov.uk/government/policies/young-people?page`

Will cause the rummager request:

`https://search.publishing.service.gov.uk/unified_search.json?start=-40(...)`

Which rummager will reject. This commit makes sure that we default to `start=0` for all invalid input.