### PR TITLE
Upgrade Slimmer, explicitly set layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.3'
-gem 'slimmer', '~> 8.2.1'
+gem 'slimmer', '9.0.0'
 gem 'gds-api-adapters', '~> 20.1.1'
 gem 'unicorn', '~> 4.8.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -272,7 +272,7 @@ DEPENDENCIES
   sdoc
   shared_mustache (~> 0.1.3)
   simplecov (~> 0.9.0)
-  slimmer (~> 8.2.1)
+  slimmer (= 9.0.0)
   uglifier (>= 1.3.0)
   unicorn (~> 4.8.1)
   webmock (~> 1.17.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
+  include Slimmer::Template
   include Slimmer::SharedTemplates
-  before_filter :set_slimmer_headers
+  slimmer_template "header_footer_only"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -10,9 +10,6 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
 
 private
-  def set_slimmer_headers
-    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "header_footer_only"
-  end
 
   def finder_base_path
     "/#{finder_slug}"


### PR DESCRIPTION
This is a no-op change to app behaviour. The same Slimmer layout is used as be
before, but set in a simple, standardised way with `slimmer_template`, which is
easier to grep for than the other methods.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use `core_layout`, and it's
actually very little, I think it would just need some tweaking of the local
grid styles.

Still, it's better to do that in a separate PR, so it can be reviewed/tested
specifically.

[1] https://github.com/alphagov/slimmer/pull/136