### PR TITLE
Keep related links in order

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -101,7 +101,7 @@ class FinderPresenter
   end
 
   def related
-    content_item.links.related
+    content_item.links.related.sort_by(&:title)
   end
 
   def results


### PR DESCRIPTION
Links don't come ordered from the content-store anymore, so we need to make sure the related links (like in the top-right corner of http://www.gov.uk/countryside-stewardship-grants) are sorted correctly.

Trello: https://trello.com/c/hBJ3RX1k