### PR TITLE
Handle content store not returning "related" links

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -101,7 +101,8 @@ class FinderPresenter
   end
 
   def related
-    content_item.links.related.sort_by(&:title)
+    related = content_item.links.related || []
+    related.sort_by(&:title)
   end
 
   def results


### PR DESCRIPTION
Content store appears to not always return entries in the links hash if there
are no links of that type. Possibly this is true for GET /v2/links as well in the publishing api.

It is marked as required in the content schemas, but the array may be empty when publishing.

I'm not sure if the behaviour should be changed elsewhere but this addresses the resulting nil errors in finder frontend.

This is visible on integration at the moment, e.g. with /api/content/government/policies/2012-olympic-and-paralympic-legacy