### PR TITLE
Clean up whitespace at bottom of page

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -13,16 +13,10 @@
 #wrapper {
   display: block;
   @extend %site-width-container;
-
-  padding-bottom: $gutter;
-
-  @include media(desktop) {
-    padding-bottom: $gutter*2;
-  }
 }
 
 #finder-frontend {
-  margin-bottom: $gutter*2;
+  margin-bottom: $gutter * 1.5;
 
   .signup-content p {
     margin: $gutter-half 0;


### PR DESCRIPTION
* Stop the “report a problem” link from floating too high above the footer
* Use the same spacing beneath the finder front-end list as the document footer uses (1.5 rather than 2)

# Before
![screen shot 2016-02-08 at 16 57 15](https://cloud.githubusercontent.com/assets/319055/12892670/16d215ee-ce85-11e5-9079-abf6190faa80.png)

# After
![screen shot 2016-02-08 at 16 56 59](https://cloud.githubusercontent.com/assets/319055/12892671/16d36a34-ce85-11e5-809e-5d3e723feda1.png)