### PR TITLE
Tweak margins in header

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -48,7 +48,6 @@
 
   header {
     @extend %grid-row;
-    margin-bottom: $gutter;
 
     .title-and-metadata {
       @include grid-column(2/3);
@@ -62,12 +61,13 @@
     }
 
     .summary {
-      margin-top: $gutter;
+      margin-bottom: $gutter;
       @include core-19;
     }
 
     .email-link {
-      margin-top: $gutter;
+      margin-bottom: $gutter;
+
       a {
         @include bold-19;
         text-decoration:none;
@@ -92,7 +92,8 @@
     .related-links {
       @include grid-column(1/3);
       @include bold-16;
-      margin: $gutter 0;
+      margin-top: $gutter * 1.5;
+      margin-bottom: $gutter * 1.5;
       list-style:none;
 
       li {


### PR DESCRIPTION
When there is no email link, and with the new component margins, a double margin appears beneath the list of items and the metadata component.

* Switch from top margins to bottom margins and remove the margin on
the header container
* Increase the margin on related links to match new title margins

## Fixes
![screen shot 2016-02-12 at 11 23 08](https://cloud.githubusercontent.com/assets/319055/13005618/088c0104-d17b-11e5-8b9c-483fd210ef16.png)

---

![screen shot 2016-02-12 at 11 24 01](https://cloud.githubusercontent.com/assets/319055/13005635/1dd07ec8-d17b-11e5-9427-f5992b35223e.png)
