### PR TITLE
Fix malformed arrays in finder params

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -43,11 +43,13 @@ private
 
   def facet_params
     # TODO Use a whitelist based on the facets in the schema
-    params.except(
+    permitted_params = params.except(
       :controller,
       :action,
       :slug,
       :format,
     )
+
+    ParamsCleaner.new(permitted_params).cleaned
   end
 end

--- a/app/lib/params_cleaner.rb
+++ b/app/lib/params_cleaner.rb
@@ -1,0 +1,27 @@
+# In some cases requests come in to this app with a mangled query string in
+# this form:
+#
+#   foo[0]=bar&foo[1]=baz
+#
+# Which translates in Rails as:
+#
+#   foo: { 0: "bar", 1: "baz" }
+#
+# While we want:
+#
+#   foo: ["bar", "baz"]
+#
+class ParamsCleaner
+  def initialize(params)
+    @params = params
+  end
+
+  def cleaned
+    @params.each do |k, v|
+      next unless v.is_a?(Hash) && v.keys.all? { |d| d.match(/\A\d+\Z/) }
+      @params[k] = v.values
+    end
+
+    @params
+  end
+end

--- a/spec/lib/params_cleaner_spec.rb
+++ b/spec/lib/params_cleaner_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe ParamsCleaner do
+  describe "#cleaned" do
+    it "makes an array of a array-like hash" do
+      params = { "foo" => { "0" => "bar", "1" => "baz" } }
+
+      cleaned = ParamsCleaner.new(params).cleaned
+
+      expect(cleaned).to eql("foo" => ["bar", "baz"])
+    end
+
+    it "leaves normal params alone" do
+      params = { "foo" => "bar" }
+
+      cleaned = ParamsCleaner.new(params).cleaned
+
+      expect(cleaned).to eql(params)
+    end
+
+    it "does not touch other types of hash-params " do
+      params = { "foo" => { "from" => "bar", "to" => "baz" } }
+
+      cleaned = ParamsCleaner.new(params).cleaned
+
+      expect(cleaned).to eql(params)
+    end
+  end
+end


### PR DESCRIPTION
Facebook (among others) sometimes mangles the URL of finders, from `foo[]=bar&foo[]=baz` into `foo[0]=bar&foo[1]=baz`.

This is forwarded incorrectly to rummager, causing an error there. This commit cleans the params in the controller.

This change is conceptually similar to https://github.com/alphagov/whitehall/blob/master/lib/whitehall/document_filter/cleaned_params.rb#L45-L52, which was added in https://github.com/alphagov/whitehall/pull/1342.

Trello: https://trello.com/c/BDz61VGO

This will solve errors like:

https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56faec2265786342c57a1200
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56faec2465786342b8a61200
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56e8fe41657863326a955000
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56fcaa2a65786342b8d31700
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56fb929965786342c5271600
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56fad3de65786342b8911200
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56eb74fe6578632750c90200
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56fa01d765786342b8080d00
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56e6fca56578633265eb0100
https://errbit.publishing.service.gov.uk/apps/54088bad0da1152a9f001417/problems/56f2a5b16578637df1ea0000