### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
+++ b/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
@@ -1,0 +1,3 @@
+<% if email_alert_subscription.body %>
+  <meta name="description" content="<%= email_alert_subscription.body %>">
+<% end %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, @signup.page_title %>
+<% content_for :head do %>
+  <%= render 'email_alert_subscription_meta', email_alert_subscription: @signup %>
+<% end %>
 
 <% if @signup.beta? %>
   <%= render partial: 'govuk_component/beta_label' %>


### PR DESCRIPTION
This commit adds meta description tags to all email alert pages, the contents of which are set to the summary associated with the relevant alert. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them