### PR TITLE
Use standard GitHub status for contract tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -7,7 +7,7 @@ env
 function github_status {
   STATUS="$1"
   MESSAGE="$2"
-  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "finder frontend contract tests" >/dev/null
+  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "Verify finder-frontend against content schemas" >/dev/null
 }
 
 function error_handler {


### PR DESCRIPTION
All other apps use a message in the form `Verify [app] against content schemas`. Using it here too will allow users to use _the alphabet_ to look for a specific application in the long list.

<img width="720" alt="screen shot 2016-09-23 at 11 02 21" src="https://cloud.githubusercontent.com/assets/233676/18782216/404efd96-817d-11e6-8c43-13f280d2b47d.png">

Related: https://github.com/alphagov/manuals-publisher/pull/746 https://github.com/alphagov/whitehall/pull/2764