### PR TITLE
Default public_timestamp to nil when not present

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,17 +1,17 @@
 class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name
 
-  def initialize(attrs, finder)
-    attrs = attrs.with_indifferent_access
-    @title = attrs.fetch(:title)
-    @link = attrs.fetch(:link)
-    @description = attrs.fetch(:description, nil)
-    @public_timestamp = attrs.fetch(:public_timestamp)
-    @is_historic = attrs.fetch(:is_historic, false)
-    @government_name = attrs.fetch(:government_name, nil)
+  def initialize(rummager_document, finder)
+    rummager_document = rummager_document.with_indifferent_access
+    @title = rummager_document.fetch(:title)
+    @link = rummager_document.fetch(:link)
+    @description = rummager_document.fetch(:description, nil)
+    @public_timestamp = rummager_document.fetch(:public_timestamp, nil)
+    @is_historic = rummager_document.fetch(:is_historic, false)
+    @government_name = rummager_document.fetch(:government_name, nil)
 
     @finder = finder
-    @attrs = attrs.slice(*metadata_keys)
+    @rummager_document = rummager_document.slice(*metadata_keys)
   end
 
   def metadata
@@ -30,7 +30,7 @@ class Document
   end
 
 private
-  attr_reader :link, :attrs, :finder, :description
+  attr_reader :link, :rummager_document, :finder, :description
 
   def metadata_keys
     date_metadata_keys + tag_metadata_keys
@@ -57,7 +57,7 @@ private
   def build_date_metadata(key)
     {
       name: key,
-      value: attrs[key],
+      value: rummager_document[key],
       type: "date",
     }
   end
@@ -69,7 +69,7 @@ private
   end
 
   def tag_labels_for(key)
-    Array(attrs.fetch(key, []))
+    Array(rummager_document.fetch(key, []))
       .map { |label| get_metadata_label(key, label) }
      .select(&:present?)
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe Document do
+  describe "initialization" do
+    it 'defaults to nil without a public timestamp' do
+      rummager_document = {
+        title: 'A title',
+        link: 'link.com'
+      }
+      finder = double(
+        'finder', date_metadata_keys: [], text_metadata_keys: []
+      )
+      document = described_class.new(rummager_document, finder)
+
+      expect(document.public_timestamp).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
We are moving old "finder-like" pages over to `finder-frontend`. One of
these finders is the people finder from Whitehall.

The Person records in Whitehall don't have a `public_timestamp` field
because they are not an edition. This means that we don't send that
information to Rummager. When `finder-frontend` fetches those records
from rummager and tries to fetch the `public_timestamp`, the
initialization of a `Document` fails.

This commit makes sure we default to `nil` when fetching the
`public_timestamp`. The reason `nil` is fine is because the default
ordering on people is by `title` (i.e. the minister's names) rather than
by `public_timestamp`.

Example person record: https://www.gov.uk/api/search.json?filter_link=/government/people/theresa-may

Part of https://trello.com/c/reCVyzpg/259-migrate-the-people-page-to-a-finder