### PR TITLE
Change breadcrumbs to use navigation helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'logstasher', '~> 0.4.8'
 gem 'shared_mustache', '~> 0.1.3'
 gem 'airbrake', '~> 4.0.0'
 gem 'chronic', '~> 0.10.2'
+gem 'govuk_navigation_helpers', '~> 2.0.0'
 
 group :assets do
   if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_navigation_helpers (2.0.0)
     hike (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -270,6 +271,7 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.0.1)
   govuk_frontend_toolkit (~> 3.1.0)
+  govuk_navigation_helpers (~> 2.0.0)
   jasmine-rails
   launchy (~> 2.4.2)
   logstasher (~> 0.4.8)
@@ -287,4 +289,4 @@ DEPENDENCIES
   webmock (~> 1.17.1)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -7,7 +7,9 @@ class FindersController < ApplicationController
     @results = ResultSetPresenter.new(finder, view_context)
 
     respond_to do |format|
-      format.html
+      format.html do
+        @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(raw_finder)
+      end
       format.json do
         render json: @results
       end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -18,14 +18,7 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'govuk_component/breadcrumbs', locals: {
-  breadcrumbs: [
-    {
-      title: "Home",
-      url: "/"
-    },
-  ]
-} %>
+<%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
 
 <% if finder.government? %>
   <%= render partial: 'govuk_component/government_navigation', locals: { active: finder.government_content_section } %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -20,11 +20,13 @@ Feature: Filtering documents
   Scenario: Visit a government finder
     Given a government finder exists
     Then I can see the government header
+    And I can see the breadcrumbs
     And I can see documents which are marked as being in history mode
 
   Scenario: Visit a policy finder
     Given a policy finder exists
     Then I can see the government header
+    And I can see the breadcrumbs
     And I can see documents which are marked as being in history mode
     And I can see documents which have government metadata
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -50,6 +50,11 @@ Then(/^I can see the government header$/) do
   page.should have_css(shared_component_selector('government_navigation'))
 end
 
+Then(/^I can see the breadcrumbs$/) do
+  visit finder_path('government/policies/benefits-reform')
+  page.should have_css(shared_component_selector('breadcrumbs'))
+end
+
 Then(/^I can see documents which are marked as being in history mode$/) do
   page.should have_css('p.historic', count: 5)
   page.should have_content("2005 to 2010 Labour government")


### PR DESCRIPTION
This commit adds the govuk_navigation_helpers and changes the finder view to use its output for breadcrumb generation. This allows finders to have breadcrumbs rather than just hardcoding in “Home”.

Paired with @klssmith 