### PR TITLE
Remove external link styles

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -53,13 +53,6 @@
       @include grid-column(2/3);
     }
 
-    a[rel="external"] {
-      @include external-link-12;
-      @include media(tablet) {
-        @include external-link-14;
-      }
-    }
-
     .summary {
       margin-bottom: $gutter;
       @include core-19;


### PR DESCRIPTION
After static was updated to latest toolkit, the external link styles
were removed but some extra styles within Finder Frontend still remained, breaking the display
of external links.

https://github.com/alphagov/govuk_frontend_toolkit/pull/293

Also fixed on frontend:
https://github.com/alphagov/frontend/pull/1049