### PR TITLE
Add topicalness facet type

### DIFF
--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -15,7 +15,6 @@ private
       OpenStruct.new(
         label: date.date.strftime("%e %B %Y"),
         parameter_key: key,
-        other_params: present_values.reject { |key, _| key == k }
       )
     }
   end

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -32,15 +32,8 @@ private
       OpenStruct.new(
         label: v.label,
         parameter_key: key,
-        other_params: other_params(v),
       )
     }
-  end
-
-  def other_params(v)
-    selected_values
-      .map(&:value)
-      .reject { |selected_value|  selected_value == v.value }
   end
 
   def selected_values

--- a/app/models/topical_facet.rb
+++ b/app/models/topical_facet.rb
@@ -1,0 +1,9 @@
+class TopicalFacet < SelectFacet
+  def allowed_values
+    [facet.open_value, facet.closed_value]
+  end
+
+  def to_partial_path
+    "select_facet"
+  end
+end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -4,6 +4,8 @@ module FacetParser
       case facet.type
       when 'text'
         SelectFacet.new(facet)
+      when 'topical'
+        TopicalFacet.new(facet)
       when 'date'
         DateFacet.new(facet)
       else

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -26,7 +26,6 @@ describe DateFacet do
         subject.sentence_fragment.preposition.should == "occurred after"
         subject.sentence_fragment.values.first.label == "22 September 1988"
         subject.sentence_fragment.values.first.parameter_key == "date_of_occurrence[from]"
-        subject.sentence_fragment.values.first.other_params == []
       }
     end
 
@@ -36,7 +35,6 @@ describe DateFacet do
         subject.sentence_fragment.preposition.should == "occurred before"
         subject.sentence_fragment.values.first.label == "22 September 2014"
         subject.sentence_fragment.values.first.parameter_key == "date_of_occurrence[to]"
-        subject.sentence_fragment.values.first.other_params == []
       }
     end
 
@@ -52,11 +50,9 @@ describe DateFacet do
 
         subject.sentence_fragment.values.first.label == "22 September 1988"
         subject.sentence_fragment.values.first.parameter_key == "date_of_occurrence[to]"
-        subject.sentence_fragment.values.first.other_params == ["to","22/09/2014"]
 
         subject.sentence_fragment.values.last.label == "22 September 2014"
         subject.sentence_fragment.values.last.parameter_key == "date_of_occurrence[from]"
-        subject.sentence_fragment.values.last.other_params == ["from","22/09/1988"]
       }
     end
   end

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -42,7 +42,6 @@ describe SelectFacet do
         subject.sentence_fragment.preposition.should == "of value"
         subject.sentence_fragment.values.first.label == "Allowed value 1"
         subject.sentence_fragment.values.first.parameter_key == "test_values"
-        subject.sentence_fragment.values.first.other_params == []
       }
     end
 
@@ -53,11 +52,9 @@ describe SelectFacet do
         subject.sentence_fragment.preposition.should == "of value"
         subject.sentence_fragment.values.first.label.should == "Allowed value 1"
         subject.sentence_fragment.values.first.parameter_key.should == "test_values"
-        subject.sentence_fragment.values.first.other_params.should == ["allowed-value-2"]
 
         subject.sentence_fragment.values.last.label.should == "Allowed value 2"
         subject.sentence_fragment.values.last.parameter_key.should == "test_values"
-        subject.sentence_fragment.values.last.other_params.should == ["allowed-value-1"]
       }
     end
 

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -4,11 +4,11 @@ describe SelectFacet do
   let(:allowed_values) {
     [
       OpenStruct.new(
-        label: "Airport price control reviews",
+        label: "Allowed value 1",
         value: "allowed-value-1"
       ),
        OpenStruct.new(
-        label: "Market investigations",
+        label: "Allowed value 2",
         value: "allowed-value-2" 
       ),
        OpenStruct.new(
@@ -51,13 +51,13 @@ describe SelectFacet do
 
       specify {
         subject.sentence_fragment.preposition.should == "of value"
-        subject.sentence_fragment.values.first.label == "Allowed value 1"
-        subject.sentence_fragment.values.first.parameter_key == "test_values"
-        subject.sentence_fragment.values.first.other_params == ["allowed-value-2"]
+        subject.sentence_fragment.values.first.label.should == "Allowed value 1"
+        subject.sentence_fragment.values.first.parameter_key.should == "test_values"
+        subject.sentence_fragment.values.first.other_params.should == ["allowed-value-2"]
 
-        subject.sentence_fragment.values.last.label == "Allowed value 2"
-        subject.sentence_fragment.values.last.parameter_key == "test_values"
-        subject.sentence_fragment.values.last.other_params == ["allowed-value-1"]
+        subject.sentence_fragment.values.last.label.should == "Allowed value 2"
+        subject.sentence_fragment.values.last.parameter_key.should == "test_values"
+        subject.sentence_fragment.values.last.other_params.should == ["allowed-value-1"]
       }
     end
 

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe TopicalFacet do
+  let(:facet_struct) {
+    open = OpenStruct.new(
+      label: "Open",
+      value: "open"
+    )
+
+    closed = OpenStruct.new(
+      label: "Closed",
+      value: "closed"
+    )
+
+    OpenStruct.new(
+      type: "topical",
+      name: "State",
+      key: "end_date",
+      preposition: "of value",
+      open_value: open,
+      closed_value: closed
+    )
+  }
+
+  subject { TopicalFacet.new(facet_struct) }
+
+  before do
+    subject.value = value
+  end
+
+  describe "#sentence_fragment" do
+    context "single value" do
+      let(:value) { ["open"] }
+
+      specify {
+        subject.sentence_fragment.preposition.should == "of value"
+        subject.sentence_fragment.values.first.label == "Open"
+        subject.sentence_fragment.values.first.parameter_key == "end_date"
+      }
+    end
+
+    context "multiple values" do
+      let(:value) { ["open", "closed"] }
+
+      specify {
+        subject.sentence_fragment.preposition.should == "of value"
+        subject.sentence_fragment.values.first.label.should == "Open"
+        subject.sentence_fragment.values.first.parameter_key.should == "end_date"
+
+        subject.sentence_fragment.values.last.label.should == "Closed"
+        subject.sentence_fragment.values.last.parameter_key.should == "end_date"
+      }
+    end
+
+    context "disallowed values" do
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
+      specify { subject.sentence_fragment.should be_nil }
+    end
+  end
+end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -41,12 +41,10 @@ RSpec.describe ResultSetPresenter do
             OpenStruct.new(
               label: 'CA98 and civil cartels',
               parameter_key: 'key_1',
-              other_params: ['mergers'],
             ),
             OpenStruct.new(
               label: 'Mergers',
               parameter_key: 'key_1',
-              other_params: ['ca98-and-civil-cartels'],
             ),
           ]
         )
@@ -70,12 +68,10 @@ RSpec.describe ResultSetPresenter do
             OpenStruct.new(
               label: 'Farming',
               parameter_key: 'key_2',
-              other_params: ['chemicals'],
             ),
             OpenStruct.new(
               label: 'Chemicals',
               parameter_key: 'key_2',
-              other_params: ['farming'],
             ),
           ]
         )
@@ -92,22 +88,10 @@ RSpec.describe ResultSetPresenter do
           OpenStruct.new(
             label: "22 June 1990",
             parameter_key: "closed_date",
-            other_params: {
-              "to"=> OpenStruct.new(
-                original_input: "22 June 1994",
-                date: Date.new,
-              )
-            },
           ),
           OpenStruct.new(
             label: "22 June 1994",
             parameter_key: "closed_date",
-            other_params: {
-              "from" => OpenStruct.new(
-                original_input: "22 June 1990",
-                date: Date.new,
-              )
-            }
           )
         ]
       )


### PR DESCRIPTION
This is a new kind of facet to dynamically split topical events into open or closed based on the end date.

This will look something like this when the finder itself is published:
<img width="990" alt="screen shot 2016-11-24 at 15 05 14" src="https://cloud.githubusercontent.com/assets/87579/20628227/a71ec030-b31c-11e6-96be-72f449eedfa2.png">

I've also removed what seems like an unused field from the presenters, and fixed some broken tests. This should not affect existing finders (I hope).

Trello: https://trello.com/c/oVfSAO9W/311-migrate-policy-areas-topical-events-index-to-a-finder
Matching schema change: https://github.com/alphagov/govuk-content-schemas/pull/441
Finder: https://github.com/alphagov/whitehall/pull/2855