### PR TITLE
Clean invalid UTF-8 characters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.3
+  Exclude:
+    # Exclude the UTF8Cleaner test because it includes invalid UTF-8 characters
+    # for testing purposes that rubocop chokes on.
+    - 'spec/lib/utf8_cleaner_spec.rb'

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -80,7 +80,7 @@ private
   end
 
   def keywords
-    params["keywords"].presence
+    UTF8Cleaner.new(params["keywords"]).cleaned
   end
 
   def default_order

--- a/app/lib/utf8_cleaner.rb
+++ b/app/lib/utf8_cleaner.rb
@@ -1,0 +1,24 @@
+# In some cases requests come in to this app with invalid UTF-8 characters
+# in the query string, for example:
+#
+#   keywords=%c0%2e%c0%2e
+#
+# We want to clean up these strings to remove the invalid characters
+class UTF8Cleaner
+  def initialize(string_to_be_cleaned)
+    @string_to_be_cleaned = string_to_be_cleaned
+  end
+
+  def cleaned
+    return unless @string_to_be_cleaned
+
+    # Doesn't actually do any conversion but removes invalid characters
+    @string_to_be_cleaned.encode(
+      'UTF-8',
+      'UTF-8',
+      invalid: :replace,
+      undef: :replace,
+      replace: ''
+    ).presence
+  end
+end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -21,7 +21,7 @@ class FinderPresenter
     @organisations = content_item.links.organisations
     @values = values
     facets.values = values
-    @keywords = values["keywords"].presence
+    @keywords = UTF8Cleaner.new(values["keywords"]).cleaned
   end
 
   def alpha?

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -3,7 +3,7 @@
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
         <label class="legend" for="finder-keyword-search">Search</label>
-        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
+        <input value="<%= UTF8Cleaner.new(params[:keywords]).cleaned %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
       </div>
       <%= render facet_collection.filters %>
       <input type="submit" value="Filter results" class="button js-live-search-fallback"/>

--- a/spec/lib/utf8_cleaner_spec.rb
+++ b/spec/lib/utf8_cleaner_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe UTF8Cleaner do
+  describe "#cleaned" do
+    it "removes any invalid UTF-8 characters from a string" do
+      string_to_be_cleaned = "Hello,\255 world".force_encoding('UTF-8')
+
+      cleaned = UTF8Cleaner.new(string_to_be_cleaned).cleaned
+
+      expect{ cleaned }.not_to raise_error
+      expect(cleaned).to eql("Hello, world")
+    end
+
+    it "returns nil if there are no valid UTF-8 characters in a string" do
+      string_to_be_cleaned = "\255".force_encoding('UTF-8')
+
+      cleaned = UTF8Cleaner.new(string_to_be_cleaned).cleaned
+
+      expect(cleaned).to be_nil
+    end
+
+    it "returns nil if nil is passed in" do
+      string_to_be_cleaned = nil
+
+      cleaned = UTF8Cleaner.new(string_to_be_cleaned).cleaned
+
+      expect(cleaned).to be_nil
+    end
+
+    it "does not touch valid UTF-8 strings" do
+      string_to_be_cleaned = "Hello, world".force_encoding('UTF-8')
+
+      cleaned = UTF8Cleaner.new(string_to_be_cleaned).cleaned
+
+      expect(cleaned).to eql("Hello, world")
+    end
+
+    it "does not touch valid multi-byte UTF-8 characters in a string" do
+      string_to_be_cleaned = "Hello,\255 world 😀".force_encoding('UTF-8')
+
+      cleaned = UTF8Cleaner.new(string_to_be_cleaned).cleaned
+
+      expect(cleaned).to eql("Hello, world 😀")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a class that removes invalid UTF-8 characters from strings. The class is used when parsing keywords passed to finder-frontend in order to fix `ArgumentError: invalid byte sequence in UTF-8` exceptions.

Trello: https://trello.com/c/piGeShKO/388-fix-some-errors-from-finder-frontend-errbit