### PR TITLE
Render a 406 when an invalid format is requested

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -21,6 +21,8 @@ class FindersController < ApplicationController
         end
       end
     end
+  rescue ActionController::UnknownFormat
+    render text: 'Not acceptable', status: 406
   end
 
 private

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -44,6 +44,12 @@ describe FindersController do
         expect(response.content_type).to eq("application/atom+xml")
         expect(response).to render_template("finders/show")
       end
+
+      it "returns a 406 if an invalid format is requested" do
+        request.headers["Accept"] = "text/plain"
+        get :show, slug: "lunch-finder"
+        expect(response.status).to eq(406)
+      end
     end
 
     describe "a finder content item with a default order exists" do


### PR DESCRIPTION
Currently, if the HTTP `accept` header sent with a request asks for a format other than HTML, JSON or Atom, an exception is raised. This commit catches the exception and serves an error with a 406 status code.

Trello: https://trello.com/c/piGeShKO/388-fix-some-errors-from-finder-frontend-errbit