### PR TITLE
Reject requests with invalid UTF-8 characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'shared_mustache', '~> 0.1.3'
 gem 'airbrake', '~> 4.0.0'
 gem 'chronic', '~> 0.10.2'
 gem 'govuk_navigation_helpers', '~> 2.0.0'
+gem 'invalid_utf8_rejector', '~> 0.0.3'
 
 group :assets do
   if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    invalid_utf8_rejector (0.0.3)
     jasmine-core (2.5.0)
     jasmine-rails (0.13.0)
       jasmine-core (>= 1.3, < 3.0)
@@ -291,6 +292,7 @@ DEPENDENCIES
   govuk-lint
   govuk_frontend_toolkit (~> 3.1.0)
   govuk_navigation_helpers (~> 2.0.0)
+  invalid_utf8_rejector (~> 0.0.3)
   jasmine-rails
   launchy (~> 2.4.2)
   logstasher (~> 0.4.8)


### PR DESCRIPTION
This commit adds a gem that rejects requests that contain invalid UTF-8 characters. This prevents `ArgumentError: invalid byte sequence in UTF-8` exceptions.

Trello: https://trello.com/c/piGeShKO/388-fix-some-errors-from-finder-frontend-errbit