### PR TITLE
Gracefully handle empty query string values

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -4,7 +4,7 @@ class FindersController < ApplicationController
   include GdsApi::Helpers
 
   def show
-    @results = ResultSetPresenter.new(finder, view_context)
+    @results = ResultSetPresenter.new(finder, filter_params, view_context)
 
     respond_to do |format|
       format.html do
@@ -48,6 +48,8 @@ private
       :format,
     )
 
-    ParamsCleaner.new(permitted_params).cleaned
+    cleaned_params = ParamsCleaner.new(permitted_params).cleaned
+
+    cleaned_params.delete_if { |_, value| value.blank? }
   end
 end

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -81,7 +81,11 @@ private
     end
 
     def user_values
-      params || {}
+      if params.is_a?(Hash)
+        params
+      else
+        {}
+      end
     end
   end
 

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -9,10 +9,11 @@ class ResultSetPresenter
            :atom_url,
            to: :finder
 
-  def initialize(finder, view_context)
+  def initialize(finder, filter_params, view_context)
     @finder = finder
     @results = finder.results.documents
     @total = finder.results.total
+    @filter_params = filter_params
     @view_context = view_context
   end
 
@@ -76,6 +77,14 @@ class ResultSetPresenter
     results.map do |result|
       SearchResultPresenter.new(result).to_hash
     end
+  end
+
+  def user_supplied_date(date_facet_key, date_facet_from_to)
+    @filter_params.fetch(date_facet_key, {}).fetch(date_facet_from_to, nil)
+  end
+
+  def user_supplied_keywords
+    @filter_params.fetch('keywords', '')
   end
 
 private

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -1,8 +1,8 @@
 <div class="filter text-filter">
   <label class="legend" for="<%= date_facet.key %>[from]"><%= date_facet.name %> after</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('from', nil) %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" aria-describedby="date-help-text-<%= date_facet.key %>" class="text" />
+  <input value="<%= @results.user_supplied_date(date_facet.key, 'from') %>" type="text" name="<%= date_facet.key %>[from]" id="<%= date_facet.key %>[from]" aria-controls="js-search-results-info" aria-describedby="date-help-text-<%= date_facet.key %>" class="text" />
 
   <label class="legend" for="<%= date_facet.key %>[to]"><%= date_facet.name %> before</label>
-  <input value="<%= params.fetch(date_facet.key, {}).fetch('to', nil) %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" aria-describedby="date-help-text-<%= date_facet.key %>"/>
+  <input value="<%= @results.user_supplied_date(date_facet.key, 'to') %>" type="text" name="<%= date_facet.key %>[to]" id="<%= date_facet.key %>[to]" aria-controls="js-search-results-info" class="text" aria-describedby="date-help-text-<%= date_facet.key %>"/>
   <span id='date-help-text-<%= date_facet.key %>' class='help-text'>For example, 2005 or 21/11/2014<span>
 </div>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -3,7 +3,7 @@
     <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
       <div class="filter text-filter">
         <label class="legend" for="finder-keyword-search">Search</label>
-        <input value="<%= params[:keywords] %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
+        <input value="<%= @results.user_supplied_keywords %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
       </div>
       <%= render facet_collection.filters %>
       <input type="submit" value="Filter results" class="button js-live-search-fallback"/>

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe ResultSetPresenter do
-  subject(:presenter) { ResultSetPresenter.new(finder, view_context) }
+  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context) }
 
   let(:finder) do
     OpenStruct.new(
@@ -19,6 +19,10 @@ RSpec.describe ResultSetPresenter do
   end
 
   let(:pagination) { double(:pagination, current_page: 1, total_pages: 2) }
+
+  let(:filter_params) { double(:filter_params, {
+    keywords: 'test'
+  })}
 
   let(:view_context) { double(:view_context) }
 


### PR DESCRIPTION
Currently, empty query string values that are defined to be dates (such as `public_timestamp[from]` and `public_timestamp[to]`) raise exceptions if they are requested with just the base name (as in, `public_timestamp` without `[from]` or `[to]`) and no value.

This commit:

1. Strips out empty query string values
2. Changes filtering facets to use filtered user input rather than taking directly from `params`

Trello: https://trello.com/c/piGeShKO/388-fix-some-errors-from-finder-frontend-errbit