### PR TITLE
Bump Slimmer to fix memory leak (and more)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.7.1'
-gem 'slimmer', '9.0.1'
+gem 'slimmer', '~> 10.1.3'
 gem 'gds-api-adapters', '~> 34.1.0'
 gem 'unicorn', '~> 4.8.1'
 gem 'logstasher', '~> 0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,13 +236,13 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
-    slimmer (9.0.1)
+    slimmer (10.1.3)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (2.12.4)
@@ -304,7 +304,7 @@ DEPENDENCIES
   sdoc
   shared_mustache (~> 0.1.3)
   simplecov (~> 0.9.0)
-  slimmer (= 9.0.1)
+  slimmer (~> 10.1.3)
   uglifier (~> 2.7, >= 2.7.2)
   unicorn (~> 4.8.1)
   webmock (~> 1.17.1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,8 +46,6 @@ node {
 
     stage("Configure environment") {
       govuk.setEnvar("RAILS_ENV", "test")
-      govuk.setEnvar("GOVUK_APP_DOMAIN", "test.gov.uk")
-      govuk.setEnvar("GOVUK_ASSET_ROOT", "http://static.test.gov.uk")
     }
 
     stage("Checkout") {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
   slimmer_template "header_footer_only"
 
   # Prevent CSRF attacks by raising an exception.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,6 @@ FinderFrontend::Application.configure do
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
-  config.slimmer.use_cache = true
   config.slimmer.asset_host = Plek.current.find('static')
 
   # Specifies the header that your server uses for sending files.

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,9 +11,12 @@ require 'cucumber/rails'
 require 'webmock/cucumber'
 require 'slimmer/test'
 
-require 'slimmer/test_helpers/shared_templates'
-World(Slimmer::TestHelpers::SharedTemplates)
+require 'slimmer/test_helpers/govuk_components'
+World(Slimmer::TestHelpers::GovukComponents)
 
+Before do
+  stub_shared_component_locales
+end
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
+require 'slimmer/test_helpers/govuk_components'
 
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
+  include Slimmer::TestHelpers::GovukComponents
+
+  before do
+    stub_shared_component_locales
+  end
 
   subject(:presenter) { described_class.new(content_item, values) }
 


### PR DESCRIPTION
Full changelog:

# 10.1.3

* Fix memory leak in components

# 10.1.2

* Bugfix for request URI's encoded as ASCII

# 10.1.1

* Bugfix for caching behaviour

# 10.1.0

* Use `Rails.cache` as the cache for templates, locales and components.
You can
remove `config.slimmer.use_cache` for your application, as you can no
longer
opt-out of caching.
* Add a `User-Agent` header to all outgoing API requests

# 10.0.0

* Removes the need_id meta tag, which is no longer used.
* Removes the functionality for breadcrumbs, related links and
artefact-powered
metatags.
* Drop support for old Rails & Ruby versions. This gem now supports
Rails 4.2 and 5.X
on Ruby 2.1 and 2.2.
* Renames `Slimmer::SharedTemplates` to `Slimmer::GovukComponents`

# 9.6.0

* Adds an 'inside header inserter' processor which allows an
application to
inject a block of HTML after the logo by including a .inside-header
element
in their application’s output.
(PR #167 https://github.com/alphagov/slimmer/pull/167)

* Remove `MetaViewportRemover` processor as it is no longer used.
(PR #166 https://github.com/alphagov/slimmer/pull/166)

# 9.5.0

* Adds a Cucumber helper that makes it easy for host applications to
configure Slimmer correctly under test.

(PR #162 https://github.com/alphagov/slimmer/pull/162)

# 9.4.0

* Adds an RSpec helper that makes it easy for host applications to
configure Slimmer correctly under test.

Fixes `stub_shared_component_locales` helper to correctly stub HTTP
requests to fetch locale information when rendering its templates.

(PR #159 https://github.com/alphagov/slimmer/pull/159)

# 9.3.2

* Bugfix: Over time, the I18n backend would be chained in each request,
causing the stack to grow too large and use too much memory

(PR #157 https://github.com/alphagov/slimmer/pull/157)

# 9.3.1

* Allows frontend apps to stub component locales for example

```ruby
class ActiveSupport::TestCase
include Slimmer::TestHelpers::SharedTemplates

def setup
stub_shared_component_locales
end
end
```

(PR #155 https://github.com/alphagov/slimmer/pull/155)

# 9.3.0

* Integrates translations from GOVUK Components to be used in
applications

When including `Slimmer::SharedComponents`, the I18nBackend will be
chained to `Slimmer::I18nBackend` allowing translations in `static` to
work in the frontend applications

(PR #152 https://github.com/alphagov/slimmer/pull/152)

# 9.2.1

* Replaces deprecated `before_filter` calls in shared templates.

# 9.2.0

* Raise a custom `CouldNotRetrieveTemplate` exception when a connection
to the assets server can't be made because of an SSL problem (PR #143).

# 9.1.0

* Allow applications to request components using full or partial
component
paths, eg "name", "name.raw" and "name.raw.html.erb". This allows
components to be nested within other components.