### PR TITLE
Add analytics meta tags to finder pages

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,7 +1,7 @@
 class FinderPresenter
   include ActionView::Helpers::UrlHelper
 
-  attr_reader :name, :slug, :organisations, :keywords, :values
+  attr_reader :name, :slug, :organisations, :keywords, :values, :content_item
 
   delegate :alpha_message,
            :beta_message,
@@ -139,8 +139,6 @@ class FinderPresenter
   end
 
 private
-
-  attr_reader :content_item
 
   def part_of
     content_item.links.part_of || []

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,6 +2,8 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
+  <%= render partial: 'govuk_component/analytics_meta_tags',
+      locals: { content_item: @finder.content_item } %>
 <% end %>
 
 <% if finder.alpha? %>


### PR DESCRIPTION
Add meta tag component to finder pages. This is in preparation for the education navigation release, which includes analysis of users' journeys through navigation and content pages. Finder pages (including policies) are part of the navigation, and using the analytics meta tags will let us track them as such.

I haven't added tests for the meta tags because I haven't seen any other projects do it, presumably because the tests would be fragile because they would have to make assumptions about what meta tags would be added. Is that right, or is it worth adding a test here?

https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages