### PR TITLE
Fix intermittent test failure on CI

### DIFF
--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -1,13 +1,7 @@
 require 'spec_helper'
-require 'slimmer/test_helpers/govuk_components'
 
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
-  include Slimmer::TestHelpers::GovukComponents
-
-  before do
-    stub_shared_component_locales
-  end
 
   subject(:presenter) { described_class.new(content_item, values) }
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe ResultSetPresenter do
-  include Slimmer::TestHelpers::GovukComponents
-
-  before do
-    stub_shared_component_locales
-  end
-
   subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context) }
 
   let(:finder) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'webmock/rspec'
 require_relative '../lib/govuk_content_schema_examples'
+require 'slimmer/test_helpers/govuk_components'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -18,6 +19,11 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
+  include Slimmer::TestHelpers::GovukComponents
+
+  config.before do
+    stub_shared_component_locales
+  end
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
This hopefully fixes intermittent test failures on CI like this one:

https://ci.integration.publishing.service.gov.uk/job/finder-frontend/job/deployed-to-production/592/console

These seem to be caused by not having stubbed `stub_shared_component_locales`, but I haven't been able to reproduce this locally. Even when running the tests with the same seed.

This adds the stubbing for all tests so that we can be sure it's not an ordering issue.

https://trello.com/c/Wi6wyHsC