### PR TITLE
Disable cacheing in development env

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -3,10 +3,16 @@ require 'gds_api/rummager'
 
 module Services
   def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.find("content-store"),
+      disable_cache: Rails.env.development?
+    )
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
+    @rummager ||= GdsApi::Rummager.new(
+      Plek.find("search"),
+      disable_cache: Rails.env.development?
+    )
   end
 end


### PR DESCRIPTION
Rummager request responses were being cached and caused surprising behaviour
in that newly added specialist documents would not show up in search results
after cacheing on the dev vm. Also disable cacheing for content store to be
consistent.