### PR TITLE
Remove specialist-frontend reference from docs

### DIFF
--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -58,8 +58,7 @@ For example, rejecting all documents which don't have a policy would need a hash
 
 A string. Optional.
 
-Not specifically used by the Finder, but used by [Specialist Frontend](https://github.com/alphagov/specialist-frontend) to link back to the Finder.
-Usually a singularised version of the title of the Finder - `"Competition and Markets Authority case"` for [`/cma-cases`](https://www.gov.uk/cma-cases) for example.
+Not specifically used by the Finder. Usually a singularised version of the title of the Finder - `"Competition and Markets Authority case"` for [`/cma-cases`](https://www.gov.uk/cma-cases) for example.
 However there are edge cases where it's not the same such as `"Medical safety alert"` for [Alerts and recalls for drugs and medical devices](https://www.gov.uk/drug-device-alerts).
 
 ## `human_readable_finder_format`


### PR DESCRIPTION
`format_name`doesn’t appear to be used by government-frontend or govuk_navigation_helpers

specialist-frontend is being retired.