### PR TITLE
Add live flag consistent with government-frontend to startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3062
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  bundle exec rails s -p 3062
+else
+  bundle exec rails s -p 3062
+fi


### PR DESCRIPTION
Allows you to run finder-frontend without running local dependencies, makes it super easy to
reproduce live issues locally.