### PR TITLE
Add a meta tag for the A/B test

### DIFF
--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -1,3 +1,4 @@
+<%= @requested_variant.analytics_meta_tag.html_safe %>
 <% if finder.description %>
   <meta name="description" content="<%= finder.description %>">
 <% end %>


### PR DESCRIPTION
Trello card: https://trello.com/c/tztMiJoy

Related PRs:
* https://github.com/alphagov/fastly-configure/pull/37
* https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/159
* https://github.com/alphagov/finder-frontend/pull/299

Related Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2303129

## Motivation

There are two policy finders on GOV.UK. The [normal policies finder](https://www.gov.uk/government/policies) and the [all policy content finder](https://www.gov.uk/government/policies/all).

The all policy content finder is hidden to regular users. You have to know the URL to be able to find it. 

This A/B test will provide evidence to help determine which finder provides users with a better journey to find the policy content they are looking for.


This step was missed in PR https://github.com/alphagov/finder-frontend/pull/299