### PR TITLE
Removing unnecessary style

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -330,10 +330,5 @@
         color: $secondary-text-colour;
       }
     }
-
-    .govuk-previous-and-next-navigation {
-      margin-top: $gutter;
-    }
-
   }
 }


### PR DESCRIPTION
- was overriding next/prev component margin top, with exactly the same value
- no longer valid anyway as CSS class has been renamed following component update

Related to: https://github.com/alphagov/static/pull/1116 and https://trello.com/b/lGnCPIP7/doing-govuk-publishing-frontend
