### PR TITLE
Remove Policy finder A/B test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'shared_mustache', '~> 0.1.3'
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'chronic', '~> 0.10.2'
 gem 'govuk_navigation_helpers', '~> 2.0.0'
-gem 'govuk_ab_testing', '~> 2.4.0'
 
 group :assets do
   if ENV['FRONTEND_TOOLKIT_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
     govuk-lint (2.1.0)
       rubocop (~> 0.43.0)
       scss_lint
-    govuk_ab_testing (2.4.0)
     govuk_frontend_toolkit (7.0.1)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
@@ -309,7 +308,6 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.0.1)
   govuk-lint (~> 2.1.0)
-  govuk_ab_testing (~> 2.4.0)
   govuk_frontend_toolkit (~> 7.0)
   govuk_navigation_helpers (~> 2.0.0)
   jasmine-rails
@@ -329,4 +327,4 @@ DEPENDENCIES
   webmock (~> 1.17.1)
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,32 +16,10 @@ private
   end
 
   def finder_slug
-    set_up_policies_ab_test
-
-    return all_policies_finder_slug if policies_ab_test_group_b?
-
     params[:slug]
   end
 
   def error_not_found
     render status: :not_found, plain: "404 error not found"
-  end
-
-  def set_up_policies_ab_test
-    ab_test = GovukAbTesting::AbTest.new(
-      "PolicyFinderTest",
-      dimension: 65
-    )
-
-    @requested_variant = ab_test.requested_variant(request.headers)
-    @requested_variant.configure_response(response)
-  end
-
-  def policies_ab_test_group_b?
-    @requested_variant.variant?('B') && params[:slug] == "government/policies"
-  end
-
-  def all_policies_finder_slug
-    params[:slug] + "/all"
   end
 end

--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -1,4 +1,3 @@
-<%= @requested_variant.analytics_meta_tag.html_safe %>
 <% if finder.description %>
   <meta name="description" content="<%= finder.description %>">
 <% end %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'gds_api/test_helpers/content_store'
 include GdsApi::TestHelpers::ContentStore
 include FixturesHelper
-include GovukAbTesting::RspecHelpers
 
 describe FindersController, type: :controller do
   describe "GET show" do
@@ -89,88 +88,6 @@ describe FindersController, type: :controller do
 
         get :show, params: { slug: 'does-not-exist' }
         expect(response.status).to eq(404)
-      end
-    end
-
-    describe "viewing a policies finder with an a/b test" do
-      before do
-        content_store_has_item(
-          '/government/policies',
-            base_path: '/government/policies',
-            title: 'Policies',
-            details: {
-              facets: [],
-            },
-            links: {
-              organisations: [],
-            },
-        )
-
-        content_store_has_item(
-          '/government/policies/all',
-            base_path: '/government/policies/all',
-            title: 'All Policies',
-            details: {
-              facets: [],
-            },
-            links: {
-              organisations: [],
-            },
-        )
-
-        content_store_has_item(
-          '/government/policies/child-policy',
-            base_path: '/government/policies/child-policy',
-            title: 'Child Policy',
-            details: {
-              facets: [],
-            },
-            links: {
-              organisations: [],
-            },
-        )
-
-        rummager_response = %|{
-            "results": [],
-            "total": 0,
-            "start": 0,
-            "facets": {},
-            "suggested_queries": []
-          }|
-
-        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=1000&fields=title,link,description,public_timestamp&order=-public_timestamp&start=0").to_return(status: 200, body: rummager_response, headers: {})
-      end
-
-      it "directs users in group A to the normal policies finder" do
-        setup_ab_variant("PolicyFinderTest", "A")
-
-        get :show, params: { slug: 'government/policies' }
-        finder_slug = subject.instance_variable_get(:@results).finder.slug
-
-        expect(response.status).to eq(200)
-        expect(finder_slug).to eq("/government/policies")
-      end
-
-      it "directs users in group B to the all policies finder" do
-        setup_ab_variant("PolicyFinderTest", "B")
-
-        get :show, params: { slug: 'government/policies' }
-        finder_slug = subject.instance_variable_get(:@results).finder.slug
-
-        expect(response.status).to eq(200)
-        expect(finder_slug).to eq("/government/policies/all")
-      end
-
-      it "directs all users to a finder that is not part of the A/B test" do
-        %w(A B).each do |variant|
-          setup_ab_variant("PolicyFinderTest", variant)
-
-          get :show, params: { slug: 'government/policies/child-policy' }
-          finder_slug = subject.instance_variable_get(:@results).finder.slug
-
-          expect(response.status).to eq(200)
-          expect(finder_slug).to eq("/government/policies/child-policy")
-        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,3 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 end
-
-GovukAbTesting.configure do |config|
-  config.acceptance_test_framework = :active_support
-end


### PR DESCRIPTION
Trello card: https://trello.com/c/v88UNJRy

Related PRs:
* https://github.com/alphagov/fastly-configure/pull/39
* https://github.com/alphagov/cdn-configs/pull/1

Related Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2303129

## Motivation

The A/B test set up to compare The [normal policies finder](https://www.gov.uk/government/policies) and the [all policy content finder](https://www.gov.uk/government/policies/all) finishes on September 13th.