### PR TITLE
Pass hash to analytics_meta_tags component

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -3,7 +3,7 @@
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
   <%= render partial: 'govuk_component/analytics_meta_tags',
-      locals: { content_item: @finder.content_item } %>
+      locals: { content_item: @finder.content_item.to_h } %>
 <% end %>
 
 <% if finder.alpha? %>


### PR DESCRIPTION
This is causing errors in production since we've switched https://github.com/alphagov/finder-frontend/pull/304. I'm not sure how to test this, except for it working on integration.