### PR TITLE
Don't use `GdsApi::Helpers`

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,8 +1,6 @@
 require 'email_alert_signup_api'
-require 'gds_api/helpers'
 
 class EmailAlertSubscriptionsController < ApplicationController
-  include GdsApi::Helpers
   protect_from_forgery except: :create
 
   def new
@@ -30,11 +28,11 @@ private
   end
 
   def content
-    @content ||= content_store.content_item(request.path).to_ostruct
+    @content ||= Services.content_store.content_item(request.path).to_ostruct
   end
 
   def finder
-    FinderPresenter.new(content_store.content_item(finder_base_path).to_ostruct)
+    FinderPresenter.new(Services.content_store.content_item(finder_base_path).to_ostruct)
   end
 
   def finder_format

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,8 +1,6 @@
 require 'gds_api/helpers'
 
 class FindersController < ApplicationController
-  include GdsApi::Helpers
-
   def show
     @results = ResultSetPresenter.new(finder, filter_params, view_context)
 


### PR DESCRIPTION
`GdsApi::Helpers` makes available a `content_store` helper, with a `GdsApi::ContentStore` client. This is inconsistent with how other applications instantiate API clients. Removing it because it's likely to surprise developers updating the API client in `Services`.