### PR TITLE
Add page expiry for site-search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,7 @@ require 'gds_api/helpers'
 
 class SearchController < ApplicationController
   include GdsApi::Helpers
+  before_action :set_expiry
   before_action :remove_search_box
 
   rescue_from GdsApi::BaseError, with: :error_503
@@ -45,6 +46,12 @@ class SearchController < ApplicationController
   end
 
 protected
+
+  def set_expiry(duration = 30.minutes)
+    unless Rails.env.development?
+      expires_in(duration, public: true)
+    end
+  end
 
   def remove_search_box
     set_slimmer_headers(remove_search: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ FinderFrontend::Application.routes.draw do
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"
 
-  if ENV['GOVUK_WEBSITE_ROOT'] =~ /integration/
+  if ENV['GOVUK_WEBSITE_ROOT'] =~ /integration/ || ENV['GOVUK_WEBSITE_ROOT'] =~ /staging/
     get "/test-search/search" => "search#index"
     get "/test-search/search/opensearch" => "search#opensearch"
   end


### PR DESCRIPTION
This ensures we maintain the same caching strategy for
site-search that was previously used in frontend.

This currently differs from the remaining finders and a task
has been raised to review/investigate if that should be the
case.

https://trello.com/c/wEUx55Bv/336-make-finder-frontend-components-and-functionality-available-to-site-search