### PR TITLE
Remove assets group from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,9 @@ gem 'govuk_ab_testing', '~> 2.4.0'
 gem 'govuk_navigation_helpers', '~> 2.0.0'
 gem 'govuk_publishing_components', '~> 1.10.0', require: false
 
-group :assets do
-  gem 'govuk_frontend_toolkit', '~> 7.0'
-  gem 'sass-rails', '~> 5.0'
-  gem 'uglifier', '~> 2.7', '>= 2.7.2'
-end
+gem 'govuk_frontend_toolkit', '~> 7.0'
+gem 'sass-rails', '~> 5.0'
+gem 'uglifier', '~> 2.7', '>= 2.7.2'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,7 @@ require "sprockets/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(:default, Rails.env)
-Bundler.require(*Rails.groups(assets: %w(development test)))
+Bundler.require(*Rails.groups)
 
 if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
   require 'govuk_publishing_components'


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

Rails hasn't used an assets group in the Gemfile since rails 4 was
released (see: http://guides.rubyonrails.org/v4.0/upgrading_ruby_on_rails.html#upgrading-from-rails-3-2-to-rails-4-0-gemfile).
This is now a rails 5 app so removing this is long overdue as is tidying
up the `Bundler.require` statement in `config/application.rb`.