### PR TITLE
Add A/B test for synonyms

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,8 +5,13 @@ class SearchController < ApplicationController
   before_action :set_expiry
   before_action :remove_search_box
 
+  helper_method :search_ab_test_variant
+  after_action :set_search_ab_test_response_header
+
   rescue_from GdsApi::BaseError, with: :error_503
   layout 'search-application'
+
+  SEARCH_AB_TEST_DIMENSION = 42
 
   def index
     search_params = SearchParameters.new(params)
@@ -24,7 +29,9 @@ class SearchController < ApplicationController
     if search_params.no_search? && params[:format] != "json"
       render(action: 'no_search_term') && return
     end
-    search_response = SearchAPI.new(search_params).search
+
+    variant = search_ab_test_variant.variant_name
+    search_response = SearchAPI.new(search_params, synonyms: variant).search
 
     @search_term = search_params.search_term
 
@@ -43,6 +50,22 @@ class SearchController < ApplicationController
       format.html
       format.json { render json: @results }
     end
+  end
+
+  def search_ab_test
+    GovukAbTesting::AbTest.new(
+      "SearchSynonyms",
+      dimension: SEARCH_AB_TEST_DIMENSION
+    )
+  end
+
+  def search_ab_test_variant
+    @_search_ab_test_variant ||=
+      search_ab_test.requested_variant(request.headers)
+  end
+
+  def set_search_ab_test_response_header
+    search_ab_test_variant.configure_response(response)
   end
 
 protected

--- a/app/lib/search_api.rb
+++ b/app/lib/search_api.rb
@@ -1,8 +1,9 @@
 require 'services'
 
 class SearchAPI
-  def initialize(params)
+  def initialize(params, ab_tests = {})
     @params = params
+    @ab_tests = ab_tests.map { |name, type| "#{name}:#{type}" }.join(',')
   end
 
   def search
@@ -11,7 +12,7 @@ class SearchAPI
 
 private
 
-  attr_reader :params
+  attr_reader :params, :ab_tests
 
   def search_results
     Services.rummager.search(rummager_params).to_hash
@@ -33,7 +34,7 @@ private
   end
 
   def rummager_params
-    params.rummager_parameters
+    params.rummager_parameters.merge(ab_tests: ab_tests)
   end
 
   def scoped_manual

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,6 +4,7 @@
   <meta name="description"
       content="Search for '<%= @search_term %>' on GOV.UK." />
   <link rel="alternate" type="application/json" href="/api/search.json?q=<%= @search_term %>">
+  <%= search_ab_test_variant.analytics_meta_tag.html_safe %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+include GdsApi::TestHelpers::ContentStore
+
+describe SearchController, type: :controller do
+  include GovukAbTesting::RspecHelpers
+  render_views
+
+  before do
+    content_store_has_item(
+      '/search',
+        base_path: '/search',
+        title: 'Search'
+    )
+
+    rummager_response = %|{
+        "results": [],
+        "total": 0,
+        "start": 0,
+        "facets": {},
+        "suggested_queries": []
+      }|
+
+    stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
+  end
+
+  context "Synonym A/B test" do
+    it "should set the correct A variant tags" do
+      with_variant SearchSynonyms: "A" do
+        get :index, params: { q: "cheese" }
+      end
+    end
+
+    it "should set the correct B variant tags" do
+      with_variant SearchSynonyms: "B" do
+        get :index, params: { q: "cheese" }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 RSpec.configure do |config|
   include Slimmer::TestHelpers::GovukComponents
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
Add an A/B test that uses the new synonym approach configured behind a flag in Rummager.

https://trello.com/c/HPbcP15S/467-configure-synonyms-a-b-test-in-finder-frontend