### PR TITLE
Fix dep warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem 'rails', '~> 5.0.1'
 gem 'slimmer', '~> 11.1.0'
-gem 'gds-api-adapters', '~> 34.1.0'
+gem 'gds-api-adapters', '~> 50.0'
 gem 'shared_mustache', '~> 0.1.3'
 gem 'govuk_app_config', '~> 1.0.0'
 gem 'chronic', '~> 0.10.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,4 +370,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     execjs (2.7.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (34.1.0)
+    gds-api-adapters (50.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -344,7 +344,7 @@ DEPENDENCIES
   binding_of_caller
   chronic (~> 0.10.2)
   cucumber-rails (~> 1.4.0)
-  gds-api-adapters (~> 34.1.0)
+  gds-api-adapters (~> 50.0)
   govuk-content-schema-test-helpers (~> 1.5)
   govuk-lint (~> 3.3.1)
   govuk_ab_testing (~> 2.4.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ private
       GovukError.notify(exception)
     end
 
-    render status: status_code, text: "#{status_code} error"
+    render status: status_code, plain: "#{status_code} error"
   end
 
   def finder_base_path

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -38,20 +38,20 @@ private
   end
 
   def finder_format
-    finder.filter.document_type
+    finder.filter['document_type']
   end
 
   def available_choices
-    content.details.email_signup_choice
+    content['details']['email_signup_choice']
   end
 
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       email_alert_api: email_alert_api,
       attributes: email_signup_attributes,
-      subscription_list_title_prefix: content.details.subscription_list_title_prefix,
+      subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
       available_choices: available_choices,
-      filter_key: content.details.email_filter_by,
+      filter_key: content['details']['email_filter_by'],
     )
   end
 

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -30,11 +30,11 @@ private
   end
 
   def content
-    @content ||= content_store.content_item!(request.path)
+    @content ||= content_store.content_item(request.path)
   end
 
   def finder
-    FinderPresenter.new(content_store.content_item!(finder_base_path))
+    FinderPresenter.new(content_store.content_item(finder_base_path))
   end
 
   def finder_format

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
 
   def arr_to_links(arr)
     arr.map { |link|
-      link_to(link.title, link.web_url)
+      link_to(link['title'], link['web_url'])
     }
   end
 end

--- a/app/lib/facet_query_builder.rb
+++ b/app/lib/facet_query_builder.rb
@@ -17,7 +17,7 @@ class FacetQueryBuilder
       # "1000,order:value.title" is specifying that we want 1000 results back
       # which are ordered by the title attribute of each value (option)
       # that is returned
-      query.merge(facet.key => "1000,order:value.title")
+      query.merge(facet['key'] => "1000,order:value.title")
     }
   end
 
@@ -26,14 +26,14 @@ private
   attr_reader :facets
 
   def dynamic_facets
-    text_facets.select { |f| f.allowed_values.blank? }
+    text_facets.select { |f| f['allowed_values'].blank? }
   end
 
   def text_facets
-    filterable_facets.select { |f| f.type == "text" }
+    filterable_facets.select { |f| f['type'] == "text" }
   end
 
   def filterable_facets
-    facets.select(&:filterable)
+    facets.select { |f| f['filterable'] }
   end
 end

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -17,7 +17,7 @@ private
   attr_reader :facets, :user_params
 
   def filters
-    @filters ||= facets.select(&:filterable).map { |f| build_filter(f) }
+    @filters ||= facets.select { |f| f['filterable'] }.map { |f| build_filter(f) }
   end
 
   def build_filter(facet)
@@ -25,9 +25,9 @@ private
       'date' => DateFilter,
       'text' => TextFilter,
       'topical' => TopicalFilter,
-    }.fetch(facet.type)
+    }.fetch(facet['type'])
 
-    params = user_params.fetch(facet.key, nil)
+    params = user_params.fetch(facet['key'], nil)
 
     filter_class.new(facet, params)
   end
@@ -39,7 +39,7 @@ private
     end
 
     def key
-      facet.key
+      facet['key']
     end
 
     def active?
@@ -99,8 +99,8 @@ private
     def value
       return nil if params.blank?
 
-      user_has_selected_open = params.include?(facet.open_value.value)
-      user_has_selected_closed = params.include?(facet.closed_value.value)
+      user_has_selected_open = params.include?(facet['open_value']['value'])
+      user_has_selected_closed = params.include?(facet['closed_value']['value'])
 
       # with both or neither selected, the filter is not used
       if user_has_selected_open && !user_has_selected_closed

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -55,19 +55,19 @@ private
     values = facet_details.fetch("options", {}).map { |f| f.fetch("value", {}) }
 
     values.map { |value|
-      OpenStruct.new(
-        label: value.fetch("title", ""),
-        value: value.fetch("slug", ""),
-      )
+      {
+        'label' => value.fetch("title", ""),
+        'value' => value.fetch("slug", ""),
+      }
     }
   end
 
   def build_pagination(documents_per_page, start_offset, total_results)
     if documents_per_page
-      OpenStruct.new(
-        current_page: (start_offset / documents_per_page) + 1,
-        total_pages: (total_results / documents_per_page.to_f).ceil,
-      )
+      {
+        'current_page' => (start_offset / documents_per_page) + 1,
+        'total_pages' => (total_results / documents_per_page.to_f).ceil,
+      }
     end
   end
 end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -34,18 +34,18 @@ private
   end
 
   def augment_content_item_with_results(content_item, search_response)
-    content_item.details.results = search_response.fetch("results")
-    content_item.details.total_result_count = search_response.fetch("total")
+    content_item['details']['results'] = search_response.fetch("results")
+    content_item['details']['total_result_count'] = search_response.fetch("total")
 
-    content_item.details.pagination = build_pagination(
-      content_item.details.default_documents_per_page,
+    content_item['details']['pagination'] = build_pagination(
+      content_item['details']['default_documents_per_page'],
       search_response.fetch('start'),
       search_response.fetch('total')
     )
 
     search_response.fetch("facets", {}).each do |facet_key, facet_details|
-      facet = content_item.details.facets.find { |f| f.key == facet_key }
-      facet.allowed_values = allowed_values_for_facet_details(facet_details) if facet
+      facet = content_item['details']['facets'].find { |f| f['key'] == facet_key }
+      facet['allowed_values'] = allowed_values_for_facet_details(facet_details) if facet
     end
 
     content_item

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -21,7 +21,7 @@ private
   attr_reader :base_path, :filter_params
 
   def fetch_content_item
-    Services.content_store.content_item!(base_path)
+    Services.content_store.content_item(base_path)
   end
 
   def fetch_search_response(content_item)

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -38,7 +38,7 @@ private
   end
 
   def documents_per_page
-    finder_content_item.details.default_documents_per_page || 1000
+    finder_content_item['details']['default_documents_per_page'] || 1000
   end
 
   def return_fields_query
@@ -61,7 +61,7 @@ private
   end
 
   def metadata_fields
-    finder_content_item.details.facets.map(&:key)
+    finder_content_item['details']['facets'].map { |f| f['key'] }
   end
 
   def order_query
@@ -85,7 +85,7 @@ private
   end
 
   def default_order
-    finder_content_item.details.default_order || "-public_timestamp"
+    finder_content_item['details']['default_order'] || "-public_timestamp"
   end
 
   def filter_query
@@ -104,17 +104,17 @@ private
 
   def filter_params
     @filter_params ||= FilterQueryBuilder.new(
-      facets: finder_content_item.details.facets,
+      facets: finder_content_item['details']['facets'],
       user_params: params,
     ).call
   end
 
   def base_filter
-    finder_content_item.details.filter.to_h
+    finder_content_item['details']['filter'].to_h
   end
 
   def base_reject
-    finder_content_item.details.reject.to_h
+    finder_content_item['details']['reject'].to_h
   end
 
   def facet_query
@@ -125,7 +125,7 @@ private
 
   def facet_params
     @facet_params ||= FacetQueryBuilder.new(
-      facets: finder_content_item.details.facets,
+      facets: finder_content_item['details']['facets'],
     ).call
   end
 end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -2,21 +2,21 @@ class DateFacet < FilterableFacet
   def sentence_fragment
     return nil unless present_values.any?
 
-    OpenStruct.new(
-      type: "date",
-      preposition: [preposition, additional_preposition].compact.join(' '),
-      values: value_fragments,
-    )
+    {
+      'type' => "date",
+      'preposition' => [preposition, additional_preposition].compact.join(' '),
+      'values' => value_fragments,
+    }
   end
 
 private
 
   def value_fragments
     present_values.map { |_, date|
-      OpenStruct.new(
-        label: date.date.strftime("%e %B %Y"),
-        parameter_key: key,
-      )
+      {
+        'label' => date.date.strftime("%e %B %Y"),
+        'parameter_key' => key,
+      }
     }
   end
 

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -1,16 +1,30 @@
 class Facet
-  delegate :key, :name, :type, :short_name, to: :facet
-
   def initialize(facet)
     @facet = facet
   end
 
+  def key
+    facet['key']
+  end
+
+  def name
+    facet['name']
+  end
+
+  def type
+    facet['type']
+  end
+
+  def short_name
+    facet['short_name']
+  end
+
   def filterable?
-    facet.filterable
+    facet['filterable']
   end
 
   def metadata?
-    facet.display_as_result_metadata
+    facet['display_as_result_metadata']
   end
 
 private

--- a/app/models/filterable_facet.rb
+++ b/app/models/filterable_facet.rb
@@ -1,7 +1,9 @@
 class FilterableFacet < Facet
   attr_writer :value
 
-  delegate :preposition, to: :facet
+  def preposition
+    facet['preposition']
+  end
 
   def to_partial_path
     self.class.name.underscore

--- a/app/models/filterable_facet.rb
+++ b/app/models/filterable_facet.rb
@@ -1,5 +1,5 @@
 class FilterableFacet < Facet
-  attr_writer :value
+  attr_accessor :value
 
   def preposition
     facet['preposition']

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -9,7 +9,20 @@ class SearchParameters
   ALLOWED_FACET_FIELDS = %w{organisations manual}.freeze
 
   def initialize(params)
-    @params = enforce_bounds(params)
+    @params = enforce_bounds(search_params(params))
+  end
+
+  def search_params(params)
+    params.
+      permit(:q, :show_organisations_filter, :start, :count,
+             :debug_score, :debug, :format,
+             # allow facets as array values like:
+             #     filter_foo[]=bar&filter_foo[]=baz
+             Hash[ALLOWED_FACET_FIELDS.map { |facet| [:"filter_#{facet}", []] }],
+             # and allow facets as single string values like
+             #     filter_foo=bar
+             *ALLOWED_FACET_FIELDS.map { |facet| :"filter_#{facet}" }).
+      to_h
   end
 
   def search_term

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -4,6 +4,9 @@ class SelectFacet < FilterableFacet
   end
 
   def options
+    # NOTE: We use a symbol-based hash here unlike all our other hash
+    # data-structures because we pass this to a govuk_component partial
+    # that expects symbol keys, not strings
     allowed_values.map do |allowed_value|
       {
         value: allowed_value['value'],

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -21,21 +21,21 @@ class SelectFacet < FilterableFacet
   def sentence_fragment
     return nil unless selected_values.any?
 
-    OpenStruct.new(
-      type: "text",
-      preposition: preposition,
-      values: value_fragments,
-    )
+    {
+      'type' => "text",
+      'preposition' => preposition,
+      'values' => value_fragments,
+    }
   end
 
 private
 
   def value_fragments
     selected_values.map { |v|
-      OpenStruct.new(
-        label: v['label'],
-        parameter_key: key,
-      )
+      {
+        'label' => v['label'],
+        'parameter_key' => key,
+      }
     }
   end
 

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -1,12 +1,14 @@
 class SelectFacet < FilterableFacet
-  delegate :allowed_values, to: :facet
+  def allowed_values
+    facet['allowed_values']
+  end
 
   def options
     allowed_values.map do |allowed_value|
       {
-        value: allowed_value.value,
-        label: allowed_value.label,
-        id: allowed_value.value,
+        value: allowed_value['value'],
+        label: allowed_value['label'],
+        id: allowed_value['value'],
         checked: selected_values.include?(allowed_value),
       }
     end
@@ -31,7 +33,7 @@ private
   def value_fragments
     selected_values.map { |v|
       OpenStruct.new(
-        label: v.label,
+        label: v['label'],
         parameter_key: key,
       )
     }
@@ -40,7 +42,7 @@ private
   def selected_values
     return [] if @value.nil?
     allowed_values.select { |option|
-      @value.include?(option.value)
+      @value.include?(option['value'])
     }
   end
 end

--- a/app/models/topical_facet.rb
+++ b/app/models/topical_facet.rb
@@ -1,6 +1,6 @@
 class TopicalFacet < SelectFacet
   def allowed_values
-    [facet.open_value, facet.closed_value]
+    [facet['open_value'], facet['closed_value']]
   end
 
   def to_partial_path

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -1,7 +1,7 @@
 module FacetParser
   def self.parse(facet)
-    if facet.filterable
-      case facet.type
+    if facet['filterable']
+      case facet['type']
       when 'text'
         SelectFacet.new(facet)
       when 'topical'

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -3,51 +3,76 @@ class FinderPresenter
 
   attr_reader :name, :slug, :organisations, :keywords, :values, :content_item
 
-  delegate :alpha_message,
-           :beta_message,
-           :default_order,
-           :document_noun,
-           :human_readable_finder_format,
-           :filter,
-           :logo_path,
-           :summary,
-           :pagination,
-           to: :"content_item.details"
-
   def initialize(content_item, values = {})
     @content_item = content_item
-    @name = content_item.title
-    @slug = content_item.base_path
-    @organisations = content_item.links.organisations
+    @name = content_item['title']
+    @slug = content_item['base_path']
+    @organisations = content_item['links'].fetch(:organisations, [])
     @values = values
     facets.values = values
     @keywords = values["keywords"].presence
   end
 
+  def alpha_message
+    content_item['details']['alpha_message']
+  end
+
+  def beta_message
+    content_item['details']['beta_message']
+  end
+
+  def default_order
+    content_item['details']['default_order']
+  end
+
+  def document_noun
+    content_item['details']['document_noun']
+  end
+
+  def human_readable_finder_format
+    content_item['details']['human_readable_finder_format']
+  end
+
+  def filter
+    content_item['details']['filter']
+  end
+
+  def logo_path
+    content_item['details']['logo_path']
+  end
+
+  def summary
+    content_item['details']['summary']
+  end
+
+  def pagination
+    content_item['details']['pagination']
+  end
+
   def alpha?
-    content_item.phase == 'alpha'
+    content_item['phase'] == 'alpha'
   end
 
   def beta?
-    content_item.phase == 'beta'
+    content_item['phase'] == 'beta'
   end
 
   def email_alert_signup
-    if content_item.links.email_alert_signup
-      content_item.links.email_alert_signup.first
+    if content_item['links']['email_alert_signup']
+      content_item['links']['email_alert_signup'].first
     end
   end
 
   def email_alert_signup_url
-    signup_link = content_item.details.signup_link
+    signup_link = content_item['details']['signup_link']
     return signup_link if signup_link.present?
 
-    email_alert_signup.web_url if email_alert_signup
+    email_alert_signup['web_url'] if email_alert_signup
   end
 
   def facets
     @facets ||= FacetCollection.new(
-      content_item.details.facets.map { |facet|
+      content_item['details']['facets'].map { |facet|
         FacetParser.parse(facet)
       }
     )
@@ -82,7 +107,7 @@ class FinderPresenter
   end
 
   def show_summaries?
-    content_item.details.show_summaries
+    content_item['details']['show_summaries']
   end
 
   def page_metadata
@@ -96,14 +121,14 @@ class FinderPresenter
   end
 
   def related
-    related = content_item.links.related || []
-    related.sort_by(&:title)
+    related = content_item['links']['related'] || []
+    related.sort_by { |link| link['title'] }
   end
 
   def results
     @results ||= ResultSetParser.parse(
-      content_item.details.results,
-      content_item.details.total_result_count,
+      content_item['details']['results'],
+      content_item['details']['total_result_count'],
       self,
     )
   end
@@ -132,25 +157,25 @@ class FinderPresenter
   end
 
   def description
-    content_item.description
+    content_item['description']
   end
 
 private
 
   def part_of
-    content_item.links.part_of || []
+    content_item['links']['part_of'] || []
   end
 
   def organisations
-    content_item.links.organisations || []
+    content_item['links']['organisations'] || []
   end
 
   def people
-    content_item.links.people || []
+    content_item['links']['people'] || []
   end
 
   def working_groups
-    content_item.links.working_groups || []
+    content_item['links']['working_groups'] || []
   end
 
   def from
@@ -164,11 +189,11 @@ private
   end
 
   def applicable_nations_html_fragment
-    nation_applicability = content_item.details.nation_applicability
+    nation_applicability = content_item['details']['nation_applicability']
     if nation_applicability
-      applies_to = nation_applicability.applies_to.map(&:titlecase)
-      alternative_policies = nation_applicability.alternative_policies.map do |alternative|
-        link_to(alternative.nation.titlecase, alternative.alt_policy_url, ({ rel: 'external' } if is_external?(alternative.alt_policy_url)))
+      applies_to = nation_applicability['applies_to'].map(&:titlecase)
+      alternative_policies = nation_applicability['alternative_policies'].map do |alternative|
+        link_to(alternative['nation'].titlecase, alternative['alt_policy_url'], ({ rel: 'external' } if is_external?(alternative['alt_policy_url'])))
       end
       if alternative_policies.any?
         "#{applies_to.to_sentence} (see policy for #{alternative_policies.to_sentence})".html_safe

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -99,9 +99,9 @@ private
   def next_and_prev_links
     return unless finder.pagination
 
-    current_page = finder.pagination.current_page
+    current_page = finder.pagination['current_page']
     previous_page = current_page - 1 if current_page > 1
-    next_page = current_page + 1 if current_page < finder.pagination.total_pages
+    next_page = current_page + 1 if current_page < finder.pagination['total_pages']
     pages = {}
 
     pages[:previous_page] = build_page_link("Previous page", previous_page) if previous_page
@@ -114,7 +114,7 @@ private
     {
       url: [finder.slug, finder.values.merge(page: page).to_query].reject(&:blank?).join("?"),
       title: page_label,
-      label: "#{page} of #{finder.pagination.total_pages}",
+      label: "#{page} of #{finder.pagination['total_pages']}",
     }
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -58,19 +58,19 @@ class ResultSetPresenter
 
   def fragment_description(fragment)
     [
-      fragment.preposition,
+      fragment['preposition'],
       fragment_to_s(fragment),
     ]
   end
 
   def fragment_to_s(fragment)
-    values = fragment.values.map { |value|
-      "<strong>#{html_escape(value.label)}</strong>"
+    values = fragment['values'].map { |value|
+      "<strong>#{html_escape(value['label'])}</strong>"
     }
 
-    if fragment.type == "text"
+    if fragment['type'] == "text"
       values.to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
-    elsif fragment.type == "date"
+    elsif fragment['type'] == "date"
       values.to_sentence(two_words_connector: ' and ')
     end
   end

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -10,15 +10,15 @@ class SignupPresenter
   end
 
   def name
-    content_item.title
+    content_item['title']
   end
 
   def body
-    content_item.description
+    content_item['description']
   end
 
   def beta?
-    content_item.details.beta
+    content_item['details']['beta']
   end
 
   def choices?
@@ -44,6 +44,6 @@ class SignupPresenter
 private
 
   def choice_data
-    content_item.details["email_signup_choice"]
+    content_item['details']["email_signup_choice"]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module FinderFrontend
 
     # Path within public/ where assets are compiled to
     config.assets.prefix = '/finder-frontend'
+
+    config.action_controller.raise_on_unfiltered_parameters = true
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -39,11 +39,11 @@ private
   end
 
   def topic_names
-    attributes.fetch("filter").collect { |x| choice_hash_by_key(x).topic_name }
+    attributes.fetch("filter").collect { |x| choice_hash_by_key(x)['topic_name'] }
   end
 
   def choice_hash_by_key(key)
-    available_choices.select { |x| x.key == key }[0]
+    available_choices.select { |x| x['key'] == key }[0]
   end
 
   def massaged_attributes

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -11,18 +11,18 @@ describe EmailAlertSignupAPI do
   }
   let(:available_choices) {
     [
-      OpenStruct.new(
+      {
         "key" => "first",
         "radio_button_name" => "First thing",
         "topic_name" => "first thing",
         "prechecked" => false,
-      ),
-      OpenStruct.new(
+      },
+      {
         "key" => "second",
         "radio_button_name" => "Second thing",
         "topic_name" => "second thing",
         "prechecked" => false,
-      ),
+      },
     ]
   }
   let(:subscription_list_title_prefix) {

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -10,15 +10,15 @@ describe SearchQueryBuilder do
   }
 
   let(:finder_content_item) {
-    double(
-      details: double(
-        facets: facets,
-        filter: double(to_h: filter),
-        reject: double(to_h: reject),
-        default_order: default_order,
-        default_documents_per_page: nil,
-      ),
-    )
+    {
+      'details' => {
+        'facets' => facets,
+        'filter' => filter,
+        'reject' => reject,
+        'default_order' => default_order,
+        'default_documents_per_page' => nil,
+      }
+    }
   }
 
   let(:facets) { [] }
@@ -34,15 +34,15 @@ describe SearchQueryBuilder do
 
   context "with pagination" do
     let(:finder_content_item) {
-      double(
-        details: double(
-          facets: facets,
-          filter: double(to_h: filter),
-          reject: double(to_h: reject),
-          default_order: default_order,
-          default_documents_per_page: 10
-        ),
-      )
+      {
+        'details' => {
+          'facets' => facets,
+          'filter' => filter,
+          'reject' => reject,
+          'default_order' => default_order,
+          'default_documents_per_page' => 10
+        }
+      }
     }
 
     it "should use documents_per_page from content item" do
@@ -64,14 +64,14 @@ describe SearchQueryBuilder do
   context "with facets" do
     let(:facets) {
       [
-        double(
-          key: "alpha",
-          filterable: false,
-        ),
-        double(
-          key: "beta",
-          filterable: false,
-        ),
+        {
+          'key' => "alpha",
+          'filterable' => false,
+        },
+        {
+          'key' => "beta",
+          'filterable' => false,
+        },
       ]
     }
 

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -22,18 +22,18 @@ describe DateFacet do
     context "single date value" do
       let(:value) { { from: "22/09/1988" } }
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("occurred after")
-        expect(subject.sentence_fragment.values.first.label).to eql("22 September 1988")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment['preposition']).to eql("occurred after")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 1988")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("date_of_occurrence")
       }
     end
 
     context "6 digit date value" do
       let(:value) { { to: "22/09/14" } }
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("occurred before")
-        expect(subject.sentence_fragment.values.first.label).to eql("22 September 2014")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment['preposition']).to eql("occurred before")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 2014")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("date_of_occurrence")
       }
     end
 
@@ -45,13 +45,13 @@ describe DateFacet do
         }
       }
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("occurred between")
+        expect(subject.sentence_fragment['preposition']).to eql("occurred between")
 
-        expect(subject.sentence_fragment.values.first.label).to eql("22 September 1988")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 1988")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("date_of_occurrence")
 
-        expect(subject.sentence_fragment.values.last.label).to eql("22 September 2014")
-        expect(subject.sentence_fragment.values.last.parameter_key).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment['values'].last['label']).to eql("22 September 2014")
+        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("date_of_occurrence")
       }
     end
   end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -1,16 +1,16 @@
 require "spec_helper"
 
 describe DateFacet do
-  let(:facet_struct) {
-    OpenStruct.new(
-      type: "date",
-      name: "Occurred",
-      key: "date_of_occurrence",
-      preposition: "occurred",
-    )
+  let(:facet_data) {
+    {
+      'type' => "date",
+      'name' => "Occurred",
+      'key' => "date_of_occurrence",
+      'preposition' => "occurred",
+    }
   }
 
-  subject { DateFacet.new(facet_struct) }
+  subject { DateFacet.new(facet_data) }
 
   before do
     subject.value = value

--- a/spec/models/facet_collection_spec.rb
+++ b/spec/models/facet_collection_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'ostruct'
 
 describe FacetCollection do
   let(:facets) { [] }
@@ -28,11 +27,11 @@ describe FacetCollection do
       }
 
       let(:case_type_facet) {
-        OpenStruct.new(key: "case_type", value: nil)
+        FilterableFacet.new('key' => "case_type")
       }
 
       let(:decision_type_facet) {
-        OpenStruct.new(key: "decision_type", value: nil)
+        FilterableFacet.new('key' => "decision_type")
       }
 
       it "should accept a hash of key/value pairs, and set the facet values for each" do

--- a/spec/models/filterable_facet_spec.rb
+++ b/spec/models/filterable_facet_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe FilterableFacet do
-  let(:facet_struct) {
-    OpenStruct.new(
-      key: "test_facet",
-      name: "Test facet",
-      preposition: "of value"
-    )
+  let(:facet_data) {
+    {
+      'key' => "test_facet",
+      'name' => "Test facet",
+      'preposition' => "of value"
+    }
   }
 
   let(:facet_class) { FilterableFacet }
-  subject { facet_class.new(facet_struct) }
+  subject { facet_class.new(facet_data) }
 
   describe "#to_partial_path" do
     context "with a Facet" do

--- a/spec/models/search_parameters_spec.rb
+++ b/spec/models/search_parameters_spec.rb
@@ -1,21 +1,25 @@
 require "spec_helper"
 
 RSpec.describe SearchParameters do
+  def search_params(params = {})
+    described_class.new(ActionController::Parameters.new(params))
+  end
+
   context '#count' do
     it 'default to default page size' do
-      params = described_class.new({})
+      params = search_params
 
       expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
     end
 
     it 'default to default page size when count < 1' do
-      params = described_class.new(count: -50)
+      params = search_params(count: -50)
 
       expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
     end
 
     it 'allow at most a hundred results' do
-      params = described_class.new(count: 10_000)
+      params = search_params(count: 10_000)
 
       expect(params.count).to eq(100)
     end
@@ -23,7 +27,7 @@ RSpec.describe SearchParameters do
 
   context '#suggest' do
     it "requests the spelling suggester by default" do
-      params = described_class.new({})
+      params = search_params
 
       expect(params.rummager_parameters[:suggest]).to eq("spelling")
     end
@@ -31,7 +35,7 @@ RSpec.describe SearchParameters do
 
   context '#start' do
     it 'start at 0 if start < 1' do
-      params = described_class.new(start: -1)
+      params = search_params(start: -1)
 
       expect(params.start).to eq(0)
     end
@@ -39,13 +43,13 @@ RSpec.describe SearchParameters do
 
   context "#filter_organisations" do
     it "pass on filter_organisations" do
-      params = described_class.new("filter_organisations" => ['ministry-of-silly-walks'])
+      params = search_params("filter_organisations" => ['ministry-of-silly-walks'])
 
       expect(params.rummager_parameters[:filter_organisations]).to eq(['ministry-of-silly-walks'])
     end
 
     it "pass on filter_organisations as an array if provided as single value" do
-      params = described_class.new("filter_organisations" => 'ministry-of-silly-walks')
+      params = search_params("filter_organisations" => 'ministry-of-silly-walks')
 
       expect(params.rummager_parameters[:filter_organisations]).to eq(['ministry-of-silly-walks'])
     end

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -39,9 +39,9 @@ describe SelectFacet do
       let(:value) { ["allowed-value-1"] }
 
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("of value")
-        expect(subject.sentence_fragment.values.first.label).to eql("Allowed value 1")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("test_values")
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_values")
       }
     end
 
@@ -49,12 +49,12 @@ describe SelectFacet do
       let(:value) { ["allowed-value-1", "allowed-value-2"] }
 
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("of value")
-        expect(subject.sentence_fragment.values.first.label).to eql("Allowed value 1")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("test_values")
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_values")
 
-        expect(subject.sentence_fragment.values.last.label).to eql("Allowed value 2")
-        expect(subject.sentence_fragment.values.last.parameter_key).to eql("test_values")
+        expect(subject.sentence_fragment['values'].last['label']).to eql("Allowed value 2")
+        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("test_values")
       }
     end
 

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -3,32 +3,32 @@ require "spec_helper"
 describe SelectFacet do
   let(:allowed_values) {
     [
-      OpenStruct.new(
-        label: "Allowed value 1",
-        value: "allowed-value-1"
-      ),
-      OpenStruct.new(
-        label: "Allowed value 2",
-        value: "allowed-value-2"
-      ),
-      OpenStruct.new(
-        label: "Remittals",
-        value: "remittals"
-      )
+      {
+        'label' => "Allowed value 1",
+        'value' => "allowed-value-1"
+      },
+      {
+        'label' => "Allowed value 2",
+        'value' => "allowed-value-2"
+      },
+      {
+        'label' => "Remittals",
+        'value' => "remittals"
+      }
     ]
   }
 
-  let(:facet_struct) {
-    OpenStruct.new(
-      type: "multi-select",
-      name: "Test values",
-      key: "test_values",
-      preposition: "of value",
-      allowed_values: allowed_values,
-    )
+  let(:facet_data) {
+    {
+      'type' => "multi-select",
+      'name' => "Test values",
+      'key' => "test_values",
+      'preposition' => "of value",
+      'allowed_values' => allowed_values,
+    }
   }
 
-  subject { SelectFacet.new(facet_struct) }
+  subject { SelectFacet.new(facet_data) }
 
   before do
     subject.value = value

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -1,28 +1,24 @@
 require "spec_helper"
 
 describe TopicalFacet do
-  let(:facet_struct) {
-    open = OpenStruct.new(
-      label: "Open",
-      value: "open"
-    )
-
-    closed = OpenStruct.new(
-      label: "Closed",
-      value: "closed"
-    )
-
-    OpenStruct.new(
-      type: "topical",
-      name: "State",
-      key: "end_date",
-      preposition: "of value",
-      open_value: open,
-      closed_value: closed
-    )
+  let(:facet_data) {
+    {
+      'type' => "topical",
+      'name' => "State",
+      'key' => "end_date",
+      'preposition' => "of value",
+      'open_value' => {
+        'label' => "Open",
+        'value' => "open"
+      },
+      'closed_value' => {
+        'label' => "Closed",
+        'value' => "closed"
+      }
+    }
   }
 
-  subject { TopicalFacet.new(facet_struct) }
+  subject { TopicalFacet.new(facet_data) }
 
   before do
     subject.value = value

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -29,9 +29,9 @@ describe TopicalFacet do
       let(:value) { %w(open) }
 
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("of value")
-        expect(subject.sentence_fragment.values.first.label).to eql("Open")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("end_date")
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Open")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("end_date")
       }
     end
 
@@ -39,12 +39,12 @@ describe TopicalFacet do
       let(:value) { %w(open closed) }
 
       specify {
-        expect(subject.sentence_fragment.preposition).to eql("of value")
-        expect(subject.sentence_fragment.values.first.label).to eql("Open")
-        expect(subject.sentence_fragment.values.first.parameter_key).to eql("end_date")
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Open")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("end_date")
 
-        expect(subject.sentence_fragment.values.last.label).to eql("Closed")
-        expect(subject.sentence_fragment.values.last.parameter_key).to eql("end_date")
+        expect(subject.sentence_fragment['values'].last['label']).to eql("Closed")
+        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("end_date")
       }
     end
 

--- a/spec/parsers/facet_parser_spec.rb
+++ b/spec/parsers/facet_parser_spec.rb
@@ -34,10 +34,10 @@ describe FacetParser do
     specify { expect(subject.preposition).to eql("of type") }
 
     it "should build a list of allowed values" do
-      expect(subject.allowed_values[0].label).to eql("Airport price control reviews")
-      expect(subject.allowed_values[0].value).to eql("airport-price-control-reviews")
-      expect(subject.allowed_values[2].label).to eql("Remittals")
-      expect(subject.allowed_values[2].value).to eql("remittals")
+      expect(subject.allowed_values[0]['label']).to eql("Airport price control reviews")
+      expect(subject.allowed_values[0]['value']).to eql("airport-price-control-reviews")
+      expect(subject.allowed_values[2]['label']).to eql("Remittals")
+      expect(subject.allowed_values[2]['value']).to eql("remittals")
     end
   end
 end

--- a/spec/parsers/facet_parser_spec.rb
+++ b/spec/parsers/facet_parser_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
 describe FacetParser do
-  context "with a select facet OpenStruct" do
-    let(:facet) {
-      OpenStruct.new(
-        type: "text",
-        filterable: true,
-        display_as_result_metadata: true,
-        name: "Case type",
-        key: "case_type",
-        preposition: "of type",
-        allowed_values: [
-          OpenStruct.new(
-            label: "Airport price control reviews",
-            value: "airport-price-control-reviews"
-          ),
-          OpenStruct.new(
-            label: "Market investigations",
-            value: "market-investigations"
-          ),
-          OpenStruct.new(
-            label: "Remittals",
-            value: "remittals"
-          )
+  context "with a select facet definition" do
+    let(:facet_definition) {
+      {
+        'type' => "text",
+        'filterable' => true,
+        'display_as_result_metadata' => true,
+        'name' => "Case type",
+        'key' => "case_type",
+        'preposition' => "of type",
+        'allowed_values' => [
+          {
+            'label' => "Airport price control reviews",
+            'value' => "airport-price-control-reviews"
+          },
+          {
+            'label' => "Market investigations",
+            'value' => "market-investigations"
+          },
+          {
+            'label' => "Remittals",
+            'value' => "remittals"
+          }
         ],
-      )
+      }
     }
-    subject { FacetParser.parse(facet) }
+    subject { FacetParser.parse(facet_definition) }
 
     specify { expect(subject).to be_a SelectFacet }
     specify { expect(subject.name).to eql("Case type") }

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('finder').to_json,
         headers: {}
     )
-    GdsApi::Response.new(dummy_http_response).to_ostruct
+    GdsApi::Response.new(dummy_http_response).to_hash
   }
 
   let(:values) { {} }
@@ -34,7 +34,7 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('policy_programme', 'policy').to_json,
         headers: {}
     )
-    GdsApi::Response.new(dummy_http_response).to_ostruct
+    GdsApi::Response.new(dummy_http_response).to_hash
   }
 
   let(:minimal_policy_content_item) {
@@ -44,7 +44,7 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('minimal_policy_area', 'policy').to_json,
         headers: {}
     )
-    GdsApi::Response.new(dummy_http_response).to_ostruct
+    GdsApi::Response.new(dummy_http_response).to_hash
   }
 
   let(:national_applicability_content_item) {
@@ -54,7 +54,7 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('policy_with_inapplicable_nations', 'policy').to_json,
         headers: {}
     )
-    GdsApi::Response.new(dummy_http_response).to_ostruct
+    GdsApi::Response.new(dummy_http_response).to_hash
   }
 
   let(:policies_finder_content_item) {
@@ -64,27 +64,27 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('policies_finder', 'finder').to_json,
         headers: {}
     )
-    GdsApi::Response.new(dummy_http_response).to_ostruct
+    GdsApi::Response.new(dummy_http_response).to_hash
   }
 
   let(:internal_policies) {
     {
-      details: OpenStruct.new(
-        facets: [],
-        nation_applicability: OpenStruct.new(
-          applies_to: %w(england northern_ireland),
-          alternative_policies: [
-            OpenStruct.new(
-              nation: "scotland",
-              alt_policy_url: "http://www.gov.uk/scottish-policy-url"
-            ),
-            OpenStruct.new(
-              nation: "wales",
-              alt_policy_url: "http://www.gov.uk/welsh-policy-url"
-            )
+      'details' => {
+        'facets' => [],
+        'nation_applicability' => {
+          'applies_to' => %w(england northern_ireland),
+          'alternative_policies' => [
+            {
+              'nation' => "scotland",
+              'alt_policy_url' => "http://www.gov.uk/scottish-policy-url"
+            },
+            {
+              'nation' => "wales",
+              'alt_policy_url' => "http://www.gov.uk/welsh-policy-url"
+            }
           ]
-        )
-      )
+        }
+      }
     }
   }
 
@@ -95,10 +95,7 @@ RSpec.describe FinderPresenter do
         body: govuk_content_schema_example('policy_with_inapplicable_nations', 'policy').to_json,
         headers: {}
     )
-    ostruct_hash = GdsApi::Response.new(dummy_http_response).to_ostruct.marshal_dump
-    OpenStruct.new(
-      ostruct_hash.merge(internal_policies)
-    )
+    GdsApi::Response.new(dummy_http_response).to_hash.merge(internal_policies)
   }
 
   describe "facets" do
@@ -170,7 +167,7 @@ RSpec.describe FinderPresenter do
     end
 
     it "has people, organisations, and working groups in the from metadata" do
-      from = government_presenter.page_metadata[:from].map(&:title)
+      from = government_presenter.page_metadata[:from].map { |p| p['title'] }
       expect(from).to include("George Dough", "Department for Work and Pensions", "Medical Advisory Group")
     end
   end

--- a/spec/presenters/government_result_spec.rb
+++ b/spec/presenters/government_result_spec.rb
@@ -2,37 +2,39 @@
 require "spec_helper"
 
 RSpec.describe GovernmentResult do
+  let(:search_params) { SearchParameters.new(ActionController::Parameters.new({})) }
+
   it "report a lack of location field as no locations" do
-    result = GovernmentResult.new(SearchParameters.new({}), {})
+    result = GovernmentResult.new(search_params, {})
     expect(result.metadata).to be_empty
   end
 
   it "report an empty list of locations as no locations" do
-    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [])
+    result = GovernmentResult.new(search_params, "world_locations" => [])
     expect(result.metadata).to be_empty
   end
 
   it "display a single world location" do
     france = { "title" => "France", "slug" => "france" }
-    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [france])
+    result = GovernmentResult.new(search_params, "world_locations" => [france])
     expect(result.metadata[0]).to eq("France")
   end
 
   it "not display individual locations when there are several" do
     france = { "title" => "France", "slug" => "france" }
     spain = { "title" => "Spain", "slug" => "spain" }
-    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [france, spain])
+    result = GovernmentResult.new(search_params, "world_locations" => [france, spain])
     expect(result.metadata[0]).to eq("multiple locations")
   end
 
   it "not display locations when there is only a slug present" do
     united_kingdom = { "slug" => "united_kingdom" }
-    result = GovernmentResult.new(SearchParameters.new({}), "world_locations" => [united_kingdom])
+    result = GovernmentResult.new(search_params, "world_locations" => [united_kingdom])
     expect(result.metadata).to be_empty
   end
 
   it "return valid metadata" do
-    result = GovernmentResult.new(SearchParameters.new({}), "public_timestamp" => "2014-10-14",
+    result = GovernmentResult.new(search_params, "public_timestamp" => "2014-10-14",
       "display_type" => "my-display-type",
       "organisations" => [{ "slug" => "org-1" }],
       "world_locations" => [{ "title" => "France", "slug" => "france" }])
@@ -40,29 +42,28 @@ RSpec.describe GovernmentResult do
   end
 
   it "return format for corporate information pages in metadata" do
-    result = GovernmentResult.new(SearchParameters.new({}), "format" => "corporate_information")
+    result = GovernmentResult.new(search_params, "format" => "corporate_information")
     expect(result.metadata).to eq(['Corporate information'])
   end
 
   it "return only display type for corporate information pages if it is present in metadata" do
-    result = GovernmentResult.new(SearchParameters.new({}), "display_type" => "my-display-type",
+    result = GovernmentResult.new(search_params, "display_type" => "my-display-type",
       "format" => "corporate_information")
     expect(result.metadata).to eq(["my-display-type"])
   end
 
   it "not return sections for deputy prime ministers office" do
-    result = GovernmentResult.new(SearchParameters.new({}), "format" => "organisation",
+    result = GovernmentResult.new(search_params, "format" => "organisation",
       "link" => "/government/organisations/deputy-prime-ministers-office")
     expect(result.sections).to be_nil
   end
 
   it "return sections for some format types" do
-    params = SearchParameters.new({})
-    minister_results               = GovernmentResult.new(params, "format" => "minister")
-    organisation_results           = GovernmentResult.new(params, "format" => "organisation")
-    person_results                 = GovernmentResult.new(params, "format" => "person")
-    worldwide_organisation_results = GovernmentResult.new(params, "format" => "worldwide_organisation")
-    mainstream_results             = GovernmentResult.new(params, "format" => "mainstream")
+    minister_results               = GovernmentResult.new(search_params, "format" => "minister")
+    organisation_results           = GovernmentResult.new(search_params, "format" => "organisation")
+    person_results                 = GovernmentResult.new(search_params, "format" => "person")
+    worldwide_organisation_results = GovernmentResult.new(search_params, "format" => "worldwide_organisation")
+    mainstream_results             = GovernmentResult.new(search_params, "format" => "mainstream")
 
     expect(minister_results.sections.length).to eq(2)
     expect(organisation_results.sections).to be_nil
@@ -73,20 +74,20 @@ RSpec.describe GovernmentResult do
   end
 
   it "return sections in correct format" do
-    minister_results = GovernmentResult.new(SearchParameters.new({}), "format" => "minister")
+    minister_results = GovernmentResult.new(search_params, "format" => "minister")
 
     expect(minister_results.sections.first.keys).to eq([:hash, :title])
   end
 
   it "have a government name when in history mode" do
-    result = GovernmentResult.new(SearchParameters.new({}), "is_historic" => true,
+    result = GovernmentResult.new(search_params, "is_historic" => true,
       "government_name" => "XXXX to YYYY Example government")
     expect(result).to be_historic
     expect(result.government_name).to eq("XXXX to YYYY Example government")
   end
 
   it "have a government name when not in history mode" do
-    result = GovernmentResult.new(SearchParameters.new({}), "is_historic" => false,
+    result = GovernmentResult.new(search_params, "is_historic" => false,
       "government_name" => "XXXX to YYYY Example government")
     expect(result).not_to be_historic
     expect(result.government_name).to eq("XXXX to YYYY Example government")

--- a/spec/presenters/non_edition_result_spec.rb
+++ b/spec/presenters/non_edition_result_spec.rb
@@ -1,10 +1,12 @@
 require "spec_helper"
 
 RSpec.describe NonEditionResult do
+  let(:search_params) { SearchParameters.new(ActionController::Parameters.new({})) }
+
   it "return document_type as the format" do
     result = NonEditionResult.new(
-      SearchParameters.new({}),
-              "document_type" => "manual_section",
+      search_params,
+      "document_type" => "manual_section",
     )
 
     expect(result.format).to eq("manual_section")
@@ -12,8 +14,8 @@ RSpec.describe NonEditionResult do
 
   it "include a humanized document_type in metadata" do
     result = NonEditionResult.new(
-      SearchParameters.new({}),
-              "document_type" => "manual_section",
+      search_params,
+      "document_type" => "manual_section",
     )
 
     expect(result.metadata).to include("Manual section")
@@ -21,8 +23,8 @@ RSpec.describe NonEditionResult do
 
   it "use a custom humanized document_type form for special cases" do
     result = NonEditionResult.new(
-      SearchParameters.new({}),
-              "document_type" => "cma_case",
+      search_params,
+      "document_type" => "cma_case",
     )
 
     expect(result.metadata).to include("CMA case")
@@ -30,9 +32,9 @@ RSpec.describe NonEditionResult do
 
   it "include public_timestamp date in metadata" do
     result = NonEditionResult.new(
-      SearchParameters.new({}),
-              "document_type" => "cma_case",
-        "public_timestamp" => "2014-12-23T12:34:56",
+      search_params,
+      "document_type" => "cma_case",
+      "public_timestamp" => "2014-12-23T12:34:56",
     )
 
     expect(result.metadata).to include("23 December 2014")
@@ -40,19 +42,19 @@ RSpec.describe NonEditionResult do
 
   it "include organisations in metadata" do
     result = NonEditionResult.new(
-      SearchParameters.new({}),
-              "document_type" => "manual",
-        "organisations" => [
-          {
-            "slug" => "home-office",
-            "title" => "Home Office",
-          },
-          {
-            "slug" => "uk-visas-and-immigration",
-            "title" => "UK Visas and Immigration",
-            "acronym" => "UKVI",
-          },
-        ],
+      search_params,
+      "document_type" => "manual",
+      "organisations" => [
+        {
+          "slug" => "home-office",
+          "title" => "Home Office",
+        },
+        {
+          "slug" => "uk-visas-and-immigration",
+          "title" => "UK Visas and Immigration",
+          "acronym" => "UKVI",
+        },
+      ],
     )
 
     expect(result.metadata).to include(

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ResultSetPresenter do
     )
   end
 
-  let(:pagination) { double(:pagination, current_page: 1, total_pages: 2) }
+  let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
 
   let(:filter_params) { double(:filter_params, keywords: 'test') }
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe ResultSetPresenter do
   subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context) }
 
   let(:finder) do
-    OpenStruct.new(
+    double(
+      FinderPresenter,
       slug: "/a-finder",
       name: 'A finder',
       results: results,
@@ -26,7 +27,8 @@ RSpec.describe ResultSetPresenter do
   let(:view_context) { double(:view_context) }
 
   let(:a_facet) do
-    OpenStruct.new(
+    double(
+      SelectFacet,
       key: 'key_1',
       selected_values: [
         {
@@ -56,7 +58,8 @@ RSpec.describe ResultSetPresenter do
   end
 
   let(:another_facet) do
-    OpenStruct.new(
+    double(
+      SelectFacet,
       key: 'key_2',
       preposition: 'about',
       selected_values: [
@@ -87,7 +90,8 @@ RSpec.describe ResultSetPresenter do
   end
 
   let(:a_date_facet) do
-    OpenStruct.new(
+    double(
+      SelectFacet,
       sentence_fragment: {
         'type' => "date",
         'preposition' => "closed between",
@@ -110,22 +114,25 @@ RSpec.describe ResultSetPresenter do
   let(:total) { 20 }
 
   let(:results) do
-    OpenStruct.new(
-      total: total,
-      documents: (1..total).map { document }
+    ResultSet.new(
+      (1..total).map { document },
+      total,
     )
   end
 
   let(:document) do
-    OpenStruct.new(
+    double(
+      Document,
       title: 'Investigation into the distribution of road fuels in parts of Scotland',
-      slug: 'slug-1',
-      metadata:
-        [
-          { name: 'Case state', value: 'Open', type: 'text' },
-          { name: 'Opened date', value: '2006-7-14', type: 'date' },
-          { name: 'Case type', value: 'CA98 and civil cartels', type: 'text' },
-        ]
+      path: 'slug-1',
+      metadata: [
+        { name: 'Case state', value: 'Open', type: 'text' },
+        { name: 'Opened date', value: '2006-7-14', type: 'date' },
+        { name: 'Case type', value: 'CA98 and civil cartels', type: 'text' },
+      ],
+      summary: 'I am a document',
+      is_historic: false,
+      government_name: 'The Government!',
     )
   end
 
@@ -229,25 +236,27 @@ RSpec.describe ResultSetPresenter do
   describe '#documents' do
     context "has one document" do
       let(:results) do
-        OpenStruct.new(
-          total: total,
-          documents: [document]
+        ResultSet.new(
+          [document],
+          total
         )
       end
+
       it 'creates a new search_result_presenter hash for each result' do
         search_result_objects = presenter.documents
         expect(search_result_objects.count).to eql(1)
-        expect(search_result_objects.first.is_a?(Hash)).to be_truthy
+        expect(search_result_objects.first).to be_a(Hash)
       end
     end
 
     context "has 3 documents" do
       let(:results) do
-        OpenStruct.new(
-          total: total,
-          documents: [document, document, document]
+        ResultSet.new(
+          [document, document, document],
+          total
         )
       end
+
       it 'creates a new document for each result' do
         search_result_objects = presenter.documents
         expect(search_result_objects.count).to eql(3)

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -29,31 +29,29 @@ RSpec.describe ResultSetPresenter do
     OpenStruct.new(
       key: 'key_1',
       selected_values: [
-        OpenStruct.new(
-          value: 'ca98-and-civil-cartels',
-          label: 'CA98 and civil cartels'
-        ),
-        OpenStruct.new(
-          value: 'mergers',
-          label: 'Mergers'
-        ),
+        {
+          'value' => 'ca98-and-civil-cartels',
+          'label' => 'CA98 and civil cartels'
+        },
+        {
+          'value' => 'mergers',
+          'label' => 'Mergers'
+        },
       ],
-      sentence_fragment: [
-        OpenStruct.new(
-          type: 'text',
-          preposition: 'of type',
-          values: [
-            OpenStruct.new(
-              label: 'CA98 and civil cartels',
-              parameter_key: 'key_1',
-            ),
-            OpenStruct.new(
-              label: 'Mergers',
-              parameter_key: 'key_1',
-            ),
-          ]
-        )
-      ],
+      sentence_fragment: {
+        'type' => 'text',
+        'preposition' => 'of type',
+        'values' => [
+          {
+            'label' => 'CA98 and civil cartels',
+            'parameter_key' => 'key_1',
+          },
+          {
+            'label' => 'Mergers',
+            'parameter_key' => 'key_1',
+          },
+        ]
+      }
     )
   end
 
@@ -62,50 +60,48 @@ RSpec.describe ResultSetPresenter do
       key: 'key_2',
       preposition: 'about',
       selected_values: [
-        OpenStruct.new(
-          value: 'farming',
-          label: 'Farming'
-        ),
-        OpenStruct.new(
-          value: 'chemicals',
-          label: 'Chemicals'
-        ),
+        {
+          'value' => 'farming',
+          'label' => 'Farming'
+        },
+        {
+          'value' => 'chemicals',
+          'label' => 'Chemicals'
+        },
       ],
-      sentence_fragment: [
-        OpenStruct.new(
-          type: 'text',
-          preposition: 'about',
-          values: [
-            OpenStruct.new(
-              label: 'Farming',
-              parameter_key: 'key_2',
-            ),
-            OpenStruct.new(
-              label: 'Chemicals',
-              parameter_key: 'key_2',
-            ),
-          ]
-        )
-      ],
+      sentence_fragment: {
+        'type' => 'text',
+        'preposition' => 'about',
+        'values' => [
+          {
+            'label' => 'Farming',
+            'parameter_key' => 'key_2',
+          },
+          {
+            'label' => 'Chemicals',
+            'parameter_key' => 'key_2',
+          },
+        ]
+      }
     )
   end
 
   let(:a_date_facet) do
     OpenStruct.new(
-      sentence_fragment: OpenStruct.new(
-        type: "date",
-        preposition: "closed between",
-        values: [
-          OpenStruct.new(
-            label: "22 June 1990",
-            parameter_key: "closed_date",
-          ),
-          OpenStruct.new(
-            label: "22 June 1994",
-            parameter_key: "closed_date",
-          )
+      sentence_fragment: {
+        'type' => "date",
+        'preposition' => "closed between",
+        'values' => [
+          {
+            'label' => "22 June 1990",
+            'parameter_key' => "closed_date",
+          },
+          {
+            'label' => "22 June 1994",
+            'parameter_key' => "closed_date",
+          }
         ]
-      )
+      }
     )
   end
 
@@ -187,7 +183,7 @@ RSpec.describe ResultSetPresenter do
     it 'includes prepositions for each facet' do
       sentence = presenter.describe_filters_in_sentence
       finder.filter_sentence_fragments.each do |fragment|
-        expect(sentence.include?(fragment[:preposition])).to be_truthy
+        expect(sentence).to include(fragment['preposition'])
       end
     end
 
@@ -216,17 +212,17 @@ RSpec.describe ResultSetPresenter do
     let(:sentence) { presenter.selected_filter_descriptions }
 
     it 'returns a string with all the facets passed to it in strong tags' do
-      finder.facets.flat_map(&:sentence_fragment).flat_map(&:values).flatten.each do |value|
-        expect(sentence.include?("<strong>#{value.label}")).to be_truthy
+      finder.facets.flat_map { |f| f.sentence_fragment['values'] }.each do |value|
+        expect(sentence).to include("<strong>#{value['label']}</strong>")
       end
     end
 
     it 'returns a string with the facet values joined correctly' do
       text_values = another_facet.selected_values
-      expect(sentence.include?("<strong>#{text_values.first.label}</strong> or <strong>#{text_values.last.label}</strong>")).to be_truthy
+      expect(sentence).to include("<strong>#{text_values.first['label']}</strong> or <strong>#{text_values.last['label']}</strong>")
 
       date_fragment = a_date_facet.sentence_fragment
-      expect(sentence.include?("<strong>#{date_fragment.values.first.label}</strong> and <strong>#{date_fragment.values.last.label}</strong>")).to be_truthy
+      expect(sentence).to include("<strong>#{date_fragment['values'].first['label']}</strong> and <strong>#{date_fragment['values'].last['label']}</strong>")
     end
   end
 

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -4,10 +4,14 @@ RSpec.describe SearchResultPresenter do
   subject(:presenter) { SearchResultPresenter.new(document) }
 
   let(:document) {
-    OpenStruct.new(
+    double(
+      Document,
       title: title,
       path: link,
       metadata: metadata,
+      summary: 'I am a document',
+      is_historic: false,
+      government_name: 'The Government!',
     )
   }
 

--- a/spec/presenters/search_result_spec.rb
+++ b/spec/presenters/search_result_spec.rb
@@ -2,14 +2,18 @@
 require "spec_helper"
 
 RSpec.describe SearchResult do
+  let(:search_params) { SearchParameters.new(ActionController::Parameters.new({})) }
+
   it "report when no examples are present" do
-    result = SearchResult.new(SearchParameters.new({}), {}).to_hash
+    result = SearchResult.new(search_params, {}).to_hash
     expect(result[:examples_present?]).to be_falsy
   end
 
   it "present examples" do
-    result = SearchResult.new(SearchParameters.new({}),
-                              "examples" => [{ "title" => "An example" }]).to_hash
+    result = SearchResult.new(
+      search_params,
+      "examples" => [{ "title" => "An example" }]
+    ).to_hash
     expect(result[:examples_present?]).to be_truthy
     expect(result[:examples]).to eq([{ "title" => "An example" }])
   end

--- a/spec/presenters/search_results_presenter_spec.rb
+++ b/spec/presenters/search_results_presenter_spec.rb
@@ -3,12 +3,16 @@ require "spec_helper"
 RSpec.describe SearchResultsPresenter do
   let(:view_content) { double(:view_content, render: 'pagination_html') }
 
+  def search_params(params)
+    SearchParameters.new(ActionController::Parameters.new(params))
+  end
+
   it "return an appropriate hash" do
     results = SearchResultsPresenter.new({
       "total" => 1,
       "results" => [{ "index" => "mainstream" }],
       "facets" => {}
-    }, SearchParameters.new(q: 'my-query'), view_content)
+    }, search_params(q: 'my-query'), view_content)
 
     expect(results.to_hash[:query]).to eq('my-query')
     expect(results.to_hash[:result_count]).to eq(1)
@@ -30,7 +34,7 @@ RSpec.describe SearchResultsPresenter do
           }]
         }
       }
-    }, SearchParameters.new(q: 'my-query'), view_content)
+    }, search_params(q: 'my-query'), view_content)
 
     expect(results.to_hash[:filter_fields].length).to eq(1)
     expect(results.to_hash[:filter_fields][0][:field]).to eq("organisations")
@@ -47,7 +51,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(q: 'my-query',
+      params = search_params(q: 'my-query',
         count: 50,
         start: 0)
       presenter = SearchResultsPresenter.new(response, params, view_content)
@@ -62,7 +66,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(count: 50,
+      params = search_params(count: 50,
         start: 150)
       presenter = SearchResultsPresenter.new(response, params, view_content)
 
@@ -77,7 +81,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(q: 'my-query',
+      params = search_params(q: 'my-query',
         count: 50,
         start: 100)
       presenter = SearchResultsPresenter.new(response, params, view_content)
@@ -92,7 +96,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(count: 50,
+      params = search_params(count: 50,
         start: 0)
       presenter = SearchResultsPresenter.new(response, params, view_content)
 
@@ -107,7 +111,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(q: 'my-query',
+      params = search_params(q: 'my-query',
         count: 50,
         start: 25)
       presenter = SearchResultsPresenter.new(response, params, view_content)
@@ -119,7 +123,7 @@ RSpec.describe SearchResultsPresenter do
       expect(view_content).not_to receive(:render)
 
       response = { 'total' => 0 }
-      params = SearchParameters.new(count: 50,
+      params = search_params(count: 50,
         start: 0)
       presenter = SearchResultsPresenter.new(response, params, view_content)
 
@@ -130,7 +134,7 @@ RSpec.describe SearchResultsPresenter do
       expect(view_content).not_to receive(:render)
 
       response = { 'total' => 25 }
-      params = SearchParameters.new(count: 50,
+      params = search_params(count: 50,
         start: 0)
       presenter = SearchResultsPresenter.new(response, params, view_content)
 
@@ -144,7 +148,7 @@ RSpec.describe SearchResultsPresenter do
       )
 
       response = { 'total' => 200 }
-      params = SearchParameters.new(q: 'my-query',
+      params = search_params(q: 'my-query',
         count: 88,
         start: 0)
       presenter = SearchResultsPresenter.new(response, params, view_content)
@@ -159,7 +163,7 @@ RSpec.describe SearchResultsPresenter do
         "total" => 1,
         "results" => [{ "document_type" => "group" }],
         "facets" => {}
-      }, SearchParameters.new(q: 'my-query'), view_content)
+      }, search_params(q: 'my-query'), view_content)
       rlist = results.to_hash[:results]
       expect(rlist.size).to eq(1)
       expect(rlist[0][:metadata]).to be_nil


### PR DESCRIPTION
When doing #331 I spotted loads of deprecation warnings in the build output so I took it upon myself to fix them.  I thought it would be easy, but it was actually fairly painful, mostly because I had to handle the gds-api-adapters upgrade that switched the responses from being openstructs (boo) to hashes (yay).  As a result I've touched loads of files, so it's probably best looking at this commit-by-commit.