### PR TITLE
Fix a missing openstruct to hash reference

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -24,9 +24,9 @@
             Select the email alerts you need
           </p>
           <% @signup.choices.each do |choice| %>
-            <%= label_tag "filter_#{choice.key}", class: 'block-label' do %>
-              <%= check_box_tag "filter[]", choice.key, choice.prechecked, class: 'checkbox', id: "filter_#{choice.key}" %>
-              <%= choice.radio_button_name %>
+            <%= label_tag "filter_#{choice['key']}", class: 'block-label' do %>
+              <%= check_box_tag "filter[]", choice['key'], choice['prechecked'], class: 'checkbox', id: "filter_#{choice['key']}" %>
+              <%= choice['radio_button_name'] %>
             <% end %>
           <% end %>
         </fieldset>

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -1,6 +1,33 @@
 {
+  "base_path": "/cma-cases/email-signup",
+  "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+  "document_type": "finder_email_signup",
+  "title": "Competition and Markets Authority cases",
+  "description": "You'll get an email each time a case is updated or a new case is published.",
   "details": {
-    "email_signup_choice": [],
-    "subscription_list_title_prefix": {}
+    "email_signup_choice": [
+      {
+        "key": "ca98-and-civil-cartels",
+        "radio_button_name": "CA98 and civil cartels",
+        "topic_name": "CA98 and civil cartels",
+        "prechecked": false
+      },
+      {
+        "key": "competition-disqualification",
+        "radio_button_name": "Competition disqualification",
+        "topic_name": "competition disqualification",
+        "prechecked": false
+      }
+    ],
+    "email_filter_by": "case_type",
+    "email_filter_name": {
+      "singular": "case type",
+      "plural": "case types"
+    },
+    "subscription_list_title_prefix": {
+      "singular": "CMA cases with the following case type: ",
+      "plural": "CMA cases with the following case types: ",
+      "many": "Competition and Markets Authority (CMA) cases: "
+    }
   }
 }

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -5,6 +5,8 @@ include FixturesHelper
 
 describe EmailAlertSubscriptionsController, type: :controller do
   include GovukContentSchemaExamples
+  render_views
+  let(:signup_finder) { cma_cases_signup_content_item }
 
   describe 'GET #new' do
     describe "finder email signup item doesn't exist" do
@@ -15,6 +17,15 @@ describe EmailAlertSubscriptionsController, type: :controller do
         expect(response.status).to eq(404)
       end
     end
+
+    describe "finder email signup item does exist" do
+      it 'returns a success' do
+        content_store_has_item('/does-exist/email-signup', signup_finder)
+        get :new, params: { slug: 'does-exist' }
+
+        expect(response).to be_success
+      end
+    end
   end
 
   describe 'POST "#create"' do
@@ -22,7 +33,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
     let(:alert_identifier) { double(:alert_identifier) }
     let(:delivery_api) { double(:delivery_api) }
     let(:finder) { govuk_content_schema_example('finder').to_hash.merge(title: alert_name) }
-    let(:signup_finder) { cma_cases_signup_content_item }
     let(:signup_api_wrapper) {
       double(:signup_api_wrapper, signup_url: 'http://www.example.com')
     }

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -44,8 +44,17 @@ describe EmailAlertSubscriptionsController, type: :controller do
       allow(EmailAlertSignupAPI).to receive(:new).and_return(signup_api_wrapper)
     end
 
-    it 'redirects to the correct email subscription url' do
+    it "fails if the relevant filters are not provided" do
       post :create, params: { slug: 'cma-cases' }
+      expect(response).to be_success
+      expect(response).to render_template('new')
+    end
+
+    it 'redirects to the correct email subscription url' do
+      post :create, params: {
+        slug: 'cma-cases',
+        filter: { 'ca98-and-civil-cartels' => '1', 'competition-disqualification' => '0' }
+      }
       expect(subject).to redirect_to('http://www.example.com')
     end
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -1,33 +1,36 @@
 require 'spec_helper'
 require 'gds_api/test_helpers/content_store'
-include GdsApi::TestHelpers::ContentStore
-include FixturesHelper
 
 describe FindersController, type: :controller do
+  include GdsApi::TestHelpers::ContentStore
+  include FixturesHelper
+  include GovukContentSchemaExamples
+  render_views
+
   describe "GET show" do
+    let(:lunch_finder) {
+      govuk_content_schema_example('finder').to_hash.merge(
+        'title' => 'Lunch Finder',
+        'base_path' => '/lunch-finder'
+      )
+    }
     describe "a finder content item exists" do
       before do
         content_store_has_item(
           '/lunch-finder',
-            base_path: '/lunch-finder',
-            title: 'Lunch Finder',
-            details: {
-              facets: [],
-            },
-            links: {
-              organisations: [],
-            },
+          lunch_finder
         )
 
         rummager_response = %|{
-            "results": [],
-            "total": 0,
-            "start": 0,
-            "facets": {},
-            "suggested_queries": []
-          }|
+          "results": [],
+          "total": 0,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
+        }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=1000&fields=title,link,description,public_timestamp&order=-public_timestamp&start=0").to_return(status: 200, body: rummager_response, headers: {})
+        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=1000&fields=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&filter_document_type=mosw_report&order=-public_timestamp&start=0").
+          to_return(status: 200, body: rummager_response, headers: {})
       end
 
       it "correctly renders a finder page" do
@@ -54,26 +57,21 @@ describe FindersController, type: :controller do
       before do
         content_store_has_item(
           '/lunch-finder',
-            base_path: '/lunch-finder',
-            title: 'Lunch Finder',
-            details: {
-              default_order: "-closing_date",
-              facets: [],
-            },
-            links: {
-              organisations: [],
-            },
+          lunch_finder.merge(
+            'details' => lunch_finder['details'].merge('default_order' => "-closing_date")
+          )
         )
 
         rummager_response = %|{
-            "results": [],
-            "total": 0,
-            "start": 0,
-            "facets": {},
-            "suggested_queries": []
-          }|
+          "results": [],
+          "total": 0,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
+        }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=1000&fields=title,link,description,public_timestamp&order=-closing_date&start=0").to_return(status: 200, body: rummager_response, headers: {})
+        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=1000&fields=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&filter_document_type=mosw_report&order=-closing_date&start=0").
+          to_return(status: 200, body: rummager_response, headers: {})
       end
 
       it "returns a 404 when requesting an atom feed, rather than a 500" do


### PR DESCRIPTION
When I deployed #342 to staging I spotted https://sentry.io/govuk/app-finder-frontend/issues/418539555/ which pointed me at a place where I'd missed the `OpenStruct` -> `Hash` transition.  This PR fixes that, and tries to improve our test coverage to avoid it happening again.

1. Use govuk schema test helpers to get more realistic finders in tests
2. Make the one json fixture we do have more realistic by copying in more data from the live api version
3. Call `render_views` in our controller specs to make sure we definitely exercise the views if we have tests for those controllers

It's far from perfect as I suspect there's still some places we have no coverage, but I did a bunch of manual testing when I deployed (just not of the email stuff as I forgot about it).