### PR TITLE
Strip whitespace from search query

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -13,7 +13,7 @@ class SearchParameters
   end
 
   def search_term
-    params[:q]
+    params[:q]&.strip&.gsub(/\s{2,}/, ' ')
   end
 
   def show_organisations_filter?


### PR DESCRIPTION
The 'Product Search Term' custom dimension sent to Google Analytics Enhanced Ecommerce may contain spaces at the beginning or end, or double spaces between words. This means that search queries with extra spaces are tracked separately from those with single spaces.

https://trello.com/c/nZ2U7b6P