### PR TITLE
Rework email alert signup api specs to fix another openstruct -> hash reference

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -54,7 +54,7 @@ private
   end
 
   def chosen_options
-    params["filter"]
+    params.permit("filter" => [])['filter']
   end
 
   def email_signup_attributes

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,8 +1,6 @@
 require 'email_alert_signup_api'
-require 'gds_api/helpers'
 
 class EmailAlertSubscriptionsController < ApplicationController
-  include GdsApi::Helpers
   protect_from_forgery except: :create
 
   def new
@@ -30,11 +28,11 @@ private
   end
 
   def content
-    @content ||= content_store.content_item(request.path)
+    @content ||= Services.content_store.content_item(request.path)
   end
 
   def finder
-    FinderPresenter.new(content_store.content_item(finder_base_path))
+    FinderPresenter.new(Services.content_store.content_item(finder_base_path))
   end
 
   def finder_format
@@ -47,7 +45,7 @@ private
 
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
-      email_alert_api: email_alert_api,
+      email_alert_api: Services.email_alert_api,
       attributes: email_signup_attributes,
       subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
       available_choices: available_choices,

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,6 @@
 require 'gds_api/content_store'
 require 'gds_api/rummager'
+require 'gds_api/email_alert_api'
 
 module Services
   def self.content_store
@@ -13,6 +14,12 @@ module Services
     @rummager ||= GdsApi::Rummager.new(
       Plek.find("search"),
       disable_cache: Rails.env.development?
+    )
+  end
+
+  def self.email_alert_api
+    @email_alert_api ||= GdsApi::EmailAlertApi.new(
+      Plek.find("email-alert-api")
     )
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -11,7 +11,7 @@ class EmailAlertSignupAPI
   end
 
   def signup_url
-    subscriber_list.subscription_url
+    subscriber_list['subscription_url']
   end
 
 private
@@ -20,7 +20,7 @@ private
 
   def subscriber_list
     response = email_alert_api.find_or_create_subscriber_list("tags" => massaged_attributes, "title" => title)
-    response.subscriber_list
+    response['subscriber_list']
   end
 
   def title

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -43,7 +43,7 @@ private
   end
 
   def choice_hash_by_key(key)
-    available_choices.select { |x| x['key'] == key }[0]
+    available_choices.detect { |x| x['key'] == key }
   end
 
   def massaged_attributes

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 require 'email_alert_signup_api'
+require 'gds_api/test_helpers/email_alert_api'
 
 describe EmailAlertSignupAPI do
-  let(:email_alert_api) { double(:email_alert_api) }
+  include GdsApi::TestHelpers::EmailAlertApi
+
   let(:attributes) {
     {
       "format" => "test-reports",
@@ -33,11 +35,9 @@ describe EmailAlertSignupAPI do
   }
   let(:filter_key) { "alert_type" }
   let(:subscription_url) { "http://www.example.org/list-id/signup" }
-  let(:mock_subscriber_list) { double(:mock_subscriber_list, subscription_url: subscription_url) }
-  let(:mock_response) { double(:mock_response, subscriber_list: mock_subscriber_list) }
   subject(:signup_api_wrapper) {
-    EmailAlertSignupAPI.new(
-      email_alert_api: email_alert_api,
+    described_class.new(
+      email_alert_api: Services.email_alert_api,
       attributes: attributes,
       available_choices: available_choices,
       subscription_list_title_prefix: subscription_list_title_prefix,
@@ -46,25 +46,45 @@ describe EmailAlertSignupAPI do
   }
 
   before do
-    allow(email_alert_api).to receive(:find_or_create_subscriber_list).and_return(mock_response)
+    email_alert_api_has_subscriber_list(
+      "tags" => {
+        "format" => "test-reports",
+        "alert_type" => %w(first second),
+      },
+      "subscription_url" => subscription_url
+    )
   end
 
   describe '#signup_url' do
     it 'returns the url email-alert-api gives back' do
+      email_alert_api_has_subscriber_list(
+        "tags" => {
+          "format" => "test-reports",
+          "alert_type" => %w(first second),
+        },
+        "subscription_url" => subscription_url
+      )
       expect(signup_api_wrapper.signup_url).to eql subscription_url
     end
 
     context 'with multiple choices selected and a title prefix' do
       it 'asks email-alert-api to find or create the subscriber list' do
-        signup_api_wrapper.signup_url
-
-        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => %w(first second),
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
           "tags" => {
             "format" => "test-reports",
             "alert_type" => %w(first second),
           },
           "title" => "Format with report types: first thing and second thing",
-        )
+        ).and_call_original
+
+        signup_api_wrapper.signup_url
       end
     end
 
@@ -76,15 +96,22 @@ describe EmailAlertSignupAPI do
         }
       }
       it 'asks email-alert-api to find or create the subscriber list' do
-        signup_api_wrapper.signup_url
-
-        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => ["first"],
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
           "tags" => {
             "format" => "test-reports",
             "alert_type" => ["first"],
           },
           "title" => "Format with report type: first thing",
-        )
+        ).and_call_original
+
+        signup_api_wrapper.signup_url
       end
     end
 
@@ -105,15 +132,22 @@ describe EmailAlertSignupAPI do
         {}
       }
       it 'asks email-alert-api to find or create the subscriber list' do
-        signup_api_wrapper.signup_url
-
-        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => %w(first second),
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
           "tags" => {
             "format" => "test-reports",
             "alert_type" => %w(first second),
           },
           "title" => "First thing and second thing",
-        )
+        ).and_call_original
+
+        signup_api_wrapper.signup_url
       end
     end
 
@@ -127,14 +161,20 @@ describe EmailAlertSignupAPI do
       let(:filter_key) { nil }
       let(:subscription_list_title_prefix) { "Format" }
       it 'asks email-alert-api to find or create the subscriber list' do
-        signup_api_wrapper.signup_url
-
-        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => "test-reports",
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
           "tags" => {
             "format" => "test-reports",
           },
           "title" => "Format",
-        )
+        ).and_call_original
+
+        signup_api_wrapper.signup_url
       end
     end
   end


### PR DESCRIPTION
Turns out that #347 wasn't the only thing we missed when doing #342.  While we did have specs that covered the email alert api and its controller, they hid the problem because they relied heavily on doubles so had the methods that were being called.  We've changed these specs to use the real api-adapters and test helpers from the gem and this finally exposes the bug (which we then fix in the next commit).