### PR TITLE
Configure email-alert-api with bearer token

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -19,7 +19,8 @@ module Services
 
   def self.email_alert_api
     @email_alert_api ||= GdsApi::EmailAlertApi.new(
-      Plek.find("email-alert-api")
+      Plek.find("email-alert-api"),
+      bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "wubbalubbadubdub")
     )
   end
 end


### PR DESCRIPTION
Email-alert-api will soon require a bearer token. This PR adds it in eager anticipation.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)