### PR TITLE
Fix rendering of related links

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -64,7 +64,7 @@
     <div class='related-links'>
       <ul>
         <% finder.related.each do |link| %>
-          <li><%= link_to link[:title], link[:web_url] %></li>
+          <li><%= link_to link['title'], link['web_url'] %></li>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
Hopefully the last remaining holdout where we expect a hash to respond
to symbol keys but now it's not an openstruct, but a parsed JSON hash
it responds to string keys.