### PR TITLE
Remove Foo=bar header from search responses

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,7 +31,7 @@ class SearchController < ApplicationController
     @spelling_suggestion = @results.spelling_suggestion
 
     fill_in_slimmer_headers(@results.result_count)
-    response.headers['foo'] = 'bar'
+
     respond_to do |format|
       format.html
       format.json { render json: @results }


### PR DESCRIPTION
This shouldn't be here...