### PR TITLE
[DO NOT MERGE] Fix keyboard navigation on search page filters

### DIFF
--- a/app/assets/javascripts/checkbox-filter.js
+++ b/app/assets/javascripts/checkbox-filter.js
@@ -18,6 +18,8 @@
     // setupHeight is called on open, but filters containing checked checkboxes will already be open
     if (this.isOpen() || !allowCollapsible) {
       this.setupHeight();
+    } else {
+      this.hideCheckboxesFromTabindex(true);
     }
 
     if(allowCollapsible){
@@ -50,12 +52,25 @@
   }
 
   CheckboxFilter.prototype.open = function open(){
+    this.hideCheckboxesFromTabindex(false);
     this.$filter.removeClass('closed');
     this.setupHeight();
   };
 
   CheckboxFilter.prototype.close = function close(){
+    this.hideCheckboxesFromTabindex(true);
     this.$filter.addClass('closed');
+  };
+
+  // allows keyboard users to reach search results without having to tab through approx 100 checkboxes
+  CheckboxFilter.prototype.hideCheckboxesFromTabindex = function hideCheckboxesFromTabindex(remove){
+    this.$checkboxes.each(function(){
+      if (remove) {
+        $(this).attr('tabindex','-1');
+      } else {
+        $(this).removeAttr('tabindex');
+      }
+    });
   };
 
   CheckboxFilter.prototype.listenForKeys = function listenForKeys(){

--- a/app/views/search/_filters.mustache
+++ b/app/views/search/_filters.mustache
@@ -12,7 +12,7 @@
               <div class="toggle"></div>
             </div>
           </div>
-          <div class="checkbox-container" id="{{field}}-filter">
+          <div class="checkbox-container" id="{{field}}-filter" tabindex="-1">
             <ul>
               {{#options.options}}
                 <li>


### PR DESCRIPTION
Attempt to fix a problem on https://www.gov.uk/search?q=test where if navigating with the keyboard the user is forced to tab through all of the organisation checkboxes (100 of them) before reaching the search results.

Tested in Voiceover on Safari, Jaws 17 and 18 on IE.
  