### PR TITLE
Run finder-frontend end to end tests downstream job as part of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(sassLint: false)
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-finder-frontend")
+  govuk.buildProject(sassLint: false, publishingE2ETests: true)
 }


### PR DESCRIPTION
Hey :wave: !

This PR will enable a set of [end-to-end tests](https://github.com/alphagov/publishing-e2e-tests) to run every time a commit is made to this repo. :boom:

You can find a list of all the finder-frontend tests by [searching for the finder_frontend tag in publishing-e2e-tests](https://github.com/search?utf8=%E2%9C%93&q=finder_frontend%3A+true+repo%3Aalphagov%2Fpublishing-e2e-tests+path%3A%2Fspec%2F&type=Code&ref=advsearch&l=&l=).

Look at the merge box below and you'll see a new check performed on this PR.

![image](https://user-images.githubusercontent.com/976274/33369450-8d36f00a-d4ec-11e7-845c-690420f1b801.png)

Any tests which are marked with the ` new ` or ` flaky ` tag won't fail the publishing-e2e-tests check, but their result will be recorded for inspection.

Enabling these tests will give increased confidence when making changes to this repo that the change doesn't break the finder-frontend in an end-to-end environment. The downside is that running these tests takes time, with build times between 6-8 minutes currently.