### PR TITLE
Allow easier development of new finders

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,20 @@ The application has jasmine tests, which can be accessed at `/specs` when the ap
 [content_schema_examples]: https://github.com/alphagov/finder-frontend/blob/master/lib/govuk_content_schema_examples.rb
 
 ## Making a new finder
+
 1. If required, add a schema to [alphagov/rummager](http://github.com/alphagov/rummager) describing your document type -- [example](https://github.com/alphagov/rummager/blob/master/config/schema/elasticsearch_types/cma_case.json)
 2. Publish a Finder Content Item to the content store. See the doc for [Finder Content Item](https://github.com/alphagov/finder-frontend/blob/master/docs/finder-content-item.md) for more info.
 3. Ensure your documents are indexed in [alphagov/rummager](http://github.com/alphagov/rummager) correctly.
+
+### Developing a finder locally
+
+You can run this application with a local file so you can develop a finder without having to publish the content item to the publishing-api.
+
+For example:
+
+```
+DEVELOPMENT_FINDER_JSON=features/fixtures/aaib_reports_example.json ./startup.sh --live
+```
 
 ### How to add a fixed filter?
 

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -21,7 +21,11 @@ private
   attr_reader :base_path, :filter_params
 
   def fetch_content_item
-    Services.content_store.content_item(base_path)
+    if ENV["DEVELOPMENT_FINDER_JSON"]
+      JSON.parse(File.read(ENV["DEVELOPMENT_FINDER_JSON"]))
+    else
+      Services.content_store.content_item(base_path)
+    end
   end
 
   def fetch_search_response(content_item)

--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -1,0 +1,196 @@
+{
+  "analytics_identifier":null,
+  "base_path":"/aaib-reports",
+  "content_id":"b7574bba-969f-4c49-855a-ae1586258ff6",
+  "content_purpose_document_supertype":"navigation",
+  "document_type":"finder",
+  "email_document_supertype":"other",
+  "first_published_at":"2015-09-03T14:47:48.000+00:00",
+  "government_document_supertype":"other",
+  "locale":"en",
+  "navigation_document_supertype":"other",
+  "need_ids":[
+
+  ],
+  "phase":"live",
+  "public_updated_at":"2018-01-24T09:55:35.000+00:00",
+  "publishing_app":"specialist-publisher",
+  "rendering_app":"finder-frontend",
+  "schema_name":"finder",
+  "search_user_need_document_supertype":"government",
+  "title":"Air Accidents Investigation Branch reports",
+  "updated_at":"2018-01-24T09:56:39.528Z",
+  "user_journey_document_supertype":"finding",
+  "withdrawn_notice":{
+
+  },
+  "publishing_request_id":"11295-1516787799.287-10.3.3.1-400",
+  "links":{
+    "organisations":[
+      {
+        "analytics_identifier":"OT248",
+        "api_path":"/api/content/government/organisations/air-accidents-investigation-branch",
+        "base_path":"/government/organisations/air-accidents-investigation-branch",
+        "content_id":"38eb5d8f-2d89-480c-8655-e2e7ac23f8f4",
+        "document_type":"organisation",
+        "locale":"en",
+        "public_updated_at":"2015-04-15T10:04:28Z",
+        "schema_name":"placeholder",
+        "title":"Air Accidents Investigation Branch",
+        "withdrawn":false,
+        "details":{
+          "brand":"department-for-transport",
+          "logo":{
+            "formatted_title":"Air Accidents<br/>Investigation Branch",
+            "image":{
+              "url":"https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/248/aaib_logo.png",
+              "alt_text":"Air Accidents Investigation Branch"
+            }
+          }
+        },
+        "links":{
+
+        },
+        "api_url":"https://www.gov.uk/api/content/government/organisations/air-accidents-investigation-branch",
+        "web_url":"https://www.gov.uk/government/organisations/air-accidents-investigation-branch"
+      }
+    ],
+    "available_translations":[
+      {
+        "title":"Air Accidents Investigation Branch reports",
+        "public_updated_at":"2018-01-24T09:55:35Z",
+        "document_type":"finder",
+        "schema_name":"finder",
+        "base_path":"/aaib-reports",
+        "description":"Find reports of AAIB investigations into air accidents and incidents",
+        "api_path":"/api/content/aaib-reports",
+        "withdrawn":false,
+        "content_id":"b7574bba-969f-4c49-855a-ae1586258ff6",
+        "locale":"en",
+        "api_url":"https://www.gov.uk/api/content/aaib-reports",
+        "web_url":"https://www.gov.uk/aaib-reports",
+        "links":{
+
+        }
+      }
+    ]
+  },
+  "description":"Find reports of AAIB investigations into air accidents and incidents",
+  "details":{
+    "document_noun":"report",
+    "filter":{
+      "document_type":"aaib_report"
+    },
+    "format_name":"Air Accidents Investigation Branch report",
+    "show_summaries":true,
+    "facets":[
+      {
+        "key":"aircraft_category",
+        "name":"Aircraft category",
+        "type":"text",
+        "preposition":"in aircraft category",
+        "display_as_result_metadata":true,
+        "filterable":true,
+        "allowed_values":[
+          {
+            "label":"Commercial - fixed wing",
+            "value":"commercial-fixed-wing"
+          },
+          {
+            "label":"Commercial - rotorcraft",
+            "value":"commercial-rotorcraft"
+          },
+          {
+            "label":"General aviation - fixed wing",
+            "value":"general-aviation-fixed-wing"
+          },
+          {
+            "label":"General aviation - rotorcraft",
+            "value":"general-aviation-rotorcraft"
+          },
+          {
+            "label":"Sport aviation and balloons",
+            "value":"sport-aviation-and-balloons"
+          },
+          {
+            "label":"Unmanned Aircraft Systems (UAS)",
+            "value":"unmanned-aircraft-systems"
+          }
+        ]
+      },
+      {
+        "key":"report_type",
+        "name":"Report type",
+        "type":"text",
+        "preposition":"of type",
+        "display_as_result_metadata":true,
+        "filterable":true,
+        "allowed_values":[
+          {
+            "label":"Annual safety report",
+            "value":"annual-safety-report"
+          },
+          {
+            "label":"Bulletin - Correspondence investigation",
+            "value":"correspondence-investigation"
+          },
+          {
+            "label":"Bulletin - Field investigation",
+            "value":"field-investigation"
+          },
+          {
+            "label":"Bulletin - Pre-1997 uncategorised monthly report",
+            "value":"pre-1997-monthly-report"
+          },
+          {
+            "label":"Foreign report",
+            "value":"foreign-report"
+          },
+          {
+            "label":"Formal report",
+            "value":"formal-report"
+          },
+          {
+            "label":"Special bulletin",
+            "value":"special-bulletin"
+          },
+          {
+            "label":"Safety study",
+            "value":"safety-study"
+          }
+        ]
+      },
+      {
+        "key":"date_of_occurrence",
+        "name":"Date of occurrence",
+        "short_name":"Occurred",
+        "type":"date",
+        "preposition":"occurred",
+        "display_as_result_metadata":true,
+        "filterable":true
+      },
+      {
+        "key":"aircraft_type",
+        "name":"Aircraft type",
+        "type":"text",
+        "display_as_result_metadata":false,
+        "filterable":false
+      },
+      {
+        "key":"location",
+        "name":"Location",
+        "type":"text",
+        "display_as_result_metadata":false,
+        "filterable":false
+      },
+      {
+        "key":"registration",
+        "name":"Registration",
+        "type":"text",
+        "display_as_result_metadata":false,
+        "filterable":false
+      }
+    ],
+    "default_documents_per_page":50
+  }
+}


### PR DESCRIPTION
To play around with building a new finder you currently have to go into one of the publishing apps (specialist publisher, policy publisher or whitehall), develop your finder and publish it to the publishing-api. This will make it available to this application. The feedback cycle for this is quite long and you'll have to have the development VM running.

This introduces a env var to override the finder. If set the app will use some JSON on your file system instead of talking to the content store.

This will allow you to quickly prototype new finders by creating a new content item in a file and running the app against it. You can copy paste `aaib_reports_example.json` or edit it.