### PR TITLE
Procfile usable in more than heroku context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
-
 RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME finder-frontend
 ENV PORT 3062
@@ -21,4 +21,4 @@ RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:pr
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
 
-CMD bash -c "bundle exec unicorn -p $PORT"
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: GOVUK_ASSET_ROOT=https://${HEROKU_APP_NAME}.herokuapp.com bin/rails server -p $PORT -e $RAILS_ENV
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3062}

--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
     },
-    "GOVUK_ASSET_ROOT": {
-      "value": "https://finder-frontend.herokuapp.com"
-    },
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,10 @@
 FinderFrontend::Application.configure do
+  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
+  # at the time of the app being built so can't be set up in the app.json
+  if !ENV.include?('GOVUK_ASSET_ROOT') && ENV['HEROKU_APP_NAME']
+    ENV['GOVUK_ASSET_ROOT'] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+  end
+
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local = false


### PR DESCRIPTION
Wider context: alphagov/publishing-e2e-tests#202

This PR adds foreman as a gem dependency of docker (as per foreman instructions) as the means to run the processes for this app.

It also changes the Procfile configuration to allow this app to be run using it outside of a heroku context.