### PR TITLE
Add feedback component to search pages too

### DIFF
--- a/app/views/layouts/search-application.html.erb
+++ b/app/views/layouts/search-application.html.erb
@@ -17,6 +17,7 @@
 <body class="mainstream <%= yield :body_classes %>">
 <div id="wrapper">
   <%= yield %>
+  <%= render 'govuk_publishing_components/components/feedback' %>
   <%= render_mustache_templates if Rails.env.development? %>
 </div>
 </body>


### PR DESCRIPTION
I didn't realise in https://github.com/alphagov/finder-frontend/pull/393 that this used a completely separate layout.

https://trello.com/c/eKtXGtBD