### PR TITLE
[Do not merge] Finder with content type groups

### DIFF
--- a/all-finder.json
+++ b/all-finder.json
@@ -56,7 +56,7 @@
           {
             "key": "content_purpose_document_supertype",
             "name": "Publication type",
-            "type": "hidden",
+            "type": "text",
             "preposition": "of type",
             "display_as_result_metadata": true,
             "filterable": true,

--- a/all-finder.json
+++ b/all-finder.json
@@ -1,0 +1,65 @@
+{
+   "analytics_identifier":null,
+   "base_path":"/aaib-reports",
+   "content_id":"b7574bba-969f-4c49-855a-ae1586258ff6",
+   "content_purpose_document_supertype":"navigation",
+   "document_type":"finder",
+   "email_document_supertype":"other",
+   "first_published_at":"2015-09-03T14:47:48.000+00:00",
+   "government_document_supertype":"other",
+   "locale":"en",
+   "navigation_document_supertype":"other",
+   "need_ids":[
+
+   ],
+   "phase":"live",
+   "public_updated_at":"2018-01-24T09:55:35.000+00:00",
+   "publishing_app":"specialist-publisher",
+   "rendering_app":"finder-frontend",
+   "schema_name":"finder",
+   "search_user_need_document_supertype":"government",
+   "title":"Latest on GOV.UK",
+   "updated_at":"2018-01-24T09:56:39.528Z",
+   "user_journey_document_supertype":"finding",
+   "withdrawn_notice":{
+
+   },
+   "links":{
+   },
+   "description":"",
+   "details":{
+      "document_noun":"page",
+      "reject":{
+        "content_store_document_type": ["browse"]
+      },
+      "show_summaries":true,
+      "facets": [
+          {
+            "key":"public_timestamp",
+            "name":"Publication date",
+            "short_name":"Published",
+            "type":"date",
+            "preposition":"published",
+            "display_as_result_metadata":true,
+            "filterable":true
+          },
+          {
+            "key": "taxons",
+            "name": "Taxonomy",
+            "type": "hidden",
+          	"preposition": "about",
+            "display_as_result_metadata": false,
+            "filterable": true
+          },
+					{
+          	"key": "content_purpose_document_supertype",
+          	"name": "Publication type",
+          	"type": "hidden",
+          	"preposition": "of type",
+          	"display_as_result_metadata": false,
+          	"filterable": true
+					}
+      ],
+      "default_documents_per_page":20
+   }
+}

--- a/all-finder.json
+++ b/all-finder.json
@@ -47,18 +47,86 @@
             "key": "taxons",
             "name": "Taxonomy",
             "type": "hidden",
-          	"preposition": "about",
-            "display_as_result_metadata": false,
-            "filterable": true
+            "preposition": "about",
+            "display_as_result_metadata": true,
+            "filterable": true,
+            "allowed_values": [
+            ]
           },
-					{
-          	"key": "content_purpose_document_supertype",
-          	"name": "Publication type",
-          	"type": "hidden",
-          	"preposition": "of type",
-          	"display_as_result_metadata": false,
-          	"filterable": true
-					}
+          {
+            "key": "content_purpose_document_supertype",
+            "name": "Publication type",
+            "type": "hidden",
+            "preposition": "of type",
+            "display_as_result_metadata": true,
+            "filterable": true,
+            "allowed_values": [
+              {
+                "label": "News",
+                "value": "news"
+              },
+              {
+                "label": "Resources",
+                "value": "resources"
+              },
+              {
+                "label": "Speeches and statements",
+                "value": "speeches-and-statements"
+              },
+              {
+                "label": "Guidance",
+                "value": "guidance"
+              },
+              {
+                "label": "Updates and alerts",
+                "value": "updates-and-alerts"
+              },
+              {
+                "label": "Contacts",
+                "value": "contacts"
+              },
+              {
+                "label": "Transactions",
+                "value": "transactions"
+              },
+              {
+                "label": "Reports",
+                "value": "reports"
+              },
+              {
+                "label": "Decisions",
+                "value": "decisions"
+              },
+              {
+                "label": "Engagement activities",
+                "value": "engagement-activities"
+              },
+              {
+                "label": "Data",
+                "value": "data"
+              },
+              {
+                "label": "Organising entities",
+                "value": "organising-entities"
+              },
+              {
+                "label": "Navigation",
+                "value": "navigation"
+              },
+              {
+                "label": "Grants and funding",
+                "value": "grants-and-funding"
+              },
+              {
+                "label": "Corporate information",
+                "value": "corporate-info"
+              },
+              {
+                "label": "Service Manual",
+                "value": "service-manual"
+              }
+            ]
+          }
       ],
       "default_documents_per_page":20
    }

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -23,6 +23,7 @@ private
   def build_filter(facet)
     filter_class = {
       'date' => DateFilter,
+      'hidden' => HiddenFilter,
       'text' => TextFilter,
       'topical' => TopicalFilter,
     }.fetch(facet['type'])
@@ -86,6 +87,12 @@ private
       else
         {}
       end
+    end
+  end
+
+  class HiddenFilter < Filter
+    def value
+      params
     end
   end
 

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -21,6 +21,12 @@ private
   attr_reader :base_path, :filter_params
 
   def fetch_content_item
+    # Temporary override to make development easier. In the real world this comes
+    # from the content store, obvs.
+    unless Rails.env.test?
+      ENV["DEVELOPMENT_FINDER_JSON"] = "all-finder.json"
+    end
+
     if ENV["DEVELOPMENT_FINDER_JSON"]
       JSON.parse(File.read(ENV["DEVELOPMENT_FINDER_JSON"]))
     else

--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -1,0 +1,6 @@
+class HiddenFacet < FilterableFacet
+  def sentence_fragment
+    return nil unless value
+    { 'values' => [value] }
+  end
+end

--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -1,6 +1,31 @@
 class HiddenFacet < FilterableFacet
+
+  def allowed_values
+    facet['allowed_values']
+  end
+
   def sentence_fragment
     return nil unless value
-    { 'values' => [value] }
+    {
+      'type' => 'text',
+      'preposition' => preposition,
+      'values' => value_fragments
+    }
+  end
+
+  def value_fragments
+    selected_values.map { |v|
+      {
+        'label' => v['label'],
+        'parameter_key' => key,
+      }
+    }
+  end
+
+  def selected_values
+    return [] if @value.nil?
+    allowed_values.select { |option|
+      @value.include?(option['value'])
+    }
   end
 end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -8,6 +8,8 @@ module FacetParser
         TopicalFacet.new(facet)
       when 'date'
         DateFacet.new(facet)
+      when 'hidden'
+        HiddenFacet.new(facet)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet.type}")
       end

--- a/app/views/finders/_hidden_facet.html.erb
+++ b/app/views/finders/_hidden_facet.html.erb
@@ -1,0 +1,1 @@
+<input type="hidden" name="<%= hidden_facet.key %>" value="<%= params[hidden_facet.key] %>" />


### PR DESCRIPTION
Prototype similar to https://github.com/alphagov/finder-frontend/pull/411 but shows content type filtering options.

![screenshot from 2018-02-23 14-48-33](https://user-images.githubusercontent.com/93511/36599872-a5806114-18a8-11e8-8b95-c425ae30867c.png)

Example:
https://finder-frontend-pr-412.herokuapp.com/find-all-the-things!11!?keywords=&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&taxons=%2Fchildcare-parenting%2Fspecial-guardianship&content_purpose_document_supertype%5B%5D=guidance