### PR TITLE
Add feedback js to search page

### DIFF
--- a/app/assets/javascripts/application-site-search.js
+++ b/app/assets/javascripts/application-site-search.js
@@ -20,3 +20,4 @@
 //= require govuk_toolkit
 //= require_tree ./modules
 //= require_tree ./components
+//= require govuk_publishing_components/components/feedback


### PR DESCRIPTION
This was missing, so the feedback component fell back to the no JS behaviour.

https://trello.com/c/L4oXZfMb