### PR TITLE
Don't load govuk_frontend_toolkit in prod

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 //= require templates
 //
 //= require live_search
-//= require govuk_toolkit
 //= require_tree ./modules
 //= require_tree ./components
 //= require govuk_publishing_components/components/feedback

--- a/app/assets/javascripts/govuk_toolkit_for_tests.js
+++ b/app/assets/javascripts/govuk_toolkit_for_tests.js
@@ -1,0 +1,1 @@
+//= require govuk_toolkit

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -7,6 +7,7 @@ src_dir: "app/assets/javascripts"
 # relative path from src_dir
 src_files:
  - "../../../spec/javascripts/helpers/jquery-1.12.4.js"
+ - "govuk_toolkit_for_tests.js" # this is provided by Static in production
  - "application.js"
  - "live-site-search.js"
  - "search.js"


### PR DESCRIPTION
We currently are loading `govuk_frontend_toolkit` twice in production because it's also included by static. This brings us exotic problems like competing versions (requiring the versions to be in lockstep) and really bizarre problems caused by type checks that fail.

https://trello.com/c/W3wgnIj8