### PR TITLE
Allow Govspeak in email signup description

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -35,7 +35,9 @@
         <% end %>
       <% end %>
 
-      <p><%= @signup.body %></p>
+      <%= render partial: 'govuk_component/govspeak', locals: {
+             content: @signup.body
+           } %>
       <%= submit_tag 'Create subscription', class: "button" %>
     <% end %>
 


### PR DESCRIPTION
This commit allows Govspeak to be embedded in the description field for email signup pages. This is so we can link to other government organisations or privacy policies where the emails sent as part of the subscription don’t come from GDS (such as drug safety updates).

Trello: https://trello.com/c/QeBmdZCN/670-update-drug-safety-update-email-signup-page