### PR TITLE
Amend finder param names

### DIFF
--- a/app/controllers/advanced_search_finder_controller.rb
+++ b/app/controllers/advanced_search_finder_controller.rb
@@ -1,5 +1,7 @@
 class AdvancedSearchFinderController < FindersController
   layout "advanced-search"
+  rescue_from AdvancedSearchFinderApi::TaxonNotFound,
+              Supergroups::NotFound, with: :error_not_found
 
 private
 

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -1,4 +1,6 @@
 class AdvancedSearchFinderApi < FinderApi
+  GROUP_SEARCH_FILTER = "group".freeze
+  SUBGROUP_SEARCH_FILTER = "subgroup".freeze
   TAXON_SEARCH_FILTER = "topic".freeze
 
   attr_reader :content_item
@@ -32,14 +34,14 @@ private
 
   def augment_facets_with_dynamic_subgroups(content_item)
     subgroups = supergroups.map(&:subgroups_as_hash).flatten
-    facet = find_facet(content_item, "content_purpose_subgroup")
+    facet = find_facet(content_item, SUBGROUP_SEARCH_FILTER)
     return unless facet
     facet["allowed_values"] = subgroups
     facet["type"] = "hidden" if subgroups.size < 2
   end
 
   def supergroups
-    Supergroups.lookup(filter_params["content_purpose_supergroup"])
+    Supergroups.lookup(filter_params[GROUP_SEARCH_FILTER])
   end
 
   def find_facet(content_item, key)

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -1,5 +1,5 @@
 class AdvancedSearchFinderApi < FinderApi
-  TAXON_SEARCH_FILTER = "taxons".freeze
+  TAXON_SEARCH_FILTER = "topic".freeze
 
   attr_reader :content_item
 

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -4,8 +4,9 @@ class AdvancedSearchFinderApi < FinderApi
   attr_reader :content_item
 
   def content_item_with_search_results
-    filter_params[TAXON_SEARCH_FILTER] = taxon["content_id"] if taxon
+    raise_on_missing_taxon_param
 
+    filter_params[TAXON_SEARCH_FILTER] = taxon["content_id"] if taxon
     content_item = fetch_content_item
     search_response = fetch_search_response(content_item)
     content_item = augment_content_item_links_with_taxon(content_item, taxon)
@@ -14,9 +15,8 @@ class AdvancedSearchFinderApi < FinderApi
 
   def taxon
     @taxon ||= Services.content_store.content_item(filter_params[TAXON_SEARCH_FILTER])
-  rescue GdsApi::ContentStore::ItemNotFound
-    filter_params.delete(TAXON_SEARCH_FILTER)
-    nil
+  rescue GdsApi::HTTPNotFound
+    raise_on_missing_taxon_at_path
   end
 
 private
@@ -45,4 +45,20 @@ private
   def find_facet(content_item, key)
     content_item["details"]["facets"].find { |f| f["key"] == key }
   end
+
+  def raise_on_missing_taxon_at_path
+    raise_taxon_not_found("No taxon found for path #{filter_params[TAXON_SEARCH_FILTER]}")
+  end
+
+  def raise_on_missing_taxon_param
+    unless filter_params.has_key?(TAXON_SEARCH_FILTER)
+      raise_taxon_not_found("#{TAXON_SEARCH_FILTER} param not present")
+    end
+  end
+
+  def raise_taxon_not_found(msg = nil)
+    raise TaxonNotFound.new(msg)
+  end
+
+  class TaxonNotFound < StandardError; end
 end

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -1,7 +1,5 @@
 class AdvancedSearchFinderApi < FinderApi
-  GROUP_SEARCH_FILTER = "group".freeze
-  SUBGROUP_SEARCH_FILTER = "subgroup".freeze
-  TAXON_SEARCH_FILTER = "topic".freeze
+  include AdvancedSearchParams
 
   attr_reader :content_item
 

--- a/app/lib/advanced_search_params.rb
+++ b/app/lib/advanced_search_params.rb
@@ -1,0 +1,5 @@
+module AdvancedSearchParams
+  GROUP_SEARCH_FILTER = "group".freeze
+  SUBGROUP_SEARCH_FILTER = "subgroup".freeze
+  TAXON_SEARCH_FILTER = "topic".freeze
+end

--- a/app/lib/facet_query_builder.rb
+++ b/app/lib/facet_query_builder.rb
@@ -17,7 +17,8 @@ class FacetQueryBuilder
       # "1000,order:value.title" is specifying that we want 1000 results back
       # which are ordered by the title attribute of each value (option)
       # that is returned
-      query.merge(facet['key'] => "1000,order:value.title")
+      key = (facet['filter_key'] || facet['key'])
+      query.merge(key => "1000,order:value.title")
     }
   end
 

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -40,7 +40,7 @@ private
     end
 
     def key
-      facet['key']
+      facet['filter_key'] || facet['key']
     end
 
     def active?

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -61,7 +61,7 @@ private
   end
 
   def metadata_fields
-    finder_content_item['details']['facets'].map { |f| f['key'] }
+    finder_content_item['details']['facets'].map { |f| (f['filter_key'] || f['key']) }
   end
 
   def order_query

--- a/app/lib/supergroups.rb
+++ b/app/lib/supergroups.rb
@@ -1,30 +1,39 @@
 class Supergroups
   def self.lookup(keys)
-    return [] unless keys
+    raise_not_found(nil) unless keys
     keys = [keys] if keys.is_a?(String)
     groups = GovukDocumentTypes.supergroups(ids: keys)
+    raise_not_found(keys) if groups.empty?
     groups.map { |g| Supergroup.new(g) }
   end
-end
 
-class Supergroup
-  attr_reader :label, :value, :subgroups
-
-  def initialize(hash)
-    @value = hash["id"]
-    @label = value.humanize
-    @subgroups = hash["subgroups"]
+  def self.raise_not_found(keys)
+    msg = "Supergroup not found for keys: '#{keys}'."
+    raise Supergroups::NotFound.new(msg)
   end
 
-  def to_h
-    {
-      "label" => label,
-      "value" => value,
-      "subgroups" => subgroups_as_hash
-    }
+  class Supergroup
+    attr_reader :label, :value, :subgroups
+
+    def initialize(hash)
+      @value = hash["id"]
+      @label = value.humanize
+      @subgroups = hash["subgroups"]
+    end
+
+    def to_h
+      {
+        "label" => label,
+        "value" => value,
+        "subgroups" => subgroups_as_hash
+      }
+    end
+
+    def subgroups_as_hash
+      subgroups.map { |sg| { "label" => sg.humanize, "value" => sg } }
+    end
+
   end
 
-  def subgroups_as_hash
-    subgroups.map { |sg| { "label" => sg.humanize, "value" => sg } }
-  end
+  class NotFound < StandardError; end
 end

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -6,7 +6,7 @@ class AdvancedSearchFinderPresenter < FinderPresenter
 
   def content_purpose_supergroups
     @content_purpose_supergroups ||=
-      Supergroups.lookup(values['content_purpose_supergroup'])
+      Supergroups.lookup(values['group'])
   end
 
   def content_purpose_subgroups

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -1,4 +1,6 @@
 class AdvancedSearchFinderPresenter < FinderPresenter
+  include AdvancedSearchParams
+
   def taxon
     # FIXME: This is probably too simplistic.
     content_item['links']['taxons'].first
@@ -6,7 +8,7 @@ class AdvancedSearchFinderPresenter < FinderPresenter
 
   def content_purpose_supergroups
     @content_purpose_supergroups ||=
-      Supergroups.lookup(values['group'])
+      Supergroups.lookup(values[GROUP_SEARCH_FILTER])
   end
 
   def content_purpose_subgroups

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -16,9 +16,7 @@ class AdvancedSearchFinderPresenter < FinderPresenter
   end
 
   def title
-    return content_purpose_supergroups_to_sentence if content_purpose_supergroups.any?
-    return taxon['title'] if taxon
-    content_item['title']
+    content_purpose_supergroups_to_sentence
   end
 
   def taxon_link

--- a/app/presenters/advanced_search_result_set_presenter.rb
+++ b/app/presenters/advanced_search_result_set_presenter.rb
@@ -32,6 +32,6 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
   end
 
   def subgroup_facet
-    finder.facets.find { |f| f.key == 'content_purpose_subgroup' }
+    finder.facets.find { |f| f.key == 'subgroup' }
   end
 end

--- a/app/presenters/advanced_search_result_set_presenter.rb
+++ b/app/presenters/advanced_search_result_set_presenter.rb
@@ -1,4 +1,6 @@
 class AdvancedSearchResultSetPresenter < ResultSetPresenter
+  include AdvancedSearchParams
+
   def to_hash
     super.merge(applied_filters: applied_filters_or_all_subgroups)
   end
@@ -32,6 +34,6 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
   end
 
   def subgroup_facet
-    finder.facets.find { |f| f.key == 'subgroup' }
+    finder.facets.find { |f| f.key == SUBGROUP_SEARCH_FILTER }
   end
 end

--- a/features/advanced_search.feature
+++ b/features/advanced_search.feature
@@ -1,15 +1,20 @@
 Feature: Advanced Search
-  Scenario: Filters documents by taxon path
+  Scenario: Without content purpose supergroup parameter
     Given a collection of tagged documents
-    When I search by taxon
-    Then I only see documents tagged to the taxon
+    When I filter by taxon alone
+    Then The page is not found
+
+  Scenario: Without taxon parameter
+    Given a collection of tagged documents
+    When I filter by content purpose supergroup alone
+    Then The page is not found
 
   Scenario: Filters documents by taxon and content purpose supergroup
     Given a collection of tagged documents in supergroup 'news_and_communications'
-    When I search by taxon and by supergroup
+    When I filter by taxon and by supergroup
     Then I only see documents tagged to the taxon within the supergroup
 
   Scenario: Filters documents by taxon, supergroup and subgroups
     Given a collection of tagged documents in supergroup 'news_and_communications' and subgroups 'news,updates_and_alerts'
-    When I search by taxon, supergroup and subgroups
+    When I filter by taxon, supergroup and subgroups
     Then I only see documents tagged to the taxon within the supergroup and subgroups

--- a/features/fixtures/advanced-search.json
+++ b/features/fixtures/advanced-search.json
@@ -34,7 +34,8 @@
       "show_summaries":true,
       "facets": [
           {
-            "key": "content_purpose_subgroup",
+            "filter_key": "content_purpose_subgroup",
+            "key": "subgroup",
             "name": "Publication type",
             "type": "text",
             "preposition": "in",
@@ -63,8 +64,9 @@
             ]
           },
           {
-            "key": "content_purpose_supergroup",
-            "name": "Content purpose supergroup",
+            "filter_key": "content_purpose_supergroup",
+            "key": "group",
+            "name": "Content group",
             "type": "hidden",
             "preposition": "",
             "display_as_result_metadata": false,

--- a/features/fixtures/advanced-search.json
+++ b/features/fixtures/advanced-search.json
@@ -52,7 +52,8 @@
             "filterable":true
           },
           {
-            "key": "taxons",
+            "filter_key": "taxons",
+            "key": "topic",
             "name": "Taxonomy",
             "type": "hidden",
             "preposition": "",

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -43,7 +43,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
 end
 
 When(/^I filter by taxon alone$/) do
-  visit "/search/advanced?taxons=/taxon"
+  visit "/search/advanced?topic=/taxon"
 end
 
 When(/^I filter by content purpose supergroup alone$/) do
@@ -51,11 +51,11 @@ When(/^I filter by content purpose supergroup alone$/) do
 end
 
 When(/^I filter by taxon and by supergroup$/) do
-  visit "/search/advanced?taxons=/taxon&content_purpose_supergroup=news_and_communications"
+  visit "/search/advanced?topic=/taxon&content_purpose_supergroup=news_and_communications"
 end
 
 When(/^I filter by taxon, supergroup and subgroups$/) do
-  visit "/search/advanced?taxons=/taxon&content_purpose_supergroup=news_and_communications&content_purpose_subgroup[]=news&content_purpose_subgroup[]=updates_and_alerts"
+  visit "/search/advanced?topic=/taxon&content_purpose_supergroup=news_and_communications&content_purpose_subgroup[]=news&content_purpose_subgroup[]=updates_and_alerts"
 end
 
 Then(/^I only see documents tagged to the taxon$/) do

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -47,23 +47,15 @@ When(/^I filter by taxon alone$/) do
 end
 
 When(/^I filter by content purpose supergroup alone$/) do
-  visit "/search/advanced?content_purpose_supergroup=news_and_communications"
+  visit "/search/advanced?group=news_and_communications"
 end
 
 When(/^I filter by taxon and by supergroup$/) do
-  visit "/search/advanced?topic=/taxon&content_purpose_supergroup=news_and_communications"
+  visit "/search/advanced?topic=/taxon&group=news_and_communications"
 end
 
 When(/^I filter by taxon, supergroup and subgroups$/) do
-  visit "/search/advanced?topic=/taxon&content_purpose_supergroup=news_and_communications&content_purpose_subgroup[]=news&content_purpose_subgroup[]=updates_and_alerts"
-end
-
-Then(/^I only see documents tagged to the taxon$/) do
-  @results.each do |result|
-    expect(page).to have_title("Taxon - GOV.UK")
-    expect(page).to have_link("Taxon", "/taxon")
-    expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
-  end
+  visit "/search/advanced?topic=/taxon&group=news_and_communications&subgroup[]=news&subgroup[]=updates_and_alerts"
 end
 
 Then(/^I only see documents tagged to the taxon within the supergroup$/) do

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -42,15 +42,19 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
                          title: "Taxon")
 end
 
-When(/^I search by taxon$/) do
+When(/^I filter by taxon alone$/) do
   visit "/search/advanced?taxons=/taxon"
 end
 
-When(/^I search by taxon and by supergroup$/) do
+When(/^I filter by content purpose supergroup alone$/) do
+  visit "/search/advanced?content_purpose_supergroup=news_and_communications"
+end
+
+When(/^I filter by taxon and by supergroup$/) do
   visit "/search/advanced?taxons=/taxon&content_purpose_supergroup=news_and_communications"
 end
 
-When(/^I search by taxon, supergroup and subgroups$/) do
+When(/^I filter by taxon, supergroup and subgroups$/) do
   visit "/search/advanced?taxons=/taxon&content_purpose_supergroup=news_and_communications&content_purpose_subgroup[]=news&content_purpose_subgroup[]=updates_and_alerts"
 end
 
@@ -78,4 +82,8 @@ Then(/^I only see documents tagged to the taxon within the supergroup and subgro
     expect(page).to have_text("1 result in updates and alerts or news")
     expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
   end
+end
+
+Then(/^The page is not found$/) do
+  expect(page).to have_content("404 error not found")
 end

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -14,7 +14,7 @@ describe AdvancedSearchFinderApi do
   }
   let(:filter_params) {
     {
-      "taxons" => "/education",
+      "topic" => "/education",
       "content_purpose_supergroup" => "news_and_communications"
     }
   }
@@ -68,7 +68,7 @@ describe AdvancedSearchFinderApi do
         allow(Services.rummager).to receive(:search).and_return(search_results)
       end
 
-      let(:filter_params) { { "taxons" => "/doesnt-exist" } }
+      let(:filter_params) { { "topic" => "/doesnt-exist" } }
 
       it "raises GdsApi::ContentStore::ItemNotFound" do
         expect {
@@ -91,7 +91,7 @@ describe AdvancedSearchFinderApi do
     context "when content_purpose_supergroup has one subgroup" do
       let(:filter_params) {
         {
-          "taxons" => "/education",
+          "topic" => "/education",
           "content_purpose_supergroup" => "services"
         }
       }
@@ -106,7 +106,7 @@ describe AdvancedSearchFinderApi do
     context "when multiple supergroups are specified" do
       let(:filter_params) {
         {
-          "taxons" => "/education",
+          "topic" => "/education",
           "content_purpose_supergroup" => %w(news_and_communications services)
         }
       }

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -70,13 +70,10 @@ describe AdvancedSearchFinderApi do
 
       let(:filter_params) { { "taxons" => "/doesnt-exist" } }
 
-      it "omits the taxon filter from search" do
+      it "raises GdsApi::ContentStore::ItemNotFound" do
         expect {
           instance.content_item_with_search_results
-        }.not_to raise_error
-
-        expect(Services.rummager).to have_received(:search)
-          .with(hash_excluding("filter_taxons" => taxon_content_id))
+        }.to raise_error(AdvancedSearchFinderApi::TaxonNotFound)
       end
     end
 

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -15,7 +15,7 @@ describe AdvancedSearchFinderApi do
   let(:filter_params) {
     {
       "topic" => "/education",
-      "content_purpose_supergroup" => "news_and_communications"
+      "group" => "news_and_communications"
     }
   }
   let(:search_results) {
@@ -82,22 +82,22 @@ describe AdvancedSearchFinderApi do
     end
 
     it "adds dynamic facet values" do
-      facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "content_purpose_subgroup" }
+      facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "subgroup" }
       facet_labels = facet["allowed_values"].map { |v| v["label"] }
 
       expect(facet_labels).to include("Speeches and statements")
     end
 
-    context "when content_purpose_supergroup has one subgroup" do
+    context "when group has one subgroup" do
       let(:filter_params) {
         {
           "topic" => "/education",
-          "content_purpose_supergroup" => "services"
+          "group" => "services"
         }
       }
 
       it "hides the dynamic facet" do
-        facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "content_purpose_subgroup" }
+        facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "subgroup" }
         expect(facet["allowed_values"]).not_to be_empty
         expect(facet["type"]).to eq("hidden")
       end
@@ -107,11 +107,11 @@ describe AdvancedSearchFinderApi do
       let(:filter_params) {
         {
           "topic" => "/education",
-          "content_purpose_supergroup" => %w(news_and_communications services)
+          "group" => %w(news_and_communications services)
         }
       }
       it "returns a mixed list of subgroups" do
-        facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "content_purpose_subgroup" }
+        facet = composed_content_item["details"]["facets"].find { |f| f["key"] == "subgroup" }
         facet_labels = facet["allowed_values"].map { |v| v["label"] }
         expected = ["Updates and alerts", "News", "Speeches and statements", "Transactions"]
         expect(facet_labels).to eq(expected)

--- a/spec/lib/filter_query_builder_spec.rb
+++ b/spec/lib/filter_query_builder_spec.rb
@@ -94,6 +94,24 @@ describe FilterQueryBuilder::TextFilter do
     end
   end
 
+  describe "#key" do
+    context "when a filter_key is present" do
+      let(:facet) { { "filter_key" => "alpha", "key" => "beta" } }
+
+      it "returns filter_key" do
+        expect(text_filter.key).to eq("alpha")
+      end
+    end
+
+    context "when a filter_key is not present" do
+      let(:facet) { { "key" => "beta" } }
+
+      it "returns key" do
+        expect(text_filter.key).to eq("beta")
+      end
+    end
+  end
+
   describe "#value" do
     context "when params is present" do
       let(:params) { [:alpha] }

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -92,6 +92,18 @@ describe SearchQueryBuilder do
         "reject_alpha" => "value",
       )
     end
+
+    context "facets with filter_keys" do
+      before do
+        facets.first["filter_key"] = "zeta"
+      end
+
+      it "should use the filter value in fields" do
+        expect(query).to include(
+          "fields" => "title,link,description,public_timestamp,zeta,beta",
+        )
+      end
+    end
   end
 
   context "without keywords" do

--- a/spec/lib/supergroups_spec.rb
+++ b/spec/lib/supergroups_spec.rb
@@ -13,8 +13,16 @@ describe Supergroups do
       expect(groups.last.label).to eq("Services")
     end
 
-    it "returns an empty array when a group isn't found" do
-      expect(Supergroups.lookup("foo")).to be_empty
+    it "raises Supergroup::NotFound when keys are empty" do
+      expect {
+        Supergroups.lookup(nil)
+      }.to raise_error(Supergroups::NotFound)
+    end
+
+    it "raises Supergroup::NotFound when a group isn't found" do
+      expect {
+        Supergroups.lookup("foo")
+      }.to raise_error(Supergroups::NotFound)
     end
 
     it "can expose subgroups as a hash" do

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -60,8 +60,10 @@ describe AdvancedSearchFinderPresenter do
 
     context "without a supergroup" do
       let(:values) { { "taxons" => "/education" } }
-      it "presents the taxon title" do
-        expect(subject.title).to eq("Education, training and skills")
+      it "raises Supergroup::NotFound" do
+        expect {
+          subject.title
+        }.to raise_error(Supergroups::NotFound)
       end
     end
 

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -27,7 +27,7 @@ describe AdvancedSearchFinderPresenter do
   let(:values) {
     {
       "group" => "news_and_communications",
-      "taxons" => "/education",
+      "topic" => "/education",
     }
   }
 
@@ -59,7 +59,7 @@ describe AdvancedSearchFinderPresenter do
     end
 
     context "without a supergroup" do
-      let(:values) { { "taxons" => "/education" } }
+      let(:values) { { "topic" => "/education" } }
       it "raises Supergroup::NotFound" do
         expect {
           subject.title
@@ -70,7 +70,7 @@ describe AdvancedSearchFinderPresenter do
     context "with multiple supergroups" do
       let(:values) {
         {
-          "taxons" => "/education",
+          "topic" => "/education",
           "group" => %w(news_and_communications services)
         }
       }

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -26,7 +26,7 @@ describe AdvancedSearchFinderPresenter do
 
   let(:values) {
     {
-      "content_purpose_supergroup" => "news_and_communications",
+      "group" => "news_and_communications",
       "taxons" => "/education",
     }
   }
@@ -71,7 +71,7 @@ describe AdvancedSearchFinderPresenter do
       let(:values) {
         {
           "taxons" => "/education",
-          "content_purpose_supergroup" => %w(news_and_communications services)
+          "group" => %w(news_and_communications services)
         }
       }
       it "presents the supergroup labels in a sentence" do


### PR DESCRIPTION
https://trello.com/c/a5f5TIhK/150-amend-finder-params

This PR makes 2 changes to the advanced search finder:

* Amends `taxons` param name to `topic`, `content_purpose_supergroup` to `group` and `content_purpose_subgroup` to `subgroup`.
* Respond with 404 when `topic` or `group` params are not present or the topic or group are not found.

#### Example
https://finder-frontend-pr-443.herokuapp.com/search/advanced?topic=/education&group[]=news_and_communications

Depends on https://github.com/alphagov/govuk-content-schemas/pull/742