### PR TITLE
Ensure that the Home breadcrumb is always displayed

### DIFF
--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -25,11 +25,16 @@ class AdvancedSearchFinderPresenter < FinderPresenter
 
   def breadcrumbs
     @data ||= GovukNavigationHelpers::TaxonBreadcrumbs.new(content_item).breadcrumbs
-    filtered = @data[:breadcrumbs].reject { |bc| bc[:is_page_parent] || bc[:is_current_page] }
+    filtered = @data[:breadcrumbs].reject { |bc| exclude_breadcrumb?(bc) }
     { breadcrumbs: filtered }
   end
 
 private
+
+  def exclude_breadcrumb?(breadcrumb)
+    breadcrumb[:is_current_page] ||
+      (breadcrumb[:url] != "/" && breadcrumb[:is_page_parent])
+  end
 
   def content_purpose_supergroups_to_sentence
     content_purpose_supergroups.map(&:label).to_sentence

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -99,5 +99,18 @@ describe AdvancedSearchFinderPresenter do
       expected = { breadcrumbs: [{ title: "Home", url: "/", is_page_parent: false }] }
       expect(subject.breadcrumbs).to eq(expected)
     end
+
+    context "for a root taxon" do
+      let(:breadcrumb_data) {
+        { breadcrumbs: [
+          { title: "Home", url: "/", is_page_parent: true },
+          { title: "Latest on GOV.UK", is_current_page: true },
+        ] }
+      }
+      it "always includes the Home breadcrumb" do
+        expect(subject.breadcrumbs[:breadcrumbs].first[:title]).to eq("Home")
+        expect(subject.breadcrumbs[:breadcrumbs].first[:url]).to eq("/")
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/hfKXtUcQ/11-list-page-breadcrumbs-inconsistent

#### Missing root breadcrumb:

![screenshot from 2018-03-22 10-37-44](https://user-images.githubusercontent.com/93511/37767631-ad92fd74-2dc2-11e8-8f97-7ce49330589d.png)


This breadcrumb can be `is_parent_page: true` (eg. for "Money" taxon) - this should not be excluded
when filtering breadcrumbs.

#### Proposed fix:
https://finder-frontend-pr-446.herokuapp.com/search/advanced?topic=/money&group=news_and_communications