### PR TITLE
Present relevant supergroup metadata

### DIFF
--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -60,5 +60,9 @@ private
     raise TaxonNotFound.new(msg)
   end
 
+  def query_builder_class
+    AdvancedSearchQueryBuilder
+  end
+
   class TaxonNotFound < StandardError; end
 end

--- a/app/lib/advanced_search_query_builder.rb
+++ b/app/lib/advanced_search_query_builder.rb
@@ -1,0 +1,9 @@
+class AdvancedSearchQueryBuilder < SearchQueryBuilder
+  def base_return_fields
+    super + %w(
+      content_purpose_supergroup
+      content_store_document_type
+      organisations
+    )
+  end
+end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -25,7 +25,7 @@ private
   end
 
   def fetch_search_response(content_item)
-    query = SearchQueryBuilder.new(
+    query = query_builder_class.new(
       finder_content_item: content_item,
       params: filter_params,
     ).call
@@ -77,5 +77,9 @@ private
         'total_pages' => (total_results / documents_per_page.to_f).ceil,
       }
     end
+  end
+
+  def query_builder_class
+    SearchQueryBuilder
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,6 @@
 class Document
-  attr_reader :title, :public_timestamp, :is_historic, :government_name
+  attr_reader :title, :public_timestamp, :is_historic, :government_name,
+              :content_purpose_supergroup, :document_type, :organisations
 
   def initialize(rummager_document, finder)
     rummager_document = rummager_document.with_indifferent_access
@@ -7,9 +8,11 @@ class Document
     @link = rummager_document.fetch(:link)
     @description = rummager_document.fetch(:description, nil)
     @public_timestamp = rummager_document.fetch(:public_timestamp, nil)
+    @document_type = rummager_document.fetch(:content_store_document_type, nil)
+    @organisations = rummager_document.fetch(:organisations, [])
+    @content_purpose_supergroup = rummager_document.fetch(:content_purpose_supergroup, nil)
     @is_historic = rummager_document.fetch(:is_historic, false)
     @government_name = rummager_document.fetch(:government_name, nil)
-
     @finder = finder
     @rummager_document = rummager_document.slice(*metadata_keys)
   end

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -2,7 +2,6 @@ class AdvancedSearchFinderPresenter < FinderPresenter
   include AdvancedSearchParams
 
   def taxon
-    # FIXME: This is probably too simplistic.
     content_item['links']['taxons'].first
   end
 

--- a/app/presenters/advanced_search_result_presenter.rb
+++ b/app/presenters/advanced_search_result_presenter.rb
@@ -1,0 +1,32 @@
+class AdvancedSearchResultPresenter < SearchResultPresenter
+  def to_hash
+    super.merge(
+      content_purpose_supergroup: search_result.content_purpose_supergroup,
+      document_type: document_type,
+      organisations: organisations,
+      publication_date: publication_date,
+      show_metadata: show_metadata?,
+    )
+  end
+
+  def document_type
+    return unless show_metadata?
+    search_result.document_type.humanize
+  end
+
+  def organisations
+    return unless show_metadata?
+    search_result.organisations.map { |o| o[:title] }.join(", ")
+  end
+
+  def publication_date
+    return unless show_metadata?
+    metadata.select { |h| h[:label] == "Public timestamp" }.first
+  end
+
+  def show_metadata?
+    return false if search_result.content_purpose_supergroup == "services"
+    return false if search_result.document_type == "guide"
+    true
+  end
+end

--- a/app/presenters/advanced_search_result_set_presenter.rb
+++ b/app/presenters/advanced_search_result_set_presenter.rb
@@ -4,7 +4,16 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
   def to_hash
     super
       .merge(applied_filters: applied_filters_or_all_subgroups)
-      .except(:atom_url)
+        .except(:atom_url)
+  end
+
+  def documents
+    results.each_with_index.map do |result, index|
+      {
+        document: AdvancedSearchResultPresenter.new(result).to_hash,
+        document_index: index + 1,
+      }
+    end
   end
 
   def any_filters_applied?
@@ -32,10 +41,7 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
       if describe_filters_in_sentence.blank?
         subgroups_as_sentence
       elsif subgroup_facet.value.blank?
-        [
-          subgroups_as_sentence,
-          describe_filters_in_sentence
-        ].to_sentence
+        [subgroups_as_sentence, describe_filters_in_sentence].to_sentence
       else
         describe_filters_in_sentence
       end

--- a/app/views/advanced_search_finder/_results.mustache
+++ b/app/views/advanced_search_finder/_results.mustache
@@ -7,6 +7,9 @@
 
 <ul data-module="track-click">
   {{#documents}}
+    {{! The following elements use BEM styles from the govuk_publishing_components/document-list component
+    for visual consistency, this might prove to be a maintenance headache in which case it would be better
+    to port the styles to the advanced-search sass file. }}
     <li class="gem-c-document-list__item">
       <h3 class="gem-c-document-list__item-title">
         <a href='{{document.link}}'

--- a/app/views/advanced_search_finder/_results.mustache
+++ b/app/views/advanced_search_finder/_results.mustache
@@ -7,8 +7,8 @@
 
 <ul data-module="track-click">
   {{#documents}}
-    <li class="document">
-      <h3>
+    <li class="gem-c-document-list__item">
+      <h3 class="gem-c-document-list__item-title">
         <a href='{{document.link}}'
            data-track-category='navFinderLinkClicked'
            data-track-action='{{finder_name}}.{{document_index}}'
@@ -19,21 +19,25 @@
       {{#document.summary}}
         <p>{{document.summary}}</p>
       {{/document.summary}}
-      {{#show_document_metadata}}
-      <dl>
-        {{#document.metadata}}
-          {{#is_text}}
-            <dt class='metadata-text-label'>{{label}}:</dt>
-            <dd class='metadata-text-value'>{{value}}</dd>
-          {{/is_text}}
-        {{/document.metadata}}
-      </dl>
-      {{/show_document_metadata}}
-      {{#document.metadata}}
-        {{#is_date}}
-          <span class='metadata-date-value'><time datetime='{{machine_date}}'>{{human_date}}</time></span>
-        {{/is_date}}
-      {{/document.metadata}}
+      {{#document.show_metadata}}
+      <ul>
+        {{#document.publication_date}}
+        <li class="gem-c-document-list__attribute">
+          <time datetime="{{machine_date}}">{{human_date}}</time>
+        </li>
+        {{/document.publication_date}}
+        {{#document.organisations}}
+        <li class="gem-c-document-list__attribute">
+          {{document.organisations}}
+        </li>
+        {{/document.organisations}}
+        {{#document.document_type}}
+        <li class="gem-c-document-list__attribute">
+          {{document.document_type}}
+        </li>
+        {{/document.document_type}}
+      </ul>
+      {{/document.show_metadata}}
       {{#document.is_historic}}
         <p class="historic">First published during the {{document.government_name}}</p>
       {{/document.is_historic}}

--- a/features/advanced_search.feature
+++ b/features/advanced_search.feature
@@ -13,8 +13,10 @@ Feature: Advanced Search
     Given a collection of tagged documents in supergroup 'news_and_communications'
     When I filter by taxon and by supergroup
     Then I only see documents tagged to the taxon within the supergroup
+    And The correct metadata is displayed for the search results
 
   Scenario: Filters documents by taxon, supergroup and subgroups
     Given a collection of tagged documents in supergroup 'news_and_communications' and subgroups 'news,updates_and_alerts'
     When I filter by taxon, supergroup and subgroups
     Then I only see documents tagged to the taxon within the supergroup and subgroups
+    And The correct metadata is displayed for the search results

--- a/features/fixtures/advanced-search.json
+++ b/features/fixtures/advanced-search.json
@@ -46,7 +46,6 @@
           {
             "key":"public_timestamp",
             "name":"Publication date",
-            "short_name":"",
             "type":"date",
             "preposition":"published",
             "display_as_result_metadata":true,

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -5,13 +5,28 @@ def finder_content_item
 end
 
 Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
-  @tagged_to_taxon = { "title" => "tagged-to-taxon", "link" => "/tagged-to-taxon" }
-  @results = [@tagged_to_taxon]
+  @tagged_to_taxon = {
+    "title" => "tagged-to-taxon",
+    "link" => "/tagged-to-taxon",
+    "content_store_document_type" => "guidance",
+    "content_purpose_supergroup" => "news_and_communications",
+  }
+  @guide_tagged_to_taxon = {
+    "title" => "guide-tagged-to-taxon",
+    "link" => "/guide-tagged-to-taxon",
+    "content_store_document_type" => "guide",
+    "content_purpose_supergroup" => "news_and_communications",
+  }
+  @results = [@tagged_to_taxon, @guide_tagged_to_taxon]
   search_params = base_search_params.merge(
     "count" => 20,
     "facet_content_purpose_subgroup" => "1000,order:value.title",
-    "fields" => %w(title link description public_timestamp content_purpose_subgroup
-      taxons content_purpose_supergroup).join(","),
+    "fields" => %w(
+      title link description public_timestamp
+      content_purpose_supergroup
+      content_store_document_type organisations
+      content_purpose_subgroup taxons
+    ).join(","),
     "order" => "-public_timestamp",
     "reject_content_store_document_type" => ["browse"],
   )
@@ -29,7 +44,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
   stub_request(:get, rummager_advanced_search_url).to_return(
     body: {
       results: @results,
-      total: 1,
+      total: 2,
       start: 0,
       facets: {},
       suggested_queries: []
@@ -62,7 +77,7 @@ Then(/^I only see documents tagged to the taxon within the supergroup$/) do
   @results.each do |result|
     expect(page).to have_title("News and communications - GOV.UK")
     expect(page).to have_link("Taxon", "/taxon")
-    expect(page).to have_text("1 result in updates and alerts, news, and speeches and statements")
+    expect(page).to have_text("2 results in updates and alerts, news, and speeches and statements")
     expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
   end
 end
@@ -71,9 +86,14 @@ Then(/^I only see documents tagged to the taxon within the supergroup and subgro
   @results.each do |result|
     expect(page).to have_title("News and communications - GOV.UK")
     expect(page).to have_link("Taxon", "/taxon")
-    expect(page).to have_text("1 result in updates and alerts or news")
+    expect(page).to have_text("2 results in updates and alerts or news")
     expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
   end
+end
+
+Then(/^The correct metadata is displayed for the search results$/) do
+  expect(page).to have_css(".gem-c-document-list__attribute", text: "Guidance")
+  expect(page).not_to have_css(".gem-c-document-list__attribute", text: "Guide")
 end
 
 Then(/^The page is not found$/) do

--- a/spec/lib/advanced_search_query_builder_spec.rb
+++ b/spec/lib/advanced_search_query_builder_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe AdvancedSearchQueryBuilder do
+  subject(:instance) { described_class.new(finder_content_item: {}) }
+  describe "#base_return_fields" do
+    it "includes document_type and organisations" do
+      expect(instance.base_return_fields).to include("content_store_document_type")
+      expect(instance.base_return_fields).to include("organisations")
+    end
+  end
+end

--- a/spec/presenters/advanced_search_result_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_presenter_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe AdvancedSearchResultPresenter do
+  let(:finder_content_item) {
+    JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
+  }
+  let(:finder) { AdvancedSearchFinderPresenter.new(finder_content_item) }
+  let(:document_type) { "guidance" }
+  let(:organisations) { [{ title: "Ministry of Defence" }] }
+  let(:public_timestamp) { "2018-03-26" }
+  let(:content_purpose_supergroup) { "news_and_communications" }
+  let(:search_result) {
+    Document.new({
+      title: "Result",
+      link: "/result",
+      content_purpose_supergroup: content_purpose_supergroup,
+      content_store_document_type: document_type,
+      organisations: organisations,
+      public_timestamp: public_timestamp,
+    }, finder)
+  }
+
+  subject(:instance) { described_class.new(search_result) }
+
+  describe "#to_hash" do
+    it "includes document_type, organisations and publication_date" do
+      expect(instance.to_hash[:document_type]).to eq("Guidance")
+      expect(instance.to_hash[:organisations]).to eq("Ministry of Defence")
+      expect(instance.to_hash[:publication_date][:machine_date]).to eq("2018-03-26")
+    end
+  end
+
+  context "when metadata is hidden" do
+    before { allow(instance).to receive(:show_metadata?).and_return(false) }
+
+    describe "#document_type" do
+      it "returns nil" do
+        expect(instance.document_type).to be_nil
+      end
+    end
+
+    describe "#organisations" do
+      it "returns nil" do
+        expect(instance.organisations).to be_nil
+      end
+    end
+
+    describe "#publication_date" do
+      it "returns nil" do
+        expect(instance.publication_date).to be_nil
+      end
+    end
+  end
+
+  describe "#show_metadata?" do
+    it "returns true for most document types and supergroups" do
+      expect(instance.show_metadata?).to be true
+    end
+
+    context "for guide document_type" do
+      let(:document_type) { "guide" }
+
+      it "returns false for the 'guide' document_type" do
+        expect(instance.show_metadata?).to be false
+      end
+    end
+
+    context "for services content group" do
+      let(:content_purpose_supergroup) { "services" }
+
+      it "returns true for other document_types" do
+        expect(instance.show_metadata?).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe AdvancedSearchResultSetPresenter do
     ).content_item_with_search_results
   end
   let(:finder) { AdvancedSearchFinderPresenter.new(finder_api, filter_params) }
-  let(:filter_params) { { "topic" => "/education", "group" => "news_and_communications" } }
+  let(:group) { "news_and_communications" }
+  let(:filter_params) { { "topic" => "/education", "group" => group } }
   let(:view_context) { double(:view_context, render: nil) }
   let(:taxon_content_id) { SecureRandom.uuid }
   let(:taxon) {


### PR DESCRIPTION
https://trello.com/c/5dqDUMJR/3-make-metadata-rules-for-supergroups-consistent-with-topic-pages

![screenshot from 2018-03-26 17-07-15](https://user-images.githubusercontent.com/93511/37918180-2b5489e6-3118-11e8-89c9-2f876e22c4a8.png)


Example: https://finder-frontend-pr-452.herokuapp.com/search/advanced?group=guidance_and_regulation&page=3&topic=%2Feducation%2Fprimary-curriculum-key-stage-1-tests-and-assessments

DNM: Depends on https://github.com/alphagov/rummager/pull/1209