### PR TITLE
Use new GovukPublishingComponents presenters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'shared_mustache', '~> 1.0.1'
 gem 'govuk_app_config', '~> 1.4.1'
 gem 'chronic', '~> 0.10.2'
 gem 'govuk_ab_testing', '~> 2.4.1'
-gem 'govuk_publishing_components', '~> 5.7.0'
+gem 'govuk_publishing_components', '~> 6.0.0'
 gem 'govuk_document_types', '~> 0.4.0'
 
 gem 'govuk_frontend_toolkit', '~> 7.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,14 +137,10 @@ GEM
     govuk_frontend_toolkit (7.4.2)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (9.2.1)
-      activesupport (~> 5.1)
-      gds-api-adapters (>= 43.0)
-      govuk_ab_testing (~> 2.4)
-    govuk_publishing_components (5.7.0)
+    govuk_publishing_components (6.0.0)
       govspeak (>= 5.0.3)
+      govuk_app_config
       govuk_frontend_toolkit
-      govuk_navigation_helpers (~> 9.2.1)
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -377,7 +373,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.4.1)
   govuk_document_types (~> 0.4.0)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_publishing_components (~> 5.7.0)
+  govuk_publishing_components (~> 6.0.0)
   jasmine-rails
   launchy (~> 2.4.2)
   pry-byebug

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -24,7 +24,7 @@ class AdvancedSearchFinderPresenter < FinderPresenter
   end
 
   def breadcrumbs
-    @data ||= GovukNavigationHelpers::TaxonBreadcrumbs.new(content_item).breadcrumbs
+    @data ||= GovukPublishingComponents::Presenters::TaxonBreadcrumbs.new(content_item).breadcrumbs
     filtered = @data[:breadcrumbs].reject { |bc| exclude_breadcrumb?(bc) }
     { breadcrumbs: filtered }
   end

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -81,7 +81,7 @@ describe AdvancedSearchFinderPresenter do
   end
 
   describe "breadcrumbs" do
-    let(:helper) { instance_double("GovukNavigationHelpers::TaxonBreadcrumbs") }
+    let(:helper) { instance_double("GovukPublishingComponents::Presenters::TaxonBreadcrumbs") }
     let(:breadcrumb_data) {
       { breadcrumbs: [
         { title: "Home", url: "/", is_page_parent: false },
@@ -91,7 +91,7 @@ describe AdvancedSearchFinderPresenter do
     }
 
     before do
-      allow(GovukNavigationHelpers::TaxonBreadcrumbs).to receive(:new).and_return(helper)
+      allow(GovukPublishingComponents::Presenters::TaxonBreadcrumbs).to receive(:new).and_return(helper)
       allow(helper).to receive(:breadcrumbs).and_return(breadcrumb_data)
     end
 


### PR DESCRIPTION
The taxonomy breadcrumbs are now generated by `GovukPublishingComponents` so that they can be shared with collections (https://github.com/alphagov/collections/pull/589).

https://trello.com/c/WJlqy3VD