### PR TITLE
Order list page results consistently with topic pages

### DIFF
--- a/app/lib/advanced_search_query_builder.rb
+++ b/app/lib/advanced_search_query_builder.rb
@@ -1,9 +1,19 @@
 class AdvancedSearchQueryBuilder < SearchQueryBuilder
+  include AdvancedSearchParams
   def base_return_fields
     super + %w(
       content_purpose_supergroup
       content_store_document_type
       organisations
     )
+  end
+
+  def default_order
+    return '-popularity' if sort_by_popularity
+    super
+  end
+
+  def sort_by_popularity
+    %w[services guidance_and_regulation].include? params[GROUP_SEARCH_FILTER]
   end
 end

--- a/spec/lib/advanced_search_query_builder_spec.rb
+++ b/spec/lib/advanced_search_query_builder_spec.rb
@@ -1,11 +1,81 @@
 require "spec_helper"
 
 RSpec.describe AdvancedSearchQueryBuilder do
-  subject(:instance) { described_class.new(finder_content_item: {}) }
+  subject(:instance) do
+    described_class.new(
+      finder_content_item: content_item,
+      params: params,
+    )
+  end
+  let(:content_item) do
+    {
+      'details' =>
+        {
+          'facets' => [],
+          'filter' => {},
+          'reject' => {},
+          'default_order' => default_order,
+          'default_documents_per_page' => nil,
+        }
+    }
+  end
+  let(:params) { {} }
+  let(:default_order) { nil }
   describe "#base_return_fields" do
     it "includes document_type and organisations" do
       expect(instance.base_return_fields).to include("content_store_document_type")
       expect(instance.base_return_fields).to include("organisations")
+    end
+  end
+
+  context 'without keywords' do
+    it 'should not include a keyword query' do
+      expect(instance.call).not_to include("q")
+    end
+
+    context 'when guidance' do
+      let(:params) { { 'group' => 'guidance_and_regulation' } }
+      it "should include an order query" do
+        expect(instance.call).to include("order" => "-popularity")
+      end
+    end
+
+    context 'when services' do
+      let(:params) { { 'group' => 'services' } }
+      it "should include an order query" do
+        expect(instance.call).to include("order" => "-popularity")
+      end
+    end
+
+    context 'when not guidance or services' do
+      let(:params) { {} }
+      it "should include an order query" do
+        expect(instance.call).to include("order" => "-public_timestamp")
+      end
+
+      context "with a custom order" do
+        let(:default_order) { "custom_field" }
+
+        it "should include a custom order query" do
+          expect(instance.call).to include("order" => "custom_field")
+        end
+      end
+    end
+  end
+
+  context "with keywords" do
+    let(:params) {
+      {
+        "keywords" => "mangoes",
+      }
+    }
+
+    it "should include a keyword query" do
+      expect(instance.call).to include("q" => "mangoes")
+    end
+
+    it "should not include an order query" do
+      expect(instance.call).not_to include("order")
     end
   end
 end


### PR DESCRIPTION
Guidance and Services order their results by popularity on topic pages, the same should be true on list pages.

Refactored AdvancedSearchQueryBuilder to order by popularity if the  'group' param is 'services' or 'guidance_and_regulation'

The Trello card is [Order list page results consistently with topic pages](https://trello.com/c/YOaZ0vdW/12-order-list-page-results-consistently-with-topic-pages)