### PR TITLE
Use button component from gem

### DIFF
--- a/app/presenters/search_results_presenter.rb
+++ b/app/presenters/search_results_presenter.rb
@@ -23,8 +23,7 @@ class SearchResultsPresenter
       filter_fields: filter_fields,
       debug_score: search_parameters.debug_score,
       first_result_number: (search_parameters.start + 1),
-      next_and_prev_links: next_and_prev_links,
-      search_fallback_button: search_fallback_button
+      next_and_prev_links: next_and_prev_links
     }
   end
 
@@ -85,10 +84,6 @@ class SearchResultsPresenter
 
   def show_organisations_filter?(facet)
     search_parameters.show_organisations_filter? || facet[:any?]
-  end
-
-  def search_fallback_button
-    view_context.render('govuk_component/button', text: 'Submit filters')
   end
 
   def next_and_prev_links

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -39,7 +39,7 @@
               %>
             <% end %>
             <div class="submit js-live-search-fallback">
-              <%= render 'govuk_component/button', text: 'Submit filters' %>
+              <%= render 'govuk_publishing_components/components/button', text: 'Submit filters' %>
             </div>
           </div>
         </div>

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -136,7 +136,7 @@ describe("liveSearch", function(){
   describe("should not display out of date results", function(){
 
     it('should not update the results if the state associated with these results is not the current state of the page', function(){
-      liveSearch.state = 'cma-cases.json?keywords=123'
+      liveSearch.state = 'cma-cases.json?keywords=123';
       spyOn(liveSearch.$resultsBlock, 'mustache');
       liveSearch.displayResults(dummyResponse, 'made up state');
       expect(liveSearch.$resultsBlock.mustache).not.toHaveBeenCalled();


### PR DESCRIPTION
Moved the button component from static to the gem https://github.com/alphagov/govuk_publishing_components/pull/271

Now updating finder-frontend to use the component from the gem, not from static.

https://trello.com/c/Ffo7meK0

