### PR TITLE
[DO NOT MERGE] Fix CI JS tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,11 +27,13 @@ group :development do
 end
 
 group :development, :test do
-  gem 'jasmine-rails'
+  gem 'ci_reporter_test_unit'
+  gem 'jasmine', '~> 2.8'
   gem 'awesome_print'
   gem 'rspec-rails', '~> 3.7.2'
   gem 'pry-byebug'
   gem 'govuk-lint', '~> 3.8.0'
+  gem 'ci_reporter_rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,14 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     chronic (0.10.2)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
+    ci_reporter_test_unit (1.0.1)
+      ci_reporter (~> 2.0)
+      test-unit (>= 2.5.5, < 4.0)
     coderay (1.1.2)
     commander (4.4.4)
       highline (~> 1.7.2)
@@ -153,12 +161,12 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jasmine-core (2.8.0)
-    jasmine-rails (0.14.7)
-      jasmine-core (>= 1.3, < 3.0)
-      phantomjs (>= 1.9)
-      railties (>= 3.2.0)
-      sprockets-rails
+    jasmine (2.99.0)
+      jasmine-core (>= 2.99.0, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.99.2)
     json (2.1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -204,6 +212,7 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
+    power_assert (1.1.1)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -258,6 +267,10 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rouge (3.1.1)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
     rspec-core (3.7.0)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -332,6 +345,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    test-unit (3.2.7)
+      power_assert
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -364,6 +379,8 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   chronic (~> 0.10.2)
+  ci_reporter_rspec
+  ci_reporter_test_unit
   cucumber-rails (~> 1.5.0)
   gds-api-adapters (~> 52.5)
   govuk-content-schema-test-helpers (~> 1.6)
@@ -373,7 +390,7 @@ DEPENDENCIES
   govuk_document_types (~> 0.4.0)
   govuk_frontend_toolkit (~> 7.4)
   govuk_publishing_components (~> 6.5.0)
-  jasmine-rails
+  jasmine (~> 2.8)
   launchy (~> 2.4.2)
   pry-byebug
   rails (~> 5.1.5)

--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,9 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'rake'
+require 'ci/reporter/rake/test_unit' if Rails.env.development? or Rails.env.test?
+require 'ci/reporter/rake/rspec' if Rails.env.development? or Rails.env.test?
 
+task default: [:spec, 'jasmine:ci']
 FinderFrontend::Application.load_tasks

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,16 +1,16 @@
 # path to parent directory of src_files
 # relative path from Rails.root
 # defaults to app/assets/javascripts
-src_dir: "app/assets/javascripts"
+#src_dir: "app/assets/javascripts"
 
 # list of file expressions to include as source files
 # relative path from src_dir
 src_files:
- - "../../../spec/javascripts/helpers/jquery-1.12.4.js"
- - "govuk_toolkit_for_tests.js" # this is provided by Static in production
- - "application.js"
- - "live-site-search.js"
- - "search.js"
+ - "spec/javascripts/helpers/jquery-1.12.4.js"
+ - "assets/govuk_toolkit_for_tests.js" # this is provided by Static in production
+ - "assets/application.js"
+ - "assets/live-site-search.js"
+ - "assets/search.js"
 
 # path to parent directory of spec_files
 # relative path from Rails.root


### PR DESCRIPTION
Jenkins wasn't running the javascript tests as part of a PR build. It is now.

This PR is probably currently failing because there were historically broken JS tests. I'll now try and fix them. I think the errors may be related to this PR - https://github.com/alphagov/finder-frontend/pull/374

