### PR TITLE
Sanitise the search term before rendering

### DIFF
--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -1,6 +1,6 @@
 <%
   if @search_term.present?
-    label_text = "<h1>Search results for <span class=\"visuallyhidden\">&ldquo;#{@search_term}&rdquo;</span></h1>"
+    label_text = "<h1>Search results for <span class=\"visuallyhidden\">&ldquo;#{sanitize(@search_term)}&rdquo;</span></h1>"
   else
     label_text = "<h1>Search GOV.UK</h1>"
   end


### PR DESCRIPTION
Using the unsanitised search term in the “Search results for” text
could result in an XSS vulnerability.