### PR TITLE
Pass safe HTML to the search component

### DIFF
--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -1,10 +1,10 @@
-<%
-  if @search_term.present?
-    label_text = "<h1>Search results for <span class=\"visuallyhidden\">&ldquo;#{sanitize(@search_term)}&rdquo;</span></h1>"
-  else
-    label_text = "<h1>Search GOV.UK</h1>"
-  end
-%>
+<% label_text = capture do %>
+  <% if @search_term.present? %>
+    <h1>Search results for <span class="visuallyhidden">&ldquo;<%= @search_term %>&rdquo;</span></h1>
+  <% else %>
+    <h1>Search GOV.UK</h1>
+  <% end %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/search", {
   inline_label: false,

--- a/features/site_search.feature
+++ b/features/site_search.feature
@@ -18,6 +18,11 @@ Feature: Site search
     And I can see the search term
     And Analytics values are sent
 
+  Scenario: When search terms are entered
+    Given search results exist
+    When I search for "<script>XSS</script>"
+    Then the search term is escaped
+
   Scenario: When an invalid search is entered
     Given no search results exist
     When I search for "search-term"

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -244,6 +244,10 @@ Then(/^I should get an error page$/) do
   expect(page.status_code).to eq(503)
 end
 
+Then("the search term is escaped") do
+  expect(page.body.to_s).not_to match("<script>XSS</script>")
+end
+
 module RummagerStubber
   def stub_rummager_results(results, _query = "search-term", suggestions = [], options = {})
     response_body = response(results, suggestions, options)
@@ -304,4 +308,5 @@ module RummagerStubber
     response([])
   end
 end
+
 World(RummagerStubber)


### PR DESCRIPTION
After https://github.com/alphagov/govuk_publishing_components/pull/283 it's no longer possible to pass unsafe HTML to the search component. By using `capture` we use Rails' escaping and sanitisation mechanism to sanitise `@search_term` and any other user input.

Also adds a test for the vulnerability fixed in https://github.com/alphagov/finder-frontend/pull/480.