### PR TITLE
Remove need_ids from the fixtures

### DIFF
--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -9,9 +9,6 @@
   "government_document_supertype":"other",
   "locale":"en",
   "navigation_document_supertype":"other",
-  "need_ids":[
-
-  ],
   "phase":"live",
   "public_updated_at":"2018-01-24T09:55:35.000+00:00",
   "publishing_app":"specialist-publisher",

--- a/features/fixtures/advanced-search.json
+++ b/features/fixtures/advanced-search.json
@@ -9,7 +9,6 @@
    "government_document_supertype":"other",
    "locale":"en",
    "navigation_document_supertype":"other",
-   "need_ids":[],
    "phase":"live",
    "public_updated_at":"2018-01-24T09:55:35.000+00:00",
    "publishing_app":"finder-frontend",


### PR DESCRIPTION
This is a deprecated field, as the needs are now represented within
the links.