### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -2,8 +2,6 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
-  <%= render partial: 'govuk_component/analytics_meta_tags',
-      locals: { content_item: @finder.content_item } %>
 <% end %>
 
 <% if finder.alpha? %>

--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -2,3 +2,5 @@
   <meta name="description" content="<%= finder.description %>">
 <% end %>
 <link rel="alternate" type="application/json" href="/api/content<%= finder.slug %>">
+
+<%= render 'govuk_publishing_components/components/meta_tags', content_item: finder.content_item %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,8 +2,6 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
-  <%= render partial: 'govuk_component/analytics_meta_tags',
-      locals: { content_item: @finder.content_item } %>
 <% end %>
 
 <% if finder.alpha? %>

--- a/app/views/layouts/search-application.html.erb
+++ b/app/views/layouts/search-application.html.erb
@@ -9,7 +9,7 @@
   <!--[if IE 8]><%= stylesheet_link_tag "application-site-search-ie8.css" %><![endif]-->
   <%= javascript_include_tag 'application-site-search', integrity: true, crossorigin: 'anonymous' %>
   <% if @content_item %>
-    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+    <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <% end %>
   <%= yield :extra_headers %>
 </head>


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags
component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/2w1AKyuW