### PR TITLE
Redirect /government/policies/brexit to /government/brexit

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -4,6 +4,8 @@ class FindersController < ApplicationController
   include GdsApi::Helpers
 
   def show
+    return redirect_to '/government/brexit' if finder_slug == 'government/policies/brexit'
+
     @results = result_set_presenter_class.new(finder, filter_params, view_context)
 
     respond_to do |format|


### PR DESCRIPTION
This will redirect users from /government/policies/brexit to
/government/brexit. We can't use short url manager to do this as we want
the content for /government/policies/brexit to still exist so it can be
tagged too.

https://trello.com/c/hO0ywmhl/105-redirect-govt-policies-brexit-to-go-to-brexit