### PR TITLE
Use metadata component from gem

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::GovukComponents
   slimmer_template "header_footer_only"
 
   # Prevent CSRF attacks by raising an exception.

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% if @signup.beta? %>
-  <%= render partial: 'govuk_component/beta_label' %>
+  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 <header>
  <div class="title-and-metadata">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -21,10 +21,7 @@
       title: finder.name
     } %>
     <% if finder.page_metadata.any? %>
-      <div class="metadata">
-        <%= render partial: 'govuk_component/metadata',
-          locals: page_metadata(finder.page_metadata) %>
-      </div>
+      <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
     <% end %>
 
     <% if finder.summary %>

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -8,7 +8,7 @@ Then(/^I can get a list of all documents with matching metadata$/) do
 
   expect(page).not_to have_content('2 reports')
   expect(page).to have_css('.filtered-results .document', count: 2)
-  expect(page).to have_css(shared_component_selector('metadata'))
+  expect(page).to have_css('.gem-c-metadata')
 
   within '.filtered-results .document:nth-child(1)' do
     expect(page).to have_link(

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -184,7 +184,7 @@ Then(/^Organisations filter should not be expanded$/) do
 end
 
 Then(/^Organisations filter should not be displayed$/) do
-  expect(page).to have_no_css(shared_component_selector('option_select'))
+  expect(page).to have_no_css('.app-c-option-select')
 end
 
 Then /^I can see the search term$/ do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,13 +12,6 @@ require 'cucumber/rspec/doubles'
 require 'webmock/cucumber'
 require 'slimmer/test'
 
-require 'slimmer/test_helpers/govuk_components'
-World(Slimmer::TestHelpers::GovukComponents)
-
-Before do
-  stub_shared_component_locales
-end
-
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,8 @@ GovukAbTesting.configure do |config|
 end
 
 RSpec.configure do |config|
-  include Slimmer::TestHelpers::GovukComponents
   config.raise_errors_for_deprecations!
-  config.before do
-    stub_shared_component_locales
-  end
+
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
This makes the app use the metadata component from the gem (https://trello.com/c/HPvqjaYP). Since this is the last usage of Static components, we can clean up the code and test helpers.

https://trello.com/c/pU7YINt1