### PR TITLE
Cache atom feeds for 5 minutes

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -3,6 +3,8 @@ require 'gds_api/helpers'
 class FindersController < ApplicationController
   include GdsApi::Helpers
 
+  ATOM_FEED_MAX_AGE = 300
+
   def show
     return redirect_to '/government/brexit' if finder_slug == 'government/policies/brexit'
 
@@ -17,6 +19,7 @@ class FindersController < ApplicationController
       end
       format.atom do
         if finder.atom_feed_enabled?
+          expires_in(ATOM_FEED_MAX_AGE, public: true)
           @feed = AtomPresenter.new(finder)
         else
           render plain: 'Not found', status: 404

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -44,6 +44,7 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/atom+xml")
         expect(response).to render_template("finders/show")
+        expect(response.headers['Cache-Control']).to eq("max-age=300, public")
       end
 
       it "returns a 406 if an invalid format is requested" do


### PR DESCRIPTION
https://trello.com/c/5GRfTtMR/233-make-atom-feeds-more-resilient

5 mins will be consistent with other atom feeds eg. [Travel Advice](https://github.com/alphagov/government-frontend/pull/941).