### PR TITLE
Fix bug in rendering of JSON response

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -107,7 +107,7 @@ private
     pages[:previous_page] = build_page_link("Previous page", previous_page) if previous_page
     pages[:next_page] = build_page_link("Next page", next_page) if next_page
 
-    view_context.render('govuk_publishing_components/components/previous_and_next_navigation', pages) if pages
+    view_context.render(formats: ["html"], partial: 'govuk_publishing_components/components/previous_and_next_navigation', locals: pages) if pages
   end
 
   def build_page_link(page_label, page)


### PR DESCRIPTION
The JSON response now renders an actual template since switching to the gem-based components (https://github.com/alphagov/finder-frontend/pull/513). This doesn't quite work automatically like it did when the component was rendered from static. It currently raises an error:

```
errorMissing partial
govuk_publishing_components/components/_previous_and_next_navigation
with {:locale=>[:en], :formats=>[:json], :variants=>[],
:handlers=>[:raw, :erb, :html, :builder, :ruby]}. Searched in: *
"/data/vhost/finder-frontend.staging.publishing.service.gov.uk/releases/
20180620102319/app/views" *
"/data/vhost/finder-frontend.staging.publishing.service.gov.uk/shared/bu
ndle/ruby/2.5.0/gems/govuk_publishing_components-9.3.0/app/views" ruby
```

We have to tell the `render` call what format to render.

The tests needed to be updated to make sure that the test renders the pagination as well.

Fixes https://sentry.io/govuk/app-finder-frontend/issues/585614924.