### PR TITLE
Reject malformed results from the finder facet

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -60,7 +60,9 @@ private
   end
 
   def allowed_values_for_facet_details(facet_details)
-    values = facet_details.fetch("options", {}).map { |f| f.fetch("value", {}) }
+    values = facet_details.fetch("options", {})
+      .reject { |f| f.dig("value", "title").nil? }
+      .map { |f| f.fetch("value", {}) }
 
     values.map { |value|
       {

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -121,6 +121,7 @@ Then(/^I can see filters based on the results$/) do
   within '.app-c-option-select' do
     expect(page).to have_selector('input#organisations-ministry-of-justice')
     expect(page).to have_content('Ministry of Justice')
+    expect(page).to_not have_selector('input#organisations-ministry-of-missing-spoons')
   end
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -375,7 +375,8 @@ module DocumentHelper
       "facets": {
         "organisations": {
           "options": [
-              {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}}
+              {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}},
+              {"value": {"slug": "ministry-of-missing-spoons"}}
           ]
         }
       },


### PR DESCRIPTION
We sometimes get facet results from Rummager that don't contain all the fields that we need to be able to render them properly. For example, using the query that we use to populate organisation facets: https://www.gov.uk/api/search.json?aggregate_organisations=5,order:value.title results in the first 3 results having no title.  (They are Welsh translations of existing organisations)

I'm investigating why these are present at all, as although it doesn't seem possible to tag content to them at the moment they seem have at least a few documents.

![screen shot 2018-07-02 at 16 25 27](https://user-images.githubusercontent.com/773037/42172663-943a58a2-7e14-11e8-8d97-ff00bc3101eb.png)
