### PR TITLE
Close large select facets by default

### DIFF
--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -31,6 +31,10 @@ class SelectFacet < FilterableFacet
     }
   end
 
+  def close_facet?
+    allowed_values.count > 10
+  end
+
 private
 
   def value_fragments

--- a/app/views/finders/_select_facet.html.erb
+++ b/app/views/finders/_select_facet.html.erb
@@ -4,6 +4,6 @@
   :aria_controls_id => "js-search-results-info",
   :options_container_id => select_facet.key,
   :options => select_facet.options,
-  :closed_on_load => select_facet_counter > 0,
+  :closed_on_load => (select_facet_counter > 0) || select_facet.close_facet?,
 }
 %>

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -30,11 +30,11 @@ describe SelectFacet do
 
   subject { SelectFacet.new(facet_data) }
 
-  before do
-    subject.value = value
-  end
-
   describe "#sentence_fragment" do
+    before do
+      subject.value = value
+    end
+
     context "single value" do
       let(:value) { ["allowed-value-1"] }
 

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -63,4 +63,30 @@ describe SelectFacet do
       specify { expect(subject.sentence_fragment).to be_nil }
     end
   end
+
+  describe "#close_facet?" do
+    context "small number of options" do
+      specify { expect(subject.close_facet?).to be false }
+    end
+
+    context "large number of options" do
+      let(:allowed_values) {
+        11.times.map { |i| { 'label' => "Label #{i}", 'value' => "allowed-value-#{i}" } }
+      }
+
+      let(:large_facet_data) {
+        {
+          'type' => "multi-select",
+          'name' => "Test values",
+          'key' => "test_values",
+          'preposition' => "of value",
+          'allowed_values' => allowed_values,
+        }
+      }
+
+      subject { SelectFacet.new(large_facet_data) }
+
+      specify { expect(subject.close_facet?).to be true }
+    end
+  end
 end


### PR DESCRIPTION
Select facets are currently collapsed by default if they are not the first facet of this type on the page.

We want to extend this such that large facets are not open by default on finders.

This is in response to this [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/3058159) noting that https://www.gov.uk/government/organisations/latest has the organisation facet open by default.  This is fine on desktop, but when viewed on mobile, the facet gets in the way, and users have to scroll past hundreds of orgs before getting to the content.

I've checked this out on the [other finders](https://www.gov.uk/api/search.json?filter_content_store_document_type=finder), and I think it's OK.

https://trello.com/c/ZBBfcPfK/92-fix-latest-organisation-content-finder-on-mobile

## Examples

### Before
![desktop](https://user-images.githubusercontent.com/773037/43649774-ee74e654-9735-11e8-815b-b504b7ba80fd.png)

![iPhone 6/7/8](https://user-images.githubusercontent.com/773037/43650115-e279a186-9736-11e8-9682-53c53f092a43.png)

### After
![desktop](https://user-images.githubusercontent.com/773037/43649773-ee5633c6-9735-11e8-84d3-50885ce614c5.png)

![iPhone 6/7/8](https://user-images.githubusercontent.com/773037/43650113-e2451772-9736-11e8-8233-7803adafb8d0.png)