### PR TITLE
Memoize the raw_finder in the FindersController

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -41,7 +41,10 @@ private
   helper_method :finder
 
   def raw_finder
-    finder_api_class.new(finder_base_path, filter_params).content_item_with_search_results
+    @raw_finder ||= finder_api_class.new(
+      finder_base_path,
+      filter_params
+    ).content_item_with_search_results
   end
 
   def filter_params


### PR DESCRIPTION
This method is called in a couple of places, so memoize the value, as
it looks like this could result in duplicate queries to Rummager.