### PR TITLE
Set rubyLintDiff to false in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ library("govuk")
 
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-finder-frontend")
-  govuk.buildProject(sassLint: false, publishingE2ETests: true, brakeman: true)
+  govuk.buildProject(sassLint: false, publishingE2ETests: true, brakeman: true, rubyLintDiff: false)
 }


### PR DESCRIPTION
To ensure CI checks all the code for linting errors.