### PR TITLE
Don't allow indexing of paginated pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :head %>
+
+  <% if params[:page] %>
+    <meta name="robots" content="noindex">
+  <% end %>
 </head>
 
 <body>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -39,7 +39,9 @@ Feature: Filtering documents
   Scenario: Visit a finder with paginated results
     Given a finder with paginated results exists
     Then I can see pagination
+    And I can see that Google can index the page
     And I can browse to the next page
+    And I can see that Google won't index the page
 
   Scenario: Visit a finder with description
     Given a finder with description exists

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -145,6 +145,16 @@ Then(/^I can browse to the next page$/) do
   expect(page).not_to have_content('Next page')
 end
 
+Then(/^I can see that Google won't index the page$/) do
+  tag = "meta[name='robots'][content='noindex']"
+  expect(page).to have_css(tag, visible: false)
+end
+
+Then(/^I can see that Google can index the page$/) do
+  tag = "meta[name='robots'][content='noindex']"
+  expect(page).not_to have_css(tag, visible: false)
+end
+
 Given(/^a finder with description exists$/) do
   stub_content_store_with_cma_cases_finder_with_description
   stub_rummager_with_cma_cases


### PR DESCRIPTION
This disallows indexing of the paginated pages for finders.

Pagination should be made noindex, so Google can still crawl through and discover content but the actual paginated result pages are excluded from Google's search results.

https://trello.com/c/bWTdUDbx