### PR TITLE
Memorise finder controller filter params

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -50,16 +50,21 @@ private
 
   def filter_params
     # TODO Use a whitelist based on the facets in the schema
-    permitted_params = params.to_unsafe_hash.except(
-      :controller,
-      :action,
-      :slug,
-      :format,
-    )
+    @filter_params ||= begin
+      permitted_params = params
+                           .to_unsafe_hash
+                           .except(
+                             :controller,
+                             :action,
+                             :slug,
+                             :format,
+                           )
 
-    cleaned_params = ParamsCleaner.new(permitted_params).cleaned
-
-    cleaned_params.delete_if { |_, value| value.blank? }
+      ParamsCleaner
+        .new(permitted_params)
+        .cleaned
+        .delete_if { |_, value| value.blank? }
+    end
   end
 
   def finder_presenter_class


### PR DESCRIPTION
A small optimisation that ensures the parameters are only filtered and cleaned once per request.