### PR TITLE
Remove the redirect for the brexit policy

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -7,8 +7,6 @@ class FindersController < ApplicationController
   ATOM_FEED_MAX_AGE = 300
 
   def show
-    return redirect_to '/government/brexit' if finder_slug == 'government/policies/brexit'
-
     @results = result_set_presenter_class.new(finder, filter_params, view_context)
 
     respond_to do |format|


### PR DESCRIPTION
The Policy page has now been properly unpublished, and that means that
the unpublishing takes care of the redirect to the Topic Page.