### PR TITLE
Policy area unpublishing atom feed support

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -18,7 +18,11 @@ class FindersController < ApplicationController
         render json: results
       end
       format.atom do
-        if finder.atom_feed_enabled?
+        if finder_api.content_item['document_type'] == 'redirect'
+          @redirect = finder_api.content_item.dig('redirects', 0, 'destination')
+          @finder_slug = finder_slug
+          render 'finders/show-redirect'
+        elsif finder.atom_feed_enabled?
           expires_in(ATOM_FEED_MAX_AGE, public: true)
           @feed = AtomPresenter.new(finder)
         else

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -9,14 +9,13 @@ class FindersController < ApplicationController
   def show
     return redirect_to '/government/brexit' if finder_slug == 'government/policies/brexit'
 
-    @results = result_set_presenter_class.new(finder, filter_params, view_context)
-
     respond_to do |format|
       format.html do
+        @results = results
         @content_item = raw_finder
       end
       format.json do
-        render json: @results
+        render json: results
       end
       format.atom do
         if finder.atom_feed_enabled?
@@ -32,6 +31,10 @@ class FindersController < ApplicationController
   end
 
 private
+
+  def results
+    result_set_presenter_class.new(finder, filter_params, view_context)
+  end
 
   def finder
     @finder ||= finder_presenter_class.new(

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -44,11 +44,15 @@ private
   end
   helper_method :finder
 
-  def raw_finder
-    @raw_finder ||= finder_api_class.new(
+  def finder_api
+    @finder_api ||= finder_api_class.new(
       finder_base_path,
       filter_params
-    ).content_item_with_search_results
+    )
+  end
+
+  def raw_finder
+    @raw_finder ||= finder_api.content_item_with_search_results
   end
 
   def filter_params

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -6,8 +6,11 @@ class FinderApi
     @filter_params = filter_params
   end
 
+  def content_item
+    @content_item ||= fetch_content_item
+  end
+
   def content_item_with_search_results
-    content_item = fetch_content_item
     search_response = fetch_search_response(content_item)
     augment_content_item_with_results(content_item, search_response)
   end

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -4,27 +4,29 @@ class EntryPresenter
            :path,
            to: :entry
 
+  WEBSITE_ROOT = Plek.current.website_root.gsub(/https?:\/\//, '')
+
   def initialize(entry)
     @entry = entry
   end
 
   def tag(schema)
-    "tag:#{website_root},#{schema_date(schema)}:#{entry.path}"
+    "tag:#{WEBSITE_ROOT},#{self.class.schema_date(schema)}:#{entry.path}"
   end
 
   def updated_at
     Time.parse(entry.public_timestamp)
   end
 
+  def self.feed_ended_id(schema, base_path)
+    "tag:#{WEBSITE_ROOT},#{schema_date(schema)}:#{base_path}/feed-ended"
+  end
+
+  def self.schema_date(schema)
+    schema.instance_variable_get(:@feed_options)[:schema_date]
+  end
+
 private
 
   attr_reader :entry
-
-  def website_root
-    Plek.current.website_root.gsub(/https?:\/\//, '')
-  end
-
-  def schema_date(schema)
-    schema.instance_variable_get(:@feed_options)[:schema_date]
-  end
 end

--- a/app/views/finders/show-redirect.atom.builder
+++ b/app/views/finders/show-redirect.atom.builder
@@ -1,0 +1,39 @@
+policy_summary = <<~SUMMARY
+  <p>
+    We're changing the way content is organised on GOV.​UK. Policy pages, and the corresponding atom feeds have been retired.
+  </p>
+
+  <p>
+    You might want to subscribe to <a href="#{absolute_url_for('/government/publications')}">publications</a> or <a href="#{absolute_url_for('/government/announcements')}">announcements</a>.
+  </p>
+SUMMARY
+
+generic_summary = <<~SUMMARY
+  <p>
+    This feed no longer exists.
+  </p>
+
+  <p>
+    You might want to subscribe to <a href="#{absolute_url_for('/government/publications')}">publications</a> or <a href="#{absolute_url_for('/government/announcements')}">announcements</a>.
+  </p>
+SUMMARY
+
+atom_feed do |feed|
+  feed.title('Feed Ended')
+
+  feed.entry(
+    nil,
+    id: EntryPresenter.feed_ended_id(feed, @finder_slug),
+    url: @redirect && absolute_url_for(@redirect),
+  ) do |entry|
+    entry.title("/#{@finder_slug} feed ended")
+
+    summary = if @finder_slug.starts_with? 'government/policies/'
+                policy_summary
+              else
+                generic_summary
+              end
+
+    entry.summary(summary, type: 'html')
+  end
+end

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -97,5 +97,5 @@ Then(/^The correct metadata is displayed for the search results$/) do
 end
 
 Then(/^The page is not found$/) do
-  expect(page).to have_content("404 error not found")
+  expect(page.status_code).to eq(404)
 end


### PR DESCRIPTION
This is an attempt to manage the atom feed component of unpublishing
the Policy pages. Currently, if the pages are unpublished, just
specifying an alternative_path, the route for the atom feed is
unchanged.

This currently results in finder-frontend crashing when it tries to
render the redirect content item like it was a finder.

These changes have finder-frontend check if the content item received
from the content store is a redirect, and if so, render an atom feed
with a single entry, explaining to the user that the atom feed no
longer exists. There is a general catch all message, and a specific
message for policy pages.

I don't know much about atom feeds, but hopefully this is better than
just reporting a 404, or redirecting to something else which isn't an
atom feed. Unfortunately, even though most policy pages have a similar
topic page, the topic pages don't have atom feed support.


This is the representation of the atom feed for a unpublished policy page in Firefox:

![feed-ended](https://user-images.githubusercontent.com/1130010/46212169-3a11f480-c32d-11e8-8766-0df662be4e3e.png)
