### PR TITLE
Don't error for the finders JSON mime type

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -15,7 +15,11 @@ class FindersController < ApplicationController
         @content_item = raw_finder
       end
       format.json do
-        render json: results
+        if finder_api.content_item['document_type'] == 'finder'
+          render json: results
+        else
+          render json: {}, status: 404
+        end
       end
       format.atom do
         if finder_api.content_item['document_type'] == 'redirect'

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -131,6 +131,13 @@ describe FindersController, type: :controller do
         expect(response.body).to include("This feed no longer exists")
       end
 
+      it 'returns a 404 for json responses' do
+        get :show, params: { slug: "unpublished-finder", format: "json" }
+
+        expect(response.status).to eq(404)
+        expect(response.content_type).to eq("application/json")
+      end
+
       context "and it was a policy finder page" do
         before do
           stub_request(:get, "#{Plek.find('content-store')}/content/government/policies/cats").to_return(


### PR DESCRIPTION
When unpublishing finders, if just an alternative path is used, the
JSON route remains. Fetch the content item, and check the
document_type before erroring when trying to fetch the search results.