### PR TITLE
[Redux] Translate content purpose fields

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -33,6 +33,8 @@ private
       params: filter_params,
     ).call
 
+    query = TranslateContentPurposeFields.new(query).call
+
     Services.rummager.search(query).to_hash
   end
 

--- a/app/lib/translate_content_purpose_fields.rb
+++ b/app/lib/translate_content_purpose_fields.rb
@@ -1,0 +1,40 @@
+class TranslateContentPurposeFields
+  def initialize(query)
+    @query = Hash(query).stringify_keys
+  end
+
+  def call
+    translate_fields_with_prefix('aggregate')
+    translate_fields_with_prefix('filter')
+    translate_fields_with_prefix('reject')
+
+    @query if @query.present?
+  end
+
+private
+
+  def translate_fields_with_prefix(prefix)
+    document_types = subgroup_document_types(prefix) || supergroup_document_types(prefix)
+
+    @query.delete("#{prefix}_content_purpose_subgroup")
+    @query.delete("#{prefix}_content_purpose_supergroup")
+
+    if document_types.present?
+      @query["#{prefix}_content_store_document_type"] = document_types.uniq.sort
+    end
+  end
+
+  def subgroup_document_types(prefix)
+    key = "#{prefix}_content_purpose_subgroup"
+    value = @query[key]
+
+    GovukDocumentTypes.subgroup_document_types(*value) if value.present?
+  end
+
+  def supergroup_document_types(prefix)
+    key = "#{prefix}_content_purpose_supergroup"
+    value = @query[key]
+
+    GovukDocumentTypes.supergroup_document_types(*value) if value.present?
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,6 @@
 class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
-              :content_purpose_supergroup, :document_type, :organisations
+              :document_type, :organisations
 
   def initialize(rummager_document, finder)
     rummager_document = rummager_document.with_indifferent_access
@@ -10,7 +10,6 @@ class Document
     @public_timestamp = rummager_document.fetch(:public_timestamp, nil)
     @document_type = rummager_document.fetch(:content_store_document_type, nil)
     @organisations = rummager_document.fetch(:organisations, [])
-    @content_purpose_supergroup = rummager_document.fetch(:content_purpose_supergroup, nil)
     @is_historic = rummager_document.fetch(:is_historic, false)
     @government_name = rummager_document.fetch(:government_name, nil)
     @finder = finder

--- a/app/presenters/advanced_search_result_presenter.rb
+++ b/app/presenters/advanced_search_result_presenter.rb
@@ -1,7 +1,7 @@
 class AdvancedSearchResultPresenter < SearchResultPresenter
   def to_hash
     super.merge(
-      content_purpose_supergroup: search_result.content_purpose_supergroup,
+      content_purpose_supergroup: content_purpose_supergroup,
       document_type: document_type,
       organisations: organisations,
       publication_date: publication_date,
@@ -25,8 +25,14 @@ class AdvancedSearchResultPresenter < SearchResultPresenter
   end
 
   def show_metadata?
-    return false if search_result.content_purpose_supergroup == "services"
+    return false if content_purpose_supergroup == "services"
     return false if search_result.document_type == "guide"
     true
+  end
+
+private
+
+  def content_purpose_supergroup
+    supertypes.fetch('content_purpose_supergroup')
   end
 end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -60,4 +60,8 @@ private
   def raw_metadata
     search_result.metadata
   end
+
+  def supertypes
+    @supertypes ||= GovukDocumentTypes.supertypes(document_type: search_result.document_type)
+  end
 end

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -33,10 +33,9 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
 
   case categorisation.strip
   when /^in supergroup '(\w+)'$/
-    search_params["filter_content_purpose_supergroup"] = $1
+    search_params["filter_content_store_document_type"] = GovukDocumentTypes.supergroup_document_types($1)
   when /^in supergroup '(\w+)' and subgroups '([\w,]+)'$/
-    search_params["filter_content_purpose_supergroup"] = $1
-    search_params["filter_content_purpose_subgroup"] = $2.split(",")
+    search_params["filter_content_store_document_type"] = GovukDocumentTypes.subgroup_document_types(*$2.split(","))
   end
 
   rummager_advanced_search_url = rummager_url(search_params)

--- a/spec/lib/translate_content_purpose_fields_spec.rb
+++ b/spec/lib/translate_content_purpose_fields_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+RSpec.describe TranslateContentPurposeFields do
+  subject(:translator) { described_class.new(query) }
+
+  let(:query) { { 'foo' => 'bar' } }
+
+  describe '.call' do
+    subject(:translated) { translator.call }
+
+    it { is_expected.to_not include(:aggregate_content_purpose_subgroup) }
+    it { is_expected.to_not include(:aggregate_content_purpose_supergroup) }
+    it { is_expected.to_not include(:filter_content_purpose_subgroup) }
+    it { is_expected.to_not include(:filter_content_purpose_supergroup) }
+    it { is_expected.to_not include(:reject_content_purpose_subgroup) }
+    it { is_expected.to_not include(:reject_content_purpose_supergroup) }
+
+    it 'preserves original query fields' do
+      is_expected.to include('foo' => 'bar')
+    end
+
+    context 'when it includes a aggregate content purpose field' do
+      let(:query) { { 'aggregate_content_purpose_subgroup' => 'news', 'foo' => 'bar' } }
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'translates content purpose attributes to content store document type' do
+        is_expected.to include('aggregate_content_store_document_type' =>
+                                 %w(fatality_notice news_article news_story press_release
+                                    world_location_news_article world_news_story))
+
+        is_expected.to_not include('aggregate_content_purpose_subgroup')
+      end
+    end
+
+    context 'when it includes a filter content purpose field' do
+      let(:query) { { 'filter_content_purpose_subgroup' => 'transactions', 'foo' => 'bar' } }
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'translates content purpose attributes to content store document type' do
+        is_expected.to include('filter_content_store_document_type' =>
+                                 %w(answer calculator completed_transaction form guide licence
+                                    local_transaction place simple_smart_answer smart_answer
+                                    step_by_step_nav transaction))
+
+        is_expected.to_not include('filter_content_purpose_subgroup')
+      end
+    end
+
+    context 'when it includes a reject content purpose field' do
+      let(:query) { { 'reject_content_purpose_subgroup' => 'regulation', 'foo' => 'bar' } }
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'translates content purpose attributes to content store document type' do
+        is_expected.to include('reject_content_store_document_type' => %w(regulation statutory_instrument))
+
+        is_expected.to_not include('reject_content_purpose_subgroup')
+      end
+    end
+
+    context 'when it includes multiple content purpose values' do
+      let(:query) do
+        {
+          'filter_content_purpose_subgroup' => %w(policy consultations),
+          'foo' => 'bar',
+        }
+      end
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'translates content purpose attributes to content store document type' do
+        is_expected.to include('filter_content_store_document_type' =>
+                                 %w(case_study closed_consultation consultation_outcome impact_assessment
+                                    open_consultation policy_paper))
+
+        is_expected.to_not include('filter_content_purpose_subgroup')
+      end
+    end
+
+    context 'when it includes content purpose subgroup and supergroup fields' do
+      let(:query) do
+        {
+          'filter_content_purpose_subgroup' => 'policy',
+          'filter_content_purpose_supergroup' => 'transparency',
+          'foo' => 'bar',
+        }
+      end
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'translates content purpose subgroup attributes to content store document type' do
+        is_expected.to include('filter_content_store_document_type' => %w(case_study impact_assessment policy_paper))
+
+        is_expected.to_not include('filter_content_purpose_subgroup', 'filter_content_purpose_supergroup')
+      end
+    end
+  end
+end

--- a/spec/presenters/advanced_search_result_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_presenter_spec.rb
@@ -19,13 +19,11 @@ RSpec.describe AdvancedSearchResultPresenter do
   let(:document_type) { "guidance" }
   let(:organisations) { [{ title: "Ministry of Defence" }] }
   let(:public_timestamp) { "2018-03-26" }
-  let(:content_purpose_supergroup) { "news_and_communications" }
   let(:taxon_content_id) { SecureRandom.uuid }
   let(:search_result) {
     Document.new({
       title: "Result",
       link: "/result",
-      content_purpose_supergroup: content_purpose_supergroup,
       content_store_document_type: document_type,
       organisations: organisations,
       public_timestamp: public_timestamp,
@@ -78,7 +76,7 @@ RSpec.describe AdvancedSearchResultPresenter do
     end
 
     context "for services content group" do
-      let(:content_purpose_supergroup) { "services" }
+      let(:document_type) { "transaction" }
 
       it "returns true for other document_types" do
         expect(instance.show_metadata?).to be false


### PR DESCRIPTION
This brings back #606 with a fix for a bug identified from manual testing.

When we translate the content purpose fields the `subgroup` fields need to take precedence over the `supergroup`. For example, if we have a URL such as `/search/advanced?subgroup[]=policy&topic=/transport&group=policy_and_engagement` we now need to only lookup the document types for the subgroup "policy". The regression meant we were also lookup for the document types for the group "policy_and_engagement" meaning our query to the Search API was too broad.