### PR TITLE
Don't override content_item in the AdvancedSearchFinderApi

### DIFF
--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -1,16 +1,16 @@
 class AdvancedSearchFinderApi < FinderApi
   include AdvancedSearchParams
 
-  attr_reader :content_item
-
   def content_item_with_search_results
     raise_on_missing_taxon_param
 
     filter_params[TAXON_SEARCH_FILTER] = taxon["content_id"] if taxon
-    content_item = fetch_content_item
     search_response = fetch_search_response(content_item)
-    content_item = augment_content_item_links_with_taxon(content_item, taxon)
-    augment_content_item_with_results(content_item, search_response)
+    content_item_with_taxon_links = augment_content_item_links_with_taxon(
+      content_item,
+      taxon
+    )
+    augment_content_item_with_results(content_item_with_taxon_links, search_response)
   end
 
   def taxon


### PR DESCRIPTION
The FinderApi class was changed to have a content_item method, but
this didn't work for the AdvancedSearchFinderApi class as it was still
handling it as an attribute.

Remove the attr_reader, and attempt to cleanup the naming in the
content_item_with_search_results method.