### PR TITLE
Present taxon base_path as topic filter param in results

### DIFF
--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -1,6 +1,12 @@
 class AdvancedSearchFinderPresenter < FinderPresenter
   include AdvancedSearchParams
 
+  def initialize(content_item, values = {})
+    super(content_item, values)
+    # Restore the original topic param value as this is used in pagination links.
+    @values[TAXON_SEARCH_FILTER] = taxon['base_path']
+  end
+
   def taxon
     content_item['links']['taxons'].first
   end

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -8,9 +8,14 @@ describe AdvancedSearchFinderPresenter do
   let(:finder_item) {
     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
   }
+  let(:taxon_content_id) { SecureRandom.uuid }
   let(:content_item) {
     finder_item.merge("links" => {
-      "taxons" => [{ "title" => "Education, training and skills", "base_path" => "/education" }]
+      "taxons" => [{
+        "base_path" => "/education",
+        "content_id" => taxon_content_id,
+        "title" => "Education, training and skills",
+      }]
     })
   }
 
@@ -30,6 +35,18 @@ describe AdvancedSearchFinderPresenter do
       "topic" => "/education",
     }
   }
+
+  describe "initialize" do
+    let(:values) { { "topic" => taxon_content_id } }
+
+    # The advanced search api rewrites the "topic" filter param with
+    # the taxon content id to make a valid rummager query.
+    # Pagination links from the result set presenter rely on the original
+    # filter params so we need to restore the original topic value (the taxon's base path).
+    it "replaces the taxon filter parameter with the taxon base path" do
+      expect(subject.values["topic"]).to eq("/education")
+    end
+  end
 
   describe "taxon_link" do
     it "builds a link to the taxon" do

--- a/spec/presenters/advanced_search_result_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_presenter_spec.rb
@@ -4,11 +4,23 @@ RSpec.describe AdvancedSearchResultPresenter do
   let(:finder_content_item) {
     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
   }
-  let(:finder) { AdvancedSearchFinderPresenter.new(finder_content_item) }
+  let(:links) {
+    {
+      "links" => {
+        "taxons" => [{
+          "base_path" => "/education",
+          "content_id" => taxon_content_id,
+          "title" => "Education, training and skills",
+        }]
+      }
+    }
+  }
+  let(:finder) { AdvancedSearchFinderPresenter.new(finder_content_item.merge(links)) }
   let(:document_type) { "guidance" }
   let(:organisations) { [{ title: "Ministry of Defence" }] }
   let(:public_timestamp) { "2018-03-26" }
   let(:content_purpose_supergroup) { "news_and_communications" }
+  let(:taxon_content_id) { SecureRandom.uuid }
   let(:search_result) {
     Document.new({
       title: "Result",

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -83,5 +83,41 @@ RSpec.describe AdvancedSearchResultSetPresenter do
         expect(instance.to_hash[:applied_filters]).to eq(expected)
       end
     end
+
+    context "next and previous links" do
+      let(:search_results) {
+        {
+          "results" => [],
+          "total" => 30,
+          "start" => 0,
+          "current_page" => 1,
+          "total_pages" => 2,
+        }
+      }
+      let(:view_context) { ActionView::Base.new }
+      let(:filter_params) {
+        {
+          "topic" => "/education",
+          "group" => "news_and_communications",
+        }
+      }
+
+      it "contains valid topic (base_path) filtering params" do
+        expect(view_context).to receive(:render)
+          .with(
+            formats: %w(html),
+            partial: 'govuk_publishing_components/components/previous_and_next_navigation',
+            locals: {
+              next_page: {
+                label: "2 of 2",
+                title: "Next page",
+                url: "/search/advanced?group=news_and_communications&page=2&topic=%2Feducation"
+              }
+            }
+          )
+
+        instance.to_hash
+      end
+    end
   end
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3248522

The [topic filter param is rewritten by the AdvancedSearchFinderApi](https://github.com/alphagov/finder-frontend/blob/master/app/lib/advanced_search_finder_api.rb#L9) in
order to generate a valid Rummager query. This doesn't work when rendering
pagination links as the value is now the topic's `content_id` and not the
original `base_path`. So make sure we replace with the original `base_path` value
before rendering the pagination links.

### Example

https://finder-frontend-pr-625.herokuapp.com/search/advanced?group=services&page=1&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&topic=%2Feducation