### PR TITLE
Add Google Analytics tracking for finder filters

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -23,6 +23,7 @@
         function(e){
           if(e.keyCode == 13) {
             // 13 is the return key
+            LiveSearch.prototype.fireTextAnalyticsEvent(e);
             this.formChange();
             e.preventDefault();
           }
@@ -65,9 +66,25 @@
             GOVUK.analytics.trackPageview(newPath);
           }
         }.bind(this)
-      );
+      )
     }
   };
+
+  LiveSearch.prototype.fireTextAnalyticsEvent = function(event) {
+    if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
+      var options = {transport: 'beacon'};
+      var category = "filterClicked";
+      var action = $('label[for="' + event.target.id + '"]')[0].innerText;
+
+      options.label = $(event.target)[0].value;
+
+      GOVUK.analytics.trackEvent(
+        category,
+        action,
+        options
+      );
+    }
+  }
 
   LiveSearch.prototype.cache = function cache(slug, data){
     if(typeof data === 'undefined'){

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -12,6 +12,11 @@ class SelectFacet < FilterableFacet
         value: allowed_value['value'],
         label: allowed_value['label'],
         id: allowed_value['value'],
+        data_attributes: {
+          track_category: "filterClicked",
+          track_action: name,
+          track_label: allowed_value['label'],
+        },
         checked: selected_values.include?(allowed_value),
       }
     end

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -1,5 +1,6 @@
 <% title_id = "option-select-title-#{title.parameterize}" %>
 <div class="app-c-option-select"
+  <% if  options.any? { |option| option[:data_attributes] } %>data-module="track-click"<% end %>
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
 >
@@ -11,18 +12,19 @@
   <div role="group" aria-labelledby="<%= title_id %>" class="options-container" id="<%= options_container_id %>">
     <div class="js-auto-height-inner">
       <% options.each do | option |%>
-      <label for="<%= key %>-<%= option[:id] %>">
-        <input
-        name="<%= key %>[]"
-        value="<%= option[:value]%>"
-        id="<%= key %>-<%= option[:id]%>"
-        type="checkbox"
-        <% if option[:checked].present? %>checked="checked"<% end %>
-        >
-        <%= option[:label] %>
+        <label for="<%= key %>-<%= option[:id] %>">
+          <%= check_box_tag(
+            "#{key}[]",
+            option[:value],
+            option[:checked].present?,
+            {
+              id: "#{key}-#{option[:id]}",
+              data: option[:data_attributes]
+            }
+          ) %>
+          <%= option[:label] %>
         </label>
       <% end %>
     </div>
-
   </div>
 </div>

--- a/app/views/components/docs/option-select.yml
+++ b/app/views/components/docs/option-select.yml
@@ -114,3 +114,36 @@ examples:
       - value: sombrero
         label: Sombrero
         id: sombrero
+  with_tracking:
+    data:
+      key: list_of_shoes
+      title: List of shoes
+      options_container_id: list_of_shoes
+      options:
+      - value: trainers
+        label: Trainers
+        id: trainers
+        data_attributes:
+          track_category: "filterClicked"
+          track_action: "List of shoes"
+          track_label: "trainers"
+          track_options:
+            dimension28: 1
+      - value: plimsolls
+        label: Plimsolls
+        id: plimsolls
+        data_attributes:
+          track_category: "filterClicked"
+          track_action: "List of shoes"
+          track_label: "plimsolls"
+          track_options:
+            dimension28: 1
+      - value: high_heels
+        label: High heels
+        id: high_heels
+        data_attributes:
+          track_category: "filterClicked"
+          track_action: "List of shoes"
+          track_label: "high_heels"
+          track_options:
+            dimension28: 1

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -33,6 +33,42 @@ describe 'components/_option-select.html.erb', type: :view do
     }
   end
 
+  def option_select_with_tracking_arguments
+    {
+      key: option_key,
+      title: "Market sector",
+      options_container_id: "list-of-sectors",
+      options: [
+        {
+          value: "aerospace",
+          label: "Aerospace",
+          id: "aerospace",
+          data_attributes: {
+            track_category: "filterClicked",
+            track_action: "Market Sector",
+            track_label: "aerospace",
+            track_options: {
+              dimension28: 1
+            }
+          }
+        },
+        {
+          value: "value",
+          label: "Label",
+          id: "ID",
+          data_attributes: {
+            track_category: "filterClicked",
+            track_action: "Market Sector",
+            track_label: "value",
+            track_options: {
+              dimension28: 2
+            }
+          }
+        }
+      ]
+    }
+  end
+
   it "renders a heading for the option select box containing the title" do
     render_component(option_select_arguments)
     expect(rendered).to have_selector(".option-select-label", text: 'Market sector')
@@ -74,6 +110,14 @@ describe 'components/_option-select.html.erb', type: :view do
     render_component(arguments)
 
     expect(rendered).to have_selector('.app-c-option-select[data-closed-on-load="true"]')
+  end
+
+  it "adds data tracking attributes when provided" do
+    render_component(option_select_with_tracking_arguments)
+    expect(rendered).to have_selector(".app-c-option-select input[data-track-category='filterClicked']")
+    expect(rendered).to have_selector(".app-c-option-select input[data-track-action='Market Sector']")
+    expect(rendered).to have_selector(".app-c-option-select input[data-track-label='aerospace']")
+    expect(rendered).to have_selector(".app-c-option-select input[data-track-options='{\"dimension28\":1}']")
   end
 
   def expect_label_and_checked_checkbox(label, id, value)


### PR DESCRIPTION
Trello: https://trello.com/c/TNs02i4D/10-adding-event-tracking-to-the-finder-frontend-finders

Adds Google Analytics tracking to finder filters, i.e: search box, dropdowns, and date filter.
