### PR TITLE
Serve a 422 (unprocessable) when rummager returns 422

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
+require 'gds_api/helpers'
+
 class ApplicationController < ActionController::Base
+  include GdsApi::Helpers
   include Slimmer::Headers
   include Slimmer::Template
   slimmer_template "header_footer_only"
@@ -7,7 +10,11 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   helper :application
+
+  # rescue_from precedence is bottom up - https://stackoverflow.com/a/9121054/170864
+  rescue_from GdsApi::BaseError, with: :error_503
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+  rescue_from GdsApi::HTTPUnprocessableEntity, with: :unprocessable_entity
 
 private
 
@@ -33,5 +40,9 @@ private
 
   def error_not_found
     render status: :not_found, plain: "404 error not found"
+  end
+
+  def unprocessable_entity
+    render status: :unprocessable_entity, plain: "422 error: unprocessable entity"
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,12 +1,7 @@
-require 'gds_api/helpers'
-
 class SearchController < ApplicationController
   layout "search_layout"
-  include GdsApi::Helpers
   before_action :set_expiry
   before_action :remove_search_box
-
-  rescue_from GdsApi::BaseError, with: :error_503
 
   def index
     search_params = SearchParameters.new(params)

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -42,11 +42,12 @@ Feature: Filtering documents
     And I can see that Google can index the page
     And I can browse to the next page
     And I can see that Google won't index the page
+    Then I browse to a huge page number and get an appropriate error
 
   Scenario: Visit a finder with description
     Given a finder with description exists
     Then I can see that the description in the metadata is present
 
-  Scenario:
+  Scenario: Link tracking
     Given a policy finder exists
     Then the links on the page have tracking attributes

--- a/features/site_search.feature
+++ b/features/site_search.feature
@@ -76,3 +76,8 @@ Feature: Site search
     Given the search API returns an error state
     When I search for "search-term"
     Then I should get an error page
+
+  Scenario: Search API refuses parameters
+    Given the search API returns an HTTP unprocessable entity error
+    When I search with bad parameters
+    Then I should get a bad request error

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -145,6 +145,13 @@ Then(/^I can browse to the next page$/) do
   expect(page).not_to have_content('Next page')
 end
 
+Then(/^I browse to a huge page number and get an appropriate error$/) do
+  stub_rummager_api_request_with_422_response(999999)
+  visit finder_path('government/policies/benefits-reform', page: 999999)
+
+  expect(page.status_code).to eq(422)
+end
+
 Then(/^I can see that Google won't index the page$/) do
   tag = "meta[name='robots'][content='noindex']"
   expect(page).to have_css(tag, visible: false)

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -112,6 +112,10 @@ When(/^I search for "([^"]*)" with show organisation flag$/) do |search_term|
   visit "/search?q=#{search_term}&show_organisations_filter=true"
 end
 
+When(/^I search with bad parameters$/) do
+  visit "/search?q=search-term&start=999999"
+end
+
 When(/^I navigate to the next page$/) do
   click_on "Next page"
 end
@@ -197,6 +201,15 @@ end
 
 Then(/^I should see a link to the previous page$/) do
   expect(page).to have_content("Previous page")
+end
+
+Given(/^the search API returns an HTTP unprocessable entity error$/) do
+  allow(SearchAPI).to receive(:new).and_raise(GdsApi::HTTPUnprocessableEntity.new(422))
+  content_store_has_item("/search", schema: 'special_route')
+end
+
+Then(/^I should get a bad request error$/) do
+  expect(page.status_code).to eq(422)
 end
 
 Then(/^Analytics values are sent$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -43,6 +43,10 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_422_response(page_number)
+    stub_request(:get, rummager_policy_other_page_search_url(page_number)).to_return(status: 422)
+  end
+
   def stub_rummager_api_request_with_policies_finder_results
     stub_request(:get, rummager_policies_finder_search_url).to_return(
       body: policies_documents_json,
@@ -153,6 +157,18 @@ module DocumentHelper
         "order" => "-public_timestamp",
         "count" => 10,
         "start" => 10,
+      )
+    )
+  end
+
+  def rummager_policy_other_page_search_url(page_number)
+    count_per_page = 10.freeze
+
+    rummager_url(
+      policy_search_params.merge(
+        "order" => "-public_timestamp",
+        "count" => count_per_page,
+        "start" => ((page_number -1) * count_per_page)
       )
     )
   end


### PR DESCRIPTION
At present when requests fail Rummager's validation ([recent example][1]), Rummager will return a 422 (unprocessable) response.  Finder-frontend receives this as a GdsApi::HTTPUnprocessableEntity exception, which results in a 500 error.

If we handle the 422 and forward it on then it makes it clear to the user (usually a script exploring
the site for vulnerabilities) that we're handling the request appropriately and that they need to do something else.

This also reduces the 500 count for alerting purposes, which at times is very noisy.  It's hard to tell the difference between legitimate server issues and vexatious use.

[1]: https://github.com/alphagov/rummager/pull/1307