### PR TITLE
Add ability to sort finders

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -99,9 +99,9 @@ private
 
     sort_option = if params['order']
                     sort_options.detect { |option| option['name'].parameterize == params['order'] }
-                  else
-                    sort_options.detect { |option| option['default'] } || { 'key' => default_order }
                   end
+
+    sort_option || sort_options.detect { |option| option['default'] } || { 'key' => default_order }
   end
 
   def keyword_query

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -65,15 +65,43 @@ private
   end
 
   def order_query
-    keywords ? order_by_relevance_query : default_order_query
+    if sort_option.present?
+      if %w(relevance -relevance).include?(sort_option['key'])
+        order_by_relevance_query
+      else
+        order_by_sort_option_query
+      end
+    elsif keywords.present?
+      order_by_relevance_query
+    else
+      order_by_default_order_query
+    end
   end
 
   def order_by_relevance_query
     {}
   end
 
-  def default_order_query
+  def order_by_default_order_query
     { "order" => default_order }
+  end
+
+  def order_by_sort_option_query
+    { 'order' => sort_option['key'] }
+  end
+
+  def sort_options
+    finder_content_item.dig('details', 'sort')
+  end
+
+  def sort_option
+    return unless sort_options.present?
+
+    sort_option = if params['order']
+                    sort_options.detect { |option| option['name'].parameterize == params['order'] }
+                  else
+                    sort_options.detect { |option| option['default'] } || { 'key' => default_order }
+                  end
   end
 
   def keyword_query

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -110,6 +110,10 @@ class FinderPresenter
   def default_sort_option
     sort
       &.detect { |option| option['default'] }
+  end
+
+  def default_sort_option_value
+    default_sort_option
       &.dig('name')
       &.parameterize
   end
@@ -117,6 +121,10 @@ class FinderPresenter
   def relevance_sort_option
     sort
       &.detect { |option| %w(relevance -relevance).include?(option['key']) }
+  end
+
+  def relevance_sort_option_value
+    relevance_sort_option
       &.dig('name')
       &.parameterize
   end
@@ -127,7 +135,12 @@ class FinderPresenter
     options = Hash[sort.collect { |option| [option['name'], option['name'].parameterize] }]
 
     disabled_option = keywords.blank? ? relevance_sort_option : ''
-    selected_option = values['order'].presence || default_sort_option
+
+    selected_option = if values['order']
+                        sort.detect { |option| option['name'].parameterize == values['order'] }
+                      end
+
+    selected_option ||= default_sort_option_value
 
     options_for_select(options, disabled: disabled_option, selected: selected_option)
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -1,4 +1,5 @@
 class FinderPresenter
+  include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::UrlHelper
 
   attr_reader :content_item, :name, :slug, :organisations, :values, :keywords
@@ -43,6 +44,10 @@ class FinderPresenter
 
   def filter
     content_item['details']['filter']
+  end
+
+  def sort
+    content_item['details']['sort']
   end
 
   def logo_path
@@ -102,6 +107,31 @@ class FinderPresenter
     metadata.select { |f| f.type == "text" }.map(&:key)
   end
 
+  def default_sort_option
+    sort
+      &.detect { |option| option['default'] }
+      &.dig('name')
+      &.parameterize
+  end
+
+  def relevance_sort_option
+    sort
+      &.detect { |option| %w(relevance -relevance).include?(option['key']) }
+      &.dig('name')
+      &.parameterize
+  end
+
+  def sort_options
+    return [] unless sort.present?
+
+    options = Hash[sort.collect { |option| [option['name'], option['name'].parameterize] }]
+
+    disabled_option = keywords.blank? ? relevance_sort_option : ''
+    selected_option = values['order'].presence || default_sort_option
+
+    options_for_select(options, disabled: disabled_option, selected: selected_option)
+  end
+
   def filter_sentence_fragments
     filters.map(&:sentence_fragment).compact
   end
@@ -149,7 +179,11 @@ class FinderPresenter
   end
 
   def atom_feed_enabled?
-    !default_order.present?
+    if sort_options.present?
+      default_sort_option.blank?
+    else
+      default_order.blank?
+    end
   end
 
   def atom_url

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -29,6 +29,7 @@ class ResultSetPresenter
       any_filters_applied: any_filters_applied?,
       atom_url: atom_url,
       next_and_prev_links: next_and_prev_links,
+      sort_options: sort_options
     }
   end
 
@@ -96,6 +97,18 @@ class ResultSetPresenter
 
   def user_supplied_keywords
     @filter_params.fetch('keywords', '')
+  end
+
+  def sort_options
+    return unless finder.sort.present?
+
+    sort_option = if @filter_params['order']
+                    finder.sort.detect { |option| option['name'].parameterize == @filter_params['order'] }
+                  end
+
+    sort_option ||= finder.default_sort_option
+
+    "sorted by <strong>" + sort_option['name'] + "</strong>" if sort_option.present?
   end
 
 private

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -44,15 +44,17 @@
 <% end %>
 
 <div class="filtering full-page-width-wrapper">
-  <%= render finder.facets %>
-  <div class='js-live-search-results-block'>
-    <div class="filtered-results">
-      <div aria-live='assertive' id='js-search-results-info'>
-        <%= render_mustache('result_count', @results.to_hash) %>
-      </div>
-      <div id='js-results'>
-        <%= render_mustache('results', @results.to_hash) %>
+  <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+    <%= render finder.facets %>
+    <div class='js-live-search-results-block'>
+      <div class="filtered-results">
+        <div aria-live='assertive' id='js-search-results-info'>
+          <%= render_mustache('result_count', @results.to_hash) %>
+        </div>
+        <div id='js-results'>
+          <%= render_mustache('results', @results.to_hash) %>
+        </div>
       </div>
     </div>
-  </div>
+  </form>
 </div>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,12 +1,10 @@
 <div class="filter-form">
   <div class="inner-block">
-    <form method="get" action="<%=finder.slug%>" class="js-live-search-form">
-      <div class="filter text-filter">
-        <label class="legend" for="finder-keyword-search">Search</label>
-        <input value="<%= @results.user_supplied_keywords %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
-      </div>
-      <%= render facet_collection.filters %>
-      <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
-    </form>
+    <div class="filter text-filter">
+      <label class="legend" for="finder-keyword-search">Search</label>
+      <input value="<%= @results.user_supplied_keywords %>" type="text" name="keywords" id="finder-keyword-search" aria-controls="js-search-results-info" class='text'/>
+    </div>
+    <%= render facet_collection.filters %>
+    <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
   </div>
 </div>

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,9 +1,8 @@
-{{#any_filters_applied}}
 <p class="result-info">
   <span class="result-count">
     {{total}}
   </span>
   {{{pluralised_document_noun}}}
   {{{applied_filters}}}
+  {{{sort_options}}}
 </p>
-{{/any_filters_applied}}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -59,19 +59,34 @@
 </header>
 
 <div class="filtering">
-  <%= render finder.facets %>
-  <div class='js-live-search-results-block'>
-    <div class="filtered-results">
-      <div aria-live='assertive' id='js-search-results-info'>
-        <% if finder.show_generic_description? %>
-          <%= render_mustache('result_count_generic', @results.to_hash) %>
-        <% else %>
-          <%= render_mustache('result_count', @results.to_hash) %>
-        <% end %>
+  <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+    <%= render finder.facets %>
+
+    <% if finder.sort.present? %>
+      <div class="filter-form">
+        <div class="govuk-form-group">
+          <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
+          <%= select_tag 'order', finder.sort_options,
+                         class: 'govuk-select js-order-results',
+                         data: { 'default-sort-option' => finder.default_sort_option,
+                                 'relevance-sort-option' => finder.relevance_sort_option } %>
+        </div>
       </div>
-      <div id='js-results'>
-        <%= render_mustache('results', @results.to_hash) %>
+    <% end %>
+
+    <div class='js-live-search-results-block'>
+      <div class="filtered-results">
+        <div aria-live='assertive' id='js-search-results-info'>
+          <% if finder.show_generic_description? %>
+            <%= render_mustache('result_count_generic', @results.to_hash) %>
+          <% else %>
+            <%= render_mustache('result_count', @results.to_hash) %>
+          <% end %>
+        </div>
+        <div id='js-results'>
+          <%= render_mustache('results', @results.to_hash) %>
+        </div>
       </div>
     </div>
-  </div>
+  </form>
 </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -68,6 +68,7 @@
           <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
           <%= select_tag 'order', finder.sort_options,
                          class: 'govuk-select js-order-results',
+                         'aria-controls': 'js-search-results-info',
                          data: { 'default-sort-option' => finder.default_sort_option,
                                  'relevance-sort-option' => finder.relevance_sort_option } %>
         </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -69,8 +69,8 @@
           <%= select_tag 'order', finder.sort_options,
                          class: 'govuk-select js-order-results',
                          'aria-controls': 'js-search-results-info',
-                         data: { 'default-sort-option' => finder.default_sort_option,
-                                 'relevance-sort-option' => finder.relevance_sort_option } %>
+                         data: { 'default-sort-option' => finder.default_sort_option_value,
+                                 'relevance-sort-option' => finder.relevance_sort_option_value } %>
         </div>
       </div>
     <% end %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -77,3 +77,16 @@ Feature: Filtering documents
     Given a finder tagged to the topic taxonomy
     Then I can see taxonomy breadcrumbs
     And I can see a breadcrumb for home
+
+  Scenario: Sorting options
+    When I view a list of news and communications
+    Then I can sort by:
+      | Most viewed      |
+      | Relevance        |
+      | Updated (newest) |
+      | Updated (oldest) |
+
+  Scenario: Sorting news and communications by most viewed
+    When I view a list of news and communications
+    And I sort by most viewed
+    Then I see the most viewed articles first

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -31,6 +31,25 @@
     },
     "format_name":"News or communiqué",
     "show_summaries":true,
+    "sort": [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
+        "name": "Updated (newest)",
+        "key": "-public_timestamp",
+        "default": true
+      },
+      {
+        "name": "Updated (oldest)",
+        "key": "public_timestamp"
+      }
+    ],
     "facets":[
       {
         "key": "part_of_taxonomy_tree",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -25,6 +25,14 @@ Then(/^I can get a list of all documents with matching metadata$/) do
   expect(page).to have_css('.filtered-results .document', count: 1)
 end
 
+When(/^I view a list of news and communications$/) do
+  content_store_has_news_and_communications_finder
+  stub_whitehall_api_world_location_request
+  stub_rummager_api_request_with_news_and_communication_results
+
+  visit finder_path('news-and-communications')
+end
+
 When(/^I search documents by keyword$/) do
   stub_keyword_search_api_request
 
@@ -259,4 +267,24 @@ Then(/^The checkbox has the correct tracking data$/) do
   expect(page).to have_css("input[type='checkbox'][data-track-action='checkboxFacet']")
   expect(page).to have_css("input[type='checkbox'][data-track-label='Open']")
   expect(page).to have_css("input[type='checkbox'][data-module='track-click']")
+end
+
+Then(/^I can sort by:$/) do |table|
+  expect(find_all('.js-order-results option').collect(&:text)).to eq(table.raw.flatten)
+end
+
+When(/^I sort by most viewed$/) do
+  select 'Most viewed', from: 'Sort by'
+  click_on 'Filter results'
+end
+
+Then(/^I see the most viewed articles first$/) do
+  within '.filtered-results .document:nth-child(1)' do
+    expect(page).to have_content('Press release from Hogwarts')
+    expect(page).to have_content('25 December 2017')
+  end
+
+  within '.filtered-results .document:nth-child(2)' do
+    expect(page).to have_content('16 November 2018')
+  end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -6,7 +6,7 @@ end
 Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 
-  expect(page).not_to have_content('2 reports')
+  expect(page).to have_content('2 reports')
   expect(page).to have_css('.filtered-results .document', count: 2)
   expect(page).to have_css('.gem-c-metadata')
 
@@ -287,4 +287,6 @@ Then(/^I see the most viewed articles first$/) do
   within '.filtered-results .document:nth-child(2)' do
     expect(page).to have_content('16 November 2018')
   end
+
+  expect(page).to have_content('sorted by Most viewed')
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -43,6 +43,14 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_news_and_communication_results
+    stub_request(:get, rummager_newest_news_and_communications_url)
+      .to_return(body: newest_news_and_communication_json)
+
+    stub_request(:get, rummager_popular_news_and_communications_url)
+      .to_return(body: popular_news_and_communication_json)
+  end
+
   def stub_rummager_api_request_with_422_response(page_number)
     stub_request(:get, rummager_policy_other_page_search_url(page_number)).to_return(status: 422)
   end
@@ -62,12 +70,24 @@ module DocumentHelper
       )
   end
 
+  def stub_whitehall_api_world_location_request
+    stub_request(:get, whitehall_admin_world_locations_api_url).to_return(
+      body: world_locations_json,
+    )
+  end
+
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
   end
 
   def content_store_has_qa_finder
     content_store_has_item('/aaib-reports', aaib_reports_content_item.to_json)
+  end
+
+  def content_store_has_news_and_communications_finder
+    finder_fixture = File.read(Rails.root.join('features/fixtures/news_and_communications.json'))
+
+    content_store_has_item('/news-and-communications', finder_fixture)
   end
 
   def content_store_has_government_finder
@@ -240,7 +260,36 @@ module DocumentHelper
     rummager_url(
       mosw_search_params.merge(
         "q" => "keyword searchable",
+        "order" => "-public_timestamp",
       )
+    )
+  end
+
+  def rummager_newest_news_and_communications_url
+    rummager_url(
+      news_and_communications_search_params
+        .merge(
+          'facet_organisations' => '1500,order:value.title',
+          'facet_people' => '1500,order:value.title',
+          'facet_world_locations' => '1500,order:value.title',
+          'order' => '-public_timestamp',
+          'count' => 20,
+          'start' => 0,
+        )
+    )
+  end
+
+  def rummager_popular_news_and_communications_url
+    rummager_url(
+      news_and_communications_search_params
+        .merge(
+          'facet_organisations' => '1500,order:value.title',
+          'facet_people' => '1500,order:value.title',
+          'facet_world_locations' => '1500,order:value.title',
+          'order' => '-popularity',
+          'count' => 20,
+          'start' => 0,
+        )
     )
   end
 
@@ -300,6 +349,10 @@ module DocumentHelper
         "order" => "title",
       )
     )
+  end
+
+  def whitehall_admin_world_locations_api_url
+    "#{Plek.current.find('whitehall-admin')}/api/world-locations"
   end
 
   def aaib_reports_json
@@ -532,6 +585,266 @@ module DocumentHelper
     }|
   end
 
+  def newest_news_and_communication_json
+    %|{
+      "results": [
+        {
+          "title": "News from Hogwarts",
+          "link": "/news-from-hogwarts",
+          "description": "Breaking wizard news from Hogwarts",
+          "public_timestamp": "2018-11-16T11:11:42Z",
+          "part_of_taxonomy_tree": [
+            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+          ],
+          "organisations": [
+            {
+              "organisation_crest": "single-identity",
+              "acronym": "MOM",
+              "link": "/organisations/ministry-of-magic",
+              "analytics_identifier": "MM1",
+              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+              "organisation_brand": "ministry-of-magic",
+              "logo_formatted_title": "Ministry of Magic",
+              "title": "Ministry of Magic",
+              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+              "slug": "ministry-of-magic",
+              "organisation_type": "other",
+              "organisation_state": "live"
+            }
+          ],
+          "index": "govuk",
+          "es_score": null,
+          "_id": "/news-from-hogwarts",
+          "elasticsearch_type": "news_article",
+          "document_type": "news_article"
+        },
+        {
+          "title": "Press release from Hogwarts",
+          "link": "/press-release-from-hogwarts",
+          "description": "An important press release from Hogwarts",
+          "public_timestamp": "2017-12-25T09:00:00Z",
+          "part_of_taxonomy_tree": [
+            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+          ],
+          "organisations": [
+            {
+              "organisation_crest": "single-identity",
+              "acronym": "MOM",
+              "link": "/organisations/ministry-of-magic",
+              "analytics_identifier": "MM1",
+              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+              "organisation_brand": "ministry-of-magic",
+              "logo_formatted_title": "Ministry of Magic",
+              "title": "Ministry of Magic",
+              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+              "slug": "ministry-of-magic",
+              "organisation_type": "other",
+              "organisation_state": "live"
+            }
+          ],
+          "index": "govuk",
+          "es_score": null,
+          "_id": "/press-release-from-hogwarts",
+          "elasticsearch_type": "press_release",
+          "document_type": "press_release"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {
+        "people": {
+          "options": [
+            {
+              "value": {
+                "slug": "harry-potter",
+                "title": "Harry Potter",
+                "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
+                "link": "/people/harry-potter"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        },
+        "organisations": {
+          "options": [
+            {
+              "value": {
+                "organisation_brand": "ministry-of-magic",
+                "logo_formatted_title": "Ministry of Magic",
+                "organisation_crest": "single-identity",
+                "title": "Ministry of Magic",
+                "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                "link": "/organisations/academy-for-social-justice-commissioning",
+                "analytics_identifier": "MM1",
+                "slug": "ministry-of-magic",
+                "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                "organisation_type": "other",
+                "organisation_state": "live"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        },
+        "world_locations": {
+          "options": [
+            {
+              "value": {
+                "slug": "azkaban",
+                "title": "Azkaban",
+                "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
+                "link": "/world/azkaban"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        }
+      },
+      "suggested_queries": []
+    }|
+  end
+
+  def popular_news_and_communication_json
+    %|{
+      "results": [
+        {
+          "title": "Press release from Hogwarts",
+          "link": "/press-release-from-hogwarts",
+          "description": "An important press release from Hogwarts",
+          "public_timestamp": "2017-12-25T09:00:00Z",
+          "part_of_taxonomy_tree": [
+            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+          ],
+          "organisations": [
+            {
+              "organisation_crest": "single-identity",
+              "acronym": "MOM",
+              "link": "/organisations/ministry-of-magic",
+              "analytics_identifier": "MM1",
+              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+              "organisation_brand": "ministry-of-magic",
+              "logo_formatted_title": "Ministry of Magic",
+              "title": "Ministry of Magic",
+              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+              "slug": "ministry-of-magic",
+              "organisation_type": "other",
+              "organisation_state": "live"
+            }
+          ],
+          "index": "govuk",
+          "es_score": null,
+          "_id": "/press-release-from-hogwarts",
+          "elasticsearch_type": "press_release",
+          "document_type": "press_release"
+        },
+        {
+          "title": "News from Hogwarts",
+          "link": "/news-from-hogwarts",
+          "description": "Breaking wizard news from Hogwarts",
+          "public_timestamp": "2018-11-16T11:11:42Z",
+          "part_of_taxonomy_tree": [
+            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+          ],
+          "organisations": [
+            {
+              "organisation_crest": "single-identity",
+              "acronym": "MOM",
+              "link": "/organisations/ministry-of-magic",
+              "analytics_identifier": "MM1",
+              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+              "organisation_brand": "ministry-of-magic",
+              "logo_formatted_title": "Ministry of Magic",
+              "title": "Ministry of Magic",
+              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+              "slug": "ministry-of-magic",
+              "organisation_type": "other",
+              "organisation_state": "live"
+            }
+          ],
+          "index": "govuk",
+          "es_score": null,
+          "_id": "/news-from-hogwarts",
+          "elasticsearch_type": "news_article",
+          "document_type": "news_article"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "facets": {
+        "people": {
+          "options": [
+            {
+              "value": {
+                "slug": "harry-potter",
+                "title": "Harry Potter",
+                "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
+                "link": "/people/harry-potter"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        },
+        "organisations": {
+          "options": [
+            {
+              "value": {
+                "organisation_brand": "ministry-of-magic",
+                "logo_formatted_title": "Ministry of Magic",
+                "organisation_crest": "single-identity",
+                "title": "Ministry of Magic",
+                "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                "link": "/organisations/academy-for-social-justice-commissioning",
+                "analytics_identifier": "MM1",
+                "slug": "ministry-of-magic",
+                "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                "organisation_type": "other",
+                "organisation_state": "live"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        },
+        "world_locations": {
+          "options": [
+            {
+              "value": {
+                "slug": "azkaban",
+                "title": "Azkaban",
+                "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
+                "link": "/world/azkaban"
+              },
+              "documents": 2
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        }
+      },
+      "suggested_queries": []
+    }|
+  end
+
   def documents_with_bad_data_json
     %|{
       "results": [
@@ -686,6 +999,43 @@ module DocumentHelper
       "start": 0,
       "facets": {},
       "suggested_queries": []
+    }|
+  end
+
+  def world_locations_json
+    %|{
+      "results": [
+        {
+          "id": "https://www.gov.uk/api/world-locations/tracy-island",
+          "title": "Tracy Island",
+          "format": "World location",
+          "updated_at": "2018-04-27T14:41:52.000+01:00",
+          "web_url": "https://www.gov.uk/world/tracy-island",
+          "analytics_identifier": "WL1",
+          "details": {
+            "slug": "tracy-island",
+            "iso2": "TI"
+          },
+          "organisations": {
+            "id": "https://www.gov.uk/api/world-locations/tracy-island/organisations",
+            "web_url": "https://www.gov.uk/world/tracy-island#organisations"
+          }
+        }
+      ],
+      "current_page": 1,
+      "total": 1,
+      "pages": 1,
+      "page_size": 20,
+      "start_index": 1,
+      "_response_info": {
+        "status": "ok",
+        "links": [
+          {
+            "href": "#{whitehall_admin_world_locations_api_url}?page=1",
+            "rel": "self"
+          }
+        ]
+      }
     }|
   end
 

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -35,6 +35,47 @@ module RummagerUrlHelper
     )
   end
 
+  def news_and_communications_search_params
+    supergroup_document_types = %w(
+      asylum_support_decision
+      authored_article
+      cma_case
+      correspondence
+      decision
+      drug_safety_update
+      employment_appeal_tribunal_decision
+      employment_tribunal_decision
+      fatality_notice
+      government_response
+      medical_safety_alert
+      news_article
+      news_story
+      oral_statement
+      press_release
+      service_standard_report
+      speech
+      tax_tribunal_decision
+      utaac_decision
+      world_location_news_article
+      world_news_story
+      written_statement
+    )
+
+    base_search_params.merge(
+      'fields' => news_and_communications_search_fields.join(','),
+      'filter_content_store_document_type' => supergroup_document_types,
+    )
+  end
+
+  def news_and_communications_search_fields
+    base_search_fields + %w(
+      part_of_taxonomy_tree
+      people
+      organisations
+      world_locations
+    )
+  end
+
   def cma_case_search_params
     base_search_params.merge(
       "fields" => cma_case_search_fields.join(","),

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -15,6 +15,7 @@ describe FindersController, type: :controller do
       )
 
       finder["details"]["default_documents_per_page"] = 10
+      finder["details"]["sort"] = nil
       finder
     end
 
@@ -67,11 +68,11 @@ describe FindersController, type: :controller do
 
     describe "a finder content item with a default order exists" do
       before do
+        sort_options = [{ 'name' => 'Closing date', 'key' => '-closing_date', 'default' => true, }]
+
         content_store_has_item(
           '/lunch-finder',
-          lunch_finder.merge(
-            'details' => lunch_finder['details'].merge('default_order' => "-closing_date")
-          )
+          lunch_finder.merge('details' => lunch_finder['details'].merge('sort' => sort_options))
         )
 
         rummager_response = %|{

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -16,10 +16,13 @@ RSpec.describe FinderPresenter do
   let(:policies_presenter) { described_class.new(policies_finder_content_item) }
 
   let(:content_item) {
+    finder_example = govuk_content_schema_example('finder')
+    finder_example['details']['sort'] = nil
+
     dummy_http_response = double(
       "net http response",
         code: 200,
-        body: govuk_content_schema_example('finder').to_json,
+        body: finder_example.to_json,
         headers: {}
     )
     GdsApi::Response.new(dummy_http_response).to_hash

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ResultSetPresenter do
       default_documents_per_page: 10,
       values: {},
       pagination: pagination,
+      sort: {},
     )
   end
 


### PR DESCRIPTION
Adds an option to the news and communications finder to provide sorting options for the results shown.

<img width="873" alt="screen shot 2018-11-23 at 09 11 26" src="https://user-images.githubusercontent.com/861310/48935505-d573b000-eeff-11e8-8eea-843ff469f5b7.png">

-------

https://trello.com/c/CF6DmPXk