### PR TITLE
Alpha version of News and Communications Finder

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,9 @@
     },
     "DEVELOPMENT_FINDER_JSON": {
       "value": "features/fixtures/advanced-search.json"
+    },
+    "NEWS_AND_COMMUNICATIONS_JSON": {
+      "value": "features/fixtures/news_and_communications.json"
     }
   },
   "image": "heroku/ruby",

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -20,11 +20,20 @@ private
   attr_reader :base_path, :filter_params
 
   def fetch_content_item
-    if ENV["DEVELOPMENT_FINDER_JSON"]
-      JSON.parse(File.read(ENV["DEVELOPMENT_FINDER_JSON"]))
+    if development_env_finder_json
+      JSON.parse(File.read(development_env_finder_json))
     else
       Services.content_store.content_item(base_path)
     end
+  end
+
+  def development_env_finder_json
+    return news_and_communications_json if is_news_and_communications?
+    ENV["DEVELOPMENT_FINDER_JSON"]
+  end
+
+  def news_and_communications_json
+    ENV['NEWS_AND_COMMUNICATIONS_JSON']
   end
 
   def fetch_search_response(content_item)
@@ -88,5 +97,9 @@ private
 
   def query_builder_class
     SearchQueryBuilder
+  end
+
+  def is_news_and_communications?
+    news_and_communications_json && base_path == "/news-and-communications"
   end
 end

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -1,0 +1,78 @@
+{
+  "analytics_identifier":null,
+  "base_path":"/news-and-communications",
+  "content_id":"622e9691-4b4f-4e9c-bce1-098b0c4f5ee2",
+  "content_purpose_document_supertype":"navigation",
+  "document_type":"finder",
+  "email_document_supertype":"other",
+  "first_published_at":"2018-11-07T14:47:48.000+00:00",
+  "government_document_supertype":"other",
+  "locale":"en",
+  "navigation_document_supertype":"other",
+  "phase":"alpha",
+  "public_updated_at":"2018-11-07T14:47:48.000+00:00",
+  "publishing_app":"finder-frontend",
+  "rendering_app":"finder-frontend",
+  "schema_name":"finder",
+  "search_user_need_document_supertype":"government",
+  "title":"News and communications",
+  "updated_at":"2018-11-07T14:47:48.000+00:00",
+  "user_journey_document_supertype":"finding",
+  "withdrawn_notice":{
+
+  },
+  "publishing_request_id":"",
+  "links":{},
+  "description":"Find news and communications from government",
+  "details":{
+    "document_noun":"document",
+    "filter":{
+      "content_purpose_supergroup":"news_and_communications"
+    },
+    "format_name":"News or communiqué",
+    "show_summaries":true,
+    "facets":[
+      {
+        "key": "part_of_taxonomy_tree",
+        "name": "Topic",
+        "short_name": "Topic",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about",
+        "allowed_values": [
+          {
+            "label": "Brexit",
+            "value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+          }
+        ]
+      },
+      {
+        "key": "people",
+        "name": "People",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": true
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "From",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "public_timestamp",
+        "short_name": "Updated",
+        "name": "Published",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page":20
+  }
+}


### PR DESCRIPTION
https://finder-frontend-pr-649.herokuapp.com/news-and-communications

This PR creates a new news and communications finder rendered by finder-frontend using a local JSON content item and the existing frontend components.

The desired components that do not meet the requirements (accessibility and new design) can be iterated after the initial alpha of the content-item is published.

This finder is not published, is in an alpha state, and will not be accessible in production.

https://trello.com/c/9BGurgtq/161-create-a-functional-news-and-communications-finder

Screenshots from http://finder-frontend.dev.gov.uk/news-and-communications?keywords=&part_of_taxonomy_tree%5B%5D=d6c2de5d-ef90-45d1-82d4-5f2438369eea&organisations%5B%5D=hm-treasury&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=

![screen shot 2018-11-07 at 12 06 38](https://user-images.githubusercontent.com/8124374/48131005-67d04e80-e286-11e8-9d21-ade5990fdac8.png)
![screen shot 2018-11-07 at 12 09 16](https://user-images.githubusercontent.com/8124374/48131006-6868e500-e286-11e8-89c7-cbc55265a752.png)
