### PR TITLE
Add world locations facet to news and communications finder

### DIFF
--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -65,6 +65,14 @@
         "filterable": true
       },
       {
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
         "key": "public_timestamp",
         "short_name": "Updated",
         "name": "Published",


### PR DESCRIPTION
This is a schema change to the news and communications finder, enabling end users (in development mode) to filter from a selection of world locations.

**NOTE:** Should be merged _after_ https://github.com/alphagov/rummager/pull/1318

![screen shot 2018-11-12 at 14 29 32](https://user-images.githubusercontent.com/8124374/48359161-4b704f80-e694-11e8-9333-b9269c7bf1aa.png)
