### PR TITLE
Add organisation breadcrumbs to finder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'jasmine-rails'
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.8.1'
+  gem 'govuk_schemas', '~> 3.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       rake
       rouge
       sass-rails (>= 5.0.4)
+    govuk_schemas (3.2.0)
+      json-schema (~> 2.8.0)
     hashdiff (0.3.7)
     highline (2.0.0)
     htmlentities (4.3.4)
@@ -384,6 +386,7 @@ DEPENDENCIES
   govuk_document_types (~> 0.9.0)
   govuk_frontend_toolkit (~> 8.1)
   govuk_publishing_components (~> 12.7.1)
+  govuk_schemas (~> 3.2)
   jasmine-rails
   launchy (~> 2.4.2)
   pry-byebug

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -11,6 +11,7 @@ class FindersController < ApplicationController
       format.html do
         @results = results
         @content_item = raw_finder
+        fetch_breadcrumbs
       end
       format.json do
         if %w[finder search].include? finder_api.content_item['document_type']
@@ -61,6 +62,14 @@ private
     @raw_finder ||= finder_api.content_item_with_search_results
   end
 
+  def fetch_breadcrumbs
+    parent_content_item = {}
+    unless params.dig("parent_path").to_s.empty?
+      parent_content_item = Services.content_store.content_item(params["parent_path"])
+    end
+    @breadcrumbs = FinderBreadcrumbsPresenter.new(parent_content_item, @content_item)
+  end
+
   def filter_params
     # TODO Use a whitelist based on the facets in the schema
     @filter_params ||= begin
@@ -70,7 +79,7 @@ private
                              :controller,
                              :action,
                              :slug,
-                             :format,
+                             :format
                            )
 
       ParamsCleaner

--- a/app/presenters/finder_breadcrumbs_presenter.rb
+++ b/app/presenters/finder_breadcrumbs_presenter.rb
@@ -1,0 +1,23 @@
+class FinderBreadcrumbsPresenter
+  def initialize(parent_content_item, finder_content_item)
+    @parent_content_item = parent_content_item
+    @finder_name = finder_content_item.dig("title")
+  end
+
+  def breadcrumbs
+    crumbs = [{ title: "Home", url: "/" }]
+
+    if @parent_content_item.dig("document_type") == "organisation"
+      crumbs << { title: 'Organisations', url: '/government/organisations' }
+      if @parent_content_item.dig("title").present?
+        crumbs << { title: @parent_content_item.dig("title"), url: @parent_content_item.dig("base_path") }
+      end
+    end
+
+    if @finder_name.present?
+      crumbs << { title: @finder_name, is_current_page: true }
+    end
+
+    crumbs
+  end
+end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -8,7 +8,8 @@
   <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+<%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
+
 
 <% if finder.government? %>
   <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -51,3 +51,15 @@ Feature: Filtering documents
   Scenario: Link tracking
     Given a policy finder exists
     Then the links on the page have tracking attributes
+
+  Scenario: Visit a finder from an organisation
+    Given an organisation finder exists
+    Then I can see a breadcrumb for home
+    And I can see a breadcrumb for all organisations
+    And I can see a breadcrumb for the organisation
+    And I can see a breadcrumb that not a link for the finder
+
+  Scenario: Visit a finder not from an organisation
+    Given a policy finder exists
+    Then I can only see home and finder breadcrumbs
+    And I can see a breadcrumb for home

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -167,10 +167,52 @@ Given(/^a finder with description exists$/) do
   stub_rummager_with_cma_cases
 end
 
-When(/I can see that the description in the metadata is present$/) do
+When(/^I can see that the description in the metadata is present$/) do
   visit "/cma-cases"
 
   desc_text = "Find reports and updates on current and historical CMA investigations"
   desc_tag = "meta[name='description'][content='#{desc_text}']"
   expect(page).to have_css(desc_tag, visible: false)
+end
+
+Given(/^an organisation finder exists$/) do
+  content_store_has_government_finder
+  stub_rummager_api_request_with_government_results
+  content_store_has_attorney_general_organisation
+
+  visit finder_path('government/policies/benefits-reform', parent_path: '/government/organisations/attorney-generals-office')
+end
+
+Then(/^I can see a breadcrumb for home$/) do
+  expect(page).to have_link("Home", href: "/")
+  expect(page).to have_css("a[data-track-category='homeLinkClicked']", text: "Home")
+  expect(page).to have_css("a[data-track-action='homeBreadcrumb']", text: "Home")
+  expect(page).to have_css("a[data-track-label='']", text: "Home")
+  expect(page).to have_css("a[data-track-options='{}']", text: "Home")
+end
+
+Then(/^I can see a breadcrumb for all organisations$/) do
+  expect(page).to have_link("Organisations", href: "/government/organisations")
+  expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Organisations")
+  expect(page).to have_css("a[data-track-action='2']", text: "Organisations")
+  expect(page).to have_css("a[data-track-label='/government/organisations']", text: "Organisations")
+  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Organisations\"}']", text: "Organisations")
+end
+
+Then(/^I can see a breadcrumb for the organisation$/) do
+  expect(page).to have_link("Attorney General's Office", href: "/government/organisations/attorney-generals-office")
+  expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Attorney General's Office")
+  expect(page).to have_css("a[data-track-action='3']", text: "Attorney General's Office")
+  expect(page).to have_css("a[data-track-label='/government/organisations/attorney-generals-office']", text: "Attorney General's Office")
+  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Attorney General\\'s Office\"}']", text: "Attorney General's Office")
+end
+
+Then(/^I can see a breadcrumb that not a link for the finder$/) do
+  expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Ministry of Silly Walks reports")
+end
+
+Then(/^I can only see home and finder breadcrumbs$/) do
+  visit finder_path('government/policies/benefits-reform')
+  expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Benefits Reform")
+  expect(page.find_all(".govuk-breadcrumbs__list-item").count).to eql(2)
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -81,6 +81,10 @@ module DocumentHelper
     )
   end
 
+  def content_store_has_attorney_general_organisation
+    content_store_has_item('/government/organisations/attorney-generals-office', govuk_content_schema_example('attorney_general', 'organisation').to_json)
+  end
+
   def search_params(params = {})
     default_search_params.merge(params).to_a.map { |tuple|
       tuple.join("=")

--- a/spec/presenters/finder_breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/finder_breadcrumbs_presenter_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe FinderBreadcrumbsPresenter do
+  let(:finder) { JSON.parse(File.read(Rails.root.join("features", "fixtures", "aaib_reports_example.json"))) }
+  let(:parent_content_item) { GovukSchemas::Example.find("organisation", example_name: "attorney_general") }
+  let(:place_content_item) { GovukSchemas::Example.find("place", example_name: "find-regional-passport-office") }
+  subject(:instance) { described_class.new(parent_content_item, finder) }
+
+  describe "breadcrumbs" do
+    it "has a link to home as the first entry" do
+      expect(instance.breadcrumbs.first).to eql(title: "Home", url: "/")
+    end
+
+    it "has a link to all organisations when the document_type is organisation" do
+      expect(parent_content_item["document_type"]).to eql("organisation")
+      expect(instance.breadcrumbs.second).to eql(title: "Organisations", url: "/government/organisations")
+    end
+
+    it "has no links to organisations when the document_type is not organisation" do
+      instance = described_class.new(place_content_item, finder)
+      expect(place_content_item["document_type"]).to_not eql("organisation")
+      expect(instance.breadcrumbs.second).to_not eql(title: "Organisations", url: "/government/organisations")
+    end
+
+    it "has an organisation link when the parent content item has a title and the document_type is organisation" do
+      expect(parent_content_item["document_type"]).to eql("organisation")
+      expect(instance.breadcrumbs.third).to eql(title: "Attorney General's Office", url: "/government/organisations/attorney-generals-office")
+    end
+
+    it "has no organisation link when the parent content item has no title and the document_type is organisation" do
+      parent_content_item["title"] = ""
+      instance = described_class.new(parent_content_item, finder)
+      urls = instance.breadcrumbs.map { |breadcrumb| breadcrumb[:url] }
+      expect(urls).to_not include("/government/organisations/attorney-generals-office")
+    end
+
+    it "displays finder title as text when the finder has a title" do
+      expect(instance.breadcrumbs.last).to eql(title: "Air Accidents Investigation Branch reports", is_current_page: true)
+    end
+
+    it "does not display a finder title when the finder has no title" do
+      finder["title"] = ""
+      instance = described_class.new(parent_content_item, finder)
+      titles = instance.breadcrumbs.map { |breadcrumb| breadcrumb[:title] }
+      expect(titles).to_not include("Air Accidents Investigation Branch reports")
+    end
+  end
+end


### PR DESCRIPTION
This adds organisation breadcrumbs to a finder. An organisation is specified in the parameters using it's base path, for example
`http://www.gov.uk/news-and-communications?parent_path=/government/organisations/hm-treasury`

Trello card: https://trello.com/c/vW7Qpp51/138-to-add-a-contextual-breadcrumb-to-the-news-and-communications-finder

Authors (alphabetically): Karl Baker, Bill Franklin, Mahmud Hussain and Oscar Wyatt

![organisation_breadcrumbs](https://user-images.githubusercontent.com/41049800/48478576-9b6a2600-e7fc-11e8-9d19-12916058d021.png)
