### PR TITLE
Rescue from invalid GDS API URLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
 
   # rescue_from precedence is bottom up - https://stackoverflow.com/a/9121054/170864
   rescue_from GdsApi::BaseError, with: :error_503
+  rescue_from GdsApi::InvalidUrl, with: :unprocessable_entity
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
   rescue_from GdsApi::HTTPUnprocessableEntity, with: :unprocessable_entity
 


### PR DESCRIPTION
This adds exception handling for invalid GDS API URLs returning 422 Unprocessable Entity instead of 500 Internal Server Error.

An example of when this can happen:

```
GET /search/advanced?group=services'&topic=%2Fmoney%2Fbusiness-tax"

#<GdsApi::InvalidUrl: GdsApi::InvalidUrl>
{"method":"GET","path":"/search/advanced","format":"html","controller":"advanced_search_finder","action":"show","status":200,"duration":0.86,"ip":"127.0.0.1","route":"advanced_search_finder#show","request_id":"2c2e27bf-3744-42f5-8805-0b9250b78d29","request":"GET /search/advanced?group=services%27\u0026topic=%2Fmoney%2Fbusiness-tax%22 HTTP/1.1","govuk_request_id":null,"varnish_id":null,"govuk_app_config":"1.10.0","source":"unknown","tags":["request"],"@timestamp":"2018-11-15T12:59:24.212Z","@version":"1"}
```