### PR TITLE
Enable faceting by World Location

### DIFF
--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -1,0 +1,15 @@
+module Registries
+  class BaseRegistries
+    def all
+      @all ||= {
+        'world_locations' => world_locations
+      }
+    end
+
+  private
+
+    def world_locations
+      @world_locations ||= WorldLocationsRegistry.new
+    end
+  end
+end

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -1,0 +1,37 @@
+module Registries
+  class WorldLocationsRegistry
+    CACHE_KEY = "registries/world_locations".freeze
+
+    def all
+      @all ||= cached_locations
+    end
+
+    def [](slug)
+      all.find { |o| o['slug'] == slug }
+    end
+
+  private
+
+    def cached_locations
+      Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        fetch_locations
+      end
+    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
+      GovukStatsd.increment("registries.world_location_api_errors")
+      []
+    end
+
+    def fetch_locations
+      fetch_locations_from_worldwide_api.map { |result|
+        {
+          'title' => result['title'],
+          'slug' => result.dig('details', 'slug')
+        }
+      }
+    end
+
+    def fetch_locations_from_worldwide_api
+      Services.worldwide_api.world_locations.with_subsequent_pages.to_a
+    end
+  end
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -23,4 +23,8 @@ module Services
       bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "wubbalubbadubdub")
     )
   end
+
+  def self.worldwide_api
+    @worldwide_api ||= GdsApi::Worldwide.new(Plek.find('whitehall-admin'))
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -105,7 +105,7 @@ private
 
   def get_metadata_label(key, tag)
     if tag.respond_to? :fetch
-      tag.fetch(finder.display_key_for_metadata_key(key))
+      tag.fetch(finder.display_key_for_metadata_key(key), '')
     else
       tag
     end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require "gds_api/test_helpers/worldwide"
+
+RSpec.describe Registries::BaseRegistries do
+  include GdsApi::TestHelpers::Worldwide
+
+  before do
+    worldwide_api_has_selection_of_locations
+  end
+
+  let(:subject) { described_class.new }
+
+  it "fetches all registries" do
+    expect(subject.all).to have_key('world_locations')
+  end
+
+  it "provides world_locations registry" do
+    expect(subject.all['world_locations']).to be_instance_of Registries::WorldLocationsRegistry
+  end
+end

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -1,0 +1,61 @@
+require "securerandom"
+require 'spec_helper'
+require "gds_api/test_helpers/worldwide"
+
+RSpec.describe Registries::WorldLocationsRegistry do
+  include GdsApi::TestHelpers::Worldwide
+
+  describe "when world locations api is available" do
+    before do
+      clear_cache
+      worldwide_api_has_locations %w(hogwarts privet-drive diagon-alley)
+    end
+
+    after { clear_cache }
+
+    subject(:registry) { described_class.new }
+
+    let(:slug) { 'privet-drive' }
+
+    it "will fetch an expanded world location by slug" do
+      fetched_document = registry[slug]
+      expect(fetched_document).to eq(
+        'title' => 'Privet Drive',
+        'slug' => slug
+      )
+    end
+
+    it "will return all expanded world locations" do
+      expect(registry.all).to contain_exactly(
+        {
+          "slug" => "hogwarts",
+          "title" => "Hogwarts"
+        },
+        {
+          "slug" => "privet-drive",
+          "title" => "Privet Drive"
+        },
+         "slug" => "diagon-alley",
+         "title" => "Diagon Alley"
+      )
+    end
+  end
+
+  describe "when world locations API is unavailable" do
+    it "will return an (uncached) empty array" do
+      clear_cache
+      world_locations_api_is_unavailable
+      expect(described_class.new.all).to eql([])
+      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+    end
+  end
+
+  def world_locations_api_is_unavailable
+    base_url = GdsApi::TestHelpers::Worldwide::WORLDWIDE_API_ENDPOINT
+    stub_request(:get, "#{base_url}/api/world-locations").to_return(status: 500)
+  end
+
+  def clear_cache
+    Rails.cache.delete(described_class::CACHE_KEY)
+  end
+end

--- a/startup.sh
+++ b/startup.sh
@@ -8,6 +8,7 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
   bundle exec rails s -p 3062
 else
   bundle exec rails s -p 3062


### PR DESCRIPTION
With this change, World Locations become available as a facet in Finders. For the moment this will only be visible on the news and communications finder (currently not available outside of development mode).

This change is necessary because rummager does not provide the required data to provide world location options in a facet. We need to get additional world location data from Whitehall, until world locations are migrated.  This data is cached in a Registry.

A longer term solution would be to bring world locations back into rummager (they were removed earlier this year). This is being considered but it may be some time before this is worked on.

I added a World Locations Registry, similar to the registries we have in Rummager. Initially I had planned to add this world location registry to rummager, but having the registry downstream of rummager (it would only be used by finder-frontend) ensures there's no dependency on Whitehall in rummager.

This unmerged PR demonstrates how this could have been implemented in Rummager:
https://github.com/alphagov/rummager/pull/1318/commits/d54d0a6e3f22148ea645cf8c34333c1174fd9fc2.

By default, the world locations finder will not be populated in development mode. It relies on Whitehall being up, so if whitehall-admin happens to be up, or if you start finder frontend with the --live flag, the world locations registry will be populated with data.

### Screenshots 

<img width="676" alt="screen shot 2018-11-16 at 17 50 34" src="https://user-images.githubusercontent.com/8124374/48638297-17649980-e9c8-11e8-92d5-728717d586e7.png">
<img width="342" alt="screen shot 2018-11-16 at 17 50 26" src="https://user-images.githubusercontent.com/8124374/48638298-17fd3000-e9c8-11e8-9dc8-7909a1dd1023.png">
