### PR TITLE
Restore contextual breadcrumbs

### DIFF
--- a/app/presenters/finder_breadcrumbs_presenter.rb
+++ b/app/presenters/finder_breadcrumbs_presenter.rb
@@ -5,13 +5,12 @@ class FinderBreadcrumbsPresenter
   end
 
   def breadcrumbs
-    crumbs = [{ title: "Home", url: "/" }]
+    return nil unless @parent_content_item.dig("document_type") == "organisation"
 
-    if @parent_content_item.dig("document_type") == "organisation"
-      crumbs << { title: 'Organisations', url: '/government/organisations' }
-      if @parent_content_item.dig("title").present?
-        crumbs << { title: @parent_content_item.dig("title"), url: @parent_content_item.dig("base_path") }
-      end
+    crumbs = [{ title: "Home", url: "/" }]
+    crumbs << { title: 'Organisations', url: '/government/organisations' }
+    if @parent_content_item.dig("title").present?
+      crumbs << { title: @parent_content_item.dig("title"), url: @parent_content_item.dig("base_path") }
     end
 
     if @finder_name.present?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -8,8 +8,11 @@
   <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
-
+<% if @breadcrumbs.breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
+<% else %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+<% end %>
 
 <% if finder.government? %>
   <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -60,6 +60,6 @@ Feature: Filtering documents
     And I can see a breadcrumb that not a link for the finder
 
   Scenario: Visit a finder not from an organisation
-    Given a policy finder exists
-    Then I can only see home and finder breadcrumbs
+    Given a finder tagged to the topic taxonomy
+    Then I can see taxonomy breadcrumbs
     And I can see a breadcrumb for home

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -96,6 +96,11 @@ Given(/^a policy finder exists$/) do
   stub_rummager_api_request_with_policy_results
 end
 
+Given(/^a finder tagged to the topic taxonomy$/) do
+  stub_content_store_with_a_taxon_tagged_finder
+  stub_rummager_with_cma_cases
+end
+
 Given(/^a collection of documents that can be filtered by dates$/) do
   stub_content_store_with_cma_cases_finder
   stub_rummager_with_cma_cases
@@ -211,8 +216,8 @@ Then(/^I can see a breadcrumb that not a link for the finder$/) do
   expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Ministry of Silly Walks reports")
 end
 
-Then(/^I can only see home and finder breadcrumbs$/) do
-  visit finder_path('government/policies/benefits-reform')
-  expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Benefits Reform")
+Then(/^I can see taxonomy breadcrumbs$/) do
+  visit finder_path('cma-cases')
+  expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Competition Act and cartels")
   expect(page.find_all(".govuk-breadcrumbs__list-item").count).to eql(2)
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -100,6 +100,37 @@ module DocumentHelper
     )
   end
 
+  def stub_content_store_with_a_taxon_tagged_finder
+    schema = govuk_content_schema_example("cma-cases", "finder").merge(
+      "links" => {
+        "taxons" => [
+          {
+            "api_path" => "/api/content/business/competition-competition-act-cartels",
+            "base_path" => "/business/competition-competition-act-cartels",
+            "content_id" => "900ee60d-32ed-4dba-9834-09f54de01d5d",
+            "document_type" => "taxon",
+            "locale" => "en",
+            "public_updated_at" => "2018-09-03T15:41:04Z",
+            "schema_name" => "taxon",
+            "title" => "Competition Act and cartels",
+            "withdrawn": false,
+            "details": {
+              "internal_name" => "Competition Act and cartels [T]",
+              "notes_for_editors" => "",
+              "visible_to_departmental_editors": false
+            },
+            "phase" => "live"
+         }
+        ]
+      })
+
+      content_store_has_item(
+        schema.fetch("base_path"),
+        schema.to_json,
+      )
+    end
+
+
   def stub_rummager_with_cma_cases
     stub_request(:get, rummager_all_cma_case_documents_url).to_return(
       body: all_cma_case_documents_json,

--- a/spec/presenters/finder_breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/finder_breadcrumbs_presenter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FinderBreadcrumbsPresenter do
     it "has no links to organisations when the document_type is not organisation" do
       instance = described_class.new(place_content_item, finder)
       expect(place_content_item["document_type"]).to_not eql("organisation")
-      expect(instance.breadcrumbs.second).to_not eql(title: "Organisations", url: "/government/organisations")
+      expect(instance.breadcrumbs).to be nil
     end
 
     it "has an organisation link when the parent content item has a title and the document_type is organisation" do


### PR DESCRIPTION
For pages like [CMA cases](https://www.gov.uk/cma-cases) we want to keep contextual breadcrumbs if we can't guess something more useful to a user's journey. Finders may be tagged to the taxonomy or something else (maybe even a step by step at some point) and we don't want to lose that.

This is best viewed with the [`?w=1` option](https://github.com/alphagov/finder-frontend/compare/restore-taxon-breadcrumbs?expand=1&w=1) because I pulled a guard clause out of the `if` statement in the breadcrumbs presenter which affected the indentation.

https://trello.com/c/vW7Qpp51/138-to-add-a-contextual-breadcrumb-to-the-news-and-communications-finder