### PR TITLE
Add multiple facets to finder email signup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,10 @@ end
 group :development, :test do
   gem 'awesome_print'
   gem 'govuk-lint', '~> 3.9.0'
+  gem 'govuk_schemas', '~> 3.2'
   gem 'jasmine-rails'
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.8.1'
-  gem 'govuk_schemas', '~> 3.2'
 end
 
 group :test do

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,3 @@
 @import 'finder_frontend';
 @import 'views/advanced-search';
+@import 'views/email';

--- a/app/assets/stylesheets/views/_email.scss
+++ b/app/assets/stylesheets/views/_email.scss
@@ -1,0 +1,3 @@
+.signup-choices {
+  margin-top: 50px;
+}

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -43,6 +43,7 @@ private
   end
 
   def finder_format
+    return nil unless finder.filter
     finder.filter['document_type']
   end
 
@@ -56,9 +57,8 @@ private
   end
 
   def email_signup_attributes
-    {
-      "format" => [finder_format],
-      "filter" => chosen_options,
-    }
+    { "filter" => chosen_options }.tap do |hash|
+      hash["format"] = [finder_format] if finder_format
+    end
   end
 end

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -29,6 +29,24 @@ class SignupPresenter
     multiple_facet_choice_data || single_facet_choice_data
   end
 
+  def choices_formatted
+    choices.map do |choice|
+      {
+        label: choice['facet_name'],
+        value: choice['facet_id'],
+        checked: choice['prechecked'],
+        items: choice['facet_choices'].map do |facet_choice|
+          {
+            name: "filter[#{choice['facet_id']}][]",
+            label: facet_choice['radio_button_name'],
+            value: facet_choice['key'],
+            checked: facet_choice['prechecked']
+          }
+        end
+      }
+    end
+  end
+
   def target
     "#"
   end
@@ -39,7 +57,7 @@ private
     [
       {
         "facet_id" => content_item['details']["email_filter_by"],
-        "facet_name" => single_facet_name,
+        "facet_name" => single_facet_name.capitalize,
         "facet_choices" => content_item['details']["email_signup_choice"]
       }
     ]

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -22,19 +22,11 @@ class SignupPresenter
   end
 
   def choices?
-    choice_data.present?
+    multiple_facet_choice_data.present? || single_facet_choice_data[0]["facet_choices"].present?
   end
 
   def choices
-    choice_data
-  end
-
-  def choice_name(choice)
-    choice_data.copy[choice]["radio_button_name"]
-  end
-
-  def choice_body(choice)
-    choice_data.copy[choice]["body"]
+    multiple_facet_choice_data || single_facet_choice_data
   end
 
   def target
@@ -43,7 +35,21 @@ class SignupPresenter
 
 private
 
-  def choice_data
-    content_item['details']["email_signup_choice"]
+  def single_facet_choice_data
+    [
+      {
+        "facet_id" => content_item['details']["email_filter_by"],
+        "facet_name" => single_facet_name,
+        "facet_choices" => content_item['details']["email_signup_choice"]
+      }
+    ]
+  end
+
+  def multiple_facet_choice_data
+    content_item['details']["email_filter_facets"]
+  end
+
+  def single_facet_name
+    content_item['details']["email_filter_name"]["plural"] || content_item['details']["email_filter_name"]
   end
 end

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -6,33 +6,18 @@
 <% if @signup_presenter.beta? %>
   <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
-<header>
- <div class="title-and-metadata">
-    <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup_presenter.name,
-      context: "Email alert subscription"
-    } %>
-  </div>
-</header>
 
 <div class="outer-block">
   <div class="signup-content">
     <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
       <% if @signup_presenter.choices? %>
-        <fieldset<%= ' class="invalid"'.html_safe if @error_message.present? %> aria-labelledby="fieldset-title">
-          <p id="fieldset-title">
-            Select the email alerts you need
-          </p>
-          <% @signup_presenter.choices.each do |facet| %>
-            <p><%= facet["facet_name"] %></p>
-            <% facet["facet_choices"].each do |choice| %>
-              <%= label_tag "filter_#{facet['facet_id']}_#{choice['key']}", class: 'block-label' do %>
-              <%= check_box_tag "filter[#{facet['facet_id']}][]", choice['key'], choice['prechecked'], class: 'checkbox', id: "filter_#{facet['facet_id']}_#{choice['key']}" %>
-              <%= choice['radio_button_name'] %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </fieldset>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: nil,
+          heading: @signup_presenter.name,
+          hint_text: "Select the email alerts you need.",
+          items: @signup_presenter.choices_formatted,
+          is_page_heading: true,
+        } %>
         <% if @error_message.present? %>
           <p class="validation-message"><%= @error_message %></p>
         <% end %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, @signup.page_title %>
+<% content_for :title, @signup_presenter.page_title %>
 <% content_for :head do %>
-  <%= render 'email_alert_subscription_meta', email_alert_subscription: @signup %>
+  <%= render 'email_alert_subscription_meta', email_alert_subscription: @signup_presenter %>
 <% end %>
 
-<% if @signup.beta? %>
+<% if @signup_presenter.beta? %>
   <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 <header>
  <div class="title-and-metadata">
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup.name,
+      title: @signup_presenter.name,
       context: "Email alert subscription"
     } %>
   </div>
@@ -18,15 +18,18 @@
 <div class="outer-block">
   <div class="signup-content">
     <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
-      <% if @signup.choices? %>
+      <% if @signup_presenter.choices? %>
         <fieldset<%= ' class="invalid"'.html_safe if @error_message.present? %> aria-labelledby="fieldset-title">
           <p id="fieldset-title">
             Select the email alerts you need
           </p>
-          <% @signup.choices.each do |choice| %>
-            <%= label_tag "filter_#{choice['key']}", class: 'block-label' do %>
-              <%= check_box_tag "filter[]", choice['key'], choice['prechecked'], class: 'checkbox', id: "filter_#{choice['key']}" %>
+          <% @signup_presenter.choices.each do |facet| %>
+            <p><%= facet["facet_name"] %></p>
+            <% facet["facet_choices"].each do |choice| %>
+              <%= label_tag "filter_#{facet['facet_id']}_#{choice['key']}", class: 'block-label' do %>
+              <%= check_box_tag "filter[#{facet['facet_id']}][]", choice['key'], choice['prechecked'], class: 'checkbox', id: "filter_#{facet['facet_id']}_#{choice['key']}" %>
               <%= choice['radio_button_name'] %>
+              <% end %>
             <% end %>
           <% end %>
         </fieldset>
@@ -35,7 +38,7 @@
         <% end %>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/govspeak', content: @signup.body.html_safe %>
+      <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
 
       <%= submit_tag 'Create subscription', class: "button" %>
     <% end %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -38,7 +38,9 @@
         <% end %>
       <% end %>
 
-      <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+      <% if @signup_presenter.body %>
+        <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+      <% end %>
 
       <%= submit_tag 'Create subscription', class: "button" %>
     <% end %>

--- a/features/fixtures/cma_cases_with_multi_facets_signup_content_item.json
+++ b/features/fixtures/cma_cases_with_multi_facets_signup_content_item.json
@@ -1,0 +1,48 @@
+{
+  "base_path": "/cma-cases/email-signup",
+  "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+  "document_type": "finder_email_signup",
+  "title": "Competition and Markets Authority cases",
+  "description": "You'll get an email each time a case is updated or a new case is published.",
+  "details": {
+    "email_filter_facets": [
+      {
+        "facet_id": "case_type",
+        "facet_name": "Case Type",
+        "facet_choices": [
+          {
+            "key": "ca98-and-civil-cartels",
+            "radio_button_name": "CA98 and civil cartels",
+            "topic_name": "CA98 and civil cartels",
+            "prechecked": false
+          },
+          {
+            "key": "competition-disqualification",
+            "radio_button_name": "Competition disqualification",
+            "topic_name": "competition disqualification",
+            "prechecked": false
+          }
+        ]
+      },
+      {
+        "facet_id": "case_state",
+        "facet_name": "Case State",
+        "facet_choices": [
+          {
+            "key": "open",
+            "radio_button_name": "Open",
+            "topic_name": "Open",
+            "prechecked": false
+          },
+          {
+            "key": "closed",
+            "radio_button_name": "Closed",
+            "topic_name": "closed",
+            "prechecked": false
+          }
+        ]
+      }
+    ],
+    "subscription_list_title_prefix": "CMA cases"
+  }
+}

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -248,13 +248,13 @@ module DocumentHelper
   end
 
   def rummager_policy_other_page_search_url(page_number)
-    count_per_page = 10.freeze
+    count_per_page = 10
 
     rummager_url(
       policy_search_params.merge(
         "order" => "-public_timestamp",
         "count" => count_per_page,
-        "start" => ((page_number -1) * count_per_page)
+        "start" => ((page_number - 1) * count_per_page)
       )
     )
   end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -33,7 +33,9 @@ private
     attributes.dup.tap do |massaged_attributes|
       available_choices.each do |choice|
         facet_id = choice["facet_id"]
-        massaged_attributes[facet_id] = (massaged_attributes['filter'] || {})[facet_id]
+        value = (massaged_attributes['filter'] || {})[facet_id]
+        next unless value
+        massaged_attributes[facet_id] = value
       end
       massaged_attributes.delete("filter")
     end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,13 +1,11 @@
+require 'email_alert_title_builder'
+
 class EmailAlertSignupAPI
   def initialize(dependencies = {})
     @email_alert_api = dependencies.fetch(:email_alert_api)
     @attributes = dependencies.fetch(:attributes)
     @subscription_list_title_prefix = dependencies.fetch(:subscription_list_title_prefix)
     @available_choices = dependencies.fetch(:available_choices)
-    @filter_key = dependencies.fetch(:filter_key)
-    if attributes['filter'].blank? && !available_choices.blank?
-      raise ArgumentError, "User must choose at least one of the available options"
-    end
   end
 
   def signup_url
@@ -16,7 +14,7 @@ class EmailAlertSignupAPI
 
 private
 
-  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :filter_key
+  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices
 
   def subscriber_list
     response = email_alert_api.find_or_create_subscriber_list("tags" => massaged_attributes, "title" => title)
@@ -24,35 +22,20 @@ private
   end
 
   def title
-    if available_choices.empty?
-      title = subscription_list_title_prefix.to_s
-    else
-      plural_or_single = if attributes.fetch("filter").length == 1
-                           "singular"
-                         else
-                           "plural"
-                         end
-      title = (subscription_list_title_prefix[plural_or_single].to_s + topic_names.to_sentence).upcase_first
-    end
-
-    title
-  end
-
-  def topic_names
-    attributes.fetch("filter").collect { |x| choice_hash_by_key(x)['topic_name'] }
-  end
-
-  def choice_hash_by_key(key)
-    available_choices.detect { |x| x['key'] == key }
+    ::EmailAlertTitleBuilder.call(
+      filter: attributes['filter'] || {},
+      subscription_list_title_prefix: subscription_list_title_prefix,
+      facets: available_choices
+    )
   end
 
   def massaged_attributes
-    massaged_attributes = attributes.dup
-    if available_choices.empty?
+    attributes.dup.tap do |massaged_attributes|
+      available_choices.each do |choice|
+        facet_id = choice["facet_id"]
+        massaged_attributes[facet_id] = (massaged_attributes['filter'] || {})[facet_id]
+      end
       massaged_attributes.delete("filter")
-    else
-      massaged_attributes[@filter_key] = massaged_attributes.delete("filter")
     end
-    massaged_attributes
   end
 end

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -1,0 +1,61 @@
+class EmailAlertTitleBuilder
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def initialize(filter:, subscription_list_title_prefix:, facets:)
+    @filter = filter
+    @subscription_list_title_prefix = subscription_list_title_prefix
+    @facets = facets
+  end
+
+  def call
+    (prefix.to_s + suffix.to_s).upcase_first
+  end
+
+private
+
+  attr_reader :filter, :subscription_list_title_prefix, :facets
+
+  def topic_names(facet)
+    filter.fetch(facet["facet_id"], []).map { |key| choice_hash_by_key(facet, key)["topic_name"] }
+  end
+
+  def topic_names_sentence(facet)
+    topic_names(facet).to_sentence
+  end
+
+  def choice_hash_by_key(facet, key)
+    facet["facet_choices"].detect { |choice| choice["key"] == key }
+  end
+
+  def selected_facets
+    facets.select { |facet| filter[facet["facet_id"]].present? }
+  end
+
+  def plural_or_single
+    if filter.fetch(facets.first["facet_id"], []).length == 1
+      "singular"
+    else
+      "plural"
+    end
+  end
+
+  def prefix
+    if facets.size == 1
+      subscription_list_title_prefix[plural_or_single].to_s
+    elsif selected_facets.empty?
+      subscription_list_title_prefix.to_s
+    elsif subscription_list_title_prefix
+      "#{subscription_list_title_prefix}with "
+    end
+  end
+
+  def suffix
+    if facets.size == 1
+      topic_names_sentence(facets.first)
+    elsif selected_facets.present?
+      selected_facets.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
+    end
+  end
+end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -5,58 +5,56 @@ require 'gds_api/test_helpers/email_alert_api'
 describe EmailAlertSignupAPI do
   include GdsApi::TestHelpers::EmailAlertApi
 
-  let(:attributes) {
-    {
-      "format" => "test-reports",
-      "filter" => %w(first second),
-    }
-  }
-  let(:available_choices) {
-    [
-      {
-        "key" => "first",
-        "radio_button_name" => "First ABC thing",
-        "topic_name" => "first ABC thing",
-        "prechecked" => false,
-      },
-      {
-        "key" => "second",
-        "radio_button_name" => "Second DEF thing",
-        "topic_name" => "second DEF thing",
-        "prechecked" => false,
-      },
-    ]
-  }
-  let(:subscription_list_title_prefix) {
-    {
-      "singular" => "Format with report type: ",
-      "plural" => "Format with report types: ",
-    }
-  }
-  let(:filter_key) { "alert_type" }
-  let(:subscription_url) { "http://www.example.org/list-id/signup" }
-  subject(:signup_api_wrapper) {
+  subject(:signup_api_wrapper) do
     described_class.new(
       email_alert_api: Services.email_alert_api,
       attributes: attributes,
       available_choices: available_choices,
       subscription_list_title_prefix: subscription_list_title_prefix,
-      filter_key: filter_key
-    )
-  }
-
-  before do
-    email_alert_api_has_subscriber_list(
-      "tags" => {
-        "format" => "test-reports",
-        "alert_type" => %w(first second),
-      },
-      "subscription_url" => subscription_url
     )
   end
 
-  describe '#signup_url' do
-    it 'returns the url email-alert-api gives back' do
+  context "with a single facet finder" do
+    let(:attributes) do
+      {
+        "format" => "test-reports",
+        "filter" => {
+            "alert_type" => %w(first second)
+          },
+      }
+    end
+    let(:available_choices) do
+      [
+        {
+          "facet_id" => "alert_type",
+          "facet_name" => "alert type",
+          "facet_choices" => [
+            {
+              "key" => "first",
+              "radio_button_name" => "First ABC thing",
+              "topic_name" => "first ABC thing",
+              "prechecked" => false
+            },
+            {
+              "key" => "second",
+              "radio_button_name" => "Second DEF thing",
+              "topic_name" => "second DEF thing",
+              "prechecked" => false,
+            }
+          ]
+        },
+      ]
+    end
+    let(:subscription_list_title_prefix) do
+      {
+        "singular" => "Format with report type: ",
+        "plural" => "Format with report types: ",
+      }
+    end
+
+    let(:subscription_url) { "http://www.example.org/list-id/signup" }
+
+    before do
       email_alert_api_has_subscriber_list(
         "tags" => {
           "format" => "test-reports",
@@ -64,11 +62,10 @@ describe EmailAlertSignupAPI do
         },
         "subscription_url" => subscription_url
       )
-      expect(signup_api_wrapper.signup_url).to eql subscription_url
     end
 
-    context 'with multiple choices selected and a title prefix' do
-      it 'asks email-alert-api to find or create the subscriber list' do
+    describe '#signup_url' do
+      it 'returns the url email-alert-api gives back' do
         email_alert_api_has_subscriber_list(
           "tags" => {
             "format" => "test-reports",
@@ -76,62 +73,175 @@ describe EmailAlertSignupAPI do
           },
           "subscription_url" => subscription_url
         )
-        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-          "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w(first second),
-          },
-          "title" => "Format with report types: first ABC thing and second DEF thing",
-        ).and_call_original
+        expect(signup_api_wrapper.signup_url).to eql subscription_url
+      end
 
-        signup_api_wrapper.signup_url
+      context 'with multiple choices selected and a title prefix' do
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+            },
+            "title" => "Format with report types: first ABC thing and second DEF thing",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'with one choice selected and a title prefix' do
+        let(:attributes) do
+          {
+            "format" => "test-reports",
+            "filter" => {
+              "alert_type" => %w[first],
+            },
+          }
+        end
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w[first],
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w[first],
+            },
+            "title" => "Format with report type: first ABC thing",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'without a title prefix' do
+        let(:subscription_list_title_prefix) { {} }
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+            },
+            "title" => "First ABC thing and second DEF thing",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'no options available' do
+        let(:available_choices) { [] }
+        let(:attributes) do
+          {
+            "format" => "test-reports",
+          }
+        end
+        let(:subscription_list_title_prefix) { "Format" }
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+            },
+            "title" => "Format",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
       end
     end
+  end
 
-    context 'with one choice selected and a title prefix' do
-      let(:attributes) {
+  context "with a multi facet finder" do
+    let(:attributes) do
+      {
+        "format" => "test-reports",
+        "filter" => {
+            "alert_type" => %w(first second),
+            "other_type" => %w(third fourth)
+          },
+      }
+    end
+    let(:available_choices) do
+      [
         {
-          "format" => "test-reports",
-          "filter" => %w[first],
-        }
-      }
-      it 'asks email-alert-api to find or create the subscriber list' do
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w[first],
-          },
-          "subscription_url" => subscription_url
-        )
-        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-          "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w[first],
-          },
-          "title" => "Format with report type: first ABC thing",
-        ).and_call_original
-
-        signup_api_wrapper.signup_url
-      end
-    end
-
-    context 'with no choice selected' do
-      let(:attributes) {
+          "facet_id" => "alert_type",
+          "facet_name" => "alert type",
+          "facet_choices" => [
+            {
+              "key" => "first",
+              "radio_button_name" => "First ABC thing",
+              "topic_name" => "first ABC thing",
+              "prechecked" => false
+            },
+            {
+              "key" => "second",
+              "radio_button_name" => "Second DEF thing",
+              "topic_name" => "second DEF thing",
+              "prechecked" => false,
+            }
+          ]
+        },
         {
+          "facet_id" => "other_type",
+          "facet_name" => "other type",
+          "facet_choices" => [
+            {
+              "key" => "third",
+              "radio_button_name" => "Third GHI thing",
+              "topic_name" => "third GHI thing",
+              "prechecked" => false
+            },
+            {
+              "key" => "fourth",
+              "radio_button_name" => "Fourth JKL thing",
+              "topic_name" => "fourth JKL thing",
+              "prechecked" => false,
+            }
+          ]
+        },
+      ]
+    end
+    let(:subscription_list_title_prefix) { "Formats " }
+    let(:subscription_url) { "http://www.example.org/list-id/signup" }
+
+    before do
+      email_alert_api_has_subscriber_list(
+        "tags" => {
           "format" => "test-reports",
-          "filter" => [],
-        }
-      }
-      it 'raises an error' do
-        expect { signup_api_wrapper.signup_url }.to raise_error(ArgumentError)
-      end
+          "alert_type" => %w(first second),
+          "other_type" => %w(third fourth)
+        },
+        "subscription_url" => subscription_url
+      )
     end
 
-    context 'without a title prefix' do
-      let(:subscription_list_title_prefix) {
-        {}
-      }
-      it 'asks email-alert-api to find or create the subscriber list' do
+    describe '#signup_url' do
+      it 'returns the url email-alert-api gives back' do
         email_alert_api_has_subscriber_list(
           "tags" => {
             "format" => "test-reports",
@@ -139,42 +249,112 @@ describe EmailAlertSignupAPI do
           },
           "subscription_url" => subscription_url
         )
-        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-          "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w(first second),
-          },
-          "title" => "First ABC thing and second DEF thing",
-        ).and_call_original
-
-        signup_api_wrapper.signup_url
+        expect(signup_api_wrapper.signup_url).to eql subscription_url
       end
-    end
 
-    context 'no options available' do
-      let(:available_choices) { [] }
-      let(:attributes) {
-        {
-          "format" => "test-reports",
-        }
-      }
-      let(:filter_key) { nil }
-      let(:subscription_list_title_prefix) { "Format" }
-      it 'asks email-alert-api to find or create the subscriber list' do
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "format" => "test-reports",
-          },
-          "subscription_url" => subscription_url
-        )
-        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-          "tags" => {
-            "format" => "test-reports",
-          },
-          "title" => "Format",
-        ).and_call_original
+      context 'with multiple choices selected and a title prefix' do
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+              "other_type" => %w(third fourth),
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+              "other_type" => %w(third fourth),
+            },
+            "title" => "Formats with alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
+          ).and_call_original
 
-        signup_api_wrapper.signup_url
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'with one choice selected and a title prefix' do
+        let(:attributes) do
+          {
+            "format" => "test-reports",
+            "filter" => {
+              "alert_type" => %w[first],
+              "other_type" => %w[],
+            },
+          }
+        end
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w[first],
+              "other_type" => %w[],
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w[first],
+              "other_type" => %w[],
+            },
+            "title" => "Formats with alert type of first ABC thing",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'without a title prefix' do
+        let(:subscription_list_title_prefix) { nil }
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+              "other_type" => %w(third fourth),
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+              "alert_type" => %w(first second),
+              "other_type" => %w(third fourth),
+            },
+            "title" => "Alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
+      end
+
+      context 'no options available' do
+        let(:available_choices) { [] }
+        let(:attributes) do
+          {
+            "format" => "test-reports",
+          }
+        end
+        let(:subscription_list_title_prefix) { "Format" }
+        it 'asks email-alert-api to find or create the subscriber list' do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => "test-reports",
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+            "tags" => {
+              "format" => "test-reports",
+            },
+            "title" => "Format",
+          ).and_call_original
+
+          signup_api_wrapper.signup_url
+        end
       end
     end
   end

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+require 'email_alert_title_builder'
+
+describe EmailAlertTitleBuilder do
+  subject do
+    described_class.call(
+      filter: filter,
+      subscription_list_title_prefix: subscription_list_title_prefix,
+      facets: facets
+    )
+  end
+
+  context 'when there are no facets' do
+    let(:filter) { nil }
+    let(:subscription_list_title_prefix) { 'Prefix' }
+    let(:facets) { [] }
+
+    it { is_expected.to eq(subscription_list_title_prefix) }
+  end
+
+  context 'when there is one facet' do
+    let(:subscription_list_title_prefix) do
+      { 'singular' => 'Prefix: ', 'plural' => 'Prefixes: ' }
+    end
+    let(:facets) do
+      [
+        {
+          'facet_id' => 'facet_id',
+          'facet_name' => 'facet name',
+          'facet_choices' => [
+            {
+              'key' => 'key_one',
+              'radio_button_name' => 'radio button name one',
+              'topic_name' => 'topic name one',
+              'prechecked' => false
+            },
+            {
+              'key' => 'key_two',
+              'radio_button_name' => 'radio button name two',
+              'topic_name' => 'topic name two',
+              'prechecked' => false
+            }
+          ],
+        }
+      ]
+    end
+
+    context 'when no choice is selected' do
+      let(:filter) { {} }
+
+      it { is_expected.to eq('Prefixes: ') }
+    end
+
+    context 'when one choice is selected' do
+      let(:filter) { { 'facet_id' => %w(key_one) } }
+
+      it { is_expected.to eq('Prefix: topic name one') }
+    end
+
+    context 'when two choices are selected' do
+      let(:filter) { { 'facet_id' => %w(key_one key_two) } }
+
+      it { is_expected.to eq('Prefixes: topic name one and topic name two') }
+    end
+  end
+
+  context 'when there are multiple facets' do
+    let(:subscription_list_title_prefix) { 'Prefix: ' }
+    let(:facets) do
+      [
+        {
+          'facet_id' => 'facet_id_one',
+          'facet_name' => 'facet name one',
+          'facet_choices' => [
+            {
+              'key' => 'key_one',
+              'radio_button_name' => 'radio button name one',
+              'topic_name' => 'topic name one',
+              'prechecked' => false
+            },
+            {
+              'key' => 'key_two',
+              'radio_button_name' => 'radio button name two',
+              'topic_name' => 'topic name two',
+              'prechecked' => false
+            }
+          ],
+        },
+        {
+          'facet_id' => 'facet_id_two',
+          'facet_name' => 'facet name two',
+          'facet_choices' => [
+            {
+              'key' => 'key_three',
+              'radio_button_name' => 'radio button name three',
+              'topic_name' => 'topic name three',
+              'prechecked' => false
+            },
+            {
+              'key' => 'key_four',
+              'radio_button_name' => 'radio button name four',
+              'topic_name' => 'topic name four',
+              'prechecked' => false
+            }
+          ],
+        }
+      ]
+    end
+
+    context 'when no choice is selected' do
+      let(:filter) { {} }
+
+      it { is_expected.to eq('Prefix: ') }
+    end
+
+    context 'when one facet is selected' do
+      context 'when one choice is selected' do
+        let(:filter) { { 'facet_id_one' => %w(key_one) } }
+
+        it { is_expected.to eq('Prefix: with facet name one of topic name one') }
+      end
+
+      context 'when two choices are selected' do
+        let(:filter) { { 'facet_id_one' => %w(key_one key_two) } }
+
+        it { is_expected.to eq('Prefix: with facet name one of topic name one and topic name two') }
+      end
+    end
+
+    context 'when two facets are selected' do
+      let(:filter) do
+        {
+          'facet_id_one' => %w(key_one key_two),
+          'facet_id_two' => %w(key_three key_four),
+        }
+      end
+
+      it { is_expected.to eq('Prefix: with facet name one of topic name one and topic name two and facet name two of topic name three and topic name four') }
+    end
+  end
+end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -10,4 +10,8 @@ module FixturesHelper
   def cma_cases_signup_content_item
     JSON.parse(File.read(fixtures_path + "/cma_cases_signup_content_item.json"))
   end
+
+  def cma_cases_with_multi_facets_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/cma_cases_with_multi_facets_signup_content_item.json"))
+  end
 end


### PR DESCRIPTION
This allows users to sign up to email alerts from finders and filtering from multiple facets rather than currently where they can only choose one.