### PR TITLE
Use public URL for worldwide API

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -25,6 +25,6 @@ module Services
   end
 
   def self.worldwide_api
-    @worldwide_api ||= GdsApi::Worldwide.new(Plek.find('whitehall-admin'))
+    @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.website_root)
   end
 end

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,6 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
   bundle exec rails s -p 3062
 else
   bundle exec rails s -p 3062


### PR DESCRIPTION
I think it's preferable to use the public API for this as it should reduce the change required if we migrate it from Whitehall at a later date.

(Also, we broke the preview apps as they don't have the env var for whitehall set)