### PR TITLE
Remember choices for email subscriptions

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -61,6 +61,8 @@
     }
   };
 
+  var currentEmailSignupPath = $("p.email-link a").attr('href')
+
   LiveSearch.prototype.formChange = function formChange(e){
     var pageUpdated;
     if(this.isNewState()){
@@ -69,6 +71,8 @@
       pageUpdated.done(
         function(){
           var newPath = window.location.pathname + "?" + $.param(this.state);
+          var newEmailSignupPath = currentEmailSignupPath + "?" + $.param(this.state);
+          $("p.email-link a").attr('href', newEmailSignupPath)
           history.pushState(this.state, '', newPath);
           if (this.canTrackPageview()) {
             GOVUK.analytics.trackPageview(newPath);

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -23,7 +23,7 @@ private
   end
 
   def signup_presenter
-    @signup_presenter ||= SignupPresenter.new(content)
+    @signup_presenter ||= SignupPresenter.new(content, params)
   end
 
   def valid_choices?

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,8 +1,9 @@
 class SignupPresenter
-  attr_reader :content_item
+  attr_reader :content_item, :params
 
-  def initialize(content_item)
+  def initialize(content_item, params)
     @content_item = content_item
+    @params = params
   end
 
   def page_title
@@ -40,7 +41,7 @@ class SignupPresenter
             name: "filter[#{choice['facet_id']}][]",
             label: facet_choice['radio_button_name'],
             value: facet_choice['key'],
-            checked: facet_choice['prechecked']
+            checked: facet_choice['prechecked'] || selected_choices.fetch(choice['facet_id'], []).include?(facet_choice['key'])
           }
         end
       }
@@ -52,6 +53,13 @@ class SignupPresenter
   end
 
 private
+
+  def selected_choices
+    facets_ids = choices.each_with_object({}) do |choice, hash|
+      hash[choice['facet_id'].to_sym] = []
+    end
+    params.permit(facets_ids).to_h
+  end
 
   def single_facet_choice_data
     [


### PR DESCRIPTION
Persist choices selected in the finder at the moment of signing up for email subscriptions, and allow choices to be automatically checked based on the query string.