### PR TITLE
Defend against breadcrumb paths that don't exist

### DIFF
--- a/features/finders.feature
+++ b/features/finders.feature
@@ -59,6 +59,11 @@ Feature: Filtering documents
     And I can see a breadcrumb for the organisation
     And I can see a breadcrumb that not a link for the finder
 
+  Scenario: Visit a finder from an organisation handling breadcrumb failures
+    Given an organisation finder exists but a bad breadcrumb path is given
+    Then I can see a breadcrumb for home
+    And no breadcrumb for all organisations
+
   Scenario: Visit a finder not from an organisation
     Given a finder tagged to the topic taxonomy
     Then I can see taxonomy breadcrumbs

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -188,6 +188,14 @@ Given(/^an organisation finder exists$/) do
   visit finder_path('government/policies/benefits-reform', parent_path: '/government/organisations/attorney-generals-office')
 end
 
+Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
+  content_store_has_government_finder
+  stub_rummager_api_request_with_government_results
+  content_store_is_missing_path
+
+  visit finder_path('government/policies/benefits-reform', parent_path: '/bernard-cribbins')
+end
+
 Then(/^I can see a breadcrumb for home$/) do
   expect(page).to have_link("Home", href: "/")
   expect(page).to have_css("a[data-track-category='homeLinkClicked']", text: "Home")
@@ -202,6 +210,10 @@ Then(/^I can see a breadcrumb for all organisations$/) do
   expect(page).to have_css("a[data-track-action='2']", text: "Organisations")
   expect(page).to have_css("a[data-track-label='/government/organisations']", text: "Organisations")
   expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Organisations\"}']", text: "Organisations")
+end
+
+And(/^no breadcrumb for all organisations$/) do
+  expect(page).to_not have_link("Organisations", href: "/government/organisations")
 end
 
 Then(/^I can see a breadcrumb for the organisation$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -85,6 +85,10 @@ module DocumentHelper
     content_store_has_item('/government/organisations/attorney-generals-office', govuk_content_schema_example('attorney_general', 'organisation').to_json)
   end
 
+  def content_store_is_missing_path
+    content_store_does_not_have_item('/bernard-cribbins')
+  end
+
   def search_params(params = {})
     default_search_params.merge(params).to_a.map { |tuple|
       tuple.join("=")


### PR DESCRIPTION
At present if we provide a `parent_path` to a path that doesn't exist in the content store, then the page errors.  This change catches 404 errors from the content store and reverts to the default breadcrumb.