### PR TITLE
Expand preselected facets

### DIFF
--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -37,7 +37,11 @@ class SelectFacet < FilterableFacet
   end
 
   def close_facet?
-    allowed_values.count > 10
+    selected_values.empty? && allowed_values.count > 10
+  end
+
+  def unselected?
+    selected_values.empty?
   end
 
 private

--- a/app/views/finders/_select_facet.html.erb
+++ b/app/views/finders/_select_facet.html.erb
@@ -1,9 +1,10 @@
+<% close_facet = select_facet.unselected? && ((select_facet_counter > 0) || select_facet.close_facet?) %>
 <%= render partial: 'components/option-select', locals: {
   :key => select_facet.key,
   :title => select_facet.name,
   :aria_controls_id => "js-search-results-info",
   :options_container_id => select_facet.key,
   :options => select_facet.options,
-  :closed_on_load => (select_facet_counter > 0) || select_facet.close_facet?,
+  :closed_on_load => close_facet,
 }
 %>

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -89,4 +89,29 @@ describe SelectFacet do
       specify { expect(subject.close_facet?).to be true }
     end
   end
+
+  describe "#unselected?" do
+    context "no selected values" do
+      specify { expect(subject.unselected?).to be true }
+    end
+
+    context "some selected values" do
+      let(:facet_data) {
+        {
+          'type' => "multi-select",
+          'name' => "Test values",
+          'key' => "test_values",
+          'preposition' => "of value",
+          'allowed_values' => [{ 'label' => 'One', 'value' => '1' }],
+        }
+      }
+
+      subject { SelectFacet.new(facet_data) }
+
+      specify do
+        subject.value = "1"
+        expect(subject.unselected?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/VIkCrzVg/81-spike-investigate-finder-facet-open-closed-state

If a finder is loaded with parameters intended to pre-filter the results
the facet filtering element should be open, otherwise the standard rules
of being the first facet in the group having less than ten items decides this.