### PR TITLE
Show title when there are no choices

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -21,6 +21,11 @@
         <% if @error_message.present? %>
           <p class="validation-message"><%= @error_message %></p>
         <% end %>
+      <% else %>
+        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+          title: @signup_presenter.name,
+          context: "Email alert subscription"
+        } %>
       <% end %>
 
       <% if @signup_presenter.body %>


### PR DESCRIPTION
We currently rely on the checkboxes component to render the title but when a finder doesn't have any email facets you don't see any title.

This brings back the functionality that was removed in https://github.com/alphagov/finder-frontend/pull/664/commits/eee8cfb395d92b88fee4b2781b24855af034fb45