### PR TITLE
Track QA choices as events

### DIFF
--- a/app/assets/javascripts/modules/track-qa-choices.js
+++ b/app/assets/javascripts/modules/track-qa-choices.js
@@ -1,0 +1,30 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.TrackQaChoices = function () {
+    this.start = function (element) {
+      track(element)
+    }
+
+    function track (element) {
+      element.on('submit', function (event) {
+        var $checkedOption, eventLabel, options
+        var $submittedForm = $(event.target)
+        var $checkedOptions = $submittedForm.find('input:checked')
+
+        $checkedOptions.each(function(index) {
+          $checkedOption = $(this)
+          eventLabel = $checkedOption.attr('name').replace('[]', '')
+          options = { transport: 'beacon', label: eventLabel }
+
+          GOVUK.analytics.trackEvent('QA option chosen', $checkedOption.val(), options)
+        })
+      })
+    }
+  }
+})(window, window.GOVUK);

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -3,7 +3,7 @@
 <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
 <div class="grid-row">
   <div class="column-two-thirds">
-    <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title">
+    <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title" data-module="track-qa-choices">
       <%= render "govuk_publishing_components/components/title", {
         title: current_facet["question"],
       } %>

--- a/spec/javascripts/modules/track-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-qa-choices.spec.js
@@ -1,0 +1,54 @@
+/* global describe beforeEach it spyOn expect */
+
+var $ = window.jQuery
+
+describe('QA choices tracker', function () {
+
+  var GOVUK = window.GOVUK || {}
+  var tracker
+  var $element
+
+  GOVUK.analytics = GOVUK.analytics || {}
+
+  beforeEach(function () {
+    GOVUK.analytics.trackEvent = function () {}
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    $element = $(
+      '<div>' +
+        '<form onsubmit="event.preventDefault()">' +
+          '<input name="sector_business_area[]" type="checkbox" value="construction">' +
+          '<input name="sector_business_area[]" type="checkbox" value="accommodation">' +
+          '<input name="sector_business_area[]" type="checkbox" value="furniture">' +
+          '<button type="submit">Next</button>' +
+        '</form>' +
+      '</div>'
+    )
+
+    tracker = new GOVUK.Modules.TrackQaChoices()
+    tracker.start($element)
+  })
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset()
+  })
+
+  it('tracks checked checkboxes when clicking submit', function () {
+    $element.find('input[value="accommodation"]').trigger('click')
+    $element.find('input[value="construction"]').trigger('click')
+    $element.find('form').trigger('submit')
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'QA option chosen', 'accommodation', { transport: 'beacon', label: 'sector_business_area' }
+    )
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'QA option chosen', 'construction', { transport: 'beacon', label: 'sector_business_area' }
+    )
+  })
+
+  it('does not track events when no choice is made', function () {
+    $element.find('form').trigger('submit')
+
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
https://trello.com/c/b4DOb2HJ/83-add-analytics-to-qa-pages

Possible solution to tracking QA pages with events:

On form submission for each step of the QA journey, the checked items generate one GA event with the question key contained in the label and the checked value as the event value. The event category is `QA option chosen`.

See screenshot for example of generated events...

![screenshot from 2018-11-23 11-30-02](https://user-images.githubusercontent.com/93511/48941356-2c36b500-ef13-11e8-89cf-85c36189e2f6.png)
