### PR TITLE
Add remaining styles

### DIFF
--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -1,0 +1,10 @@
+.grid-row {
+  @extend %grid-row;
+
+  .column-third {
+    @include grid-column( 1/3 );
+  }
+  .column-two-thirds {
+    @include grid-column( 2/3 );
+  }
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -9,6 +9,7 @@
 @import "not-ie-conditional";
 
 @import "reset";
+@import "grid";
 @import "components/*";
 @import "govuk_publishing_components/all_components";
 

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -1,67 +1,70 @@
 <% content_for :title, title %>
 
 <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
-
-<form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title">
-  <%= render "govuk_publishing_components/components/title", {
-    title: current_facet["question"],
-  } %>
-  <%= render "govuk_publishing_components/components/govspeak", {
-    content: "<div class=\"summary\"><p>#{current_facet['description']}</p></div>".html_safe
-  } %>
-  <% if multiple_question? %>
-    <% filter_groups.each do |filter_group| %>
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: "#{current_facet['facet']['key']}[]",
-        heading: filter_group["name"],
-        hint_text: "",
-        items: nested_options(filter_group)
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title">
+      <%= render "govuk_publishing_components/components/title", {
+        title: current_facet["question"],
       } %>
-    <% end %>
-  <% elsif single_wrapped_question? %>
-    <% checkboxes = render "govuk_publishing_components/components/checkboxes", {
-      name: "#{current_facet['facet']['key']}[]",
-      items: options
-    } %>
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "yes-no-choice",
-      items: [
-        {
-          value: "yes",
-          text: "Yes",
-          conditional: checkboxes
-        },
-        {
-          value: "no",
-          text: "No"
-        }
-      ]
-    } %>
-  <% else %>
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "#{current_facet['facet']['key']}[]",
-      items: options
-    } %>
-  <% end %>
-  <% filtered_params.each_pair do |key, values| %>
-    <% values.each do |value| %>
-      <input type="hidden" name="<%= key %>[]" value="<%= value %>">
-    <% end %>
-  <% end %>
-  <% unless last_page? %>
-    <input type="hidden" name="page" value="<%= next_page %>">
-  <% end %>
-  <% unless current_facet["hint_text"].nil? || current_facet["hint_title"].nil? %>
-    <%= render "govuk_publishing_components/components/details", {
-      title: current_facet["hint_title"]
-    } do %>
-      <%= current_facet["hint_text"] %>
-    <% end %>
-  <% end %>
-  <div class="govuk-form-footer">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Next"
-    } %>
-    <a class="govuk-form-footer__alt-cta-link" href="<%= skip_link_url %>">Skip this question</a>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        content: "<div class=\"summary\"><p>#{current_facet['description']}</p></div>".html_safe
+      } %>
+      <% if multiple_question? %>
+        <% filter_groups.each do |filter_group| %>
+          <%= render "govuk_publishing_components/components/checkboxes", {
+            name: "#{current_facet['facet']['key']}[]",
+            heading: filter_group["name"],
+            hint_text: "",
+            items: nested_options(filter_group)
+          } %>
+        <% end %>
+      <% elsif single_wrapped_question? %>
+        <% checkboxes = render "govuk_publishing_components/components/checkboxes", {
+          name: "#{current_facet['facet']['key']}[]",
+          items: options
+        } %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "yes-no-choice",
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              conditional: checkboxes
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ]
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "#{current_facet['facet']['key']}[]",
+          items: options
+        } %>
+      <% end %>
+      <% filtered_params.each_pair do |key, values| %>
+        <% values.each do |value| %>
+          <input type="hidden" name="<%= key %>[]" value="<%= value %>">
+        <% end %>
+      <% end %>
+      <% unless last_page? %>
+        <input type="hidden" name="page" value="<%= next_page %>">
+      <% end %>
+      <% unless current_facet["hint_text"].nil? || current_facet["hint_title"].nil? %>
+        <%= render "govuk_publishing_components/components/details", {
+          title: current_facet["hint_title"]
+        } do %>
+          <%= current_facet["hint_text"] %>
+        <% end %>
+      <% end %>
+      <div class="govuk-form-footer">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Next"
+        } %>
+        <a class="govuk-form-footer__alt-cta-link" href="<%= skip_link_url %>">Skip this question</a>
+      </div>
+    </form>
   </div>
-</form>
+</div>


### PR DESCRIPTION
Bumps the components gem to bring in [support for radio legends to be page titles](https://github.com/alphagov/govuk_publishing_components/pull/635) and adds a basic grid to the QA pages to limit the main column width.

## Basic grid on QA pages
<img width="825" alt="qa-pages-new-grid" src="https://user-images.githubusercontent.com/87140/48915090-5cc81180-ee75-11e8-9dd5-85659a555f6f.png">

## Allow legends to be page titles on radios
<img width="791" alt="radio-legend-as-page-title" src="https://user-images.githubusercontent.com/87140/48915160-939e2780-ee75-11e8-9db0-b2bbdb13fecb.png">

