### PR TITLE
Add generic description option for finders

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -25,6 +25,10 @@ class FinderPresenter
     content_item['phase'].in?(%w[alpha beta])
   end
 
+  def show_generic_description?
+    content_item['details']['generic_description']
+  end
+
   def default_order
     content_item['details']['default_order']
   end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -20,6 +20,7 @@ class ResultSetPresenter
   def to_hash
     {
       total: total > 1000 ? "1,000+" : total,
+      generic_description: generic_description,
       pluralised_document_noun: document_noun.pluralize(total),
       applied_filters: describe_filters_in_sentence,
       documents: documents,
@@ -33,6 +34,11 @@ class ResultSetPresenter
 
   def any_filters_applied?
     filter_sentence_fragments.length.positive? || keywords.present?
+  end
+
+  def generic_description
+    publications = "publication".pluralize(total)
+    "#{publications} matched your criteria"
   end
 
   def describe_filters_in_sentence

--- a/app/views/finders/_result_count_generic.mustache
+++ b/app/views/finders/_result_count_generic.mustache
@@ -1,0 +1,8 @@
+{{#any_filters_applied}}
+<p class="result-info">
+  <span class="result-count">
+    {{total}}
+  </span>
+  {{{generic_description}}}
+</p>
+{{/any_filters_applied}}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -63,7 +63,11 @@
   <div class='js-live-search-results-block'>
     <div class="filtered-results">
       <div aria-live='assertive' id='js-search-results-info'>
-        <%= render_mustache('result_count', @results.to_hash)%>
+        <% if finder.show_generic_description? %>
+          <%= render_mustache('result_count_generic', @results.to_hash) %>
+        <% else %>
+          <%= render_mustache('result_count', @results.to_hash) %>
+        <% end %>
       </div>
       <div id='js-results'>
         <%= render_mustache('results', @results.to_hash) %>

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe ResultSetPresenter do
 
     it 'returns an appropriate hash' do
       expect(presenter.to_hash[:total]).to eql(total)
+      expect(presenter.to_hash[:generic_description].present?).to be_truthy
       expect(presenter.to_hash[:pluralised_document_noun].present?).to be_truthy
       expect(presenter.to_hash[:documents].present?).to be_truthy
       expect(presenter.to_hash[:page_count].present?).to be_truthy


### PR DESCRIPTION
This commit adds an option for finders to display a generic filter description of “X publications matched your criteria” rather than constructing a sentence based on the selected filters.