### PR TITLE
Show description on all QA pages where there is one

### DIFF
--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -4,13 +4,17 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title" data-module="track-qa-choices">
-      <% if multiple_question? %>
-        <%= render "govuk_publishing_components/components/title", {
-          title: current_facet["question"],
-        } %>
+      <%= render "govuk_publishing_components/components/title", {
+        title: current_facet["question"],
+      } %>
+
+      <% if current_facet["description"] %>
         <%= render "govuk_publishing_components/components/govspeak", {
           content: "<div class=\"summary\"><p>#{current_facet['description']}</p></div>".html_safe
         } %>
+      <% end %>
+
+      <% if multiple_question? %>
         <% filter_groups.each do |filter_group| %>
           <%= render "govuk_publishing_components/components/checkboxes", {
             name: "#{current_facet['facet']['key']}[]",
@@ -26,8 +30,6 @@
         } %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "yes-no-choice",
-          heading: current_facet["question"],
-          is_page_heading: true,
           items: [
             {
               value: "yes",
@@ -43,8 +45,6 @@
       <% else %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "#{current_facet['facet']['key']}[]",
-          heading: current_facet["question"],
-          is_page_heading: true,
           items: options
         } %>
       <% end %>


### PR DESCRIPTION
Currently we rely on the checkboxes component to render the title but it's unable to include the description. So instead we can pull the description out and render it outside the form component.