### PR TITLE
Reject facet values on a radio button if no is selected

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -120,10 +120,25 @@ private
   helper_method :skip_link_url
 
   def filtered_params
+    params = permitted_params
+
+    facet_keys = facets.map { |facet| facet["key"] }
+
+    rejected_keys = facet_keys.select do |facet_key|
+      params["#{facet_key}-yesno"] == "no"
+    end
+
+    params.except(*rejected_keys)
+  end
+  helper_method :filtered_params
+
+  def permitted_params
+    permitted_yesnos = facets.map { |facet| :"#{facet['key']}-yesno" }
+
     permitted_keys = facets.each_with_object({}) do |facet, keys|
       keys[facet["key"]] = []
     end
-    params.permit(permitted_keys)
+
+    params.permit(*permitted_yesnos, permitted_keys)
   end
-  helper_method :filtered_params
 end

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -29,7 +29,7 @@
           items: options
         } %>
         <%= render "govuk_publishing_components/components/radio", {
-          name: "yes-no-choice",
+          name: "#{current_facet['facet']['key']}-yesno",
           items: [
             {
               value: "yes",
@@ -48,9 +48,13 @@
           items: options
         } %>
       <% end %>
-      <% filtered_params.each_pair do |key, values| %>
-        <% values.each do |value| %>
-          <input type="hidden" name="<%= key %>[]" value="<%= value %>">
+      <% filtered_params.each_pair do |key, value| %>
+        <% if value.is_a?(Array) %>
+          <% value.each do |v| %>
+            <input type="hidden" name="<%= key %>[]" value="<%= v %>">
+          <% end %>
+        <% else %>
+          <input type="hidden" name="<%= key %>" value="<%= value %>">
         <% end %>
       <% end %>
       <% unless last_page? %>


### PR DESCRIPTION
Currently if a user chooses the facet values from a yes of a radio question, they get passed through to the finder. To avoid this, we can change the name of the radio button to include the key of the facet and check whether it's set to no when passing the selected filters along.

Paired with @edwardkerry.

[Trello Card](https://trello.com/c/Omy5xGJ8/100-spike-whether-choosing-yes-selecting-one-or-more-checkboxes-and-then-clicking-no-could-deselect-the-yes-options-previously-chose)