### PR TITLE
Remove dev finder config from Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,9 +29,6 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
-    "DEVELOPMENT_FINDER_JSON": {
-      "value": "features/fixtures/advanced-search.json"
-    },
     "NEWS_AND_COMMUNICATIONS_JSON": {
       "value": "features/fixtures/news_and_communications.json"
     }


### PR DESCRIPTION
This configuration currently overrides all finders (apart from the news and communications finder) when in Heroku review apps.

If we need to use this config value, it should be specifically added back in (in the Heroku settings panel) for the review apps for those PRs, otherwise it's really hard to check a few finders to ensure that changes we make aren't breaking anything.

(See the confusion in https://github.com/alphagov/finder-frontend/pull/684 for a bit more context)