### PR TITLE
Redirect final Q&A page submission to the finder page

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -7,6 +7,7 @@ class QaController < ApplicationController
   def show
     return error_not_found unless ENV["FINDER_FRONTEND_ENABLE_QA"]
 
+    redirect_to_finder if finder_page?
     raw_finder
   end
 
@@ -28,8 +29,7 @@ private
 
   def page
     params.permit(:page)
-    params[:page] = 1 if params[:page].nil?
-    params[:page].to_i.clamp(1, facets.length)
+    params[:page].to_i.clamp(1, facets.length + 1)
   end
 
   def question_type
@@ -96,25 +96,26 @@ private
   end
   helper_method :nested_options
 
-  def last_page?
-    page == facets.length
-  end
-  helper_method :last_page?
-
   def next_page
     page + 1
   end
   helper_method :next_page
 
-  def next_page_url
-    return qa_config["finder_base_path"] if last_page?
+  def finder_page?
+    page == facets.length + 1
+  end
 
+  def next_page_url
     qa_config["base_path"]
   end
   helper_method :next_page_url
 
+  def redirect_to_finder
+    redirect_to qa_config["finder_base_path"] + '?' + filtered_params.to_query
+  end
+
   def skip_link_url
-    page_number = { page: next_page } unless last_page?
+    page_number = { page: next_page }
     next_page_url + "?" + filtered_params.merge(page_number).to_query
   end
   helper_method :skip_link_url

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -57,9 +57,7 @@
           <input type="hidden" name="<%= key %>" value="<%= value %>">
         <% end %>
       <% end %>
-      <% unless last_page? %>
         <input type="hidden" name="page" value="<%= next_page %>">
-      <% end %>
       <% unless current_facet["hint_text"].nil? || current_facet["hint_title"].nil? %>
         <%= render "govuk_publishing_components/components/details", {
           title: current_facet["hint_title"]

--- a/features/qa.feature
+++ b/features/qa.feature
@@ -48,4 +48,5 @@ Feature: QA
 
     Scenario: Answering the final question
       Given I am answering the final question
-      Then submitting my answer will send me to the finder results page
+      When I submit my answer
+      Then I am redirected to the finder results page

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -66,7 +66,7 @@ Given /^I am answering the final question/ do
   visit "#{qa_path}?page=#{page_number}"
 end
 
-Then /^submitting my answer will send me to the finder results page/ do
+Then /^I am redirected to the finder results page/ do
   finder_url = mock_qa_config['finder_base_path']+'?'
-  expect(page).to have_selector(:css, "a[href='#{finder_url}']")
+  expect(current_url).to match(finder_url)
 end


### PR DESCRIPTION
If the final question in a Q&A is a `yes-no` radio button option with nested checkboxes, currently choosing some `yes` checkboxes and then choosing the `no` radio button will submit all choices directly to the Finder.

This change adds the ability for the Q&A view to submit the last Q&A response with an incremented page param. This allows the Q&A controller to recognise the last facet has been answered, to filter the submitted parameters to remove any `yes-no` discrepancies, and redirect to the finder page. 