### PR TITLE
Remove accommodation facet value from energy section

### DIFF
--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -26,7 +26,6 @@ pages:
           - "public-administration-and-defence"
       - name: "Energy, environmental services and agriculture"
         filters:
-          - "accommodation-restaurants-and-catering-services"
           - "agriculture"
           - "electricity"
           - "environmental-services"


### PR DESCRIPTION
It belongs in the consumer good section where it is currently.

[Trello Card](https://trello.com/c/9TBBkThu/136-remove-accommodation-restaurants-and-catering-services-from-energy-environmental-services-and-agriculture)