### PR TITLE
Don't wrap QA description in a summary div

### DIFF
--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -10,7 +10,7 @@
 
       <% if current_facet["description"] %>
         <%= render "govuk_publishing_components/components/govspeak", {
-          content: "<div class=\"summary\"><p>#{current_facet['description']}</p></div>".html_safe
+          content: current_facet["description"].html_safe
         } %>
       <% end %>
 


### PR DESCRIPTION
The summary div removes gaps between paragraphs which doesn't look good when there is more than one paragraph in the description.

We also don't need to wrap these in p tags because the descriptions coming from the configuration file already have these.

[Trello Card](https://trello.com/c/kOKalkQk/139-add-line-breaks-to-summary-description-text)