### PR TITLE
Remove policy feature tests

### DIFF
--- a/features/finders.feature
+++ b/features/finders.feature
@@ -31,12 +31,6 @@ Feature: Filtering documents
     Then I can see the government header
     And I can see documents which are marked as being in history mode
 
-  Scenario: Visit a policy finder
-    Given a policy finder exists
-    Then I can see the government header
-    And I can see documents which are marked as being in history mode
-    And I can see documents which have government metadata
-
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist
     Then I can get a list of all documents with good metadata
@@ -58,7 +52,7 @@ Feature: Filtering documents
     Then I can see that the description in the metadata is present
 
   Scenario: Link tracking
-    Given a policy finder exists
+    Given a government finder exists
     Then the links on the page have tracking attributes
 
   Scenario: Visit a finder from an organisation

--- a/features/step_definitions/analyics_steps.rb
+++ b/features/step_definitions/analyics_steps.rb
@@ -9,7 +9,7 @@ Then(/^the links on the page have tracking attributes$/) do
   first_link = document_links.first
 
   expect(first_link['data-track-category']).to eq('navFinderLinkClicked')
-  expect(first_link['data-track-action']).to eq('Benefits Reform.1')
+  expect(first_link['data-track-action']).to eq('Ministry of Silly Walks reports.1')
   expect(first_link['data-track-label']).to eq(first_link['href'])
 
   options = JSON.parse(first_link['data-track-options'])

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -99,11 +99,6 @@ Then(/^I can get a list of all documents with good metadata$/) do
   end
 end
 
-Given(/^a policy finder exists$/) do
-  content_store_has_policy_finder
-  stub_rummager_api_request_with_policy_results
-end
-
 Given(/^a finder tagged to the topic taxonomy$/) do
   stub_content_store_with_a_taxon_tagged_finder
   stub_rummager_with_cma_cases
@@ -124,23 +119,23 @@ Then(/^I only see documents with matching dates$/) do
 end
 
 Given(/^a finder with a dynamic filter exists$/) do
-  content_store_has_policies_finder
-  stub_rummager_api_request_with_policies_finder_results
+  content_store_has_mosw_reports_finder
+  stub_rummager_api_request
 end
 
 Then(/^I can see filters based on the results$/) do
-  visit finder_path('government/policies')
+  visit finder_path('mosw-reports')
 
-  within '.app-c-option-select' do
-    expect(page).to have_selector('input#organisations-ministry-of-justice')
-    expect(page).to have_content('Ministry of Justice')
-    expect(page).to_not have_selector('input#organisations-ministry-of-missing-spoons')
+  within first('.app-c-option-select') do
+    expect(page).to have_selector('input#walk_type-backward')
+    expect(page).to have_content('Hopscotch')
+    expect(page).to_not have_selector('input#organisations-ministry-of-silly-walks')
   end
 end
 
 Given(/^a finder with paginated results exists$/) do
-  content_store_has_policy_finder
-  stub_rummager_api_request_with_policy_results
+  content_store_has_government_finder_with_10_items
+  stub_rummager_api_request_with_10_government_results
 end
 
 Then(/^I can see pagination$/) do
@@ -151,7 +146,7 @@ Then(/^I can see pagination$/) do
 end
 
 Then(/^I can browse to the next page$/) do
-  stub_rummager_api_request_with_page_2_policy_results
+  stub_rummager_api_request_with_10_government_results_page_2
   visit finder_path('government/policies/benefits-reform', page: 2)
 
   expect(page).to have_content('Previous page')

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -25,20 +25,20 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_10_government_results
+    stub_request(:get, rummager_10_documents_url).to_return(
+      body: government_documents_json,
+    )
+  end
+
   def stub_rummager_api_request_with_bad_data
     stub_request(:get, rummager_all_documents_url).to_return(
       body: documents_with_bad_data_json,
     )
   end
 
-  def stub_rummager_api_request_with_policy_results
-    stub_request(:get, rummager_policy_search_url).to_return(
-      body: government_documents_json,
-    )
-  end
-
-  def stub_rummager_api_request_with_page_2_policy_results
-    stub_request(:get, rummager_policy_page_2_search_url).to_return(
+  def stub_rummager_api_request_with_10_government_results_page_2
+    stub_request(:get, rummager_10_documents_page_2_url).to_return(
       body: government_documents_page_2_json,
     )
   end
@@ -52,7 +52,7 @@ module DocumentHelper
   end
 
   def stub_rummager_api_request_with_422_response(page_number)
-    stub_request(:get, rummager_policy_other_page_search_url(page_number)).to_return(status: 422)
+    stub_request(:get, rummager_document_other_page_search_url(page_number)).to_return(status: 422)
   end
 
   def stub_rummager_api_request_with_policies_finder_results
@@ -98,12 +98,11 @@ module DocumentHelper
     )
   end
 
-  def content_store_has_policy_finder
+  def content_store_has_government_finder_with_10_items
     base_path = '/government/policies/benefits-reform'
-    content_store_has_item(
-      base_path,
-      govuk_content_schema_example('policy_area', 'policy').to_json
-    )
+    content_item = govuk_content_schema_example('finder').merge('base_path' => base_path)
+    content_item['details']['default_documents_per_page'] = 10
+    content_store_has_item(base_path, content_item.to_json)
   end
 
   def content_store_has_policies_finder
@@ -247,6 +246,25 @@ module DocumentHelper
     )
   end
 
+  def rummager_10_documents_url
+    rummager_url(
+      mosw_search_params.merge(
+        "order" => "-public_timestamp",
+        "count" => 10,
+      )
+    )
+  end
+
+  def rummager_10_documents_page_2_url
+    rummager_url(
+      mosw_search_params.merge(
+        "order" => "-public_timestamp",
+        "count" => 10,
+        "start" => 10,
+      )
+    )
+  end
+
   def rummager_hopscotch_walks_url
     rummager_url(
       mosw_search_params.merge(
@@ -303,21 +321,11 @@ module DocumentHelper
     )
   end
 
-  def rummager_policy_page_2_search_url
-    rummager_url(
-      policy_search_params.merge(
-        "order" => "-public_timestamp",
-        "count" => 10,
-        "start" => 10,
-      )
-    )
-  end
-
-  def rummager_policy_other_page_search_url(page_number)
+  def rummager_document_other_page_search_url(page_number)
     count_per_page = 10
 
     rummager_url(
-      policy_search_params.merge(
+      mosw_search_params.merge(
         "order" => "-public_timestamp",
         "count" => count_per_page,
         "start" => ((page_number - 1) * count_per_page)


### PR DESCRIPTION
This commit removes or repurposes tests related to policies since these have now been retired.