### PR TITLE
Ensure consistent display of results count templates on finders

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -22,6 +22,8 @@
     this.$relevanceOrderOption = this.$orderSelect.find('option[value=' + this.$orderSelect.data('relevance-sort-option') + ']');
     this.$relevanceOrderOptionIndex = this.$relevanceOrderOption.index();
 
+    this.resultCountTemplate = this.setResultCountTemplate();
+
     if(GOVUK.support.history()){
       this.saveState();
 
@@ -50,6 +52,14 @@
       $(window).on('popstate', this.popState.bind(this));
     } else {
       this.$form.find('.js-live-search-fallback').show();
+    }
+  };
+
+  LiveSearch.prototype.setResultCountTemplate = function setResultCountTemplate(){
+    if (this.$countBlock.find('#generic').length == 1){
+      return '_result_count_generic';
+    } else {
+      return '_result_count';
     }
   };
 
@@ -221,7 +231,7 @@
     // still the latest to stop results being overwritten by stale data
     if(action == $.param(this.state)) {
       this.$resultsBlock.mustache(this.templateDir + '_results', results);
-      this.$countBlock.mustache(this.templateDir + '_result_count', results);
+      this.$countBlock.mustache(this.templateDir + this.resultCountTemplate, results);
       this.$atomAutodiscoveryLink.attr('href', results.atom_url);
     }
   };

--- a/app/views/finders/_result_count_generic.mustache
+++ b/app/views/finders/_result_count_generic.mustache
@@ -1,5 +1,5 @@
 {{#any_filters_applied}}
-<p class="result-info">
+<p class="result-info" id="generic">
   <span class="result-count">
     {{total}}
   </span>

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -216,6 +216,24 @@ describe("liveSearch", function(){
     });
   });
 
+  describe("setResultCountTemplate", function(){
+    describe("finders with generic descriptions", function(){
+      beforeEach(function () {
+        $count = $('<div aria-live="assertive" id="js-search-results-info"><p class="result-info" id="generic"></p></div>');
+        liveSearch.$countBlock = $count;
+      });
+
+      it("should return the generic result count template", function () {
+        expect(liveSearch.setResultCountTemplate()).toEqual('_result_count_generic')
+      });
+    });
+
+    it("should return the default result count template", function(){
+      expect(liveSearch.setResultCountTemplate()).toEqual('_result_count');
+    });
+  });
+
+
   describe("popState", function(){
     var dummyHistoryState;
 


### PR DESCRIPTION
A finder results page can be rendered with either a generic or a query
specific results count template. Updating the query triggers an ajax call, which
causes this template to re-render as the specific version.

This commit ensures that the original results count template is always the one
displayed.

[Trello](https://trello.com/c/ztzAmATY/149-bug-old-prepositions-appearing-rather-than-generic-x-publications-matched-your-criteria-in-finder)