### PR TITLE
Add email link to results

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -14,7 +14,7 @@
     this.$countBlock = options.$results.find('#js-search-results-info');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
-    this.$emailLink = $("p.email-link a");
+    this.$emailLink = $(".email-link");
 
     this.emailSignupHref = this.$emailLink.attr('href');
 
@@ -223,6 +223,7 @@
       this.$resultsBlock.mustache(this.templateDir + '_results', results);
       this.$countBlock.mustache(this.templateDir + '_result_count', results);
       this.$atomAutodiscoveryLink.attr('href', results.atom_url);
+      this.$emailLink.attr('href', results.email_url);
     }
   };
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -61,21 +61,6 @@
       @include core-19;
     }
 
-    .email-link {
-      margin-bottom: $gutter;
-
-      a {
-        @include bold-19;
-        text-decoration:none;
-        background: image-url('mail-icon.png') 0 40% no-repeat;
-        @include device-pixel-ratio(2.0) {
-          background-image: image-url('mail-icon-retina.png');
-          background-size: $gutter-two-thirds 14px;
-        }
-        padding-left: $gutter;
-      }
-    }
-
     .logo {
       @include grid-column(1/3);
       margin: $gutter 0;
@@ -246,10 +231,21 @@
         padding-right: $gutter-one-third / 2;
       }
       a {
-        background: image-url('feed-icon-black.png') 0 40% no-repeat;
         font-weight: bold;
         padding: 0 $gutter-one-third 0 $gutter-half;
         text-decoration: none;
+      }
+      .email-link {
+        background: image-url('mail-icon.png') 0 40% no-repeat;
+        padding-left: 22px;
+
+        @include device-pixel-ratio(2.0) {
+          background-image: image-url('mail-icon-retina.png');
+          background-size: $gutter-two-thirds 14px;
+        }
+      }
+      .atom-feed {
+        background: image-url('feed-icon-black.png') 0 40% no-repeat;
       }
     }
 

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -203,6 +203,14 @@ class FinderPresenter
     ["#{slug}.atom", values.to_query].reject(&:blank?).join("?") if atom_feed_enabled?
   end
 
+  def has_feed_url
+    atom_url.present? || email_alert_signup_url.present?
+  end
+
+  def email_url
+    [email_alert_signup_url, values.to_query].reject(&:blank?).join("?") if email_alert_signup_url.present?
+  end
+
   def description
     content_item['description']
   end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -7,6 +7,8 @@ class ResultSetPresenter
            :filter_sentence_fragments,
            :keywords,
            :atom_url,
+           :email_url,
+           :has_feed_url,
            to: :finder
 
   def initialize(finder, filter_params, view_context)
@@ -28,6 +30,8 @@ class ResultSetPresenter
       finder_name: finder.name,
       any_filters_applied: any_filters_applied?,
       atom_url: atom_url,
+      has_feed_url: has_feed_url,
+      email_url: email_url,
       next_and_prev_links: next_and_prev_links,
       sort_options: sort_options
     }

--- a/app/views/advanced_search_finder/_results.mustache
+++ b/app/views/advanced_search_finder/_results.mustache
@@ -1,9 +1,14 @@
-{{#atom_url}}
+{{#has_feed_url}}
   <div class="feed">
     <span>Get updates to this list</span>
-    <a href="{{atom_url}}">feed</a>
+    {{#atom_url}}
+      <a class="atom-feed" href="{{atom_url}}">feed</a>
+    {{/atom_url}}
+    {{#email_url}}
+      <a class="email-link" href="{{email_url}}">email</a>
+    {{/email_url}}
   </div>
-{{/atom_url}}
+{{/has_feed_url}}
 
 <ul data-module="track-click">
   {{#documents}}

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -1,9 +1,14 @@
-{{#atom_url}}
+{{#has_feed_url}}
   <div class="feed">
     <span>Get updates to this list</span>
-    <a href="{{atom_url}}">feed</a>
+    {{#atom_url}}
+      <a class="atom-feed" href="{{atom_url}}">feed</a>
+    {{/atom_url}}
+    {{#email_url}}
+      <a class="email-link" href="{{email_url}}">email</a>
+    {{/email_url}}
   </div>
-{{/atom_url}}
+{{/has_feed_url}}
 
 <ul data-module="track-click">
   {{#documents}}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -33,12 +33,6 @@
         <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
       </div>
     <% end %>
-
-    <% if finder.email_alert_signup_url %>
-      <p class='email-link'>
-        <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
-      </p>
-    <% end %>
   </div>
 
   <% if finder.logo_path %>


### PR DESCRIPTION
This adds an email link next to the atom feed on finders.
It moves the existing email signup link to the results.