### PR TITLE
Always render generic result count template

### DIFF
--- a/app/views/finders/_result_count_generic.mustache
+++ b/app/views/finders/_result_count_generic.mustache
@@ -1,8 +1,8 @@
-{{#any_filters_applied}}
 <p class="result-info" id="generic">
+  {{#any_filters_applied}}
   <span class="result-count">
     {{total}}
   </span>
   {{{generic_description}}}
+  {{/any_filters_applied}}
 </p>
-{{/any_filters_applied}}


### PR DESCRIPTION
Accessing a finder with a generic results count description without applying
any filters (or accessing the url directly) does not render the description template.
Interacting with a facet then renders the non-generic results count description.

This commit ensures that the generic results count template is always rendered, even
if empty of content. Interacting with facets will then display the correct generic
results count text.