### PR TITLE
Allow finders to be cached for 5 minutes

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -4,6 +4,10 @@ class FindersController < ApplicationController
   layout "finder_layout"
   include GdsApi::Helpers
 
+  before_action do
+    expires_in(5.minutes, public: true)
+  end
+
   ATOM_FEED_MAX_AGE = 300
 
   def show


### PR DESCRIPTION
Calling `expires_in` sets a `Cache-Control` header for a page. This commit allows finder pages to be cached. This affects proper finders like https://www.gov.uk/aaib-reports and advanced search like https://www.gov.uk/search/advanced?group=services&topic=%2Feducation. This will cause the pages to be cached by both Fastly (our CDN) and our Varnish caching layer.

We're keeping the cache TTL low because we think there's a need to see new documents quite quickly. Nevertheless, this should increase the number of cache hits, which speeds up response times and scalability by alleviating load on our origin servers.

https://trello.com/c/whG5Wfr8