### PR TITLE
Support 'or' combine_mode facets

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -38,6 +38,10 @@ private
     "features/fixtures/news_and_communications.json"
   end
 
+  def merge_and_deduplicate(search_response)
+    search_response.fetch("results")[0]
+  end
+
   def fetch_search_response(content_item)
     query = query_builder_class.new(
       finder_content_item: content_item,
@@ -46,7 +50,11 @@ private
 
     query = TranslateContentPurposeFields.new(query).call
 
-    Services.rummager.search(query).to_hash
+    searches = [query]
+
+    merge_and_deduplicate(
+      Services.rummager.batch_search(searches).to_hash
+    )
   end
 
   def augment_content_item_with_results(content_item, search_response)

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -61,17 +61,17 @@ private
   end
 
   def fetch_search_response(content_item)
-    query = query_builder_class.new(
+    queries = query_builder_class.new(
       finder_content_item: content_item,
       params: filter_params,
     ).call
 
-    query = TranslateContentPurposeFields.new(query).call
-
-    searches = [query]
+    queries = queries.map do |query|
+      TranslateContentPurposeFields.new(query).call
+    end
 
     merge_and_deduplicate(
-      Services.rummager.batch_search(searches).to_hash
+      Services.rummager.batch_search(queries).to_hash
     )
   end
 

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -8,14 +8,16 @@ class SearchQueryBuilder
 
   def call
     [
-      pagination_query,
-      return_fields_query,
-      keyword_query,
-      filter_query,
-      reject_query,
-      order_query,
-      facet_query,
-    ].reduce(&:merge)
+      [
+        pagination_query,
+        return_fields_query,
+        keyword_query,
+        filter_query,
+        reject_query,
+        order_query,
+        facet_query,
+      ].reduce(&:merge)
+    ]
   end
 
 private

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -42,11 +42,13 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
 
   stub_request(:get, rummager_advanced_search_url).to_return(
     body: {
-      results: @results,
-      total: 2,
-      start: 0,
-      facets: {},
-      suggested_queries: []
+      results: [
+        results: @results,
+        total: 2,
+        start: 0,
+        facets: {},
+        suggested_queries: []
+      ]
     }.to_json
   )
   content_store_has_item("/search/advanced", finder_content_item)

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -67,11 +67,11 @@ module DocumentHelper
   end
 
   def stub_rummager_api_request_with_qa_finder_results
-    stub_request(:get, rummager_url({}) )
+    stub_request(:get, rummager_url({}))
       .with(
         query: hash_including({})
       ).to_return(
-         body: aaib_reports_json
+         body: aaib_reports_search_results
       )
   end
 
@@ -383,32 +383,36 @@ module DocumentHelper
     "#{Plek.current.find('whitehall-admin')}/api/world-locations"
   end
 
-  def aaib_reports_json
+  def aaib_reports_search_results
     %|{
       "results": [
         {
-          "title": "Acme keyword searchable walk",
-          "public_timestamp": "2010-10-06",
-          "summary": "ACME researched a new type of silly walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "backwards",
-            "label": "Backwards"
-          }],
-          "place_of_origin": [{
-            "value": "scotland",
-            "label": "Scotland"
-          }],
-          "creator": "Wile E Coyote",
-          "date_of_introduction": "2014-08-28",
-          "link": "mosw-reports/acme-keyword-searchable-walk",
-          "_id": "mosw-reports/acme-keyword-searchable-walk"
+          "results": [
+            {
+              "title": "Acme keyword searchable walk",
+              "public_timestamp": "2010-10-06",
+              "summary": "ACME researched a new type of silly walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "backwards",
+                "label": "Backwards"
+              }],
+              "place_of_origin": [{
+                "value": "scotland",
+                "label": "Scotland"
+              }],
+              "creator": "Wile E Coyote",
+              "date_of_introduction": "2014-08-28",
+              "link": "mosw-reports/acme-keyword-searchable-walk",
+              "_id": "mosw-reports/acme-keyword-searchable-walk"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 1,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -416,28 +420,32 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "Acme keyword searchable walk",
-          "public_timestamp": "2010-10-06",
-          "summary": "ACME researched a new type of silly walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "backwards",
-            "label": "Backwards"
-          }],
-          "place_of_origin": [{
-            "value": "scotland",
-            "label": "Scotland"
-          }],
-          "creator": "Wile E Coyote",
-          "date_of_introduction": "2014-08-28",
-          "link": "mosw-reports/acme-keyword-searchable-walk",
-          "_id": "mosw-reports/acme-keyword-searchable-walk"
+          "results": [
+            {
+              "title": "Acme keyword searchable walk",
+              "public_timestamp": "2010-10-06",
+              "summary": "ACME researched a new type of silly walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "backwards",
+                "label": "Backwards"
+              }],
+              "place_of_origin": [{
+                "value": "scotland",
+                "label": "Scotland"
+              }],
+              "creator": "Wile E Coyote",
+              "date_of_introduction": "2014-08-28",
+              "link": "mosw-reports/acme-keyword-searchable-walk",
+              "_id": "mosw-reports/acme-keyword-searchable-walk"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 1,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -445,66 +453,78 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "West London wobbley walk",
-          "public_timestamp": "2014-11-25",
-          "summary": "MOSW researched a new type of silly walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "backward",
-            "label": "Backward"
-          }],
-          "place_of_origin": [{
-            "value": "england",
-            "label": "England"
-          }],
-          "creator": "Road Runner",
-          "date_of_introduction": "2003-12-30",
-          "link": "mosw-reports/west-london-wobbley-walk",
-          "_id": "mosw-reports/west-london-wobbley-walk"
-        },
-        {
-          "title": "The Gerry Anderson",
-          "public_timestamp": "2010-10-06",
-          "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "hopscotch",
-            "label": "Hopscotch"
-          }],
-          "place_of_origin": [{
-            "value": "northern-ireland",
-            "label": "Northern Ireland"
-          }],
-          "creator": "",
-          "date_of_introduction": "1914-08-28",
-          "link": "mosw-reports/the-gerry-anderson",
-          "_id": "mosw-reports/the-gerry-anderson"
+          "results": [
+            {
+              "title": "West London wobbley walk",
+              "public_timestamp": "2014-11-25",
+              "summary": "MOSW researched a new type of silly walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "backward",
+                "label": "Backward"
+              }],
+              "place_of_origin": [{
+                "value": "england",
+                "label": "England"
+              }],
+              "creator": "Road Runner",
+              "date_of_introduction": "2003-12-30",
+              "link": "mosw-reports/west-london-wobbley-walk",
+              "_id": "mosw-reports/west-london-wobbley-walk"
+            },
+            {
+              "title": "The Gerry Anderson",
+              "public_timestamp": "2010-10-06",
+              "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "hopscotch",
+                "label": "Hopscotch"
+              }],
+              "place_of_origin": [{
+                "value": "northern-ireland",
+                "label": "Northern Ireland"
+              }],
+              "creator": "",
+              "date_of_introduction": "1914-08-28",
+              "link": "mosw-reports/the-gerry-anderson",
+              "_id": "mosw-reports/the-gerry-anderson"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
   def government_documents_json
     %|{
-      "results": #{government_document_results_json},
-      "total": 20,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      "results": [
+        {
+          "results": #{government_document_results_json},
+          "total": 20,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
+        }
+      ]
     }|
   end
 
   def government_documents_page_2_json
     %|{
-      "results": #{government_document_results_json(5)},
-      "total": 20,
-      "start": 10,
-      "facets": {},
-      "suggested_queries": []
+      "results": [
+        {
+          "results": #{government_document_results_json(5)},
+          "total": 20,
+          "start": 10,
+          "facets": {},
+          "suggested_queries": []
+        }
+      ]
     }|
   end
 
@@ -561,55 +581,59 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "Education",
-          "summary": "Education",
-          "format": "policy",
-          "creator": "Dale Cooper",
-          "public_timestamp": "2007-02-14T00:00:00.000+01:00",
-          "is_historic": true,
-          "display_type": "Policy",
-          "organisations": [{
-            "slug": "ministry-of-justice",
-            "link": "/government/organisations/ministry-of-justice",
-            "title": "Ministry of Justice",
-            "acronym": "MoJ",
-            "organisation_state": "live"
-          }],
-          "government_name": "2005 to 2010 Labour government",
-          "link": "/government/policies/education",
-          "_id": "/government/policies/education"
-        },
-        {
-          "title": "Afghanistan",
-          "public_timestamp": "2015-03-14T00:00:00.000+01:00",
-          "summary": "What the government is doing about Afghanistan",
-          "format": "policy",
-          "creator": "Dale Cooper",
-          "is_historic": false,
-          "organisations": [{
-            "slug": "ministry-of-justice",
-            "link": "/government/organisations/ministry-of-justice",
-            "title": "Ministry of Justice",
-            "acronym": "MoJ",
-            "organisation_state": "live"
-          }],
-          "display_type": "Policy",
-          "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
-          "link": "/government/policies/afghanistan",
-          "_id": "/government/policies/afghanistan"
+          "results": [
+            {
+              "title": "Education",
+              "summary": "Education",
+              "format": "policy",
+              "creator": "Dale Cooper",
+              "public_timestamp": "2007-02-14T00:00:00.000+01:00",
+              "is_historic": true,
+              "display_type": "Policy",
+              "organisations": [{
+                "slug": "ministry-of-justice",
+                "link": "/government/organisations/ministry-of-justice",
+                "title": "Ministry of Justice",
+                "acronym": "MoJ",
+                "organisation_state": "live"
+              }],
+              "government_name": "2005 to 2010 Labour government",
+              "link": "/government/policies/education",
+              "_id": "/government/policies/education"
+            },
+            {
+              "title": "Afghanistan",
+              "public_timestamp": "2015-03-14T00:00:00.000+01:00",
+              "summary": "What the government is doing about Afghanistan",
+              "format": "policy",
+              "creator": "Dale Cooper",
+              "is_historic": false,
+              "organisations": [{
+                "slug": "ministry-of-justice",
+                "link": "/government/organisations/ministry-of-justice",
+                "title": "Ministry of Justice",
+                "acronym": "MoJ",
+                "organisation_state": "live"
+              }],
+              "display_type": "Policy",
+              "government_name": "2010 to 2015 Conservative and Liberal Democrat Coalition government",
+              "link": "/government/policies/afghanistan",
+              "_id": "/government/policies/afghanistan"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {
+            "organisations": {
+              "options": [
+                  {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}},
+                  {"value": {"slug": "ministry-of-missing-spoons"}}
+              ]
+            }
+          },
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {
-        "organisations": {
-          "options": [
-              {"value": {"title": "Ministry of Justice", "slug": "ministry-of-justice"}},
-              {"value": {"slug": "ministry-of-missing-spoons"}}
-          ]
-        }
-      },
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -617,129 +641,133 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "News from Hogwarts",
-          "link": "/news-from-hogwarts",
-          "description": "Breaking wizard news from Hogwarts",
-          "public_timestamp": "2018-11-16T11:11:42Z",
-          "part_of_taxonomy_tree": [
-            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
-          ],
-          "organisations": [
+          "results": [
             {
-              "organisation_crest": "single-identity",
-              "acronym": "MOM",
-              "link": "/organisations/ministry-of-magic",
-              "analytics_identifier": "MM1",
-              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-              "organisation_brand": "ministry-of-magic",
-              "logo_formatted_title": "Ministry of Magic",
-              "title": "Ministry of Magic",
-              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-              "slug": "ministry-of-magic",
-              "organisation_type": "other",
-              "organisation_state": "live"
+              "title": "News from Hogwarts",
+              "link": "/news-from-hogwarts",
+              "description": "Breaking wizard news from Hogwarts",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/news-from-hogwarts",
+              "elasticsearch_type": "news_article",
+              "document_type": "news_article"
+            },
+            {
+              "title": "Press release from Hogwarts",
+              "link": "/press-release-from-hogwarts",
+              "description": "An important press release from Hogwarts",
+              "public_timestamp": "2017-12-25T09:00:00Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/press-release-from-hogwarts",
+              "elasticsearch_type": "press_release",
+              "document_type": "press_release"
             }
           ],
-          "index": "govuk",
-          "es_score": null,
-          "_id": "/news-from-hogwarts",
-          "elasticsearch_type": "news_article",
-          "document_type": "news_article"
-        },
-        {
-          "title": "Press release from Hogwarts",
-          "link": "/press-release-from-hogwarts",
-          "description": "An important press release from Hogwarts",
-          "public_timestamp": "2017-12-25T09:00:00Z",
-          "part_of_taxonomy_tree": [
-            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
-          ],
-          "organisations": [
-            {
-              "organisation_crest": "single-identity",
-              "acronym": "MOM",
-              "link": "/organisations/ministry-of-magic",
-              "analytics_identifier": "MM1",
-              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-              "organisation_brand": "ministry-of-magic",
-              "logo_formatted_title": "Ministry of Magic",
-              "title": "Ministry of Magic",
-              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-              "slug": "ministry-of-magic",
-              "organisation_type": "other",
-              "organisation_state": "live"
+          "total": 2,
+          "start": 0,
+          "facets": {
+            "people": {
+              "options": [
+                {
+                  "value": {
+                    "slug": "harry-potter",
+                    "title": "Harry Potter",
+                    "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
+                    "link": "/people/harry-potter"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            },
+            "organisations": {
+              "options": [
+                {
+                  "value": {
+                    "organisation_brand": "ministry-of-magic",
+                    "logo_formatted_title": "Ministry of Magic",
+                    "organisation_crest": "single-identity",
+                    "title": "Ministry of Magic",
+                    "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                    "link": "/organisations/academy-for-social-justice-commissioning",
+                    "analytics_identifier": "MM1",
+                    "slug": "ministry-of-magic",
+                    "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                    "organisation_type": "other",
+                    "organisation_state": "live"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            },
+            "world_locations": {
+              "options": [
+                {
+                  "value": {
+                    "slug": "azkaban",
+                    "title": "Azkaban",
+                    "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
+                    "link": "/world/azkaban"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
             }
-          ],
-          "index": "govuk",
-          "es_score": null,
-          "_id": "/press-release-from-hogwarts",
-          "elasticsearch_type": "press_release",
-          "document_type": "press_release"
+          },
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {
-        "people": {
-          "options": [
-            {
-              "value": {
-                "slug": "harry-potter",
-                "title": "Harry Potter",
-                "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
-                "link": "/people/harry-potter"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        },
-        "organisations": {
-          "options": [
-            {
-              "value": {
-                "organisation_brand": "ministry-of-magic",
-                "logo_formatted_title": "Ministry of Magic",
-                "organisation_crest": "single-identity",
-                "title": "Ministry of Magic",
-                "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-                "link": "/organisations/academy-for-social-justice-commissioning",
-                "analytics_identifier": "MM1",
-                "slug": "ministry-of-magic",
-                "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-                "organisation_type": "other",
-                "organisation_state": "live"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        },
-        "world_locations": {
-          "options": [
-            {
-              "value": {
-                "slug": "azkaban",
-                "title": "Azkaban",
-                "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
-                "link": "/world/azkaban"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        }
-      },
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -747,129 +775,133 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "Press release from Hogwarts",
-          "link": "/press-release-from-hogwarts",
-          "description": "An important press release from Hogwarts",
-          "public_timestamp": "2017-12-25T09:00:00Z",
-          "part_of_taxonomy_tree": [
-            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
-          ],
-          "organisations": [
+          "results": [
             {
-              "organisation_crest": "single-identity",
-              "acronym": "MOM",
-              "link": "/organisations/ministry-of-magic",
-              "analytics_identifier": "MM1",
-              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-              "organisation_brand": "ministry-of-magic",
-              "logo_formatted_title": "Ministry of Magic",
-              "title": "Ministry of Magic",
-              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-              "slug": "ministry-of-magic",
-              "organisation_type": "other",
-              "organisation_state": "live"
+              "title": "Press release from Hogwarts",
+              "link": "/press-release-from-hogwarts",
+              "description": "An important press release from Hogwarts",
+              "public_timestamp": "2017-12-25T09:00:00Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/press-release-from-hogwarts",
+              "elasticsearch_type": "press_release",
+              "document_type": "press_release"
+            },
+            {
+              "title": "News from Hogwarts",
+              "link": "/news-from-hogwarts",
+              "description": "Breaking wizard news from Hogwarts",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/news-from-hogwarts",
+              "elasticsearch_type": "news_article",
+              "document_type": "news_article"
             }
           ],
-          "index": "govuk",
-          "es_score": null,
-          "_id": "/press-release-from-hogwarts",
-          "elasticsearch_type": "press_release",
-          "document_type": "press_release"
-        },
-        {
-          "title": "News from Hogwarts",
-          "link": "/news-from-hogwarts",
-          "description": "Breaking wizard news from Hogwarts",
-          "public_timestamp": "2018-11-16T11:11:42Z",
-          "part_of_taxonomy_tree": [
-            "4bc72a8b-6011-457a-87e0-06dbb427cf36"
-          ],
-          "organisations": [
-            {
-              "organisation_crest": "single-identity",
-              "acronym": "MOM",
-              "link": "/organisations/ministry-of-magic",
-              "analytics_identifier": "MM1",
-              "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-              "organisation_brand": "ministry-of-magic",
-              "logo_formatted_title": "Ministry of Magic",
-              "title": "Ministry of Magic",
-              "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-              "slug": "ministry-of-magic",
-              "organisation_type": "other",
-              "organisation_state": "live"
+          "total": 2,
+          "start": 0,
+          "facets": {
+            "people": {
+              "options": [
+                {
+                  "value": {
+                    "slug": "harry-potter",
+                    "title": "Harry Potter",
+                    "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
+                    "link": "/people/harry-potter"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            },
+            "organisations": {
+              "options": [
+                {
+                  "value": {
+                    "organisation_brand": "ministry-of-magic",
+                    "logo_formatted_title": "Ministry of Magic",
+                    "organisation_crest": "single-identity",
+                    "title": "Ministry of Magic",
+                    "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                    "link": "/organisations/academy-for-social-justice-commissioning",
+                    "analytics_identifier": "MM1",
+                    "slug": "ministry-of-magic",
+                    "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                    "organisation_type": "other",
+                    "organisation_state": "live"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            },
+            "world_locations": {
+              "options": [
+                {
+                  "value": {
+                    "slug": "azkaban",
+                    "title": "Azkaban",
+                    "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
+                    "link": "/world/azkaban"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
             }
-          ],
-          "index": "govuk",
-          "es_score": null,
-          "_id": "/news-from-hogwarts",
-          "elasticsearch_type": "news_article",
-          "document_type": "news_article"
+          },
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {
-        "people": {
-          "options": [
-            {
-              "value": {
-                "slug": "harry-potter",
-                "title": "Harry Potter",
-                "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",
-                "link": "/people/harry-potter"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        },
-        "organisations": {
-          "options": [
-            {
-              "value": {
-                "organisation_brand": "ministry-of-magic",
-                "logo_formatted_title": "Ministry of Magic",
-                "organisation_crest": "single-identity",
-                "title": "Ministry of Magic",
-                "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
-                "link": "/organisations/academy-for-social-justice-commissioning",
-                "analytics_identifier": "MM1",
-                "slug": "ministry-of-magic",
-                "public_timestamp": "2017-12-15T11:11:02.000+00:00",
-                "organisation_type": "other",
-                "organisation_state": "live"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        },
-        "world_locations": {
-          "options": [
-            {
-              "value": {
-                "slug": "azkaban",
-                "title": "Azkaban",
-                "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
-                "link": "/world/azkaban"
-              },
-              "documents": 2
-            }
-          ],
-          "documents_with_no_value": 0,
-          "total_options": 2,
-          "missing_options": 0,
-          "scope": "exclude_field_filter"
-        }
-      },
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -877,40 +909,44 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "West London wobbley walk",
-          "public_timestamp": "2014-11-25",
-          "summary": "MOSW researched a new type of silly walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "backward",
-            "label": "Backward"
-          }],
-          "place_of_origin": [null],
-          "creator": "Road Runner",
-          "date_of_introduction": "2003-12-30",
-          "link": "mosw-reports/west-london-wobbley-walk",
-          "_id": "mosw-reports/west-london-wobbley-walk"
-        },
-        {
-          "title": "The Gerry Anderson",
-          "public_timestamp": "2010-10-06",
-          "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
-          "document_type": "mosw_report",
-          "walk_type": [null],
-          "place_of_origin": [{
-            "value": "northern-ireland",
-            "label": "Northern Ireland"
-          }],
-          "creator": "",
-          "date_of_introduction": "1914-08-28",
-          "link": "mosw-reports/the-gerry-anderson",
-          "_id": "mosw-reports/the-gerry-anderson"
+          "results": [
+            {
+              "title": "West London wobbley walk",
+              "public_timestamp": "2014-11-25",
+              "summary": "MOSW researched a new type of silly walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "backward",
+                "label": "Backward"
+              }],
+              "place_of_origin": [null],
+              "creator": "Road Runner",
+              "date_of_introduction": "2003-12-30",
+              "link": "mosw-reports/west-london-wobbley-walk",
+              "_id": "mosw-reports/west-london-wobbley-walk"
+            },
+            {
+              "title": "The Gerry Anderson",
+              "public_timestamp": "2010-10-06",
+              "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
+              "document_type": "mosw_report",
+              "walk_type": [null],
+              "place_of_origin": [{
+                "value": "northern-ireland",
+                "label": "Northern Ireland"
+              }],
+              "creator": "",
+              "date_of_introduction": "1914-08-28",
+              "link": "mosw-reports/the-gerry-anderson",
+              "_id": "mosw-reports/the-gerry-anderson"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -918,28 +954,32 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "The Gerry Anderson",
-          "public_timestamp": "2010-10-06",
-          "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
-          "document_type": "mosw_report",
-          "walk_type": [{
-            "value": "hopscotch",
-            "label": "Hopscotch"
-          }],
-          "place_of_origin": [{
-            "value": "northern-ireland",
-            "label": "Northern Ireland"
-          }],
-          "creator": "",
-          "date_of_introduction": "1914-08-28",
-          "link": "mosw-reports/the-gerry-anderson",
-          "_id": "mosw-reports/the-gerry-anderson"
+          "results": [
+            {
+              "title": "The Gerry Anderson",
+              "public_timestamp": "2010-10-06",
+              "summary": "Rhyming slang for Dander, an Irish colloquialism for walk",
+              "document_type": "mosw_report",
+              "walk_type": [{
+                "value": "hopscotch",
+                "label": "Hopscotch"
+              }],
+              "place_of_origin": [{
+                "value": "northern-ireland",
+                "label": "Northern Ireland"
+              }],
+              "creator": "",
+              "date_of_introduction": "1914-08-28",
+              "link": "mosw-reports/the-gerry-anderson",
+              "_id": "mosw-reports/the-gerry-anderson"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 1,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -947,54 +987,58 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "Big Beer Co / Salty Snacks Ltd merger inquiry",
-          "public_timestamp": "2015-03-17T09:18:18+00:00",
-          "summary": "The CMA is investigating the merging of Big Beer Co and Salty Snacks Ltd.",
-          "document_type": "cma_case",
-          "case_type": [{
-            "value": "mergers",
-            "label": "Mergers"
-          }],
-          "case_state": [{
-            "value": "closed",
-            "label": "Closed"
-          }],
-          "market_sector": [{
-            "value": "food-manufacturing",
-            "label": "Food manufacturing"
-          }],
-          "opened_date": "2015-02-14",
-          "closed_date": "2016-02-14",
-          "link": "cma-cases/big-beer-co-salty-snacks-ltd-merger",
-          "_id": "cma-cases/big-beer-co-salty-snacks-ltd-merger"
-        },
-        {
-          "title": "Bakery market investigation",
-          "public_timestamp": "2015-01-06T10:34:17+00:00",
-          "summary": "The CMA is investigation the supply and marketing of pizza-cakes in Great Britain.",
-          "document_type": "cma_case",
-          "case_type": [{
-            "value": "markets",
-            "label": "Markets"
-          }],
-          "case_state": [{
-            "value": "closed",
-            "label": "Closed"
-          }],
-          "market_sector": [{
-            "value": "food-manufacturing",
-            "label": "Food manufacturing"
-          }],
-          "opened_date": "2014-10-31",
-          "closed_date": "2015-10-31",
-          "link": "cma-cases/bakery-market-investigation",
-          "_id": "cma-cases/bakery-market-investigation"
+          "results": [
+            {
+              "title": "Big Beer Co / Salty Snacks Ltd merger inquiry",
+              "public_timestamp": "2015-03-17T09:18:18+00:00",
+              "summary": "The CMA is investigating the merging of Big Beer Co and Salty Snacks Ltd.",
+              "document_type": "cma_case",
+              "case_type": [{
+                "value": "mergers",
+                "label": "Mergers"
+              }],
+              "case_state": [{
+                "value": "closed",
+                "label": "Closed"
+              }],
+              "market_sector": [{
+                "value": "food-manufacturing",
+                "label": "Food manufacturing"
+              }],
+              "opened_date": "2015-02-14",
+              "closed_date": "2016-02-14",
+              "link": "cma-cases/big-beer-co-salty-snacks-ltd-merger",
+              "_id": "cma-cases/big-beer-co-salty-snacks-ltd-merger"
+            },
+            {
+              "title": "Bakery market investigation",
+              "public_timestamp": "2015-01-06T10:34:17+00:00",
+              "summary": "The CMA is investigation the supply and marketing of pizza-cakes in Great Britain.",
+              "document_type": "cma_case",
+              "case_type": [{
+                "value": "markets",
+                "label": "Markets"
+              }],
+              "case_state": [{
+                "value": "closed",
+                "label": "Closed"
+              }],
+              "market_sector": [{
+                "value": "food-manufacturing",
+                "label": "Food manufacturing"
+              }],
+              "opened_date": "2014-10-31",
+              "closed_date": "2015-10-31",
+              "link": "cma-cases/bakery-market-investigation",
+              "_id": "cma-cases/bakery-market-investigation"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 2,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 
@@ -1002,31 +1046,35 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "Big Beer Co / Salty Snacks Ltd merger inquiry",
-          "public_timestamp": "2015-03-17T09:18:18+00:00",
-          "summary": "The CMA is investigating the merging of Big Beer Co and Salty Snacks Ltd.",
-          "document_type": "cma_case",
-          "case_type": [{
-            "value": "mergers",
-            "label": "Mergers"
-          }],
-          "case_state": [{
-            "value": "open",
-            "label": "Open"
-          }],
-          "market_sector": [{
-            "value": "food-manufacturing",
-            "label": "Food manufacturing"
-          }],
-          "opened_date": "2015-02-14",
-          "link": "cma-cases/big-beer-co-salty-snacks-ltd-merger",
-          "_id": "cma-cases/big-beer-co-salty-snacks-ltd-merger"
+          "results": [
+            {
+              "title": "Big Beer Co / Salty Snacks Ltd merger inquiry",
+              "public_timestamp": "2015-03-17T09:18:18+00:00",
+              "summary": "The CMA is investigating the merging of Big Beer Co and Salty Snacks Ltd.",
+              "document_type": "cma_case",
+              "case_type": [{
+                "value": "mergers",
+                "label": "Mergers"
+              }],
+              "case_state": [{
+                "value": "open",
+                "label": "Open"
+              }],
+              "market_sector": [{
+                "value": "food-manufacturing",
+                "label": "Food manufacturing"
+              }],
+              "opened_date": "2015-02-14",
+              "link": "cma-cases/big-beer-co-salty-snacks-ltd-merger",
+              "_id": "cma-cases/big-beer-co-salty-snacks-ltd-merger"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "facets": {},
+          "suggested_queries": []
         }
-      ],
-      "total": 1,
-      "start": 0,
-      "facets": {},
-      "suggested_queries": []
+      ]
     }|
   end
 

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -1,6 +1,7 @@
 module RummagerUrlHelper
   def rummager_url(params)
-    "#{Plek.current.find('search')}/search.json?#{params.to_query}"
+    query = { search: [{ 0 => params }] }.to_query
+    "#{Plek.current.find('search')}/batch_search.json?#{query}"
   end
 
   def mosw_search_params

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -27,15 +27,21 @@ describe FindersController, type: :controller do
         )
 
         rummager_response = %|{
-          "results": [],
-          "total": 11,
-          "start": 0,
-          "facets": {},
-          "suggested_queries": []
+          "results": [
+            {
+              "results": [],
+              "total": 11,
+              "start": 0,
+              "facets": {},
+              "suggested_queries": []
+            }
+          ]
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=10&fields=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&filter_document_type=mosw_report&order=-public_timestamp&start=0").
-          to_return(status: 200, body: rummager_response, headers: {})
+        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
+
+        stub_request(:get, url)
+          .to_return(status: 200, body: rummager_response, headers: {})
       end
 
       it "correctly renders a finder page" do
@@ -76,14 +82,18 @@ describe FindersController, type: :controller do
         )
 
         rummager_response = %|{
-          "results": [],
-          "total": 0,
-          "start": 0,
-          "facets": {},
-          "suggested_queries": []
+          "results": [
+            {
+              "results": [],
+              "total": 0,
+              "start": 0,
+              "facets": {},
+              "suggested_queries": []
+            }
+          ]
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/search.json?count=10&fields=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&filter_document_type=mosw_report&order=-closing_date&start=0").
+        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
           to_return(status: 200, body: rummager_response, headers: {})
       end
 

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -39,8 +39,8 @@ describe AdvancedSearchFinderApi do
         .with("/education")
         .and_return(taxon)
 
-      allow(Services.rummager).to receive(:search)
-        .and_return(search_results)
+      allow(Services.rummager).to receive(:batch_search)
+        .and_return("results" => [search_results])
     end
 
     let(:composed_content_item) { instance.content_item_with_search_results }
@@ -55,8 +55,8 @@ describe AdvancedSearchFinderApi do
     it "calls the search API with the taxon content_id" do
       instance.content_item_with_search_results
 
-      expect(Services.rummager).to have_received(:search)
-        .with(hash_including("filter_part_of_taxonomy_tree" => taxon_content_id))
+      expect(Services.rummager).to have_received(:batch_search)
+        .with([hash_including("filter_part_of_taxonomy_tree" => taxon_content_id)])
     end
 
     context "when an invalid taxon path is specified in params" do
@@ -65,7 +65,7 @@ describe AdvancedSearchFinderApi do
           .with("/doesnt-exist")
           .and_raise(GdsApi::ContentStore::ItemNotFound.new("ContentItem not found"))
 
-        allow(Services.rummager).to receive(:search).and_return(search_results)
+        allow(Services.rummager).to receive(:batch_search).and_return("results" => [search_results])
       end
 
       let(:filter_params) { { "topic" => "/doesnt-exist" } }

--- a/spec/lib/advanced_search_query_builder_spec.rb
+++ b/spec/lib/advanced_search_query_builder_spec.rb
@@ -30,34 +30,34 @@ RSpec.describe AdvancedSearchQueryBuilder do
 
   context 'without keywords' do
     it 'should not include a keyword query' do
-      expect(instance.call).not_to include("q")
+      expect(instance.call.first).not_to include("q")
     end
 
     context 'when guidance' do
       let(:params) { { 'group' => 'guidance_and_regulation' } }
       it "should include an order query" do
-        expect(instance.call).to include("order" => "-popularity")
+        expect(instance.call.first).to include("order" => "-popularity")
       end
     end
 
     context 'when services' do
       let(:params) { { 'group' => 'services' } }
       it "should include an order query" do
-        expect(instance.call).to include("order" => "-popularity")
+        expect(instance.call.first).to include("order" => "-popularity")
       end
     end
 
     context 'when not guidance or services' do
       let(:params) { {} }
       it "should include an order query" do
-        expect(instance.call).to include("order" => "-public_timestamp")
+        expect(instance.call.first).to include("order" => "-public_timestamp")
       end
 
       context "with a custom order" do
         let(:default_order) { "custom_field" }
 
         it "should include a custom order query" do
-          expect(instance.call).to include("order" => "custom_field")
+          expect(instance.call.first).to include("order" => "custom_field")
         end
       end
     end
@@ -71,11 +71,11 @@ RSpec.describe AdvancedSearchQueryBuilder do
     }
 
     it "should include a keyword query" do
-      expect(instance.call).to include("q" => "mangoes")
+      expect(instance.call.first).to include("q" => "mangoes")
     end
 
     it "should not include an order query" do
-      expect(instance.call).not_to include("order")
+      expect(instance.call.first).not_to include("order")
     end
   end
 end

--- a/spec/lib/finder_api_spec.rb
+++ b/spec/lib/finder_api_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe FinderApi do
+  context "when merging and de-duplicating" do
+    subject { described_class.new("/finder", {}).content_item_with_search_results }
+
+    def result_item(id, title, score:)
+      {
+        "_id" => id,
+        "title" => title,
+        "es_score" => score,
+      }
+    end
+
+    before do
+      allow(Services.content_store).to receive(:content_item)
+        .with("/finder")
+        .and_return(
+          "details" => {
+            "facets" => []
+          },
+        )
+
+      allow(Services.rummager).to receive(:batch_search)
+        .and_return(
+          "results" => [
+            {
+              "results" => [
+                result_item("/register-to-vote", "Register to Vote", score: 1),
+              ],
+            },
+            {
+              "results" => [
+                result_item("/hmrc", "HMRC", score: 10),
+                result_item("/register-to-vote", "Register to Vote", score: 2),
+              ],
+            },
+          ]
+        )
+    end
+
+    it "de-duplicates the content" do
+      results = subject.fetch("details").fetch("results")
+      expect(results.first).to match(hash_including("_id" => "/hmrc"))
+      expect(results.second).to match(hash_including("_id" => "/register-to-vote"))
+    end
+  end
+end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -6,7 +6,7 @@ describe SearchQueryBuilder do
     SearchQueryBuilder.new(
       finder_content_item: finder_content_item,
       params: params,
-    ).call
+    ).call.first
   }
 
   let(:finder_content_item) {
@@ -183,7 +183,7 @@ describe SearchQueryBuilder do
       SearchQueryBuilder.new(
         finder_content_item: finder_content_item,
         params: params
-      ).call
+      ).call.first
     end
   end
 end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -134,7 +134,7 @@ describe SearchQueryBuilder do
       end
 
       it "should filter on both alpha and beta in the second query" do
-        expect(queries.second["filter_alpha"]).to eq(%w(test))
+        expect(queries.second["filter_alpha"]).to be_nil
         expect(queries.second["filter_beta"]).to eq(%w(test))
       end
     end

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe AdvancedSearchResultSetPresenter do
     allow(Services.content_store).to receive(:content_item)
       .with("/education")
       .and_return(taxon)
-    allow(Services.rummager).to receive(:search)
-      .and_return(search_results)
+    allow(Services.rummager).to receive(:batch_search)
+      .and_return("results" => [search_results])
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
This changes finder-frontend to use the Rummager batch search endpoint to perform the searches. 

- When the query should be an AND across the facets (which is the default behaviour) it just performs a single search as before but using the new endpoint.
- When the query should be an OR across the facets, it performs a query for each facet and then merges and de-duplicates the results.

Recommended to look at the diff without whitespace changes.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/848.