### PR TITLE
Use grid in finders

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -114,14 +114,6 @@
   }
 
   .filter-form {
-    @include grid-column(1/3);
-  }
-  .filtered-results {
-    @include grid-column(2/3);
-  }
-
-  .filter-form {
-
     .js-enabled & .button {
       display:none;
     }

--- a/app/assets/stylesheets/views/_advanced-search.scss
+++ b/app/assets/stylesheets/views/_advanced-search.scss
@@ -6,8 +6,7 @@
   }
 
   .breadcrumb-wrapper,
-  .title-and-metadata,
-  .filter-form {
+  .title-and-metadata {
     padding-left: 0;
   }
 

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -45,11 +45,6 @@ main.search {
     }
 
     .filter-form {
-      @include media(tablet){
-        float: left;
-        width: $one-third;
-      }
-
       .info {
         margin: 0 0 15px;
       }
@@ -271,7 +266,6 @@ main.search {
 
   //  checkbox CSS imported here to ensure correct scoping
 
-  .filter-form,
   .filtered-results {
     @include media(tablet) {
       float: left;

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,16 +1,14 @@
 <div class="filter-form">
-  <div class="inner-block">
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: "Search"
-      },
-      name: "keywords",
-      value: @results.user_supplied_keywords,
-      id: "finder-keyword-search",
-      controls: "js-search-results-info"
-    } if finder.show_keyword_search? %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Search"
+    },
+    name: "keywords",
+    value: @results.user_supplied_keywords,
+    id: "finder-keyword-search",
+    controls: "js-search-results-info"
+  } if finder.show_keyword_search? %>
 
-    <%= render facet_collection.filters %>
-    <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
-  </div>
+  <%= render facet_collection.filters %>
+  <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
 </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -58,12 +58,14 @@
   <% end %>
 </header>
 
-<div class="filtering">
-  <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
-    <%= render finder.facets %>
+<form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+  <div class="grid-row">
+    <div class="column-third">
+      <%= render finder.facets %>
+    </div>
 
-    <% if finder.sort.present? %>
-      <div class="filter-form">
+    <div class="column-two-thirds">
+      <% if finder.sort.present? %>
         <div class="govuk-form-group">
           <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
           <%= select_tag 'order', finder.sort_options,
@@ -72,22 +74,22 @@
                          data: { 'default-sort-option' => finder.default_sort_option_value,
                                  'relevance-sort-option' => finder.relevance_sort_option_value } %>
         </div>
-      </div>
-    <% end %>
+      <% end %>
 
-    <div class='js-live-search-results-block'>
-      <div class="filtered-results">
-        <div aria-live='assertive' id='js-search-results-info'>
-          <% if finder.show_generic_description? %>
-            <%= render_mustache('result_count_generic', @results.to_hash) %>
-          <% else %>
-            <%= render_mustache('result_count', @results.to_hash) %>
-          <% end %>
-        </div>
-        <div id='js-results'>
-          <%= render_mustache('results', @results.to_hash) %>
+      <div class='js-live-search-results-block'>
+        <div class="filtered-results">
+          <div aria-live='assertive' id='js-search-results-info'>
+            <% if finder.show_generic_description? %>
+              <%= render_mustache('result_count_generic', @results.to_hash) %>
+            <% else %>
+              <%= render_mustache('result_count', @results.to_hash) %>
+            <% end %>
+          </div>
+          <div id='js-results'>
+            <%= render_mustache('results', @results.to_hash) %>
+          </div>
         </div>
       </div>
     </div>
-  </form>
-</div>
+  </div>
+</form>

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -59,7 +59,7 @@ When(/^I search documents by keyword$/) do
 
   @keyword_search = "keyword searchable"
 
-  within '.filtering' do
+  within '.filter-form' do
     fill_in("Search", with: @keyword_search)
   end
 


### PR DESCRIPTION
Use standard grid for finder layouts, rather than custom classes. This should result in no changes to the appearance of finders but will enable us to remove some unnecessary CSS and also iterate the layout more easily in future.