### PR TITLE
Omit search box when there are no results

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -149,6 +149,10 @@ class FinderPresenter
     filters.map(&:sentence_fragment).compact
   end
 
+  def show_keyword_search?
+    keywords.present? || facets.any? || results.total.positive?
+  end
+
   def show_summaries?
     content_item['details']['show_summaries']
   end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -8,7 +8,7 @@
       value: @results.user_supplied_keywords,
       id: "finder-keyword-search",
       controls: "js-search-results-info"
-    } %>
+    } if finder.show_keyword_search? %>
 
     <%= render facet_collection.filters %>
     <input type="submit" value="Filter results" class="button js-live-search-fallback"/>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -26,6 +26,12 @@ Feature: Filtering documents
     When I search documents by keyword
     Then I see all documents which contain the keywords
 
+  Scenario: Hiding keyword search
+    Given no results
+    When I view the finder with no keywords and no facets
+    Then I see no results
+    And there is no keyword search box
+
   Scenario: Visit a government finder
     Given a government finder exists
     Then I can see the government header

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -3,6 +3,24 @@ Given(/^a collection of documents exist$/) do
   stub_rummager_api_request
 end
 
+Given(/^no results$/) do
+  content_store_has_mosw_reports_finder_with_no_facets
+  stub_rummager_api_request_with_no_results
+end
+
+When(/^I view the finder with no keywords and no facets$/) do
+  visit finder_path('mosw-reports')
+end
+
+Then(/I see no results$/) do
+  expect(page).to have_content('0 reports')
+  expect(page).to have_css('.filtered-results .document', count: 0)
+end
+
+And(/there is no keyword search box$/) do
+  expect(page).to_not have_css('#finder-keyword-search')
+end
+
 Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -51,6 +51,11 @@ module DocumentHelper
       .to_return(body: popular_news_and_communication_json)
   end
 
+  def stub_rummager_api_request_with_no_results
+    stub_request(:get, rummager_0_documents_url)
+      .to_return(body: %|{ "results": [], "total": 0, "start": 0}|)
+  end
+
   def stub_rummager_api_request_with_422_response(page_number)
     stub_request(:get, rummager_document_other_page_search_url(page_number)).to_return(status: 422)
   end
@@ -78,6 +83,12 @@ module DocumentHelper
 
   def content_store_has_mosw_reports_finder
     content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
+  end
+
+  def content_store_has_mosw_reports_finder_with_no_facets
+    finder = govuk_content_schema_example('finder')
+    finder["details"]["facets"] = []
+    content_store_has_item('/mosw-reports', finder.to_json)
   end
 
   def content_store_has_qa_finder
@@ -242,6 +253,15 @@ module DocumentHelper
     rummager_url(
       mosw_search_params.merge(
         "order" => "-public_timestamp",
+      )
+    )
+  end
+
+  def rummager_0_documents_url
+    rummager_url(
+      mosw_search_params_no_facets.merge(
+        "order" => "-public_timestamp",
+        "count" => 1500
       )
     )
   end

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -10,6 +10,13 @@ module RummagerUrlHelper
     )
   end
 
+  def mosw_search_params_no_facets
+    base_search_params.merge(
+      "fields" => base_search_fields.join(","),
+      "filter_document_type" => "mosw_report",
+    )
+  end
+
   def mosw_search_fields
     base_search_fields + %w(
       walk_type


### PR DESCRIPTION
We want the search box to be visible if there:
 - are results
 - are keywords specified
 - are other facets present that may have filtered the results to zero

We're trying to reduce the number of times the search box is present when it is useless.  A drawback is that we don't want it to keep appearing and disappearing without an obvious reason for it.  For this reason, we're being a little cautious about the scenarios in which this occurs.

I suspect further user testing might allow us to expand on this.