### PR TITLE
increase the unicorn worker count to 4

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,4 @@
 require "govuk_app_config/govuk_unicorn"
 GovukUnicorn.configure(self)
+
+worker_processes 4


### PR DESCRIPTION
This commit increases the number of unicorn workers from 2 to 6 per instance. This allows more requests to be handled simultaneously. This affects proper finders and advanced search and should make them able to handle larger numbers of unique requests at the same time 

### Testing
This was tested using gatling on staging. In general it has helped to lower the upper limits of response time. The following screenshots were from data following tests involving ~5k requests using about 500 unique URL's

Before
<img width="456" alt="screen shot 2018-12-10 at 13 57 46" src="https://user-images.githubusercontent.com/24547207/49737065-bd33bd00-fc83-11e8-896e-0bb94e83d301.png">

After
<img width="458" alt="screen shot 2018-12-10 at 13 57 57" src="https://user-images.githubusercontent.com/24547207/49737071-c1f87100-fc83-11e8-88e8-9c0f705ed1e4.png">

