### PR TITLE
Don't re-order the de-duplicated content

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -50,7 +50,6 @@ private
 
     all_unique_results = results
       .flat_map { |hash| hash["results"] }
-      .sort_by { |hash| hash["es_score"] }.reverse
       .uniq { |hash| hash["_id"] }
 
     {

--- a/spec/lib/finder_api_spec.rb
+++ b/spec/lib/finder_api_spec.rb
@@ -41,8 +41,8 @@ describe FinderApi do
 
     it "de-duplicates the content" do
       results = subject.fetch("details").fetch("results")
-      expect(results.first).to match(hash_including("_id" => "/hmrc"))
-      expect(results.second).to match(hash_including("_id" => "/register-to-vote"))
+      expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
+      expect(results.second).to match(hash_including("_id" => "/hmrc"))
     end
   end
 end


### PR DESCRIPTION
The order of the content we're seeing with this code makes less sense than if we just join it based on the order of the facets.