### PR TITLE
Add spec file for 'qa_to_content' controller

### DIFF
--- a/app/controllers/qa_to_content_controller.rb
+++ b/app/controllers/qa_to_content_controller.rb
@@ -10,11 +10,9 @@ class QaToContentController < ApplicationController
   def show
     return error_not_found unless ENV["FINDER_FRONTEND_ENABLE_QA_TO_CONTENT"]
 
-    if params[first_question["id"]].present?
-      redirect_to_guidance params[first_question["id"]]
-    else
-      render 'qa_to_content/show'
-    end
+    return redirect_to content_url if redirect_to_content?
+
+    render "qa_to_content/show"
   end
 
 private
@@ -33,14 +31,14 @@ private
   end
   helper_method :breadcrumbs
 
-  def questions
-    @questions ||= qa_config["questions"]
+  def question
+    @question ||= qa_config["questions"].first
   end
+  helper_method :question
 
-  def first_question
-    questions.first
+  def content_url
+    @content_url ||= params[question["id"]]
   end
-  helper_method :first_question
 
   def format_options(options)
     options.map do |option|
@@ -51,20 +49,13 @@ private
   end
   helper_method :format_options
 
-  def is_a_permitted_destinations(url)
-    found = false
-    first_question["options"].each do |option|
-      if option["value"] == url
-        found = true
-        break
-      end
+  def content_url_valid?
+    question["options"].any? do |option|
+      option["value"] == content_url
     end
-    found
   end
 
-  def redirect_to_guidance(url)
-    if is_a_permitted_destinations(url)
-      redirect_to url
-    end
+  def redirect_to_content?
+    content_url.present? && content_url_valid?
   end
 end

--- a/app/views/qa_to_content/show.html.erb
+++ b/app/views/qa_to_content/show.html.erb
@@ -11,16 +11,16 @@
     <form action="" method="get">
 
       <%= render "govuk_publishing_components/components/title", {
-        title: first_question["question"],
+        title: question["question"],
         margin_bottom: 4
       } %>
       <%= render "govuk_publishing_components/components/hint", {
-        text: first_question["hint"].html_safe,
+        text: question["hint"].html_safe,
         classes: "govuk-!-padding-bottom-5"
       } %>
       <%= render "govuk_publishing_components/components/radio", {
-        name: first_question["id"],
-        items: format_options(first_question["options"])
+        name: question["id"],
+        items: format_options(question["options"])
       } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Next"

--- a/features/fixtures/uk_nationals_in_eu.yaml
+++ b/features/fixtures/uk_nationals_in_eu.yaml
@@ -1,0 +1,21 @@
+---
+base_path: "/uk-nationals-in-eu"
+title: UK nationals in the EU
+questions:
+  - id: where_do_you_live
+    question: Where do you live?
+    hint: |
+      Choose your country or <a href="https://www.gov.uk/guidance/advice-for-british-nationals-travelling-and-living-in-europe">check the guidance for all UK nationals living in the EU</a>.
+    type: radio
+    options:
+      - text: Austria
+        value: /guidance/living-in-austria
+      - text: Belgium
+        value: /guidance/living-in-belgium
+      - text: Bulgaria
+        value: /guidance/living-in-bulgaria
+      - text: Croatia
+        value: /guidance/living-in-croatia
+      - text: Switzerland
+        value: /guidance/living-in-switzerland
+

--- a/spec/controllers/qa_to_content_controller_spec.rb
+++ b/spec/controllers/qa_to_content_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+
+describe QaToContentController, type: :controller do
+  include FixturesHelper
+  render_views
+  ENV["FINDER_FRONTEND_ENABLE_QA_TO_CONTENT"] = "true"
+
+  describe "GET show" do
+    let(:uk_nationals_in_eu_yaml) { uk_nationals_in_eu_config }
+    let(:question)                { uk_nationals_in_eu_yaml["questions"].first }
+    let(:params)                  { {} }
+
+    before do
+      allow_any_instance_of(QaController).to receive(:qa_config).and_return(uk_nationals_in_eu_yaml)
+      get :show, params: params
+    end
+
+    describe "viewing the question" do
+      it "correctly renders a QA to Content page" do
+        expect(response.status).to eq(200)
+        expect(response).to render_template("qa_to_content/show")
+      end
+
+      it "renders the title" do
+        expect(response.body).to include(uk_nationals_in_eu_yaml["title"])
+      end
+
+      it "renders the first question" do
+        expect(response.body).to include(question["question"])
+      end
+
+      it "renders the first question hint" do
+        expect(response.body).to include(question["hint"])
+      end
+
+      it "renders the options as radio buttons" do
+        first_option = question["options"].first
+        last_option = question["options"].last
+        expect(response.body).to have_css(".govuk-radios__input[type='radio'][value='#{first_option['value']}']")
+        expect(response.body).to have_css(".govuk-radios__input[type='radio'][value='#{last_option['value']}']")
+      end
+    end
+
+    describe "submitting an option" do
+      context "when the option is valid" do
+        let(:params) { { question["id"] => question["options"].first["value"] } }
+
+        it "redirects to the chosen option's URL" do
+          expect(response).to redirect_to(question["options"].first["value"])
+        end
+      end
+
+      context "when the option is invalid" do
+        let(:params) { { question["id"] => '/non-matching-url' } }
+
+        it "renders the question" do
+          expect(response).to render_template('qa_to_content/show')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -11,6 +11,10 @@ module FixturesHelper
     YAML.load_file(fixtures_path + "/aaib_reports_qa.yaml")
   end
 
+  def uk_nationals_in_eu_config
+    YAML.load_file(fixtures_path + "/uk_nationals_in_eu.yaml")
+  end
+
   def cma_cases_content_item
     JSON.parse(File.read(fixtures_path + "/cma_cases_content_item.json"))
   end


### PR DESCRIPTION
This PR adds a test file for the QA to Content controller.

Using these tests, it also refactors the controller to: 

- make some methods a little more `Ruby-ish`
- remove references to `guidance`, which is tied to the current use case
- remove references to `first question`, as current logic will only allow for one question