### PR TITLE
Remove "in the" and "in" from nationals in the eu routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ FinderFrontend::Application.routes.draw do
   get '/prepare-business-uk-leaving-eu' => 'qa#show'
 
   # Q&A frontend for "UK Nationals in the EU" (www.gov.uk/uk-nationals-in-the-eu)
-  get '/uk-nationals-living-in-the-eu' => 'qa_to_content#show'
+  get '/uk-nationals-living-eu' => 'qa_to_content#show'
 
   get '/search/advanced' => 'advanced_search_finder#show'
 

--- a/lib/uk_nationals_living_in_the_eu.yaml
+++ b/lib/uk_nationals_living_in_the_eu.yaml
@@ -1,5 +1,5 @@
 ---
-base_path: "/uk-nationals-in-eu"
+base_path: "/uk-nationals-eu"
 title: UK nationals in the EU
 questions:
   - id: where_do_you_live


### PR DESCRIPTION
Related - https://github.com/alphagov/finder-frontend/pull/734 - but I think this is the actual change we want as at 9:40am 11 December.
Still needs a corresponding PR in rummager.