### PR TITLE
Allow content store document type and supertypes

### DIFF
--- a/app/lib/translate_content_purpose_fields.rb
+++ b/app/lib/translate_content_purpose_fields.rb
@@ -14,7 +14,8 @@ class TranslateContentPurposeFields
 private
 
   def translate_fields_with_prefix(prefix)
-    document_types = subgroup_document_types(prefix) || supergroup_document_types(prefix)
+    document_types = Array(content_store_document_types(prefix))
+    document_types += Array(subgroup_document_types(prefix) || supergroup_document_types(prefix))
 
     @query.delete("#{prefix}_content_purpose_subgroup")
     @query.delete("#{prefix}_content_purpose_supergroup")
@@ -22,6 +23,11 @@ private
     if document_types.present?
       @query["#{prefix}_content_store_document_type"] = document_types.uniq.sort
     end
+  end
+
+  def content_store_document_types(prefix)
+    key = "#{prefix}_content_store_document_type"
+    @query.delete(key)
   end
 
   def subgroup_document_types(prefix)

--- a/spec/lib/translate_content_purpose_fields_spec.rb
+++ b/spec/lib/translate_content_purpose_fields_spec.rb
@@ -106,5 +106,26 @@ RSpec.describe TranslateContentPurposeFields do
         is_expected.to_not include('filter_content_purpose_subgroup', 'filter_content_purpose_supergroup')
       end
     end
+
+    context 'when it also includes content store document types' do
+      let(:query) do
+        {
+            'filter_content_purpose_subgroup' => 'policy',
+            'filter_content_purpose_supergroup' => 'transparency',
+            'filter_content_store_document_type' => %w(travel_advice_index case_study),
+            'foo' => 'bar',
+        }
+      end
+
+      it 'preserves original query fields' do
+        is_expected.to include('foo' => 'bar')
+      end
+
+      it 'includes the document types with the relevant translated supertypes' do
+        is_expected.to include('filter_content_store_document_type' => %w(case_study impact_assessment policy_paper travel_advice_index))
+
+        is_expected.to_not include('filter_content_purpose_subgroup', 'filter_content_purpose_supergroup')
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously if a supertype was specified, it would overwrite any content store document types that were present.  This means that you couldn't do ad hoc combinations of supertypes and document types.

We now have a need to do this so that we can include a specific format in a particular finder that does not usually belong a supertype.

https://trello.com/c/UDfCG0jA/184-add-foreign-travel-advice-index-to-going-abroad-finder