### PR TITLE
Style checkboxes to be smaller in size

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -103,4 +103,44 @@
       }
     }
   }
+
+  // This is a temporary overwrite for checkboxes
+  // These styles should be removed in favour of small checkboxes from the Design System
+  .govuk-checkboxes__item {
+    min-height: 26px;
+    margin-bottom: 10px;
+    padding: 0 0 0 30px;
+  }
+
+  .govuk-checkboxes__item:last-child,
+  .govuk-checkboxes__item:last-of-type {
+    margin-bottom: 0;
+  }
+
+  .govuk-checkboxes__input {
+    top: 5px;
+    left: 0;
+    width: 26px;
+    height: 26px;
+  }
+
+  .govuk-checkboxes__label {
+    padding: 8px 5px 2px;
+    font-size: 16px;
+  }
+
+  .govuk-checkboxes__input + .govuk-checkboxes__label::before {
+    top: 5px;
+    width: 26px;
+    height: 26px;
+  }
+
+  .govuk-checkboxes__input + .govuk-checkboxes__label::after {
+    top: 12px;
+    left: 5.5px;
+    width: 12px;
+    height: 5px;
+    border-width: 0 0 3px 3px;
+  }
+
 }


### PR DESCRIPTION
I'm aware there is a new version of [small version for checkboxes](https://github.com/alphagov/govuk-design-system-backlog/issues/162) coming from the Design System, but until that is ready I'd add these temporary overwrites. When the new ones will be ready and implemented in the [shared library of components](https://github.com/alphagov/govuk_publishing_components) this code will be removed and we will rely on the [Design System](https://github.com/alphagov/govuk-frontend) code.

@miaallers @markhurrell I'd like your input for this quick fix when you have time and I'm happy to discuss how can we further improve this component (i.e. replacing the top-right chevron – currently a stretched raster image).

### Before
Default
<img width="301" alt="screen shot 2018-12-17 at 09 38 23" src="https://user-images.githubusercontent.com/788096/50079764-662d6b00-01e2-11e9-8dfc-a456f4930f1e.png">

Selected
<img width="300" alt="screen shot 2018-12-17 at 09 38 54" src="https://user-images.githubusercontent.com/788096/50079802-82310c80-01e2-11e9-8f0f-2864ea6d7ddf.png">

### After
Default
<img width="300" alt="screen shot 2018-12-17 at 09 38 38" src="https://user-images.githubusercontent.com/788096/50079809-89581a80-01e2-11e9-8eb2-0e5e7feffae6.png">

Selected
<img width="301" alt="screen shot 2018-12-17 at 09 39 01" src="https://user-images.githubusercontent.com/788096/50079782-6fb6d300-01e2-11e9-91c8-67b6a7ef52fd.png">
