### PR TITLE
Topic faceting improvements

### DIFF
--- a/app/assets/javascripts/taxonomy-select.js
+++ b/app/assets/javascripts/taxonomy-select.js
@@ -9,12 +9,13 @@
 
   function TaxonomySelect(options) {
     this.$el = options.$el;
+    this.options = this.instantiateOptions();
   }
 
   TaxonomySelect.prototype.update = function updateTaxonomyFacet(){
     this.disableSubTaxonFacet();
-    this.showRelevantSubTaxons();
     this.resetSubTaxonValue();
+    this.showRelevantSubTaxons();
   };
 
   TaxonomySelect.prototype.$topLevelTaxon = function $topLevelTaxon() {
@@ -31,17 +32,28 @@
   };
 
   TaxonomySelect.prototype.showRelevantSubTaxons = function showRelevantSubTaxons() {
-    var parentTaxon = this.$topLevelTaxon().val();
+    var taxons = this.options[this.$topLevelTaxon().val()],
+        subtaxon = this.$subTaxon();
+
+    subtaxon.find('option').each(function(){
+      if ($(this).val()) { $(this).remove(); }
+    })
+
+    subtaxon.append(taxons);
+  };
+
+  TaxonomySelect.prototype.instantiateOptions = function() {
+    var options = {};
 
     this.$subTaxon().find('option').each(function(){
-      var taxon = $(this),
-          isChildOfSelected = $(taxon).attr('data-topic-parent') === parentTaxon,
-          isDefaultOption = !$(taxon).val(),
-          shouldDisplay = isChildOfSelected || isDefaultOption;
+      var parent = $(this).attr('data-topic-parent');
 
-      $(taxon).toggle(shouldDisplay);
+      options[parent] = options[parent] || []
+      options[parent].push(this)
     });
-  };
+
+    return options;
+  }
 
   TaxonomySelect.prototype.resetSubTaxonValue = function resetSubTaxonValue() {
     var selected = this.$subTaxon().find(':selected'),

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -150,6 +150,12 @@
     margin-bottom: $gutter;
   }
 
+  .app-taxonomy-select {
+    .govuk-select {
+      width: 100%;
+    }
+  }
+
   .radio-filter {
     padding: 0 $gutter-one-third;
 

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -60,7 +60,9 @@ private
         {
           text: v['title'],
           value: v['content_id'],
-          parent: v['parent'],
+          data_attributes: {
+            topic_parent: v['parent'],
+          },
           selected: v['content_id'] == @value[LEVEL_TWO_TAXON_KEY]
         }
       }

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,23 +1,16 @@
 <div class="app-taxonomy-select">
   <%= render "govuk_publishing_components/components/select", {
     id: 'level_one_taxon',
-    label: "Filter by topic",
+    label: "Topic",
     options: taxon_facet.topics
   }
   %>
   <div class="js-required govuk-form-group gem-c-select">
-    <label class="govuk-label" for="level_two_taxon">
-     Filter by sub-topic
-    </label>
-    <select class="govuk-select" id="level_two_taxon" name="level_two_taxon">
-      <% taxon_facet.sub_topics.each do |topic| %>
-        <option
-          data-topic-parent="<%= topic[:parent] %>"
-          value="<%= topic[:value] %>"
-          <% if topic[:selected] %>selected<% end %>>
-          <%= topic[:text] %>
-        </option>
-      <% end %>
-    </select>
+    <%= render "govuk_publishing_components/components/select", {
+      id: 'level_two_taxon',
+      label: "Sub-topic",
+      options: taxon_facet.sub_topics
+    }
+    %>
   </div>
 </div>

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -70,7 +70,7 @@ describe TaxonFacet do
       expect(sub_topic.keys).to contain_exactly(
         :value,
         :text,
-        :parent,
+        :data_attributes,
         :selected
       )
     end


### PR DESCRIPTION
This fixes an issue in Safari where unavailable sub-topic options aren't removed from the sub-topic select.

Safari [does not support](https://stackoverflow.com/a/15025961) `$(option).toggle()`. So rather than trying to hide unavailable sub-topics, we need to remove them from the DOM.

Review app: https://finder-frontend-pr-743.herokuapp.com