### PR TITLE
Add tracking to taxonomy facet

### DIFF
--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -46,6 +46,11 @@ private
         value: v['content_id'],
         text: v['title'],
         sub_topics: v['children'],
+        data_attributes: {
+          track_category: "filterClicked",
+          track_action: "level_one_taxon",
+          track_label: v['title'],
+        },
         selected: v['content_id'] == @value[LEVEL_ONE_TAXON_KEY]
       }
     }
@@ -61,6 +66,9 @@ private
           text: v['title'],
           value: v['content_id'],
           data_attributes: {
+            track_category: "filterClicked",
+            track_action: "level_two_taxon",
+            track_label: v['title'],
             topic_parent: v['parent'],
           },
           selected: v['content_id'] == @value[LEVEL_TWO_TAXON_KEY]

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -45,7 +45,8 @@ describe TaxonFacet do
           :value,
           :text,
           :sub_topics,
-          :selected
+          :selected,
+          :data_attributes
         )
       end
     end


### PR DESCRIPTION
https://trello.com/c/5iPpo7IR/193-add-tracking-to-topic-subtopic-facet

This adds tracking attributes to select options on level one and two taxons.

End users won't see a difference as a result of this change.