### PR TITLE
Fix bug with displayed sort option on Sort By select box

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -136,7 +136,7 @@ class FinderPresenter
 
     disabled_option = keywords.blank? ? relevance_sort_option_value : ''
 
-    selected_option = values['order'] unless values['order'].nil? && sort.detect { |option| option['name'].parameterize == values['order'] }.nil?
+    selected_option = values['order'] unless values['order'].nil? || sort.detect { |option| option['name'].parameterize == values['order'] }.nil?
     selected_option ||= default_sort_option_value
 
     options_for_select(options, selected: selected_option, disabled: disabled_option)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -136,8 +136,11 @@ class FinderPresenter
 
     disabled_option = keywords.blank? ? relevance_sort_option_value : ''
 
-    selected_option = values['order'] unless values['order'].nil? || sort.detect { |option| option['name'].parameterize == values['order'] }.nil?
-    selected_option ||= default_sort_option_value
+    selected_option = if values['order'].present? && sort.any? { |option| option['name'].parameterize == values['order'] }
+                        values['order']
+                      else
+                        default_sort_option_value
+                      end
 
     options_for_select(options, selected: selected_option, disabled: disabled_option)
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -134,15 +134,12 @@ class FinderPresenter
 
     options = Hash[sort.collect { |option| [option['name'], option['name'].parameterize] }]
 
-    disabled_option = keywords.blank? ? relevance_sort_option : ''
+    disabled_option = keywords.blank? ? relevance_sort_option_value : ''
 
-    selected_option = if values['order']
-                        sort.detect { |option| option['name'].parameterize == values['order'] }
-                      end
-
+    selected_option = values['order'] unless values['order'].nil? && sort.detect { |option| option['name'].parameterize == values['order'] }.nil?
     selected_option ||= default_sort_option_value
 
-    options_for_select(options, disabled: disabled_option, selected: selected_option)
+    options_for_select(options, selected: selected_option, disabled: disabled_option)
   end
 
   def filter_sentence_fragments

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -86,12 +86,6 @@ RSpec.describe FinderPresenter do
       expect(presenter.sort_options).to eql([])
     end
 
-    it "returns sort options when sort is present" do
-      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>"
-
-      expect(presenter_with_sort.sort_options).to eql(expected_options)
-    end
-
     it "returns sort options without relevance when keywords is not present" do
       expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>"
 

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -3,19 +3,31 @@ require 'spec_helper'
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
 
-  subject(:presenter) { described_class.new(content_item, values) }
+  subject(:presenter) { described_class.new(content_item(no_sort_options), values) }
+  subject(:presenter_with_sort) { described_class.new(content_item(sort_options_without_relevance), values) }
 
-  let(:content_item) {
-    finder_example = govuk_content_schema_example('finder')
-    finder_example['details']['sort'] = nil
+  let(:no_sort_options) { nil }
 
-    dummy_http_response = double(
-      "net http response",
-        code: 200,
-        body: finder_example.to_json,
-        headers: {}
-    )
-    GdsApi::Response.new(dummy_http_response).to_hash
+  let(:sort_options_without_relevance) {
+    [
+      { "name" => "Most viewed" },
+      { "name" => "Updated (newest)" }
+    ]
+  }
+
+  let(:sort_options_with_relevance) {
+    [
+      { "name" => "Most viewed" },
+      { "name" => "Updated (newest)" },
+      { "name" => "Relevance", "key" => "relevance" }
+    ]
+  }
+
+  let(:sort_options_with_default) {
+    [
+      { "name" => "Most viewed" },
+      { "name" => "Updated (oldest)", "default" => "Updated (oldest)" }
+    ]
   }
 
   let(:values) { {} }
@@ -67,5 +79,78 @@ RSpec.describe FinderPresenter do
         expect(presenter.atom_url).to eql("/mosw-reports.atom?format=publication&keyword=legal&state=open")
       end
     end
+  end
+
+  describe "#sort_options" do
+    it "returns an empty array when sort is not present" do
+      expect(presenter.sort_options).to eql([])
+    end
+
+    it "returns sort options when sort is present" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>"
+
+      expect(presenter_with_sort.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options without relevance when keywords is not present" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>"
+
+      expect(presenter_with_sort.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options with relevance disabled when keywords is blank" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>\n<option disabled=\"disabled\" value=\"relevance\">Relevance</option>"
+
+      presenter = described_class.new(content_item(sort_options_with_relevance), values)
+
+      expect(presenter.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options with relevance enabled when keywords is not blank" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>\n<option value=\"relevance\">Relevance</option>"
+
+      presenter = described_class.new(content_item(sort_options_with_relevance), "keywords" => "something not blank")
+
+      expect(presenter.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options with no option selected when order is specified but does not exist in options" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option value=\"updated-newest\">Updated (newest)</option>"
+
+      presenter = described_class.new(content_item(sort_options_without_relevance), "order" => "option_that_does_not_exist")
+
+      expect(presenter.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options with default option selected when order is not specified and default option exists" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option selected=\"selected\" value=\"updated-oldest\">Updated (oldest)</option>"
+
+      presenter = described_class.new(content_item(sort_options_with_default), values)
+
+      expect(presenter.sort_options).to eql(expected_options)
+    end
+
+    it "returns sort options with option selected when order is specified and exists in options" do
+      expected_options = "<option value=\"most-viewed\">Most viewed</option>\n<option selected=\"selected\" value=\"updated-newest\">Updated (newest)</option>"
+
+      presenter = described_class.new(content_item(sort_options_without_relevance), "order" => "updated-newest")
+
+      expect(presenter.sort_options).to eql(expected_options)
+    end
+  end
+
+private
+
+  def content_item(sort_options)
+    finder_example = govuk_content_schema_example('finder')
+    finder_example['details']['sort'] = sort_options
+
+    dummy_http_response = double(
+      "net http response",
+      code: 200,
+      body: finder_example.to_json,
+      headers: {}
+    )
+    GdsApi::Response.new(dummy_http_response).to_hash
   end
 end


### PR DESCRIPTION
This PR fixes the Sort By select box to display the correct sort option when the page is refreshed.

Trello card: https://trello.com/c/zdcfNCoZ

Solo: @karlbaker02