### PR TITLE
Refine 'Prepare for Eu Exit' finder SEO indexing

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -211,8 +211,8 @@ class FinderPresenter
     content_item['description']
   end
 
-  def should_have_canonical_link?
-    slug == '/find-eu-exit-guidance-business'
+  def canonical_link?
+    content_item['details']['canonical_link']
   end
 
 private

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -211,6 +211,10 @@ class FinderPresenter
     content_item['description']
   end
 
+  def should_have_canonical_link?
+    slug == '/find-eu-exit-guidance-business'
+  end
+
 private
 
   def part_of

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
-  <% if finder.should_have_canonical_link? %>
+  <% if finder.canonical_link? %>
     <link rel="canonical" href="<%= ENV['GOVUK_WEBSITE_ROOT'] + finder.slug %>">
   <% end %>
 <% end %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -2,6 +2,9 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.atom_url) %>
   <%= render 'finder_meta', finder: finder %>
+  <% if finder.should_have_canonical_link? %>
+    <link rel="canonical" href="<%= ENV['GOVUK_WEBSITE_ROOT'] + finder.slug %>">
+  <% end %>
 <% end %>
 
 <% if finder.show_phase_banner? %>

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -1,4 +1,9 @@
 <% content_for :title, title %>
+<% content_for :head do %>
+  <% unless params[:page] %>
+    <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
 
 <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
 <div class="grid-row">

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -65,6 +65,21 @@ describe FindersController, type: :controller do
         expect(response.content_type).to eq("application/json")
       end
 
+      describe "canonical links" do
+        it "does not add a canonical link by default" do
+          get :show, params: { slug: "lunch-finder" }
+          expect(response.body).not_to include('<link rel="canonical"')
+        end
+
+        it "has a canonical link for the eu-exit-guidance-business finder" do
+          eu_exit_finder = '/find-eu-exit-guidance-business'
+          allow_any_instance_of(FinderPresenter).to receive(:slug).and_return(eu_exit_finder)
+          get :show, params: { slug: "lunch-finder" }
+
+          expect(response.body).to include("<link rel=\"canonical\" href=\"#{ENV['GOVUK_WEBSITE_ROOT']}#{eu_exit_finder}\">")
+        end
+      end
+
       it "returns a 406 if an invalid format is requested" do
         request.headers["Accept"] = "text/plain"
         get :show, params: { slug: "lunch-finder" }

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -66,17 +66,34 @@ describe FindersController, type: :controller do
       end
 
       describe "canonical links" do
-        it "does not add a canonical link by default" do
+        let(:canonical_finder) do
+          finder = govuk_content_schema_example('finder').to_hash.merge(
+            'title' => 'Canonical Finder',
+            'base_path' => '/canonical-finder',
+          )
+
+          finder['details']['canonical_link'] = true
+          finder["details"]["default_documents_per_page"] = 10
+          finder["details"]["sort"] = nil
+          finder
+        end
+
+        before do
+          content_store_has_item(
+            '/canonical_finder',
+            canonical_finder
+          )
+        end
+
+        it "are not shown if the finder does not have a canonical_link field" do
           get :show, params: { slug: "lunch-finder" }
           expect(response.body).not_to include('<link rel="canonical"')
         end
 
-        it "has a canonical link for the eu-exit-guidance-business finder" do
-          eu_exit_finder = '/find-eu-exit-guidance-business'
-          allow_any_instance_of(FinderPresenter).to receive(:slug).and_return(eu_exit_finder)
-          get :show, params: { slug: "lunch-finder" }
+        it "are shown if the finder has a canonical_link field" do
+          get :show, params: { slug: "canonical_finder" }
 
-          expect(response.body).to include("<link rel=\"canonical\" href=\"#{ENV['GOVUK_WEBSITE_ROOT']}#{eu_exit_finder}\">")
+          expect(response.body).to include("<link rel=\"canonical\" href=\"#{ENV['GOVUK_WEBSITE_ROOT']}/canonical-finder\">")
         end
       end
 

--- a/spec/controllers/qa_controller_spec.rb
+++ b/spec/controllers/qa_controller_spec.rb
@@ -38,6 +38,10 @@ describe QaController, type: :controller do
       context "on the first page" do
         before { get :show }
 
+        it "sets a robots no-index metatag" do
+          expect(response.body).to include('<meta name="robots" content="noindex">')
+        end
+
         it "renders the first facet's question" do
           expect(response.body).to include(aaib_reports_qa_config_yaml["pages"][aaib_reports_finder_facets.first["key"]]["question"])
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'simplecov'
 SimpleCov.start
 
 ENV["RAILS_ENV"] ||= 'test'
+ENV['GOVUK_WEBSITE_ROOT'] ||= 'https://www.test.gov.uk'
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'webmock/rspec'

--- a/startup.sh
+++ b/startup.sh
@@ -11,5 +11,6 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
   bundle exec rails s -p 3062
 else
+  GOVUK_WEBSITE_ROOT=localhost:3062 \
   bundle exec rails s -p 3062
 fi


### PR DESCRIPTION
Currently only QA pages with a page param are no-indexed by the finder-layout. This PR adds a check in the QA show partial to add a no-index tag if a page param is not present.

Currently potentially all Finder pages may be indexed by search engines. The finder schemas have an update to include a `canonical_link` field. If `true`, a canonical link to the base finder path will be rendered, to prevent too much indexing.

[trello card](https://trello.com/c/SSiqQC1b/175-correct-indexing-for-the-finder-and-qa)

Update to schema: https://github.com/alphagov/govuk-content-schemas/pull/851