### PR TITLE
Allow caching the QA in Fastly and Varnish

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -1,6 +1,10 @@
 class QaController < ApplicationController
   layout "finder_layout"
 
+  before_action do
+    expires_in(5.minutes, public: true)
+  end
+
   def show
     redirect_to_finder if finder_page?
     raw_finder


### PR DESCRIPTION
Similar to what we've done to normal finders (https://github.com/alphagov/finder-frontend/pull/722) we want to set approriate cache headers on the QA tool allowing it to be cached by Fastly and Varnish.