### PR TITLE
Progressively disclose facets on mobile devices

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -25,6 +25,8 @@
     this.resultCountTemplate = this.setResultCountTemplate();
     this.getTaxonomyFacet().update();
 
+    this.$form.find('.js-toggle-progressive-disclosed-elements').on('click', this.toggleProgressivelyDisclosedFacets.bind(this))
+
     if(GOVUK.support.history()){
       this.saveState();
 
@@ -63,6 +65,10 @@
       return '_result_count';
     }
   };
+
+  LiveSearch.prototype.toggleProgressivelyDisclosedFacets = function toggleProgressivelyDisclosedFacets() {
+    this.$form.find('.js-progressively-disclosed-facets').toggle();
+  }
 
   LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet() {
     this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: $('.app-taxonomy-select') });

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -129,6 +129,21 @@
     }
   }
 
+  .progressive-disclosure {
+    display: none;
+
+    @include media(mobile) {
+      display: block;
+      margin-bottom: $gutter-two-thirds;
+    }
+  }
+
+  .progressively-disclosed {
+    @include media(mobile) {
+      display: none;
+    }
+  }
+
   .help-text {
     @include core-14;
     display:block;

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -9,6 +9,12 @@
     controls: "js-search-results-info"
   } if finder.show_keyword_search? %>
 
-  <%= render facet_collection.filters %>
+  <button type="button" class="gem-c-button govuk-button progressive-disclosure js-toggle-progressive-disclosed-elements">
+    More search options
+  </button>
+
+  <div class="progressively-disclosed js-progressively-disclosed-facets">
+      <%= render facet_collection.filters %>
+  </div>
   <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
 </div>


### PR DESCRIPTION
https://trello.com/c/HeKk9mpK/192-add-progressive-disclosure-to-facets-on-mobile

This will hide facets on mobile devices and display a toggle button.

Awaiting design/product review. Please see the Heroku application (and reduce screen size to mobile width to see effect).