### PR TITLE
Revert "Adds accessible autocomplete facet to finders"

### DIFF
--- a/app/assets/stylesheets/components/_date-filter.scss
+++ b/app/assets/stylesheets/components/_date-filter.scss
@@ -5,3 +5,8 @@
     margin-bottom: $gutter;
   }
 }
+
+.app-c-date-filter__help-text {
+  @include core-16;
+  display: block;
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -234,7 +234,7 @@
       margin: 0 0 $gutter-half 0;
 
       .result-count {
-        @include bold-27;
+        @include bold-48;
         margin-right: $gutter-one-third / 2;
       }
     }

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -3,15 +3,24 @@ class SelectFacet < FilterableFacet
     facet['allowed_values']
   end
 
-  def options
-    [["", ""]] + allowed_values.map { |allowed_value| [allowed_value['label'], allowed_value['value']] }
-  end
-
-  def data_attributes
-    {
-      track_category: "filterClicked",
-      track_action: key
-    }
+  def options(controls, key)
+    # NOTE: We use a symbol-based hash here unlike all our other hash
+    # data-structures because we pass this to a govuk_component partial
+    # that expects symbol keys, not strings
+    allowed_values.map do |allowed_value|
+      {
+        value: allowed_value['value'],
+        label: allowed_value['label'],
+        id: "#{key}-#{allowed_value['value']}",
+        data_attributes: {
+          track_category: "filterClicked",
+          track_action: name,
+          track_label: allowed_value['label'],
+        },
+        checked: selected_values.include?(allowed_value),
+        controls: controls || nil
+      }
+    end
   end
 
   def value=(new_value)
@@ -37,10 +46,8 @@ class SelectFacet < FilterableFacet
     selected_values.empty? && allowed_values.count > 10
   end
 
-  def selected_option
-    return nil unless selected_values.any?
-
-    selected_values.first.values
+  def unselected?
+    selected_values.empty?
   end
 
 private

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -1,6 +1,5 @@
 class ResultSetPresenter
   include ERB::Util
-  include ActionView::Helpers::NumberHelper
 
   attr_reader :finder, :document_noun, :results, :total
 
@@ -20,7 +19,7 @@ class ResultSetPresenter
 
   def to_hash
     {
-      total: number_with_delimiter(total, delimiter: ','),
+      total: total > 1000 ? "1,000+" : total,
       generic_description: generic_description,
       pluralised_document_noun: document_noun.pluralize(total),
       applied_filters: selected_filter_descriptions,
@@ -80,7 +79,7 @@ class ResultSetPresenter
 
     sort_option ||= finder.default_sort_option
 
-    "<span class='visually-hidden'>, sorted by <strong>" + sort_option['name'] + "</strong></span>" if sort_option.present?
+    "sorted by <strong>" + sort_option['name'] + "</strong>" if sort_option.present?
   end
 
 private

--- a/app/views/components/_date-filter.html.erb
+++ b/app/views/components/_date-filter.html.erb
@@ -15,7 +15,7 @@
       id: key + "[from]",
       value: from_value,
       controls: aria_controls_id,
-      hint: "For example, 2005 or 21/11/2014"
+      describedby: "date-help-text-" + key
     } %>
 
     <%= render "govuk_publishing_components/components/input", {
@@ -26,7 +26,11 @@
       id: key + "[to]",
       value: to_value,
       controls: aria_controls_id,
-      hint: "For example, 2005 or 21/11/2014"
+      describedby: "date-help-text-" + key
     } %>
+
+    <span id="date-help-text-<%= key %>" class="app-c-date-filter__help-text">
+      For example, 2005 or 21/11/2014
+    </span>
   </div>
 <% end %>

--- a/app/views/finders/_select_facet.html.erb
+++ b/app/views/finders/_select_facet.html.erb
@@ -1,9 +1,10 @@
-<%= render "govuk_publishing_components/components/accessible_autocomplete", {
-    id: select_facet.key,
-    label: {
-        text: select_facet.name
-    },
-    options: select_facet.options,
-    selected_option: select_facet.selected_option, # TODO: Make the component accept multiple
-    data_attributes: select_facet.data_attributes }
+<% close_facet = select_facet.unselected? && ((select_facet_counter > 0) || select_facet.close_facet?) %>
+<%= render partial: 'components/option-select', locals: {
+  :key => select_facet.key,
+  :title => select_facet.name,
+  :aria_controls_id => "js-search-results-info",
+  :options_container_id => select_facet.key,
+  :options => select_facet.options("js-search-results-info", select_facet.key),
+  :closed_on_load => close_facet,
+}
 %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -41,9 +41,9 @@ Feature: Filtering documents
     Given a collection of documents with bad metadata exist
     Then I can get a list of all documents with good metadata
 
-  Scenario: Visit a finder autocomplete
-    Given a finder with autocomplete exists
-    Then I can filter based on the results
+  Scenario: Visit a finder with dynamic filter
+    Given a finder with a dynamic filter exists
+    Then I can see filters based on the results
 
   Scenario: Visit a finder with paginated results
     Given a finder with paginated results exists

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -52,16 +52,6 @@
     ],
     "facets":[
       {
-        "filter_key": "all_part_of_taxonomy_tree",
-        "keys": ["level_one_taxon", "level_two_taxon"],
-        "name": "topic",
-        "short_name": "topic",
-        "type": "taxon",
-        "display_as_result_metadata": false,
-        "filterable": true,
-        "preposition": "about"
-      },
-      {
         "key": "related_to_brexit",
         "filter_key": "all_part_of_taxonomy_tree",
         "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
@@ -76,20 +66,30 @@
         "preposition": "about"
       },
       {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": ["level_one_taxon", "level_two_taxon"],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key": "people",
+        "name": "People",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": true
+      },
+      {
         "key": "organisations",
         "name": "Organisation",
         "short_name": "From",
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
-      },
-      {
-        "key": "people",
-        "name": "Person",
-        "preposition": "from",
-        "type": "text",
-        "display_as_result_metadata": false,
         "filterable": true
       },
       {

--- a/features/qa.feature
+++ b/features/qa.feature
@@ -12,7 +12,7 @@ Feature: QA
       Given I am answering a single answer question
       Then I should see a collection of radio buttons
       When I select a radio button
-      When I select a radio button
+      When I select another radio button
       When I submit my answer
       Then my options are persisted as url params
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -137,34 +137,18 @@ Then(/^I only see documents with matching dates$/) do
   assert_cma_cases_are_filtered_by_date
 end
 
-Given(/^a finder with autocomplete exists$/) do
+Given(/^a finder with a dynamic filter exists$/) do
   content_store_has_mosw_reports_finder
   stub_rummager_api_request
 end
 
-Then(/^I can filter based on the results$/) do
+Then(/^I can see filters based on the results$/) do
   visit finder_path('mosw-reports')
 
-  expect(page).to have_content("2 reports")
-  within ".filtered-results" do
-    expect(page).to have_content("West London wobbley walk")
-    expect(page).to have_content("The Gerry Anderson")
-  end
-
-  within first('.gem-c-accessible-autocomplete') do
-    expect(page).to have_selector('select#walk_type')
-    select("Hopscotch", from: "walk_type").select_option
-  end
-  click_on "Filter results"
-
-  within(".result-info") do
-    expect(page).to have_content("1 report")
-    expect(page).to have_content("Of Type")
-    expect(page).to have_content("Hopscotch")
-  end
-  within ".filtered-results" do
-    expect(page).not_to have_content("West London wobbley walk")
-    expect(page).to have_content("The Gerry Anderson")
+  within first('.app-c-option-select') do
+    expect(page).to have_selector('input#walk_type-backward')
+    expect(page).to have_content('Hopscotch')
+    expect(page).to_not have_selector('input#organisations-ministry-of-silly-walks')
   end
 end
 

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -23,7 +23,7 @@ Then /^I should see a collection of radio buttons/ do
   expect(page).to have_css('.govuk-radios')
 end
 
-When /^I select a radio button/ do
+When /^I select (.*?) radio button/ do |amount|
   button = find(:radio_button, checked: false, match: :first)
   button.set(true)
   @radio_params = "#{button[:name]}=#{button[:value]}"
@@ -37,8 +37,8 @@ When /^I select multiple checkboxes/ do
   @checkbox_params ||= ""
   checkboxes = find_all(:checkbox, visible: true)
   checkboxes.each do |ch|
-    ch.check
-    @checkbox_params << "#{ch[:name]}=#{ch[:value]}&"
+      ch.check
+      @checkbox_params << "#{ch[:name]}=#{ch[:value]}&"
   end
 end
 
@@ -67,6 +67,6 @@ Given /^I am answering the final question/ do
 end
 
 Then /^I am redirected to the finder results page/ do
-  finder_url = mock_qa_config['finder_base_path'] + '?'
+  finder_url = mock_qa_config['finder_base_path']+'?'
   expect(current_url).to match(finder_url)
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -134,7 +134,6 @@ Then(/^I am able to see organisations with abbreviations$/) do
   @results.each do |result|
     acronym = result.dig("organisations", 0, "acronym")
     next unless acronym
-
     org_title = result.dig('organisations', 0, 'title')
     if org_title != acronym
       within("ul.attributes li", text: acronym) do
@@ -148,7 +147,6 @@ Then(/^I am able to see organisations without abbreviations$/) do
   @results.each do |result|
     acronym = result.dig("organisations", 0, "acronym")
     next unless acronym
-
     org_title = result.dig('organisations', 0, 'title')
     if org_title == acronym
       within("ul.attributes li", text: acronym) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -73,7 +73,7 @@ module DocumentHelper
       .with(
         query: hash_including({})
       ).to_return(
-        body: aaib_reports_search_results
+         body: aaib_reports_search_results
       )
   end
 
@@ -171,14 +171,14 @@ module DocumentHelper
             "phase" => "live"
          }
         ]
-      }
-    )
+      })
 
-    content_store_has_item(
-      schema.fetch("base_path"),
-      schema.to_json,
-    )
-  end
+      content_store_has_item(
+        schema.fetch("base_path"),
+        schema.to_json,
+      )
+    end
+
 
   def stub_rummager_with_cma_cases
     stub_request(:get, rummager_all_cma_case_documents_url).to_return(
@@ -231,11 +231,11 @@ module DocumentHelper
       body: all_cma_case_documents_json,
     )
     cma_case_documents_filtered_by_supergroup = rummager_url(
-      cma_case_search_params.merge(
-        "filter_case_state" => %w(open),
-        "order" => "-public_timestamp"
-      )
-    )
+        cma_case_search_params.merge(
+            "filter_case_state" => %w(open),
+            "order" => "-public_timestamp"
+            )
+         )
 
     stub_request(:get, cma_case_documents_filtered_by_supergroup).to_return(
       body: filtered_cma_case_documents_json,

--- a/features/support/qa_helper.rb
+++ b/features/support/qa_helper.rb
@@ -17,7 +17,7 @@ module QAHelper
   end
 
   def mock_qa_config
-    @mock_qa_config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
+    @config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
   end
 
   def first_question
@@ -25,11 +25,13 @@ module QAHelper
   end
 
   def get_question_by_type(type)
-    mock_qa_config["pages"].select { |_key, value| value["question_type"] == type }.values.first['question']
+    mock_qa_config["pages"].select do |key, value|
+      value["question_type"] == type
+    end.values.first['question']
   end
 
   def get_page_number(question)
-    mock_qa_config["pages"].each_with_index do |(_key, value), index|
+    mock_qa_config["pages"].each_with_index do |(key, value), index|
       return index + 1 if value["question"] == question
     end
   end

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -79,8 +79,8 @@ module RummagerUrlHelper
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
-      organisations
       people
+      organisations
       world_locations
     )
   end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/spec/components/date_filter_spec.rb
+++ b/spec/components/date_filter_spec.rb
@@ -24,4 +24,17 @@ describe 'components/_date-filter.html.erb', type: :view do
     expect(rendered).to have_selector("input[name='key\[to\]'][value='user to']")
     expect(rendered).to have_selector("input[name='key\[from\]'][value='user from']")
   end
+
+  it "includes help text with unique ID based on key" do
+    render partial: 'components/date-filter', locals: { key: 'key', name: 'name' }
+
+    expect(rendered).to have_selector("#date-help-text-key")
+    expect(rendered).to have_selector("[aria-describedby='date-help-text-key']")
+  end
+
+  it "adds an id to the component based on key" do
+    render partial: 'components/date-filter', locals: { key: 'keyForId', name: 'name' }
+
+    expect(rendered).to have_selector(".app-c-date-filter#keyForId")
+  end
 end

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -1,5 +1,5 @@
 describe("liveSearch", function(){
-  var $form, $results, _supportHistory, liveSearch, $autocompleteForm;
+  var $form, $results, _supportHistory, liveSearch;
   var dummyResponse = {
     "total":1,
     "pluralised_document_noun":"reports",
@@ -108,7 +108,7 @@ describe("liveSearch", function(){
     liveSearch.updateResults();
     expect(jQuery.ajax).toHaveBeenCalledWith({url: '/somewhere.json', data: {not: "cached"}, searchState : 'not=cached'});
     expect(ajaxCallback.done).toHaveBeenCalled();
-    ajaxCallback.done.calls.mostRecent().args[0]('response data');
+    ajaxCallback.done.calls.mostRecent().args[0]('response data')
     expect(liveSearch.displayResults).toHaveBeenCalled();
     expect(liveSearch.resultCache['not=cached']).toBe('response data');
   });
@@ -122,7 +122,7 @@ describe("liveSearch", function(){
     spyOn(jQuery, 'ajax').and.returnValue(ajaxCallback);
 
     liveSearch.updateResults();
-    ajaxCallback.error.calls.mostRecent().args[0]();
+    ajaxCallback.error.calls.mostRecent().args[0]()
     expect(liveSearch.showErrorIndicator).toHaveBeenCalled();
   });
 
@@ -224,7 +224,7 @@ describe("liveSearch", function(){
       });
 
       it("should return the generic result count template", function () {
-        expect(liveSearch.setResultCountTemplate()).toEqual('_result_count_generic');
+        expect(liveSearch.setResultCountTemplate()).toEqual('_result_count_generic')
       });
     });
 
@@ -258,34 +258,34 @@ describe("liveSearch", function(){
 
   describe("restoreBooleans", function(){
     beforeEach(function(){
-      liveSearch.state = [{name:"list_1[]", value:"checkbox_1"}, {name:"list_1[]", value:"checkbox_2"}, {name:'list_2[]', value:"radio_1"}];
+      liveSearch.state = [{name:"list_1[]", value:"checkbox_1"}, {name:"list_1[]", value:"checkbox_2"}, {name:'list_2[]', value:"radio_1"}]
       liveSearch.$form = $('<form action="/somewhere" class="js-live-search-form"><input id="check_1" type="checkbox" name="list_1[]" value="checkbox_1"><input type="checkbox" id="check_2"  name="list_1[]" value="checkbox_2"><input type="radio" id="radio_1"  name="list_2[]" value="radio_1"><input type="radio" id="radio_2"  name="list_2[]" value="radio_2"><input type="submit"/></form>');
     });
 
     it("should check a checkbox if in the state it is checked in the history", function(){
-      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(0);
+      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(0)
       liveSearch.restoreBooleans();
-      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(2);
+      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(2)
     });
 
     it("should not check all the checkboxes if only one is checked", function(){
-      liveSearch.state = [{name:"list_1[]", value:"checkbox_2"}];
-      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(0);
+      liveSearch.state = [{name:"list_1[]", value:"checkbox_2"}]
+      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(0)
       liveSearch.restoreBooleans();
       expect(liveSearch.$form.find('input[type=checkbox]:checked')[0].id).toBe('check_2');
-      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(1);
+      expect(liveSearch.$form.find('input[type=checkbox]:checked').length).toBe(1)
     });
 
     it("should pick a radiobox if in the state it is picked in the history", function(){
-      expect(liveSearch.$form.find('input[type=radio]:checked').length).toBe(0);
+      expect(liveSearch.$form.find('input[type=radio]:checked').length).toBe(0)
       liveSearch.restoreBooleans();
-      expect(liveSearch.$form.find('input[type=radio]:checked').length).toBe(1);
+      expect(liveSearch.$form.find('input[type=radio]:checked').length).toBe(1)
     });
   });
 
   describe("restoreKeywords", function(){
     beforeEach(function(){
-       liveSearch.state = [{name:"text_1", value:"Monday"}];
+       liveSearch.state = [{name:"text_1", value:"Monday"}]
        liveSearch.$form = $('<form action="/somewhere"><input id="text_1" type="text" name="text_1"><input id="text_2" type="text" name="text_2"></form>');
      });
 
@@ -295,6 +295,6 @@ describe("liveSearch", function(){
        liveSearch.restoreTextInputs();
        expect(liveSearch.$form.find('#text_1').val()).toBe('Monday');
        expect(liveSearch.$form.find('#text_2').val()).toBe('');
-     });
+     })
   });
 });

--- a/spec/models/select_facet_spec.rb
+++ b/spec/models/select_facet_spec.rb
@@ -64,33 +64,54 @@ describe SelectFacet do
     end
   end
 
-  describe "#data_attributes" do
-    specify {
-      expect(subject.data_attributes[:track_category]).to eql('filterClicked')
-      expect(subject.data_attributes[:track_action]).to eql('test_values')
-    }
-  end
-
-
-  describe "#options" do
-    specify {
-      expect(subject.options).to eql([["", ""], ["Allowed value 1", "allowed-value-1"], ["Allowed value 2", "allowed-value-2"], %w(Remittals remittals)])
-    }
-  end
-
-  describe "#selected_options" do
-    before do
-      subject.value = value
+  describe "#close_facet?" do
+    context "small number of options" do
+      specify { expect(subject.close_facet?).to be false }
     end
 
+    context "large number of options" do
+      let(:allowed_values) {
+        11.times.map { |i| { 'label' => "Label #{i}", 'value' => "allowed-value-#{i}" } }
+      }
+
+      let(:large_facet_data) {
+        {
+          'type' => "multi-select",
+          'name' => "Test values",
+          'key' => "test_values",
+          'preposition' => "of value",
+          'allowed_values' => allowed_values,
+        }
+      }
+
+      subject { SelectFacet.new(large_facet_data) }
+
+      specify { expect(subject.close_facet?).to be true }
+    end
+  end
+
+  describe "#unselected?" do
     context "no selected values" do
-      let(:value) { [] }
-      specify { expect(subject.selected_option).to be_nil }
+      specify { expect(subject.unselected?).to be true }
     end
 
-    context "selected values" do
-      let(:value) { %w(allowed-value-1 allowed-value-2) }
-      specify { expect(subject.selected_option).to eql(["Allowed value 1", "allowed-value-1"]) }
+    context "some selected values" do
+      let(:facet_data) {
+        {
+          'type' => "multi-select",
+          'name' => "Test values",
+          'key' => "test_values",
+          'preposition' => "of value",
+          'allowed_values' => [{ 'label' => 'One', 'value' => '1' }],
+        }
+      }
+
+      subject { SelectFacet.new(facet_data) }
+
+      specify do
+        subject.value = "1"
+        expect(subject.unselected?).to be false
+      end
     end
   end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ResultSetPresenter do
     end
 
     it 'returns an appropriate hash' do
-      expect(presenter.to_hash[:total]).to eql(total.to_s)
+      expect(presenter.to_hash[:total]).to eql(total)
       expect(presenter.to_hash[:generic_description].present?).to be_truthy
       expect(presenter.to_hash[:pluralised_document_noun].present?).to be_truthy
       expect(presenter.to_hash[:documents].present?).to be_truthy


### PR DESCRIPTION
Reverts alphagov/finder-frontend#740

This should be reverted as removing filters does not work with autocomplete items.

Steps to reproduce:

1. Go to this link: https://www-origin.integration.publishing.service.gov.uk/aaib-reports?keywords=&aircraft_category=commercial-rotorcraft&report_type=&date_of_occurrence%5Bfrom%5D=&date_of_occurrence%5Bto%5D=
2. Click the 'X' next to the filter 'commercial - aircraft'