### PR TITLE
Fix Remove Filter function for Autocomplete items

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -16,8 +16,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var removeFilterValue = $(this).data('value');
       var removeFilterFacet = $(this).data('facet');
 
-      var inputSelector = getSelectorForInput(removeFilterName, removeFilterValue);
-      var $input = $('#' + removeFilterFacet).find(inputSelector);
+      var $input = $('#' + removeFilterFacet)
+
+      if (!$input.is('input')) {
+        var inputSelector = getSelectorForInput(removeFilterName, removeFilterValue);
+        $input = $input.find(inputSelector);
+      }
 
       var elementType = $input.prop('tagName');
       var inputType = $input.prop('type');
@@ -33,7 +37,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var currentVal = $input.val();
         var newVal = $.trim(currentVal.replace(removeFilterValue, ''));
 
-        $input.val(newVal).trigger('change');
+        $input.val("").trigger('change');
       }
       else if (elementType == 'OPTION') {
         $('#' + removeFilterFacet).val("").trigger('change');


### PR DESCRIPTION
There is an issue where filters selected from an autocomplete option
select [1] do not get removed when the user clicks on the remove icon.

This will fix that. It is caused by the weird way that autocomplete
works, in that there are two input/selects that a user changes when
they use the autocomplete component.

[1] https://github.com/alphagov/accessible-autocomplete