### PR TITLE
Fix remove filter on checkbox type facets

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -27,7 +27,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     function setInputState(elementType, inputType, $input, removeFilterValue, removeFilterFacet) {
       if (inputType == 'checkbox') {
-        $input.trigger('click');
+        $input.prop("checked", false);
+        $input.trigger('change');
       }
       else if (inputType == 'text' || inputType == 'search') {
         var currentVal = $input.val();


### PR DESCRIPTION
This issue is caused by the Checkbox module:
https://github.com/alphagov/govuk-frontend/blob/e41a9b39ccc8fff13fe64a09f868ce64a7e4d502/src/components/checkboxes/checkboxes.js#L44

This is the way that code works:

1. User adds filters via a checkbox
2. We display a tag element for that checkbox
3. User clicks on the tag element, to 'unclick' the checkbox.
4. This code listens for any click on the form, and is informed there has been a click. It then adds `govuk-checkboxes__conditional--hidden` to the results block, hiding it.

This is unintented behaviour and should be fixed there.

In the meantime, this performs the same operation but avoids usage
of click().