### PR TITLE
Add services finder

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,6 +31,9 @@
     },
     "NEWS_AND_COMMUNICATIONS_JSON": {
       "value": "features/fixtures/news_and_communications.json"
+    },
+    "SERVICES_JSON": {
+      "value": "features/fixtures/services.json"
     }
   },
   "image": "heroku/ruby",

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -29,6 +29,7 @@ private
 
   def development_env_finder_json
     return news_and_communications_json if is_news_and_communications?
+    return services_json if is_services?
 
     ENV["DEVELOPMENT_FINDER_JSON"]
   end
@@ -36,6 +37,11 @@ private
   def news_and_communications_json
     # Hard coding this in during development
     "features/fixtures/news_and_communications.json"
+  end
+
+  def services_json
+    # Hard coding this in during development
+    "features/fixtures/services.json"
   end
 
   def merge_and_deduplicate(search_response)
@@ -140,6 +146,10 @@ private
 
   def is_news_and_communications?
     base_path == "/news-and-communications"
+  end
+
+  def is_services?
+    base_path == "/services"
   end
 
   def registries

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -85,8 +85,18 @@ Feature: Filtering documents
       | Relevance        |
       | Updated (newest) |
       | Updated (oldest) |
+    When I view a list of services
+    Then I can sort by:
+      | A-Z         |
+      | Most viewed |
+      | Relevance   |
 
   Scenario: Sorting news and communications by most viewed
     When I view a list of news and communications
     And I sort by most viewed
     Then I see the most viewed articles first
+
+  Scenario: Sorting services A-Z
+    When I view a list of services
+    And I sort by A-Z
+    Then I see services in alphabetical order

--- a/features/fixtures/services.json
+++ b/features/fixtures/services.json
@@ -1,0 +1,70 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/services",
+  "content_id": "642caf21-e071-472e-9ea0-82d3c797dd64",
+  "content_purpose_document_supertype": "navigation",
+  "description": "Find services from government",
+  "details": {
+    "default_documents_per_page": 20,
+    "document_noun": "service",
+    "facets": [
+      {
+        "display_as_result_metadata": false,
+        "filter_key": "all_part_of_taxonomy_tree",
+        "filterable": true,
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
+        "name": "topic",
+        "preposition": "about",
+        "short_name": "topic",
+        "type": "taxon"
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "organisations",
+        "name": "Organisation",
+        "preposition": "from",
+        "short_name": "From",
+        "type": "text"
+      }
+    ],
+    "filter": {
+      "content_purpose_supergroup": "services"
+    },
+    "show_summaries": true,
+    "sort": [
+      {
+        "key": "-title",
+        "name": "A-Z"
+      },
+      {
+        "default": true,
+        "key": "-popularity",
+        "name": "Most viewed"
+      },
+      {
+        "key": "-relevance",
+        "name": "Relevance"
+      }
+    ]
+  },
+  "document_type": "finder",
+  "email_document_supertype": "other",
+  "first_published_at": "2019-01-15T13:00:00.000+00:00",
+  "government_document_supertype": "other",
+  "links": {},
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "phase": "alpha",
+  "public_updated_at": "2019-01-15T13:00:00.000+00:00",
+  "publishing_app": "finder-frontend",
+  "rendering_app": "finder-frontend",
+  "schema_name": "finder",
+  "search_user_need_document_supertype": "government",
+  "title": "Services",
+  "updated_at": "2019-01-15T13:00:00.000+00:00",
+  "user_journey_document_supertype": "finding"
+}

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -52,6 +52,14 @@ When(/^I view a list of news and communications$/) do
   visit finder_path('news-and-communications')
 end
 
+When(/^I view a list of services$/) do
+  topic_taxonomy_has_taxons
+  content_store_has_services_finder
+  stub_rummager_api_request_with_services_results
+
+  visit finder_path('services')
+end
+
 When(/^I search documents by keyword$/) do
   stub_keyword_search_api_request
 
@@ -294,6 +302,11 @@ When(/^I sort by most viewed$/) do
   click_on 'Filter results'
 end
 
+When(/^I sort by A-Z$/) do
+  select 'A-Z', from: 'Sort by'
+  click_on 'Filter results'
+end
+
 Then(/^I see the most viewed articles first$/) do
   within '.filtered-results .document:nth-child(1)' do
     expect(page).to have_content('Press release from Hogwarts')
@@ -305,4 +318,16 @@ Then(/^I see the most viewed articles first$/) do
   end
 
   expect(page).to have_content('sorted by Most viewed')
+end
+
+Then(/^I see services in alphabetical order$/) do
+  within '.filtered-results .document:nth-child(1)' do
+    expect(page).to have_content('Apply for your full broomstick licence')
+  end
+
+  within '.filtered-results .document:nth-child(2)' do
+    expect(page).to have_content('Register a magical spell')
+  end
+
+  expect(page).to have_content('sorted by A-Z')
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -53,6 +53,14 @@ module DocumentHelper
       .to_return(body: popular_news_and_communication_json)
   end
 
+  def stub_rummager_api_request_with_services_results
+    stub_request(:get, rummager_alphabetical_services_url)
+      .to_return(body: alpabetical_services_json)
+
+    stub_request(:get, rummager_popular_services_url)
+      .to_return(body: popular_services_json)
+  end
+
   def stub_rummager_api_request_with_no_results
     stub_request(:get, rummager_0_documents_url)
       .to_return(body: %|{ "results": [], "total": 0, "start": 0}|)
@@ -109,6 +117,12 @@ module DocumentHelper
       base_path,
       govuk_content_schema_example('finder').merge('base_path' => base_path).to_json
     )
+  end
+
+  def content_store_has_services_finder
+    finder_fixture = File.read(Rails.root.join('features/fixtures/services.json'))
+
+    content_store_has_item('/services', finder_fixture)
   end
 
   def content_store_has_government_finder_with_10_items
@@ -321,6 +335,30 @@ module DocumentHelper
           'count' => 20,
           'start' => 0,
         )
+    )
+  end
+
+  def rummager_popular_services_url
+    rummager_url(
+      services_search_params
+        .merge(
+          'facet_organisations' => '1500,order:value.title',
+          'order' => '-popularity',
+          'count' => 20,
+          'start' => 0,
+          )
+    )
+  end
+
+  def rummager_alphabetical_services_url
+    rummager_url(
+      services_search_params
+        .merge(
+          'facet_organisations' => '1500,order:value.title',
+          'order' => '-title',
+          'count' => 20,
+          'start' => 0,
+          )
     )
   end
 
@@ -882,6 +920,206 @@ module DocumentHelper
                     "title": "Azkaban",
                     "content_id": "db3c2a86-2060-4c37-b8a4-9e3c4e6c91e2",
                     "link": "/world/azkaban"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            }
+          },
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def alpabetical_services_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Apply for your full broomstick licence",
+              "link": "apply-for-your-full-broomstick-licence",
+              "description": "How to get your full broomstick licence once you've passed your broomstick test",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/news-from-hogwarts",
+              "elasticsearch_type": "transaction",
+              "document_type": "transaction"
+            },
+            {
+              "title": "Register a spell",
+              "link": "/register-a-spell",
+              "description": "Register a magical spell",
+              "public_timestamp": "2017-12-25T09:00:00Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/register-a-spell",
+              "elasticsearch_type": "transaction",
+              "document_type": "transaction"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {
+            "organisations": {
+              "options": [
+                {
+                  "value": {
+                    "organisation_brand": "ministry-of-magic",
+                    "logo_formatted_title": "Ministry of Magic",
+                    "organisation_crest": "single-identity",
+                    "title": "Ministry of Magic",
+                    "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                    "link": "/organisations/academy-for-social-justice-commissioning",
+                    "analytics_identifier": "MM1",
+                    "slug": "ministry-of-magic",
+                    "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                    "organisation_type": "other",
+                    "organisation_state": "live"
+                  },
+                  "documents": 2
+                }
+              ],
+              "documents_with_no_value": 0,
+              "total_options": 2,
+              "missing_options": 0,
+              "scope": "exclude_field_filter"
+            }
+          },
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def popular_services_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Register a spell",
+              "link": "/register-a-spell",
+              "description": "Register a magical spell",
+              "public_timestamp": "2017-12-25T09:00:00Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/register-a-spell",
+              "elasticsearch_type": "transaction",
+              "document_type": "transaction"
+            },
+            {
+              "title": "Apply for your full broomstick licence",
+              "link": "apply-for-your-full-broomstick-licence",
+              "description": "How to get your full broomstick licence once you've passed your broomstick test",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "4bc72a8b-6011-457a-87e0-06dbb427cf36"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/news-from-hogwarts",
+              "elasticsearch_type": "transaction",
+              "document_type": "transaction"
+            }
+          ],
+          "total": 2,
+          "start": 0,
+          "facets": {
+            "organisations": {
+              "options": [
+                {
+                  "value": {
+                    "organisation_brand": "ministry-of-magic",
+                    "logo_formatted_title": "Ministry of Magic",
+                    "organisation_crest": "single-identity",
+                    "title": "Ministry of Magic",
+                    "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                    "link": "/organisations/academy-for-social-justice-commissioning",
+                    "analytics_identifier": "MM1",
+                    "slug": "ministry-of-magic",
+                    "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                    "organisation_type": "other",
+                    "organisation_state": "live"
                   },
                   "documents": 2
                 }

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -76,12 +76,42 @@ module RummagerUrlHelper
     )
   end
 
+  def services_search_params
+    supergroup_document_types = %w(
+      answer
+      calculator
+      completed_transaction
+      form
+      guide
+      licence
+      local_transaction
+      place
+      simple_smart_answer
+      smart_answer
+      step_by_step_nav
+      transaction
+    )
+
+    base_search_params.merge(
+      'fields' => services_search_fields.join(','),
+      'filter_content_store_document_type' => supergroup_document_types,
+      'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
+      )
+  end
+
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
       people
       organisations
       world_locations
+    )
+  end
+
+  def services_search_fields
+    base_search_fields + %w(
+      part_of_taxonomy_tree
+      organisations
     )
   end
 


### PR DESCRIPTION
This adds a finder for all content that belongs to the services content purpose supergroup.

See https://trello.com/c/tnXEduxo
Review app https://finder-frontend-pr-783.herokuapp.com/services

![services - gov uk 2019-01-16 11-00-46](https://user-images.githubusercontent.com/2715/51244870-0f9c8380-197e-11e9-9af3-317cee43b413.png)
