### PR TITLE
Add default preposition

### DIFF
--- a/app/models/filterable_facet.rb
+++ b/app/models/filterable_facet.rb
@@ -1,8 +1,10 @@
 class FilterableFacet < Facet
   attr_accessor :value
 
+  DEFAULT_PREPOSITION = 'related to'.freeze
+
   def preposition
-    facet['preposition']
+    facet['preposition'] || DEFAULT_PREPOSITION
   end
 
   def to_partial_path

--- a/spec/models/filterable_facet_spec.rb
+++ b/spec/models/filterable_facet_spec.rb
@@ -23,4 +23,21 @@ describe FilterableFacet do
       specify { expect(subject.to_partial_path).to eql("example_facet") }
     end
   end
+
+  describe '#preposition' do
+    let(:default_preposition) {
+      facet_class.new(
+        'key' => "test_facet",
+        'name' => "Facet without preposition"
+      )
+    }
+
+    it "has a default preposition" do
+      expect(default_preposition.preposition).to eq('related to')
+    end
+
+    it "has a preposition specified in the facet content" do
+      expect(subject.preposition).to eq(facet_data['preposition'])
+    end
+  end
 end


### PR DESCRIPTION
This will allow no preposition to be set, which some finder content items don't have.

This is in response to "undefined method `titlecase' for nil:NilClass" errors that we're seeing on staging which is caused by missing prepositions.