### PR TITLE
Fix advanced search keyword facet

### DIFF
--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -10,7 +10,9 @@ class KeywordFacet
       'key' => key,
       'preposition' => 'containing',
       'values' => value_fragments,
-      'word_connectors' => {}
+      'word_connectors' => {
+        words_connector: ''
+      }
     }
   end
 

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -17,6 +17,8 @@ describe KeywordFacet do
         expect(first_word['parameter_key']).to eql("keywords")
         expect(first_word['label']).to eql("Happy")
         expect(second_word['label']).to eql("Christmas")
+
+        expect(subject.sentence_fragment['word_connectors'][:words_connector]).to eql("")
       }
     end
 


### PR DESCRIPTION
This ensures that we can perform multiple word keyword searches
in advanced search. The error would occur because there was
no word connector specified for the keyword facet.

Related error:
https://sentry.io/govuk/app-finder-frontend/issues/846706923/

We checked other facets and it looks like this is the only one to have no word connector set.