### PR TITLE
Finder for Research and Statistics supergroup

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,18 +28,6 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
-    },
-    "ALL_CONTENT_JSON": {
-      "value": "features/fixtures/all_content.json"
-    },
-    "NEWS_AND_COMMUNICATIONS_JSON": {
-      "value": "features/fixtures/news_and_communications.json"
-    },
-    "SERVICES_JSON": {
-      "value": "features/fixtures/services.json"
-    },
-    "TRANSPARENCY_AND_FREEDOM_OF_INFORMATION_RELEASES": {
-      "value": "features/fixtures/transparency_and_freedom_of_information_releases.json"
     }
   },
   "image": "heroku/ruby",

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -127,6 +127,10 @@
       @include core-16;
       margin-bottom: $gutter;
     }
+
+    .govuk-select {
+      width: 100%;
+    }
   }
 
   .help-text {
@@ -140,12 +144,6 @@
 
   .app-c-option-select {
     margin-bottom: $gutter;
-  }
-
-  .app-taxonomy-select {
-    .govuk-select {
-      width: 100%;
-    }
   }
 
   .radio-filter {

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -26,6 +26,7 @@ private
       'date' => Filters::DateFilter,
       'hidden' => Filters::HiddenFilter,
       'text' => Filters::TextFilter,
+      'dropdown_select' => Filters::DropdownSelectFilter,
       'topical' => Filters::TopicalFilter,
       'taxon' => Filters::TaxonFilter,
     }.fetch(facet['type'])

--- a/app/lib/filters/dropdown_select_filter.rb
+++ b/app/lib/filters/dropdown_select_filter.rb
@@ -1,0 +1,17 @@
+module Filters
+  class DropdownSelectFilter < Filter
+    def value
+      Array(parsed_value)
+    end
+
+  private
+
+    def parsed_value
+      return unless params.present?
+
+      JSON.parse params
+    rescue JSON::ParserError
+      params
+    end
+  end
+end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -27,35 +27,6 @@ private
     end
   end
 
-  def development_env_finder_json
-    return all_content_json if is_all_content?
-    return news_and_communications_json if is_news_and_communications?
-    return services_json if is_services?
-    return transparency_and_freedom_of_information_releases_json if is_transparency_and_freedom_of_information_releases?
-
-    ENV["DEVELOPMENT_FINDER_JSON"]
-  end
-
-  def all_content_json
-    # Hard coding this in during development
-    "features/fixtures/all_content.json"
-  end
-
-  def news_and_communications_json
-    # Hard coding this in during development
-    "features/fixtures/news_and_communications.json"
-  end
-
-  def services_json
-    # Hard coding this in during development
-    "features/fixtures/services.json"
-  end
-
-  def transparency_and_freedom_of_information_releases_json
-    # Hard coding this in during development
-    "features/fixtures/transparency_and_freedom_of_information_releases.json"
-  end
-
   def merge_and_deduplicate(search_response)
     results = search_response.fetch("results")
 
@@ -156,20 +127,27 @@ private
     SearchQueryBuilder
   end
 
-  def is_all_content?
-    base_path == "/all-content"
+  FINDERS_IN_DEVELOPMENT = {
+    "/news-and-communications" => "news_and_communications",
+    "/statistics" => "statistics",
+    "/services" => "services",
+    "/transparency-and-freedom-of-information-releases" => "transparency_and_freedom_of_information_releases",
+    "/all-content" => "all_content",
+  }.freeze
+
+  def development_env_finder_json
+    return development_json if is_development_json?
+
+    ENV["DEVELOPMENT_FINDER_JSON"]
   end
 
-  def is_news_and_communications?
-    base_path == "/news-and-communications"
+  def development_json
+    # Hard coding this in during development
+    "features/fixtures/#{FINDERS_IN_DEVELOPMENT[base_path]}.json"
   end
 
-  def is_services?
-    base_path == "/services"
-  end
-
-  def is_transparency_and_freedom_of_information_releases?
-    base_path == "/transparency-and-freedom-of-information-releases"
+  def is_development_json?
+    base_path.present? && FINDERS_IN_DEVELOPMENT[base_path].present?
   end
 
   def registries

--- a/app/models/dropdown_select_facet.rb
+++ b/app/models/dropdown_select_facet.rb
@@ -1,6 +1,4 @@
 class DropdownSelectFacet < FilterableFacet
-  attr_writer :value
-
   def allowed_values
     facet['allowed_values']
   end
@@ -29,6 +27,10 @@ class DropdownSelectFacet < FilterableFacet
     }
   end
 
+  def has_filters?
+    selected_value.any?
+  end
+
 private
 
   def value_fragment
@@ -39,10 +41,14 @@ private
   end
 
   def selected_value
-    return {} if @value.nil?
+    return default_value if @value.nil?
 
     allowed_values.find { |option|
       @value == option['value']
     } || {}
+  end
+
+  def default_value
+    allowed_values.find { |option| option['default'] } || {}
   end
 end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -8,12 +8,16 @@ module FacetParser
         TopicalFacet.new(facet)
       when 'taxon'
         TaxonFacet.new(facet)
+      when 'link'
+        LinkFacet.new(facet)
       when 'date'
         DateFacet.new(facet)
       when 'hidden'
         HiddenFacet.new(facet)
       when 'checkbox'
         CheckboxFacet.new(facet)
+      when 'dropdown_select'
+        DropdownSelectFacet.new(facet)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet.type}")
       end

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -1,0 +1,116 @@
+{
+  "analytics_identifier":null,
+  "base_path":"/statistics",
+  "content_id":"8f827d53-9ad1-4b90-b6ae-2301c1ecdf02",
+  "content_purpose_document_supertype":"navigation",
+  "document_type":"finder",
+  "email_document_supertype":"other",
+  "first_published_at":"2019-01-15T14:47:48.000+00:00",
+  "government_document_supertype":"other",
+  "locale":"en",
+  "navigation_document_supertype":"other",
+  "phase":"alpha",
+  "public_updated_at":"2019-01-15T14:47:48.000+00:00",
+  "publishing_app":"finder-frontend",
+  "rendering_app":"finder-frontend",
+  "schema_name":"finder",
+  "search_user_need_document_supertype":"government",
+  "title":"Statistics",
+  "updated_at":"2019-01-15T14:47:48.000+00:00",
+  "user_journey_document_supertype":"finding",
+  "withdrawn_notice":{},
+  "publishing_request_id":"",
+  "links":{},
+  "description":"Find statistics from government",
+  "details":{
+    "document_noun":"statistic",
+    "filter":{
+    },
+    "format_name":"statistic",
+    "show_summaries":true,
+    "sort": [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
+        "name": "Updated (newest)",
+        "key": "-public_timestamp",
+        "default": true
+      },
+      {
+        "name": "Updated (oldest)",
+        "key": "public_timestamp"
+      },
+      {
+        "name": "Release date (latest)",
+        "key": "-release_timestamp"
+      },
+      {
+        "name": "Release date (oldest)",
+        "key": "release_timestamp"
+      }
+    ],
+    "facets":[
+      {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": ["level_one_taxon", "level_two_taxon"],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "From",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key":"content_store_document_type",
+        "name":"Statistics",
+        "type":"dropdown_select",
+        "display_as_result_metadata":false,
+        "filterable":true,
+        "preposition": "that are",
+        "allowed_values": [
+          {
+            "text": "Published",
+            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]",
+            "default": true
+          },
+          {
+            "text": "Upcoming",
+            "value": "[\"statistics_announcement\",\"national_statistics_announcement\",\"official_statistics_announcement\"]"
+          }
+        ]
+      },
+      {
+        "key": "public_timestamp",
+        "short_name": "Updated",
+        "name": "Updated",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page":20
+  }
+}


### PR DESCRIPTION
This adds a research and statistics finder representing the research_and_statistics supergroup [1].

This JSON has not been published as a content item yet, so are only available for development for now and will be published later (and removed from here) like the news and communications JSON

Trello link [3]

[1] https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml#L568
[2] https://www.gov.uk/government/statistics
[3] https://trello.com/c/h026plmk/201-create-finder-for-research-and-statistics-supergroup