### PR TITLE
Add transparency and freedom of information releases finder

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,6 +34,9 @@
     },
     "SERVICES_JSON": {
       "value": "features/fixtures/services.json"
+    },
+    "TRANSPARENCY_AND_FREEDOM_OF_INFORMATION_RELEASES": {
+      "value": "features/fixtures/transparency_and_freedom_of_information_releases.json"
     }
   },
   "image": "heroku/ruby",

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -30,6 +30,7 @@ private
   def development_env_finder_json
     return news_and_communications_json if is_news_and_communications?
     return services_json if is_services?
+    return transparency_and_freedom_of_information_releases_json if is_transparency_and_freedom_of_information_releases?
 
     ENV["DEVELOPMENT_FINDER_JSON"]
   end
@@ -42,6 +43,11 @@ private
   def services_json
     # Hard coding this in during development
     "features/fixtures/services.json"
+  end
+
+  def transparency_and_freedom_of_information_releases_json
+    # Hard coding this in during development
+    "features/fixtures/transparency_and_freedom_of_information_releases.json"
   end
 
   def merge_and_deduplicate(search_response)
@@ -150,6 +156,10 @@ private
 
   def is_services?
     base_path == "/services"
+  end
+
+  def is_transparency_and_freedom_of_information_releases?
+    base_path == "/transparency-and-freedom-of-information-releases"
   end
 
   def registries

--- a/features/fixtures/transparency_and_freedom_of_information_releases.json
+++ b/features/fixtures/transparency_and_freedom_of_information_releases.json
@@ -1,0 +1,90 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/transparency-and-freedom-of-information-releases",
+  "content_id": "9d21cee6-990b-4e87-b254-cada0e2ec4db",
+  "content_purpose_document_supertype": "navigation",
+  "description": "Find transparency and freedom of information releases from government",
+  "details": {
+    "default_documents_per_page": 20,
+    "document_noun": "release",
+    "facets": [
+      {
+        "display_as_result_metadata": false,
+        "filter_key": "all_part_of_taxonomy_tree",
+        "filterable": true,
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
+        "name": "topic",
+        "preposition": "about",
+        "short_name": "topic",
+        "type": "taxon"
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "organisations",
+        "name": "Organisation",
+        "preposition": "from",
+        "short_name": "From",
+        "type": "text"
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text"
+      },
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "public_timestamp",
+        "name": "Updated",
+        "short_name": "Updated",
+        "type": "date"
+      }
+    ],
+    "filter": {
+      "content_purpose_supergroup": "transparency"
+    },
+    "show_summaries": true,
+    "sort": [
+      {
+        "key": "-popularity",
+        "name": "Most viewed"
+      },
+      {
+        "key": "-relevance",
+        "name": "Relevance"
+      },
+      {
+        "default": true,
+        "key": "-public_timestamp",
+        "name": "Updated (newest)"
+      },
+      {
+        "key": "public_timestamp",
+        "name": "Updated (oldest)"
+      }
+    ]
+  },
+  "document_type": "finder",
+  "email_document_supertype": "other",
+  "first_published_at": "2019-01-16T11:00:00.000+00:00",
+  "government_document_supertype": "other",
+  "links": {},
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "phase": "alpha",
+  "public_updated_at": "2019-01-16T11:00:00.000+00:00",
+  "publishing_app": "finder-frontend",
+  "rendering_app": "finder-frontend",
+  "schema_name": "finder",
+  "search_user_need_document_supertype": "government",
+  "title": "Transparency and freedom of information releases",
+  "updated_at": "2019-01-16T11:00:00.000+00:00",
+  "user_journey_document_supertype": "finding"
+}


### PR DESCRIPTION
Adds a finder displaying all content that has a content purpose supergroup of transparency.

![transparency and freedom of information releases - gov uk 2019-01-17 13-51-07](https://user-images.githubusercontent.com/2715/51323026-fcadb000-1a5e-11e9-8970-82964ca04816.png)

See https://trello.com/c/PQR2hDK1
Review https://finder-frontend-pr-790.herokuapp.com/transparency-and-freedom-of-information-releases