### PR TITLE
Track page views of cached pages

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -102,13 +102,18 @@
         function(){
           var newPath = window.location.pathname + "?" + $.param(this.state);
           history.pushState(this.state, '', newPath);
-          if (this.canTrackPageview()) {
-            GOVUK.analytics.trackPageview(newPath);
-          }
         }.bind(this)
       )
     }
+    this.trackPageView();
   };
+
+  LiveSearch.prototype.trackPageView = function trackPageView() {
+    if (this.canTrackPageview()) {
+      var newPath = window.location.pathname + "?" + $.param(this.state);
+      GOVUK.analytics.trackPageview(newPath);
+    }
+  }
 
   LiveSearch.prototype.fireTextAnalyticsEvent = function(event) {
     if (this.canTrackPageview()) {


### PR DESCRIPTION
Currently we dont fire a GA pageView event when displaying a cached
result set. For performance analyses we want to track page views
every time the form changes, regardless of whether a request is sent.