### PR TITLE
Frontend changes to finders

### DIFF
--- a/app/assets/stylesheets/components/_date-filter.scss
+++ b/app/assets/stylesheets/components/_date-filter.scss
@@ -5,8 +5,3 @@
     margin-bottom: $gutter;
   }
 }
-
-.app-c-date-filter__help-text {
-  @include core-16;
-  display: block;
-}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -234,7 +234,7 @@
       margin: 0 0 $gutter-half 0;
 
       .result-count {
-        @include bold-48;
+        @include bold-27;
         margin-right: $gutter-one-third / 2;
       }
     }

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -80,7 +80,7 @@ class ResultSetPresenter
 
     sort_option ||= finder.default_sort_option
 
-    "sorted by <strong>" + sort_option['name'] + "</strong>" if sort_option.present?
+    "<span class='visually-hidden'>sorted by <strong>" + sort_option['name'] + "</strong></span>" if sort_option.present?
   end
 
 private

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -1,5 +1,6 @@
 class ResultSetPresenter
   include ERB::Util
+  include ActionView::Helpers::NumberHelper
 
   attr_reader :finder, :document_noun, :results, :total
 
@@ -19,7 +20,7 @@ class ResultSetPresenter
 
   def to_hash
     {
-      total: total > 1000 ? "1,000+" : total,
+      total: number_with_delimiter(total),
       generic_description: generic_description,
       pluralised_document_noun: document_noun.pluralize(total),
       applied_filters: selected_filter_descriptions,

--- a/app/views/components/_date-filter.html.erb
+++ b/app/views/components/_date-filter.html.erb
@@ -15,7 +15,7 @@
       id: key + "[from]",
       value: from_value,
       controls: aria_controls_id,
-      describedby: "date-help-text-" + key
+      hint: "For example, 2005 or 21/11/2014"
     } %>
 
     <%= render "govuk_publishing_components/components/input", {
@@ -26,11 +26,7 @@
       id: key + "[to]",
       value: to_value,
       controls: aria_controls_id,
-      describedby: "date-help-text-" + key
+      hint: "For example, 2005 or 21/11/2014"
     } %>
-
-    <span id="date-help-text-<%= key %>" class="app-c-date-filter__help-text">
-      For example, 2005 or 21/11/2014
-    </span>
   </div>
 <% end %>

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -52,6 +52,16 @@
     ],
     "facets":[
       {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "keys": ["level_one_taxon", "level_two_taxon"],
+        "name": "topic",
+        "short_name": "topic",
+        "type": "taxon",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about"
+      },
+      {
         "key": "related_to_brexit",
         "filter_key": "all_part_of_taxonomy_tree",
         "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
@@ -66,14 +76,13 @@
         "preposition": "about"
       },
       {
-        "filter_key": "all_part_of_taxonomy_tree",
-        "keys": ["level_one_taxon", "level_two_taxon"],
-        "name": "topic",
-        "short_name": "topic",
-        "type": "taxon",
-        "display_as_result_metadata": false,
-        "filterable": true,
-        "preposition": "about"
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "From",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
       },
       {
         "key": "people",
@@ -81,15 +90,6 @@
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": false,
-        "filterable": true
-      },
-      {
-        "key": "organisations",
-        "name": "Organisation",
-        "short_name": "From",
-        "preposition": "from",
-        "type": "text",
-        "display_as_result_metadata": true,
         "filterable": true
       },
       {

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -102,8 +102,8 @@ module RummagerUrlHelper
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
-      people
       organisations
+      people
       world_locations
     )
   end

--- a/spec/components/date_filter_spec.rb
+++ b/spec/components/date_filter_spec.rb
@@ -24,17 +24,4 @@ describe 'components/_date-filter.html.erb', type: :view do
     expect(rendered).to have_selector("input[name='key\[to\]'][value='user to']")
     expect(rendered).to have_selector("input[name='key\[from\]'][value='user from']")
   end
-
-  it "includes help text with unique ID based on key" do
-    render partial: 'components/date-filter', locals: { key: 'key', name: 'name' }
-
-    expect(rendered).to have_selector("#date-help-text-key")
-    expect(rendered).to have_selector("[aria-describedby='date-help-text-key']")
-  end
-
-  it "adds an id to the component based on key" do
-    render partial: 'components/date-filter', locals: { key: 'keyForId', name: 'name' }
-
-    expect(rendered).to have_selector(".app-c-date-filter#keyForId")
-  end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ResultSetPresenter do
     end
 
     it 'returns an appropriate hash' do
-      expect(presenter.to_hash[:total]).to eql(total)
+      expect(presenter.to_hash[:total]).to eql(total.to_s)
       expect(presenter.to_hash[:generic_description].present?).to be_truthy
       expect(presenter.to_hash[:pluralised_document_noun].present?).to be_truthy
       expect(presenter.to_hash[:documents].present?).to be_truthy


### PR DESCRIPTION
Makes a few frontend adjustments to the finders, specifically:

- reduces size of results number (was too big, matched H1)
- make results number show actual number of results, not "1,000+"
- reorder the facets to improve ease of use
- hide the 'sorted by' facet display from sighted users but not screen readers (sighted users can see what they've selected, screen reader users have the visuallyhidden text announced to them when they change the sort option)
- update the date facets to use components, improving the position of the hint text and the spacing in general

Trello card: https://trello.com/c/oKo6gvZw/190-make-frontend-changes-to-news-and-comms-finder-following-review

Example urls:

- https://finder-frontend-pr-799.herokuapp.com/administrative-appeals-tribunal-decisions
- https://finder-frontend-pr-799.herokuapp.com/news-and-communications

Some of these changes apply to the news and communications finder, which isn't live yet, so the screenshots below aren't brilliant examples, sorry.

Before:

![screen shot 2019-01-18 at 14 01 45](https://user-images.githubusercontent.com/861310/51391325-ac4f5480-1b29-11e9-8eee-40721e6b5fb6.png)

After:

![screen shot 2019-01-18 at 14 02 04](https://user-images.githubusercontent.com/861310/51391329-afe2db80-1b29-11e9-9b57-13554cd941df.png)

