### PR TITLE
Fix bug with checkbox facet and facet tags

### DIFF
--- a/app/views/finders/_checkbox_facet.html.erb
+++ b/app/views/finders/_checkbox_facet.html.erb
@@ -9,7 +9,7 @@
         id: checkbox_facet.id,
         checked: checkbox_facet.is_checked?,
         data_attributes: checkbox_facet.data,
-        controls: "js-search-results-info"
+        aria_controls_id: "js-search-results-info"
       }
     ]
   } %>


### PR DESCRIPTION
This PR fixes a bug which causes the facet tags to disappear if the following are performed in order (more cases are avaiable, this is an example):

- Choose a topic
- Filter by content related to Brexit only by clicking on checkbox
- Remove content related to Brexit only filter by clicking on checkbox

Once here, the facet tags and the number of results will disappear, even though a) the topic facet tag is still present and b) there are only a subset of results available.

The checkbox facet partial was using `controls` - this should instead be `aria_controls_id`, as is the case with all of the other facet partials.

**Before:**

Initial load
<img width="986" alt="screen shot 2019-01-18 at 16 33 46" src="https://user-images.githubusercontent.com/5422487/51400427-4de1a080-1b40-11e9-95e1-649191763932.png">

Selecting a topic

<img width="991" alt="screen shot 2019-01-18 at 16 34 13" src="https://user-images.githubusercontent.com/5422487/51400428-4de1a080-1b40-11e9-9f14-b60a7b23dcd8.png">

Selecting Brexit only results

<img width="1012" alt="screen shot 2019-01-18 at 16 34 23" src="https://user-images.githubusercontent.com/5422487/51400429-4de1a080-1b40-11e9-97b7-afb50527bb8e.png">

Removing Brexit only results

<img width="989" alt="screen shot 2019-01-18 at 16 34 36" src="https://user-images.githubusercontent.com/5422487/51400430-4de1a080-1b40-11e9-9c1e-3e7e199aecdf.png">

You can see here that facet tags have disappeared entirely, but the topic facet tag still persists and the results are still filtered by this.

**After**

Removing Brexit only results - now the facet tags are correctly displayed

<img width="991" alt="screen shot 2019-01-18 at 16 42 40" src="https://user-images.githubusercontent.com/5422487/51400431-4de1a080-1b40-11e9-8d04-f0c1ce0ac6b4.png">


Solo: @karlbaker02