### PR TITLE
[wip] Use subscription component for email link

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -14,8 +14,8 @@
     this.$countBlock = options.$results.find('#js-search-results-info');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
-    this.$emailLink = $("p.email-link a");
 
+    this.$emailLink = $(".gem-c-subscription-links a");
     this.emailSignupHref = this.$emailLink.attr('href');
 
     this.$orderSelect = this.$form.find('.js-order-results');
@@ -78,6 +78,9 @@
 
     this.$emailLink.attr(
       'href', this.emailSignupHref + "?" + $.param(this.state)
+    );
+    this.$emailLink.attr(
+      'data-track-action', this.emailSignupHref + "?" + $.param(this.state)
     );
   };
 

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -17,12 +17,6 @@
     <div class="title-and-metadata">
       <%= finder.taxon_link %>
       <%= render partial: 'govuk_publishing_components/components/title', locals: { title: finder.title, inverse: true } %>
-
-      <% if finder.email_alert_signup_url %>
-        <p class='email-link'>
-          <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
-        </p>
-      <% end %>
     </div>
 
     <% if finder.logo_path %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -38,9 +38,16 @@
     <% end %>
 
     <% if finder.email_alert_signup_url %>
-      <p class='email-link'>
-        <%= link_to "Subscribe to email alerts", finder.email_alert_signup_url %>
-      </p>
+      <%= render "govuk_publishing_components/components/subscription-links", {
+        email_signup_link: finder.email_alert_signup_url,
+        email_signup_link_text: "Subscribe to email alerts",
+        email_signup_link_data_attributes: {
+          module: "track-click",
+          track_category: "emailAlertLinkClicked",
+          track_action: finder.email_alert_signup_url,
+          track_label: "",
+        }
+      } %>
     <% end %>
   </div>
 

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -7,6 +7,10 @@ Feature: Filtering documents
     Given a collection of documents exist
     Then I can get a list of all documents with matching metadata
 
+  Scenario: Email alert signups
+    Given a finder exists with an email signup link
+    And I can see an email alert signup
+
   Scenario: Filter documents by date
     Given a collection of documents that can be filtered by dates
     When I use a date filter

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -8,6 +8,11 @@ Given(/^no results$/) do
   stub_rummager_api_request_with_no_results
 end
 
+Given(/^a finder exists with an email signup link$/) do
+  content_store_has_mosw_reports_finder
+  stub_rummager_api_request
+end
+
 When(/^I view the finder with no keywords and no facets$/) do
   visit finder_path('mosw-reports')
 end
@@ -330,4 +335,10 @@ Then(/^I see services in alphabetical order$/) do
   end
 
   expect(page).to have_content('sorted by A-Z')
+end
+
+And(/^I can see an email alert signup$/) do
+  visit finder_path('mosw-reports')
+  expect(page).to have_link('Subscribe to email alerts', href: 'https://www.gov.uk/mosw-reports/email-signup')
+
 end

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -34,11 +34,12 @@ describe("liveSearch", function(){
   };
 
   beforeEach(function () {
+    $emailLink = $("<section class='gem-c-subscription-links'><a href='/subscribe/link'>Subscribe</a></section>")
     $form = $('<form action="/somewhere" class="js-live-search-form"><input type="checkbox" name="field" value="sheep" checked><input type="submit" value="Filter results" class="button js-live-search-fallback"/></form>');
     $results = $('<div class="js-live-search-results-block"></div>');
     $count = $('<div aria-live="assertive" id="js-search-results-info"><p class="result-info"></p></div>');
     $atomAutodiscoveryLink = $("<link href='http://an-atom-url.atom' rel='alternate' title='ATOM' type='application/atom+xml'>");
-    $('body').append($form).append($results).append($atomAutodiscoveryLink);
+    $('body').append($form).append($results).append($atomAutodiscoveryLink).append($emailLink);
 
     _supportHistory = GOVUK.support.history;
     GOVUK.support.history = function(){ return true; };
@@ -51,6 +52,12 @@ describe("liveSearch", function(){
     $form.remove();
     $results.remove();
     GOVUK.support.history = _supportHistory;
+  });
+
+  it("should update the subscription link with the current selected items", function(){
+    var emailLink = $(".gem-c-subscription-links a");
+    expect(emailLink.attr('href')).toEqual('/subscribe/link?field=sheep');
+    expect(emailLink.attr('data-track-action')).toEqual('/subscribe/link?field=sheep');
   });
 
   it("should save initial state", function(){


### PR DESCRIPTION
This also adds tracking for the link, and some tests for the email link behaviour.

I've removed the email link from the advanced search as this isn't used.

https://finder-frontend-pr-801.herokuapp.com/cma-cases (for example)

https://trello.com/c/l6kGfBhh/230-add-missing-facet-tag-and-email-alert-tracking