### PR TITLE
Move date range hint text below form labels

### DIFF
--- a/app/assets/stylesheets/components/_date-filter.scss
+++ b/app/assets/stylesheets/components/_date-filter.scss
@@ -5,8 +5,3 @@
     margin-bottom: $gutter;
   }
 }
-
-.app-c-date-filter__help-text {
-  @include core-16;
-  display: block;
-}

--- a/app/views/components/_date-filter.html.erb
+++ b/app/views/components/_date-filter.html.erb
@@ -15,7 +15,7 @@
       id: key + "[from]",
       value: from_value,
       controls: aria_controls_id,
-      describedby: "date-help-text-" + key
+      hint: "For example, 2005 or 21/11/2014"
     } %>
 
     <%= render "govuk_publishing_components/components/input", {
@@ -26,11 +26,7 @@
       id: key + "[to]",
       value: to_value,
       controls: aria_controls_id,
-      describedby: "date-help-text-" + key
+      hint: "For example, 2005 or 21/11/2014"
     } %>
-
-    <span id="date-help-text-<%= key %>" class="app-c-date-filter__help-text">
-      For example, 2005 or 21/11/2014
-    </span>
   </div>
 <% end %>


### PR DESCRIPTION
See https://trello.com/c/19KMqZyc

Before:

![news and communications - gov uk 2019-01-21 11-00-39](https://user-images.githubusercontent.com/2715/51470530-0b041080-1d6c-11e9-8534-8aee38b7c961.png)

After:

![news and communications - gov uk 2019-01-21 11-00-12](https://user-images.githubusercontent.com/2715/51470539-12c3b500-1d6c-11e9-8355-94eeec44892b.png)
