### PR TITLE
Sort batch search results

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -63,6 +63,7 @@ private
       link
       description
       public_timestamp
+      popularity
     )
   end
 

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -22,7 +22,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
     "count" => 20,
     "facet_content_purpose_subgroup" => "1500,order:value.title",
     "fields" => %w(
-      title link description public_timestamp
+      title link description public_timestamp popularity
       content_purpose_supergroup
       content_store_document_type organisations
       content_purpose_subgroup part_of_taxonomy_tree

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -159,6 +159,7 @@ module RummagerUrlHelper
       link
       description
       public_timestamp
+      popularity
     )
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -38,7 +38,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
+        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
 
         stub_request(:get, url)
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -125,7 +125,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
+        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
           to_return(status: 200, body: rummager_response, headers: {})
       end
 

--- a/spec/lib/finder_api_spec.rb
+++ b/spec/lib/finder_api_spec.rb
@@ -1,14 +1,14 @@
 require "spec_helper"
 
 describe FinderApi do
-  context "when merging and de-duplicating" do
-    subject { described_class.new("/finder", {}).content_item_with_search_results }
-
-    def result_item(id, title, score:)
+  context "when merging, de-duplicating and sorting" do
+    def result_item(id, title, score:, popularity:, updated:)
       {
         "_id" => id,
         "title" => title,
         "es_score" => score,
+        "popularity" => popularity,
+        "public_timestamp" => updated
       }
     end
 
@@ -20,29 +20,124 @@ describe FinderApi do
             "facets" => []
           },
         )
-
-      allow(Services.rummager).to receive(:batch_search)
-        .and_return(
-          "results" => [
-            {
-              "results" => [
-                result_item("/register-to-vote", "Register to Vote", score: 1),
-              ],
-            },
-            {
-              "results" => [
-                result_item("/hmrc", "HMRC", score: 10),
-                result_item("/register-to-vote", "Register to Vote", score: 2),
-              ],
-            },
-          ]
-        )
     end
 
-    it "de-duplicates the content" do
-      results = subject.fetch("details").fetch("results")
-      expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
-      expect(results.second).to match(hash_including("_id" => "/hmrc"))
+    shared_examples 'sorts by other fields' do
+      context 'most-recent' do
+        subject { described_class.new("/finder", 'order' => 'most-recent').content_item_with_search_results }
+
+        it "de-duplicates and sorts by public_updated descending" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
+          expect(results.second).to match(hash_including("_id" => "/hmrc"))
+        end
+      end
+
+      context 'most-viewed' do
+        subject { described_class.new("/finder", 'order' => 'most-viewed').content_item_with_search_results }
+
+        it "de-duplicates and sorts by popularity descending" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
+          expect(results.second).to match(hash_including("_id" => "/hmrc"))
+        end
+      end
+
+      context 'a-to-z' do
+        subject { described_class.new("/finder", 'order' => 'a-to-z').content_item_with_search_results }
+
+        it "de-duplicates and sorts by title descending" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("title" => "HMRC"))
+          expect(results.second).to match(hash_including("title" => "Register to Vote"))
+        end
+      end
+    end
+
+    context 'when keywords are not used' do #Rummager returns nil for es_score
+      before do
+        allow(Services.rummager).to receive(:batch_search)
+          .and_return(
+            "results" => [
+              {
+                "results" => [
+                  result_item("/register-to-vote", "Register to Vote", score: nil, updated: "14-12-19", popularity: 3),
+                ],
+              },
+              {
+                "results" => [
+                  result_item("/hmrc", "HMRC", score: nil, updated: "14-12-18", popularity: 2),
+                  result_item("/register-to-vote", "Register to Vote", score: nil, updated: "14-12-19", popularity: 3),
+                ],
+              },
+            ]
+        )
+      end
+
+      it_behaves_like 'sorts by other fields'
+
+      context 'default' do
+        subject { described_class.new("/finder", {}).content_item_with_search_results }
+
+        it "de-duplicates and returns in the order rummager returns" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
+          expect(results.second).to match(hash_including("_id" => "/hmrc"))
+        end
+      end
+
+      context 'most-relevant' do
+        subject { described_class.new("/finder", 'order' => 'most-relevant').content_item_with_search_results }
+
+        it "de-duplicates and returns in the order rummager returns" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
+          expect(results.second).to match(hash_including("_id" => "/hmrc"))
+        end
+      end
+    end
+
+    context 'when keywords exist in search' do
+      before do
+        allow(Services.rummager).to receive(:batch_search)
+          .and_return(
+            "results" => [
+              {
+                "results" => [
+                  result_item("/register-to-vote", "Register to Vote", score: 1, updated: "14-12-19", popularity: 3),
+                ],
+              },
+              {
+                "results" => [
+                  result_item("/hmrc", "HMRC", score: 10, updated: "14-12-18", popularity: 2),
+                  result_item("/register-to-vote", "Register to Vote", score: 2, updated: "14-12-19", popularity: 3),
+                ],
+              },
+            ]
+        )
+      end
+
+      it_behaves_like 'sorts by other fields'
+
+      context 'default' do
+        subject { described_class.new("/finder", {}).content_item_with_search_results }
+
+        it "de-duplicates and sorts by es_score descending" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("title" => "HMRC"))
+          expect(results.second).to match(hash_including("title" => "Register to Vote"))
+        end
+      end
+
+      context 'most-relevant' do
+        subject { described_class.new("/finder", 'order' => 'most-relevant').content_item_with_search_results }
+
+        it "de-duplicates and sorts by es_score descending" do
+          results = subject.fetch("details").fetch("results")
+          expect(results.first).to match(hash_including("title" => "HMRC"))
+          expect(results.second).to match(hash_including("title" => "Register to Vote"))
+        end
+      end
     end
   end
 end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -58,7 +58,7 @@ describe SearchQueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp",
+        "fields" => "title,link,description,public_timestamp,popularity",
       )
     end
   end
@@ -85,7 +85,7 @@ describe SearchQueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,alpha,beta",
       )
     end
 
@@ -102,7 +102,7 @@ describe SearchQueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,zeta,beta",
         )
       end
     end


### PR DESCRIPTION
We want to be able to sort search results. This is only possible within each facet if the `OR` is being used between facets within the finder.

This is because each of the `OR` parts is sent separately to Rummager as a `batch_search`

This PR sorts the results locally if there is more than a single result from Rummager (`OR` and therefore multiple queries).

Where there is a single result, the results are returned in the order we receive them from Rummager.

There is a [related PR in govuk-app-deployment-secrets](https://github.com/alphagov/govuk-app-deployment-secrets/pull/46) that enables the drop-down.

Trello: https://trello.com/c/JgohmaDW/3-add-sort-order-to-the-business-finder-results-page

Url to test: https://finder-frontend-pr-803.herokuapp.com/find-eu-exit-guidance-business?business_activity-yesno=no&employ_eu_citizens%5B%5D=no&eu_uk_government_funding-yesno=no&intellectual_property%5B%5D=copyright&intellectual_property-yesno=yes&personal_data-yesno=no&sector_business_area%5B%5D=computer-services&order=a-to-z

# Screenshots

## Before
![screen shot 2019-01-22 at 10 19 53](https://user-images.githubusercontent.com/511319/51528798-60552600-1e2f-11e9-8d1c-1abb1260ff2f.png)

## After
![screen shot 2019-01-22 at 10 20 04](https://user-images.githubusercontent.com/511319/51528811-6814ca80-1e2f-11e9-9a5e-822bc50c26fc.png)
