### PR TITLE
Allow filtering on document_type and supergroup

### DIFF
--- a/app/lib/translate_content_purpose_fields.rb
+++ b/app/lib/translate_content_purpose_fields.rb
@@ -15,7 +15,7 @@ private
 
   def translate_fields_with_prefix(prefix)
     document_types = Array(content_store_document_types(prefix))
-    document_types += Array(subgroup_document_types(prefix) || supergroup_document_types(prefix))
+    document_types += Array(subgroup_document_types(prefix) || supergroup_document_types(prefix)) unless document_types.any?
 
     @query.delete("#{prefix}_content_purpose_subgroup")
     @query.delete("#{prefix}_content_purpose_supergroup")

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -25,6 +25,7 @@
   "details":{
     "document_noun":"statistic",
     "filter":{
+      "content_purpose_supergroup": "research_and_statistics"
     },
     "format_name":"statistic",
     "show_summaries":true,
@@ -92,9 +93,12 @@
         "preposition": "that are",
         "allowed_values": [
           {
+            "text": "Published and unpublished",
+            "value": ""
+          },
+          {
             "text": "Published",
-            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]",
-            "default": true
+            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]"
           },
           {
             "text": "Upcoming",

--- a/spec/lib/translate_content_purpose_fields_spec.rb
+++ b/spec/lib/translate_content_purpose_fields_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe TranslateContentPurposeFields do
         is_expected.to include('foo' => 'bar')
       end
 
-      it 'includes the document types with the relevant translated supertypes' do
-        is_expected.to include('filter_content_store_document_type' => %w(case_study impact_assessment policy_paper travel_advice_index))
+      it 'does not get included if relevant translated supertypes are already present' do
+        is_expected.to include('filter_content_store_document_type' => %w(case_study travel_advice_index))
 
         is_expected.to_not include('filter_content_purpose_subgroup', 'filter_content_purpose_supergroup')
       end


### PR DESCRIPTION
This will allow users to filter by document type and supergroup.

Supergroup filters are to be deprecated. Internally, finder-frontend
has a class TranslateContentPurposeFields that transforms supergroup
filters (content_purpose_supergroup) to document type filters
(content_store_document_type).

The problem is that, if you have a document_type facet/filter, then
this can only expand the search. For example, if you are viewing the
news and communications finder, this will be filtered by
the news_and_communications supergroup (this gets turned into a
document_type filter of document_type[]=news_story,article,... etc).
If you wanted to just view documents of type press release on that
finder, this wouldnt be possible.

This code enables one to filter by supergroup OR by a provided set
of document types. The supergroup will be the default unless the
document types are provided. The expected use case is filtering
down supergroups by subgroupings of document types.

An example of this is included in this commit, where I make
the research_and_statistics finder filterable by document type
sets of Published/Upcoming/All statuses of stats.