### PR TITLE
Adds support for email alerts that uses facets

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -69,7 +69,7 @@ private
       begin
         parent_content_item = Services.content_store.content_item(params["parent_path"])
       rescue GdsApi::HTTPNotFound
-        #parent_path is user input so we don't mind if it's bad
+        # parent_path is user input so we don't mind if it's bad
         GovukStatsd.increment("breadcrumb.parent_path_not_found")
       end
     end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -31,6 +31,10 @@ class Facet
     facet['display_as_result_metadata']
   end
 
+  def value
+    nil
+  end
+
 private
 
   def and_word_connectors

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -72,7 +72,17 @@ class FinderPresenter
     signup_link = content_item['details']['signup_link']
     return signup_link if signup_link.present?
 
-    email_alert_signup['web_url'] if email_alert_signup
+    filtered_values = {}
+    facets.each do |facet|
+      next if facet.value.nil?
+
+      next if facet.value.is_a?(Hash) && facet.value.values.delete_if(&:blank?).empty?
+
+      next if facet.value.is_a?(Array) && facet.value.empty?
+
+      filtered_values[facet.key] = facet.value
+    end
+    "#{email_alert_signup['web_url']}?#{filtered_values.to_query}" if email_alert_signup
   end
 
   def facets

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,4 +1,6 @@
 class SignupPresenter
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::CaptureHelper
   attr_reader :content_item, :params
 
   def initialize(content_item, params)
@@ -23,29 +25,34 @@ class SignupPresenter
   end
 
   def choices?
-    multiple_facet_choice_data.present? || single_facet_choice_data[0]["facet_choices"].present?
+    multiple_facet_choice_data.present? || single_facet_choice_data[0]['facet_choices'].present?
   end
 
   def choices
-    multiple_facet_choice_data || single_facet_choice_data
+    return multiple_facet_choice_data unless multiple_facet_choice_data.empty?
+
+    single_facet_choice_data
   end
 
   def choices_formatted
-    choices.map do |choice|
-      {
-        label: choice['facet_name'],
-        value: choice['facet_id'],
-        checked: choice['prechecked'],
-        items: choice['facet_choices'].map do |facet_choice|
-          {
-            name: "filter[#{choice['facet_id']}][]",
-            label: facet_choice['radio_button_name'],
-            value: facet_choice['key'],
-            checked: facet_choice['prechecked'] || selected_choices.fetch(choice['facet_id'], []).include?(facet_choice['key'])
-          }
-        end
-      }
+    formatted_choices = choices.map do |choice|
+      if choice.dig('facet_choices')
+        {
+          label: choice['facet_name'],
+          value: choice['facet_id'],
+          checked: choice['prechecked'],
+          items: choice['facet_choices'].map do |facet_choice|
+            {
+              name: "filter[#{choice['facet_id']}][]",
+              label: facet_choice['radio_button_name'],
+              value: facet_choice['key'],
+              checked: facet_choice['prechecked'] || selected_choices.fetch(choice['facet_id'], []).include?(facet_choice['key'])
+            }
+          end
+        }
+      end
     end
+    formatted_choices.compact
   end
 
   def target
@@ -64,21 +71,21 @@ private
   def single_facet_choice_data
     [
       {
-        "facet_id" => content_item['details']["email_filter_by"],
-        "facet_name" => single_facet_name,
-        "facet_choices" => content_item['details']["email_signup_choice"]
+        'facet_id' => content_item['details']['email_filter_by'],
+        'facet_name' => single_facet_name,
+        'facet_choices' => content_item['details']['email_signup_choice']
       }
     ]
   end
 
   def multiple_facet_choice_data
-    content_item['details']["email_filter_facets"]
+    content_item['details']['email_filter_facets']
   end
 
   def single_facet_name
-    email_filter_name = content_item["details"]["email_filter_name"]
+    email_filter_name = content_item['details']['email_filter_name']
     return nil unless email_filter_name
 
-    (email_filter_name["plural"] || email_filter_name).capitalize
+    (email_filter_name['plural'] || email_filter_name).capitalize
   end
 end

--- a/app/presenters/signup_url_hidden_params_presenter.rb
+++ b/app/presenters/signup_url_hidden_params_presenter.rb
@@ -1,0 +1,39 @@
+class SignupUrlHiddenParamsPresenter
+  def initialize(content_item, view_context)
+    @content_item = content_item
+    @view_context = view_context
+  end
+
+  def hidden_params
+    @hidden_params ||= clean_filtered_params
+  end
+
+private
+
+  attr_reader :content_item, :view_context
+
+  def clean_filtered_params
+    @clean_filtered_params ||= begin
+      ParamsCleaner
+        .new(filtered_params)
+        .cleaned
+        .delete_if { |_, value| value.blank? }
+    end
+  end
+
+  def filtered_params
+    facet_choices = content_item['details'].fetch('email_filter_facets', []).reject { |facet| facet.key?('facet_choices') }
+    params = view_context.params.to_unsafe_hash
+    filtered_params = Hash.new { |hash, key| hash[key] = []; }
+    facet_choices.each do |facet_choice|
+      key = facet_choice['facet_name']
+      if params.key?(key) && params[key].present?
+        translated_filter_key = facet_choice['filter_key'] || key
+        value = params[key]
+        operator = value.is_a?(Array) ? 'concat' : '<<'
+        filtered_params[translated_filter_key].public_send(operator, value)
+      end
+    end
+    filtered_params
+  end
+end

--- a/app/views/email_alert_subscriptions/facets/checkbox.html.erb
+++ b/app/views/email_alert_subscriptions/facets/checkbox.html.erb
@@ -1,0 +1,7 @@
+<%= render "govuk_publishing_components/components/checkboxes", {
+    name: nil,
+    heading: @signup_presenter.name,
+    hint_text: "Select the email alerts you need.",
+    items: @signup_presenter.choices_formatted,
+    is_page_heading: true,
+} %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,7 +9,8 @@
 
 <div class="outer-block">
   <div class="signup-content">
-    <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
+    <%= form_tag email_alert_subscriptions_path(hidden_params: hidden_params), class: 'signup-choices form' do %>
+
       <% if @signup_presenter.choices? %>
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: nil,

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -101,3 +101,13 @@ Feature: Filtering documents
     When I view a list of services
     And I sort by A-Z
     Then I see services in alphabetical order
+
+  Scenario: Subscribing to email alerts
+    Given a collection of documents exist that can be filtered by checkbox
+    When I use a checkbox filter
+    Then I can sign up to email alerts for allowed filters
+
+  Scenario: Subscribing to email alerts with disallowed facets
+    Given a collection of documents exist that can be filtered by checkbox
+    When I use a checkbox filter and another disallowed filter
+    Then I can sign up to email alerts for allowed filters

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -24,6 +24,7 @@
       "singular": "case type",
       "plural": "case types"
     },
+    "email_filter_facets": [],
     "subscription_list_title_prefix": {
       "singular": "CMA cases with the following case type: ",
       "plural": "CMA cases with the following case types: ",

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -22,7 +22,24 @@
 
   },
   "publishing_request_id":"",
-  "links":{},
+  "links": {
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/news-and-communications/email-signup",
+        "base_path": "/find-eu-exit-guidance-business/email-signup",
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2018-12-17T10:22:17Z",
+        "schema_name": "finder_email_signup",
+        "title": "Find EU Exit guidance for your business",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/news-and-communications/email-signup",
+        "web_url": "/news-and-communications/email-signup"
+      }
+    ]
+  },
   "description":"Find news and communications from government",
   "details":{
     "document_noun":"result",

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -1,0 +1,52 @@
+{
+  "base_path": "/news-and-communications/email-signup",
+  "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+  "document_type": "finder_email_signup",
+  "title": "News and communications",
+  "description": "You'll get an email each time news or communications are published.",
+  "details": {
+    "email_filter_by": "level_one_taxon",
+    "email_filter_name": {
+      "singular": "topic",
+      "plural": "topics"
+    },
+    "subscription_list_title_prefix": {
+      "singular": "CMA cases with the following case type: ",
+      "plural": "CMA cases with the following case types: ",
+      "many": "Competition and Markets Authority (CMA) cases: "
+    },
+    "email_filter_facets": [
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "document_type",
+        "facet_name": "document_type"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world_locations"
+      },
+      {
+        "filter_key": "part_of_taxonomy_tree",
+        "facet_id": "level_one_taxon",
+        "facet_name": "level_one_taxon"
+      },
+      {
+        "filter_key": "part_of_taxonomy_tree",
+        "facet_id": "level_two_taxon",
+        "facet_name": "level_two_taxon"
+      },
+      {
+        "filter_key": "part_of_taxonomy_tree",
+        "facet_id": "has_brexit",
+        "facet_name": "has_brexit"
+      }
+    ]
+  }
+}

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,9 +1,13 @@
 require_relative '../../lib/govuk_content_schema_examples'
 require_relative "../../spec/helpers/taxonomy_spec_helper"
+require 'gds_api/test_helpers/email_alert_api'
+require 'gds_api/test_helpers/content_store'
 
 module DocumentHelper
   include GovukContentSchemaExamples
   include TaxonomySpecHelper
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GdsApi::TestHelpers::ContentStore
 
   def stub_rummager_api_request
     stub_request(:get, rummager_all_documents_url).to_return(
@@ -254,6 +258,23 @@ module DocumentHelper
     stub_request(:get, cma_case_documents_filtered_by_supergroup).to_return(
       body: filtered_cma_case_documents_json,
     )
+  end
+
+  def stub_rummager_with_cma_cases_for_supergroups_checkbox_and_date
+    stub_request(:get, rummager_all_cma_case_documents_url).to_return(
+        body: all_cma_case_documents_json,
+        )
+    cma_case_documents_filtered_by_supergroup = rummager_url(
+        cma_case_search_params.merge(
+            'filter_case_state' => %w(open),
+            'order' => '-public_timestamp',
+            'filter_closed_date' => 'from:2015-11-01'
+        )
+    )
+
+    stub_request(:get, cma_case_documents_filtered_by_supergroup).to_return(
+        body: filtered_cma_case_documents_json,
+        )
   end
 
   def rummager_all_documents_url

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -18,15 +18,19 @@ private
   attr_reader :filter, :subscription_list_title_prefix, :facets
 
   def topic_names(facet)
-    filter.fetch(facet["facet_id"], []).map { |key| choice_hash_by_key(facet, key)["topic_name"] }
+    filter.fetch(facet["facet_id"], []).map { |key| choice_by_key(facet, key) }
   end
 
   def topic_names_sentence(facet)
     topic_names(facet).to_sentence
   end
 
-  def choice_hash_by_key(facet, key)
-    facet["facet_choices"].detect { |choice| choice["key"] == key }
+  def choice_by_key(facet, key)
+    if facet.dig("facet_choices")
+      facet["facet_choices"].detect { |choice| choice["key"] == key }["topic_name"]
+    else
+      []
+    end
   end
 
   def selected_facets

--- a/spec/presenters/signup_url_hidden_params_presenter_spec.rb
+++ b/spec/presenters/signup_url_hidden_params_presenter_spec.rb
@@ -1,0 +1,73 @@
+require "spec_helper"
+
+RSpec.describe SignupUrlHiddenParamsPresenter do
+  include FixturesHelper
+
+  let(:view_context) { double(:view_context) }
+  let(:params) { double(:params) }
+
+  let(:signup_finder) { cma_cases_signup_content_item }
+
+  describe '#url' do
+    before(:each) do
+      allow(view_context).to receive(:params).and_return(params)
+    end
+
+    it "returns empty hash if none passed in" do
+      allow(params).to receive(:to_unsafe_hash).and_return({})
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder, view_context)
+      expect(presenter.hidden_params).to eql({})
+    end
+
+    it "returns hash with values if they are included in the content_item" do
+      signup_finder_content_item = cma_cases_signup_content_item.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_name' => 'filter_part_of_taxonomy'
+          }
+        ]
+      end
+
+      allow(params).to receive(:to_unsafe_hash).and_return('filter_part_of_taxonomy' => 'some-taxon')
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, view_context)
+      expect(presenter.hidden_params).to eql('filter_part_of_taxonomy' => %w(some-taxon))
+    end
+
+    it "returns empty hash if email_filter_facet are includes facet_choices in the content_item" do
+      signup_finder_content_item = cma_cases_signup_content_item.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_name' => 'filter_part_of_taxonomy',
+            'facet_choices' => [
+              {
+                "key": 'taxon',
+                "radio_button_name": 'Filter by some taxon',
+                "topic_name": 'Some taxon',
+                "prechecked": false
+              }
+            ]
+          }
+        ]
+      end
+
+      allow(params).to receive(:to_unsafe_hash).and_return('filter_part_of_taxonomy' => 'some-taxon')
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, view_context)
+      expect(presenter.hidden_params).to eql({})
+    end
+
+    it "translates a facet name into a filter key if it is present" do
+      signup_finder_content_item = cma_cases_signup_content_item.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_name' => 'some_arbitrary_facet_name',
+            'filter_key' => 'a_filter_key_rummager_can_filter_by',
+          }
+        ]
+      end
+
+      allow(params).to receive(:to_unsafe_hash).and_return('some_arbitrary_facet_name' => 'some-taxon')
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, view_context)
+      expect(presenter.hidden_params).to eql('a_filter_key_rummager_can_filter_by' => %w(some-taxon))
+    end
+  end
+end


### PR DESCRIPTION
Adds support for facets selected in finder to be passed onto email alerts so that users can sign up to a custom email alert
I'm deliberately not explaining how it works - if the the reviewer can assess if they are able to understand how to allow facets to be passed on to email alerts and for those facets to not be shown to someone using the system (as we may have taxonomy, people, organisations etc. it may not be desirable to allow users to edit their choices)

Trello: https://trello.com/c/TnK2c8fF/169-add-the-ability-to-sign-up-for-emails-on-the-news-and-communications-finder