### PR TITLE
Add acceptance tests for live sorting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem 'cucumber-rails', '~> 1.6.0', require: false
   gem 'dalli', '~> 2.7.9'
   gem 'govuk-content-schema-test-helpers', '~> 1.6'
+  gem 'govuk_test'
   gem 'launchy', '~> 2.4.2'
   gem 'rails-controller-testing'
   gem 'simplecov', '~> 0.16.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     awesome_print (1.8.0)
@@ -66,6 +68,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     chronic (0.10.2)
     coderay (1.1.2)
     commander (4.4.7)
@@ -155,6 +162,11 @@ GEM
       sass-rails (>= 5.0.4)
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
+    govuk_test (0.3.1)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     highline (2.0.0)
     htmlentities (4.3.4)
@@ -162,6 +174,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jasmine-core (2.99.2)
     jasmine-rails (0.14.8)
@@ -224,6 +237,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.6)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -301,6 +315,7 @@ GEM
     rubocop-rspec (1.30.1)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
       crass (~> 1.0.2)
@@ -322,6 +337,9 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     sdoc (1.0.0)
       rdoc (>= 5.0)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     shared_mustache (1.0.1)
@@ -391,6 +409,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (~> 8.1)
   govuk_publishing_components (~> 13.6.1)
   govuk_schemas (~> 3.2)
+  govuk_test
   jasmine-rails
   launchy (~> 2.4.2)
   pry-byebug

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -25,6 +25,6 @@
       </main>
       <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
-    <%= render_mustache_templates if Rails.env.development? %>
+    <%= render_mustache_templates unless Rails.env.production? %>
   </body>
 </html>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -92,11 +92,37 @@ Feature: Filtering documents
       | Most viewed |
       | Relevance   |
 
+  @javascript
+  Scenario: Live sorting options
+    When I view a list of news and communications
+    Then I can sort by:
+      | Most viewed      |
+      | Updated (newest) |
+      | Updated (oldest) |
+    When I view a list of services
+    Then I can sort by:
+      | A-Z         |
+      | Most viewed |
+
   Scenario: Sorting news and communications by most viewed
+    When I view a list of news and communications
+    And I sort by most viewed
+    And I filter the results
+    Then I see the most viewed articles first
+
+  @javascript
+  Scenario: Live sorting news and communications by most viewed
     When I view a list of news and communications
     And I sort by most viewed
     Then I see the most viewed articles first
 
+  Scenario: Live sorting services A-Z
+    When I view a list of services
+    And I sort by A-Z
+    And I filter the results
+    Then I see services in alphabetical order
+
+  @javascript
   Scenario: Sorting services A-Z
     When I view a list of services
     And I sort by A-Z

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -299,11 +299,13 @@ end
 
 When(/^I sort by most viewed$/) do
   select 'Most viewed', from: 'Sort by'
-  click_on 'Filter results'
 end
 
 When(/^I sort by A-Z$/) do
   select 'A-Z', from: 'Sort by'
+end
+
+When(/^I filter the results$/) do
   click_on 'Filter results'
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,8 +9,13 @@ SimpleCov.start
 
 require 'cucumber/rails'
 require 'cucumber/rspec/doubles'
+
 require 'webmock/cucumber'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 require 'slimmer/test'
+
+GovukTest.configure
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any


### PR DESCRIPTION
This configures the Cucumber acceptance tests to use the [Chrome browser](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) to assert the correct live search finder behaviour.

Previously this was not being tested as the tests were using the [Rack Test](https://github.com/rack-test/rack-test) driver.

This builds on top of #805 which updated Slimmer's test templates to include the necessary JavaScript feature detection hooks needed to enable the JavaScript live search behaviour.

Part of https://trello.com/c/VENEFcz5