### PR TITLE
Fix selected facet count

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -22,7 +22,7 @@
     if(allowCollapsible){
 
       // Attach listener to update checked count
-      this.$options.on('click', this.updateCheckedCount.bind(this));
+      this.$options.on('change', this.updateCheckedCount.bind(this));
 
       // Replace div.container-head with a button
       this.replaceHeadWithButton();


### PR DESCRIPTION
Trello: https://trello.com/c/1v2pEfv1/32-bug-facet-tag-removal-doesnt-update-the-count-on-facet-boxes

When removing facet tags, the count of selected items on the left hand side of the page didn't update. This left you with, for example, "5 selected" when you actually had nothing left selected.

## Before
<img width="325" alt="screen shot 2019-01-22 at 16 22 24" src="https://user-images.githubusercontent.com/29889908/51599951-c0fc6580-1ef8-11e9-84a1-cec8b3d73709.png">

This PR resolves that so the selected count is updated on "change" (which is what is triggered when the facet tags are removed) rather than on "click".