### PR TITLE
Add lint to the default rake task

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -18,7 +18,7 @@ class FindersController < ApplicationController
         if %w[finder search].include? finder_api.content_item['document_type']
           render json: results
         else
-          render json: {}, status: 404
+          render json: {}, status: :not_found
         end
       end
       format.atom do
@@ -30,12 +30,12 @@ class FindersController < ApplicationController
           expires_in(ATOM_FEED_MAX_AGE, public: true)
           @feed = AtomPresenter.new(finder)
         else
-          render plain: 'Not found', status: 404
+          render plain: 'Not found', status: :not_found
         end
       end
     end
   rescue ActionController::UnknownFormat
-    render plain: 'Not acceptable', status: 406
+    render plain: 'Not acceptable', status: :not_acceptable
   end
 
 private

--- a/app/lib/filters/dropdown_select_filter.rb
+++ b/app/lib/filters/dropdown_select_filter.rb
@@ -7,7 +7,7 @@ module Filters
   private
 
     def parsed_value
-      return unless params.present?
+      return if params.blank?
 
       JSON.parse params
     rescue JSON::ParserError

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -109,7 +109,7 @@ private
   end
 
   def sort_option
-    return unless sort_options.present?
+    return if sort_options.blank?
 
     sort_option = if params['order']
                     sort_options.detect { |option| option['name'].parameterize == params['order'] }

--- a/app/lib/translate_content_purpose_fields.rb
+++ b/app/lib/translate_content_purpose_fields.rb
@@ -8,7 +8,7 @@ class TranslateContentPurposeFields
     translate_fields_with_prefix('filter')
     translate_fields_with_prefix('reject')
 
-    @query if @query.present?
+    @query.presence
   end
 
 private

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -15,7 +15,7 @@ class EntryPresenter
   end
 
   def updated_at
-    Time.parse(entry.public_timestamp)
+    Time.zone.parse(entry.public_timestamp)
   end
 
   def self.feed_ended_id(schema, base_path)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -130,7 +130,7 @@ class FinderPresenter
   end
 
   def sort_options
-    return [] unless sort.present?
+    return [] if sort.blank?
 
     options = Hash[sort.collect { |option| [option['name'], option['name'].parameterize] }]
 

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -67,7 +67,7 @@ class ResultSetPresenter
   end
 
   def sort_options
-    return unless finder.sort.present?
+    return if finder.sort.blank?
 
     sort_option = if @filter_params['order']
                     finder.sort.detect { |option| option['name'].parameterize == @filter_params['order'] }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,4 @@
 FinderFrontend::Application.configure do
-
   # We use the non-default in memory cache store for development purposes.
   # It assumes memcached is running on localhost on the default port.
   #

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -85,7 +85,6 @@ end
 
 Then(/^I only see documents tagged to the taxon tree within the supergroup and subgroups$/) do
   @results.each do |result|
-    all_facet_tags = page.all(:css, "facet-tag")
     expect(page).to have_title("News and communications - GOV.UK")
     expect(page).to have_link("Taxon", href: "/taxon")
     expect(page).to have_text("2 results")

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -23,7 +23,7 @@ Then /^I should see a collection of radio buttons/ do
   expect(page).to have_css('.govuk-radios')
 end
 
-When /^I select (.*?) radio button/ do |amount|
+When /^I select (.*?) radio button/ do |_amount|
   button = find(:radio_button, checked: false, match: :first)
   button.set(true)
   @radio_params = "#{button[:name]}=#{button[:value]}"
@@ -37,8 +37,8 @@ When /^I select multiple checkboxes/ do
   @checkbox_params ||= ""
   checkboxes = find_all(:checkbox, visible: true)
   checkboxes.each do |ch|
-      ch.check
-      @checkbox_params << "#{ch[:name]}=#{ch[:value]}&"
+    ch.check
+    @checkbox_params << "#{ch[:name]}=#{ch[:value]}&"
   end
 end
 
@@ -67,6 +67,6 @@ Given /^I am answering the final question/ do
 end
 
 Then /^I am redirected to the finder results page/ do
-  finder_url = mock_qa_config['finder_base_path']+'?'
+  finder_url = mock_qa_config['finder_base_path'] + '?'
   expect(current_url).to match(finder_url)
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -134,6 +134,7 @@ Then(/^I am able to see organisations with abbreviations$/) do
   @results.each do |result|
     acronym = result.dig("organisations", 0, "acronym")
     next unless acronym
+
     org_title = result.dig('organisations', 0, 'title')
     if org_title != acronym
       within("ul.attributes li", text: acronym) do
@@ -147,6 +148,7 @@ Then(/^I am able to see organisations without abbreviations$/) do
   @results.each do |result|
     acronym = result.dig("organisations", 0, "acronym")
     next unless acronym
+
     org_title = result.dig('organisations', 0, 'title')
     if org_title == acronym
       within("ul.attributes li", text: acronym) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -81,7 +81,7 @@ module DocumentHelper
       .with(
         query: hash_including({})
       ).to_return(
-         body: aaib_reports_search_results
+        body: aaib_reports_search_results
       )
   end
 
@@ -106,7 +106,7 @@ module DocumentHelper
   end
 
   def content_store_has_news_and_communications_finder
-    finder_fixture = File.read(Rails.root.join('features/fixtures/news_and_communications.json'))
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'news_and_communications.json'))
 
     content_store_has_item('/news-and-communications', finder_fixture)
   end
@@ -120,7 +120,7 @@ module DocumentHelper
   end
 
   def content_store_has_services_finder
-    finder_fixture = File.read(Rails.root.join('features/fixtures/services.json'))
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'services.json'))
 
     content_store_has_item('/services', finder_fixture)
   end
@@ -185,14 +185,14 @@ module DocumentHelper
             "phase" => "live"
          }
         ]
-      })
+      }
+)
 
-      content_store_has_item(
-        schema.fetch("base_path"),
-        schema.to_json,
-      )
-    end
-
+    content_store_has_item(
+      schema.fetch("base_path"),
+      schema.to_json,
+    )
+  end
 
   def stub_rummager_with_cma_cases
     stub_request(:get, rummager_all_cma_case_documents_url).to_return(
@@ -245,10 +245,10 @@ module DocumentHelper
       body: all_cma_case_documents_json,
     )
     cma_case_documents_filtered_by_supergroup = rummager_url(
-        cma_case_search_params.merge(
-            "filter_case_state" => %w(open),
-            "order" => "-public_timestamp"
-            )
+      cma_case_search_params.merge(
+        "filter_case_state" => %w(open),
+        "order" => "-public_timestamp"
+          )
          )
 
     stub_request(:get, cma_case_documents_filtered_by_supergroup).to_return(

--- a/features/support/qa_helper.rb
+++ b/features/support/qa_helper.rb
@@ -17,7 +17,7 @@ module QAHelper
   end
 
   def mock_qa_config
-    @config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
+    @mock_qa_config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
   end
 
   def first_question
@@ -25,13 +25,14 @@ module QAHelper
   end
 
   def get_question_by_type(type)
-    mock_qa_config["pages"].select do |key, value|
+    selected_questions = mock_qa_config["pages"].select do |_key, value|
       value["question_type"] == type
-    end.values.first['question']
+    end
+    selected_questions.values.first['question']
   end
 
   def get_page_number(question)
-    mock_qa_config["pages"].each_with_index do |(key, value), index|
+    mock_qa_config["pages"].each_with_index do |(_key, value), index|
       return index + 1 if value["question"] == question
     end
   end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,5 @@
+task default: :lint
 desc "Run govuk-lint with similar params to CI"
-task "lint" do
+task :lint do
   sh "bundle exec govuk-lint-ruby --format clang app config features Gemfile lib spec"
 end

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -76,7 +76,7 @@ describe DateParser do
     expected_date = Date.new(year, 11, 26)
 
     # Stub Time.now to a known date
-    pretend_today = Time.new(year, 3, 11)
+    pretend_today = Time.zone.local(year, 3, 11)
     allow(Time).to receive(:now).and_return(pretend_today)
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require_relative '../lib/govuk_content_schema_examples'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
# What

Add linting to the default rake task.

Also fixes the existing lint errors.

# Why
You don't discover lint errors until CI and we should know sooner (fail fast)