### PR TITLE
Fix facet tag text overlap issue

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -372,7 +372,7 @@
     margin-left: 0;
 
     .js-enabled & {
-      margin-left: 5px;
+      margin-left: 10px;
     }
   }
 


### PR DESCRIPTION
Fixes a small issue where the focus state of a facet tag was overlapping the text of the facet tag very slightly.

**Before**

![screen shot 2019-01-24 at 15 03 28](https://user-images.githubusercontent.com/861310/51687092-a950da00-1fe9-11e9-8902-3d1ccb54b8fd.png)

**After**

![screen shot 2019-01-24 at 15 03 11](https://user-images.githubusercontent.com/861310/51687104-b077e800-1fe9-11e9-95c9-3af5217172d9.png)


Trello card: https://trello.com/c/p5fu9yP4/237-fix-facet-focus-bug