### PR TITLE
Fix no js layout for finder search button

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -114,7 +114,7 @@
   }
 
   .filter-form {
-    .js-enabled & .button {
+    .js-enabled & .button__wrapper {
       display:none;
     }
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -19,5 +19,10 @@
     </div>
   </div>
 
-  <input type="submit" value="Filter results" class="button js-live-search-fallback"/>
+  <div class="js-live-search-fallback button__wrapper">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Filter results",
+      margin_bottom: true
+    } %>
+  </div>
 </div>


### PR DESCRIPTION
Add some space underneath the no-js fallback button `Filter results` on finders, by using the button component with bottom margin.

**Before**

![image](https://user-images.githubusercontent.com/861310/51689167-077fbc00-1fee-11e9-8618-544000c80c56.png)

**After**

![screen shot 2019-01-24 at 15 30 28](https://user-images.githubusercontent.com/861310/51688837-4f521380-1fed-11e9-8fa1-ce8e6ce6eaf8.png)


Trello card: https://trello.com/c/bouG4gcg/247-fix-no-js-finder-layout-on-mobile
