### PR TITLE
Enhance the spec:javascript task dependencies

### DIFF
--- a/lib/tasks/jasmine_rails.rake
+++ b/lib/tasks/jasmine_rails.rake
@@ -1,10 +1,13 @@
-task default: 'jasmine:test'
+# The jasmine-rails gem isn't loaded in production, so only evaluate
+# this code if it's relevant
+if Rake::Task.task_defined? 'spec:javascript'
+  task default: 'spec:javascript'
 
-namespace :jasmine do
-  desc "Run JavaScript tests"
-  task test: :environment do
-    Rake::Task["shared_mustache:compile"].invoke
-    Rake::Task["spec:javascript"].invoke
-    Rake::Task["shared_mustache:clean"].invoke
+  namespace :spec do
+    Rake::Task[:javascript].enhance ['shared_mustache:compile']
+
+    Rake::Task[:javascript].enhance do
+      Rake::Task['shared_mustache:clean'].invoke
+    end
   end
 end


### PR DESCRIPTION
Rather than defining a new rake task. This means that running the
standard spec:javascript task provided by the jasmine-rails gem will
work, rather than failing with missing shared_mustache templates.