### PR TITLE
[Do not merge] POC Promote documents

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -277,6 +277,10 @@
         a {
           text-decoration:none;
         }
+
+        &.document-heading--pinned {
+          @include govuk-font($size: 24, $weight: bold);
+        }
       }
 
       dl {

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -32,7 +32,7 @@ class Document
   end
 
   def summary
-    if finder.show_summaries? && description.present?
+    if description.present? && (finder.show_summaries? || promoted)
       # This truncates the description at the end of the first sentence
       description.gsub(/\.\s[A-Z].*/, '.')
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,6 +14,13 @@ class Document
     @government_name = rummager_document.fetch(:government_name, nil)
     @finder = finder
     @rummager_document = rummager_document.slice(*metadata_keys)
+
+    # TODO: REMOVE ME
+    # This is POC data to demonstrate content promotion.
+    finder.links[:ordered_related_items] = [{
+      title: "Prepare to drive in the EU after Brexit",
+      base_path: "/government/publications/prepare-to-drive-in-the-eu-after-brexit",
+    }]
   end
 
   def metadata
@@ -29,6 +36,12 @@ class Document
       # This truncates the description at the end of the first sentence
       description.gsub(/\.\s[A-Z].*/, '.')
     end
+  end
+
+  def promoted
+    finder.links[:ordered_related_items].find { |item|
+      item[:title] == title && item[:base_path] == path
+    }.present?
   end
 
 private

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -2,12 +2,13 @@ class FinderPresenter
   include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::UrlHelper
 
-  attr_reader :content_item, :name, :slug, :organisations, :values, :keywords
+  attr_reader :content_item, :name, :slug, :organisations, :values, :keywords, :links
 
   def initialize(content_item, values = {})
     @content_item = content_item
     @name = content_item['title']
     @slug = content_item['base_path']
+    @links = content_item['links']
     @organisations = content_item['links'].fetch('organisations', [])
     @values = values
     facets.values = values

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -50,7 +50,13 @@ class ResultSetPresenter
   end
 
   def documents
-    results.each_with_index.map do |result, index|
+    sorted_results = results.sort do |x, y|
+      return -1 if x.promoted
+
+      y.promoted ? -1 : 0
+    end
+
+    sorted_results.each_with_index.map do |result, index|
       {
         document: SearchResultPresenter.new(result).to_hash,
         document_index: index + 1

--- a/app/presenters/search_result.rb
+++ b/app/presenters/search_result.rb
@@ -23,7 +23,7 @@ class SearchResult
     end
   end
 
-  result_accessor :link, :title, :format, :es_score, :public_timestamp
+  result_accessor :link, :title, :format, :es_score, :public_timestamp, :promoted
 
   # External links have a truncated version of their URLs displayed on the
   # results page, but there's little benefit to displaying the URL scheme

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -2,6 +2,7 @@ class SearchResultPresenter
   delegate :title,
            :summary,
            :is_historic,
+           :promoted,
            :government_name,
            to: :search_result
 
@@ -17,6 +18,7 @@ class SearchResultPresenter
       is_historic: is_historic,
       government_name: government_name,
       metadata: metadata,
+      promoted: promoted,
     }
   end
 

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -8,7 +8,7 @@
 <ul data-module="track-click">
   {{#documents}}
     <li class="document">
-      <h3>
+      <h3 {{#document.promoted}}class="document-heading--pinned"{{/document.promoted}}>
         <a href='{{document.link}}'
            data-track-category='navFinderLinkClicked'
            data-track-action='{{finder_name}}.{{document_index}}'

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -15,4 +15,23 @@ describe Document do
       expect(document.public_timestamp).to be_nil
     end
   end
+
+  describe "promoted?" do
+    let(:finder) do
+      double(:finder,
+             date_metadata_keys: [],
+             text_metadata_keys: [],
+             links: {
+               ordered_related_items: [{ title: "Foo", base_path: "/foo" }]
+             })
+    end
+
+    it "is true when the finder links contains a match" do
+      expect(described_class.new({ title: "Foo", link: "/foo" }, finder).promoted).to be true
+    end
+
+    it "is false when the finder links don't include a match" do
+      expect(described_class.new({ title: "Bar", link: "/foo" }, finder).promoted).to be false
+    end
+  end
 end


### PR DESCRIPTION
Proof of concept for https://trello.com/c/vgbMOK0e/62-a-content-item-can-be-pinned-to-the-top-of-a-sector-list-when-finder-results-are-organised-by-topic

Please do not merge.

Promotes documents based on their presence in the finder's `links[:ordered_related_items]` collection.

![screenshot from 2019-01-28 10-26-31](https://user-images.githubusercontent.com/93511/51830470-d81bc880-22e7-11e9-9b84-5a346a055ba7.png)

