### PR TITLE
Update README for instructions on how to run JavaScript tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ $ bundle exec rake
 ```
 
 The application has jasmine tests, which can be accessed at `/specs` when the application is running in development mode. These are also run when `rake`, above, is run.
+To run JavaScript tests separately: 
+`bundle exec rake jasmine:test`
 
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
 [content_schema_examples]: https://github.com/alphagov/finder-frontend/blob/master/lib/govuk_content_schema_examples.rb


### PR DESCRIPTION
Added instructions on how to run JavaScript tests as it can be confused with another rake task, which is `bundle exec rake spec:javascript`. But this rake task does not compile mustache, which needs doing to set up JavaScript, therefore, you need to run `bundle exec rake jasmine:test` instead.