### PR TITLE
Move sort by option beneath number of results

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -229,7 +229,8 @@
     .result-info {
       @include core-16;
       vertical-align: baseline;
-      margin: 0 0 $gutter-half 0;
+      margin: 0 0 $gutter 0;
+      border-bottom: solid 1px govuk-colour("black");
 
       .result-count {
         @include bold-27;

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -68,18 +68,6 @@
     </div>
 
     <div class="column-two-thirds">
-      <% if finder.sort.present? %>
-        <div class="govuk-form-group">
-          <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
-          <%= select_tag 'order', finder.sort_options,
-                         class: 'govuk-select js-order-results',
-                         'aria-controls': 'js-search-results-info',
-                         data: { 'default-sort-option' => finder.default_sort_option_value,
-                                 'relevance-sort-option' => finder.relevance_sort_option_value,
-                                 'module' => 'track-select-change'} %>
-        </div>
-      <% end %>
-
       <div class='js-live-search-results-block'>
         <div class="filtered-results">
           <div aria-live='assertive' id='js-search-results-info' data-module="remove-filter">
@@ -89,6 +77,19 @@
               <%= render_mustache('result_count', @results.to_hash) %>
             <% end %>
           </div>
+
+          <% if finder.sort.present? %>
+            <div class="govuk-form-group">
+              <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
+              <%= select_tag 'order', finder.sort_options,
+                             class: 'govuk-select js-order-results',
+                             'aria-controls': 'js-search-results-info',
+                             data: { 'default-sort-option' => finder.default_sort_option_value,
+                                     'relevance-sort-option' => finder.relevance_sort_option_value,
+                                     'module' => 'track-select-change'} %>
+            </div>
+          <% end %>
+
           <div id='js-results'>
             <%= render_mustache('results', @results.to_hash) %>
           </div>


### PR DESCRIPTION
Moves the 'sort by' option in finders beneath the number of results, instead of above.

**Before:**

![screen shot 2019-01-28 at 12 37 17](https://user-images.githubusercontent.com/861310/51836827-795f4a80-22f9-11e9-87e3-e9c96a89c5bb.png)

**After:**

![screen shot 2019-01-29 at 14 10 39](https://user-images.githubusercontent.com/861310/51913986-b1d15800-23cf-11e9-977b-68492b4f34ff.png)

Example URL: https://finder-frontend-pr-830.herokuapp.com/news-and-communications

Trello card: https://trello.com/c/BcttAOsB/236-move-results-number-above-sort-select