### PR TITLE
Enable dynamic faceting and default filters on email subscriptions

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -76,9 +76,11 @@
     this.previousState = this.state;
     this.state = state;
 
-    this.$emailLink.attr(
-      'href', this.emailSignupHref + "?" + $.param(this.state)
-    );
+    if (this.emailSignupHref) {
+      this.$emailLink.attr(
+        'href', this.emailSignupHref.split('?')[0] + "?" + $.param(this.state)
+      );
+    }
   };
 
   LiveSearch.prototype.popState = function popState(event){

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,4 +43,23 @@ private
   def unprocessable_entity
     render status: :unprocessable_entity, plain: "422 error: unprocessable entity"
   end
+
+  def filter_params
+    # TODO Use a whitelist based on the facets in the schema
+    @filter_params ||= begin
+      permitted_params = params
+                           .to_unsafe_hash
+                           .except(
+                             :controller,
+                             :action,
+                             :slug,
+                             :format
+                           )
+
+      ParamsCleaner
+        .new(permitted_params)
+        .cleaned
+        .delete_if { |_, value| value.blank? }
+    end
+  end
 end

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -4,14 +4,15 @@ class EmailAlertSubscriptionsController < ApplicationController
   layout "finder_layout"
   protect_from_forgery except: :create
   before_action :signup_presenter
-
-  def new; end
+  helper_method :hidden_params
 
   def create
-    if valid_choices?
+    error_message = email_alert_signup_api.validate!
+
+    if error_message.nil? && valid_choices?
       redirect_to email_alert_signup_api.signup_url
     else
-      @error_message = "Please choose an email alert"
+      @error_message = error_message || "Please choose an email alert"
       render action: :new
     end
   end
@@ -19,27 +20,54 @@ class EmailAlertSubscriptionsController < ApplicationController
 private
 
   def content
-    @content ||= Services.content_store.content_item(request.path)
+    @content ||= fetch_content_item(request.path)
   end
 
   def signup_presenter
     @signup_presenter ||= SignupPresenter.new(content, params)
   end
 
+  def hidden_params
+    SignupUrlHiddenParamsPresenter.new(content, filter_params).hidden_params
+  end
+
   def valid_choices?
-    !signup_presenter.choices? || at_least_one_filter_chosen?
+    !signup_presenter.choices? || at_least_one_filter_chosen? || has_default_filters?
   end
 
   def at_least_one_filter_chosen?
     chosen_options.any?(&:present?)
   end
 
+  def has_default_filters?
+    default_filters.present? && default_filters.any?
+  end
+
   def chosen_options
-    params.permit("filter" => {})['filter'].to_h
+    params
+      .permit("filter" => {})['filter']
+      .to_h
+      .merge(
+        filter_params.fetch('hidden_params', {})
+      )
+  end
+
+  def fetch_content_item(content_item_path)
+    FinderApi.new(content_item_path, {}).content_item
+  end
+
+  def email_alert_signup_api
+    EmailAlertSignupAPI.new(
+      email_alert_api: Services.email_alert_api,
+      attributes: email_signup_attributes,
+      default_attributes: default_filters,
+      subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
+      available_choices: signup_presenter.choices,
+    )
   end
 
   def finder
-    FinderPresenter.new(Services.content_store.content_item(finder_base_path))
+    @finder ||= FinderPresenter.new(fetch_content_item(finder_base_path))
   end
 
   def finder_format
@@ -48,18 +76,13 @@ private
     finder.filter['document_type']
   end
 
-  def email_alert_signup_api
-    EmailAlertSignupAPI.new(
-      email_alert_api: Services.email_alert_api,
-      attributes: email_signup_attributes,
-      subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
-      available_choices: signup_presenter.choices,
-    )
-  end
-
   def email_signup_attributes
     { "filter" => chosen_options }.tap do |hash|
       hash["format"] = [finder_format] if finder_format
     end
+  end
+
+  def default_filters
+    content['details'].fetch('filter', {})
   end
 end

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -4,7 +4,7 @@ class EmailAlertSubscriptionsController < ApplicationController
   layout "finder_layout"
   protect_from_forgery except: :create
   before_action :signup_presenter
-  helper_method :hidden_params
+  helper_method :subscriber_list_params
 
   def create
     error_message = email_alert_signup_api.validate!
@@ -27,8 +27,8 @@ private
     @signup_presenter ||= SignupPresenter.new(content, params)
   end
 
-  def hidden_params
-    SignupUrlHiddenParamsPresenter.new(content, filter_params).hidden_params
+  def subscriber_list_params
+    SubscriberListParamsPresenter.new(content, filter_params).subscriber_list_params
   end
 
   def valid_choices?
@@ -48,7 +48,7 @@ private
       .permit("filter" => {})['filter']
       .to_h
       .merge(
-        filter_params.fetch('hidden_params', {})
+        filter_params.fetch('subscriber_list_params', {})
       )
   end
 

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -69,30 +69,11 @@ private
       begin
         parent_content_item = Services.content_store.content_item(params["parent_path"])
       rescue GdsApi::HTTPNotFound
-        #parent_path is user input so we don't mind if it's bad
+        # parent_path is user input so we don't mind if it's bad
         GovukStatsd.increment("breadcrumb.parent_path_not_found")
       end
     end
     FinderBreadcrumbsPresenter.new(parent_content_item, @content_item)
-  end
-
-  def filter_params
-    # TODO Use a whitelist based on the facets in the schema
-    @filter_params ||= begin
-      permitted_params = params
-                           .to_unsafe_hash
-                           .except(
-                             :controller,
-                             :action,
-                             :slug,
-                             :format
-                           )
-
-      ParamsCleaner
-        .new(permitted_params)
-        .cleaned
-        .delete_if { |_, value| value.blank? }
-    end
   end
 
   def finder_presenter_class

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -158,6 +158,7 @@ private
     "/transparency-and-freedom-of-information-releases" => "transparency_and_freedom_of_information_releases",
     "/all-content" => "all_content",
     "/policy-papers-and-consultations" => 'policy_and_engagement',
+    "/news-and-communications/email-signup" => 'news_and_communications_signup_content_item',
   }.freeze
 
   def development_env_finder_json

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -27,6 +27,10 @@ class Facet
     facet['filterable']
   end
 
+  def has_filters?
+    false
+  end
+
   def metadata?
     facet['display_as_result_metadata']
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -74,7 +74,19 @@ class FinderPresenter
     signup_link = content_item['details']['signup_link']
     return signup_link if signup_link.present?
 
-    email_alert_signup['web_url'] if email_alert_signup
+    filtered_values = facets.each_with_object({}) do |facet, hash|
+      next unless facet.has_filters?
+
+      next if facet.value.nil?
+
+      next if facet.value.is_a?(Hash) && facet.value.values.all?(&:blank?)
+
+      next if facet.value.is_a?(Array) && facet.value.empty?
+
+      hash[facet.key] = facet.value
+    end
+
+    "#{email_alert_signup['web_url']}?#{filtered_values.to_query}" if email_alert_signup
   end
 
   def facets

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -41,9 +41,7 @@ class SignupPresenter
   end
 
   def choices_formatted
-    @choices_formatted ||= choices.map { |choice|
-      next unless choice['facet_choices'] && choice["facet_choices"].any?
-
+    @choices_formatted ||= facets_with_choicess.map { |choice|
       {
         label: choice['facet_name'],
         value: choice['facet_id'],
@@ -65,6 +63,12 @@ class SignupPresenter
   end
 
 private
+
+  def facets_with_choicess
+    choices.select { |choice|
+      choice['facet_choices'] && choice["facet_choices"].any?
+    }
+  end
 
   def selected_choices
     facets_ids = choices.each_with_object({}) do |choice, hash|

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,4 +1,6 @@
 class SignupPresenter
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::CaptureHelper
   attr_reader :content_item, :params
 
   def initialize(content_item, params)
@@ -22,16 +24,26 @@ class SignupPresenter
     content_item['details']['beta']
   end
 
+  def can_modify_choices?
+    choices? && choices_formatted.any?
+  end
+
   def choices?
     multiple_facet_choice_data.present? || single_facet_choice_data[0]["facet_choices"].present?
   end
 
   def choices
-    multiple_facet_choice_data || single_facet_choice_data
+    if multiple_facet_choice_data.present? && multiple_facet_choice_data.any?
+      return multiple_facet_choice_data
+    end
+
+    single_facet_choice_data
   end
 
   def choices_formatted
-    choices.map do |choice|
+    @choices_formatted ||= choices.map { |choice|
+      next unless choice['facet_choices'] && choice["facet_choices"].any?
+
       {
         label: choice['facet_name'],
         value: choice['facet_id'],
@@ -45,7 +57,7 @@ class SignupPresenter
           }
         end
       }
-    end
+    }.compact
   end
 
   def target

--- a/app/presenters/signup_url_hidden_params_presenter.rb
+++ b/app/presenters/signup_url_hidden_params_presenter.rb
@@ -1,0 +1,45 @@
+class SignupUrlHiddenParamsPresenter
+  def initialize(content_item, params)
+    @content_item = content_item
+    @params = params
+  end
+
+  def hidden_params
+    @hidden_params ||= filtered_params
+  end
+
+private
+
+  attr_reader :content_item, :params
+
+  def filtered_params
+    facets.each_with_object(hash_with_default_as_array) { |facet, hash|
+      next unless params[facet['facet_id']].present?
+
+      key = facet_filter_key(facet)
+      value = facet_filter_value(facet)
+
+      hash[key].concat Array(value)
+    }
+  end
+
+  def facets
+    allowed_facets.reject { |facet| facet.key?('facet_choices') }
+  end
+
+  def allowed_facets
+    content_item['details'].fetch('email_filter_facets', [])
+  end
+
+  def hash_with_default_as_array
+    Hash.new { |hash, key| hash[key] = []; }
+  end
+
+  def facet_filter_key(facet)
+    facet['filter_key'] || facet['facet_id']
+  end
+
+  def facet_filter_value(facet)
+    facet['filter_value'] || params[facet['facet_id']]
+  end
+end

--- a/app/presenters/subscriber_list_params_presenter.rb
+++ b/app/presenters/subscriber_list_params_presenter.rb
@@ -1,11 +1,11 @@
-class SignupUrlHiddenParamsPresenter
+class SubscriberListParamsPresenter
   def initialize(content_item, params)
     @content_item = content_item
     @params = params
   end
 
-  def hidden_params
-    @hidden_params ||= filtered_params
+  def subscriber_list_params
+    @subscriber_list_params ||= filtered_params
   end
 
 private
@@ -13,13 +13,17 @@ private
   attr_reader :content_item, :params
 
   def filtered_params
-    facets.each_with_object(hash_with_default_as_array) { |facet, hash|
-      next unless params[facet['facet_id']].present?
-
+    used_facets.each_with_object(hash_with_default_as_array) { |facet, hash|
       key = facet_filter_key(facet)
       value = facet_filter_value(facet)
 
       hash[key].concat Array(value)
+    }
+  end
+
+  def used_facets
+    facets.select { |facet|
+      params[facet['facet_id']].present?
     }
   end
 

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,7 +9,7 @@
 
 <div class="outer-block">
   <div class="signup-content">
-    <%= form_tag email_alert_subscriptions_path(hidden_params: hidden_params), class: 'signup-choices form' do %>
+    <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices form' do %>
 
       <% if @signup_presenter.can_modify_choices? %>
         <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,8 +9,9 @@
 
 <div class="outer-block">
   <div class="signup-content">
-    <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
-      <% if @signup_presenter.choices? %>
+    <%= form_tag email_alert_subscriptions_path(hidden_params: hidden_params), class: 'signup-choices form' do %>
+
+      <% if @signup_presenter.can_modify_choices? %>
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: nil,
           heading: @signup_presenter.name,

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -128,7 +128,7 @@ Feature: Filtering documents
     And I sort by A-Z
     Then I see services in alphabetical order
 
-   @javascript
+  @javascript
   Scenario Outline: Removing checkbox filter
     When I view the news and communications finder
     And I click button <filter> and select facet <facet>
@@ -146,3 +146,13 @@ Feature: Filtering documents
     And I fill in some keywords
     And I click the Keyword1 remove link
     Then The keyword textbox is empty
+
+  Scenario: Subscribing to email alerts
+    Given a collection of documents exist that can be filtered by checkbox
+    When I use a checkbox filter
+    Then I can sign up to email alerts for allowed filters
+
+  Scenario: Subscribing to email alerts with disallowed facets
+    Given a collection of documents exist that can be filtered by checkbox
+    When I use a checkbox filter and another disallowed filter
+    Then I can sign up to email alerts for allowed filters

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -22,7 +22,24 @@
 
   },
   "publishing_request_id":"",
-  "links":{},
+  "links": {
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/news-and-communications/email-signup",
+        "base_path": "/news-and-communications/email-signup",
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2018-12-17T10:22:17Z",
+        "schema_name": "finder_email_signup",
+        "title": "News and communications",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/news-and-communications/email-signup",
+        "web_url": "/news-and-communications/email-signup"
+      }
+    ]
+  },
   "description":"Find news and communications from government",
   "details":{
     "document_noun":"result",

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -30,17 +30,17 @@
       },
       {
         "facet_id": "level_one_taxon",
-        "filter_key": "part_of_taxonomy_tree",
+        "filter_key": "all_part_of_taxonomy_tree",
         "facet_name": "topics"
       },
       {
         "facet_id": "level_two_taxon",
-        "filter_key": "part_of_taxonomy_tree",
+        "filter_key": "all_part_of_taxonomy_tree",
         "facet_name": "topics"
       },
       {
         "facet_id": "related_to_brexit",
-        "filter_key": "part_of_taxonomy_tree",
+        "filter_key": "all_part_of_taxonomy_tree",
         "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
         "facet_name": "topics"
       }

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -1,0 +1,49 @@
+{
+  "base_path": "/news-and-communications/email-signup",
+  "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+  "document_type": "finder_email_signup",
+  "title": "News and communications",
+  "description": "You'll get an email each time news or communications are published.",
+  "details": {
+    "filter": {
+      "content_purpose_supergroup": "news_and_communications"
+    },
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "News and communications ",
+    "email_filter_facets": [
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "document_type",
+        "facet_name": "document types"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "related_to_brexit",
+        "filter_key": "part_of_taxonomy_tree",
+        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -149,6 +149,11 @@ When(/^I use a date filter$/) do
   apply_date_filter
 end
 
+When(/^I use a collection of documents exist that can be filtered by checkbox filter$/) do
+  visit_cma_cases_finder
+  apply_date_filter
+end
+
 Then(/^I only see documents with matching dates$/) do
   assert_cma_cases_are_filtered_by_date
 end
@@ -275,6 +280,7 @@ end
 Given(/^a collection of documents exist that can be filtered by checkbox$/) do
   stub_content_store_with_cma_cases_finder_for_supergroup_checkbox_filter
   stub_rummager_with_cma_cases_for_supergroups_checkbox
+  stub_rummager_with_query_validation_request
   visit_cma_cases_finder
 end
 
@@ -381,4 +387,32 @@ end
 
 Then(/^The keyword textbox is empty$/) do
   expect(page).to have_field('Search', with: '')
+end
+
+When(/^I use a checkbox filter and another disallowed filter$/) do
+  find("label", text: "Show open cases").click
+  fill_in("closed_date[from]", with: "1st November 2015")
+  stub_rummager_with_cma_cases_for_supergroups_checkbox_and_date
+  click_on "Filter results"
+end
+
+Then(/^I can sign up to email alerts for allowed filters$/) do
+  email_alert_api_has_subscriber_list(
+    "tags" => { "case_state" => { "0" => "open" }, "format" => { "0" => "cma_case" } },
+    'subscription_url' => 'http://www.rathergood.com'
+  )
+
+  signup_content_item = cma_cases_with_multi_facets_signup_content_item
+  signup_content_item['details']['email_filter_facets'] = [{ 'facet_id' => 'case_state', 'facet_name' => 'case_state' }]
+
+  content_store_has_item('/cma-cases/email-signup', signup_content_item)
+
+  click_link('Subscribe to email alerts')
+
+  begin
+    click_on('Create subscription')
+  rescue ActionController::RoutingError
+    expect(page.status_code).to eq(302)
+    expect(page.response_headers['Location']).to eql('http://www.rathergood.com')
+  end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -398,7 +398,7 @@ end
 
 Then(/^I can sign up to email alerts for allowed filters$/) do
   email_alert_api_has_subscriber_list(
-    "tags" => { "case_state" => { "0" => "open" }, "format" => { "0" => "cma_case" } },
+    "tags" => { "case_state" => { any: { "0" => "open" } }, "format" => { any: { "0" => "cma_case" } } },
     'subscription_url' => 'http://www.rathergood.com'
   )
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -270,7 +270,6 @@ module DocumentHelper
   def stub_rummager_with_query_validation_request
     stub_validation_of_valid_query(
       'filter_case_state[]' => 'open',
-      'filter_content_purpose_supergroup' => nil,
       'filter_format[]' => 'cma_case',
     )
   end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,4 +1,5 @@
 require 'email_alert_title_builder'
+require 'validate_query'
 
 class EmailAlertSignupAPI
   def initialize(dependencies = {})
@@ -6,18 +7,27 @@ class EmailAlertSignupAPI
     @attributes = dependencies.fetch(:attributes)
     @subscription_list_title_prefix = dependencies.fetch(:subscription_list_title_prefix)
     @available_choices = dependencies.fetch(:available_choices)
+    @default_attributes = dependencies.fetch(:default_attributes, {})
   end
 
   def signup_url
     subscriber_list['subscription_url']
   end
 
+  def validate!
+    validater.validate
+  end
+
 private
 
-  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices
+  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :default_attributes
 
   def subscriber_list
-    response = email_alert_api.find_or_create_subscriber_list("tags" => massaged_attributes, "title" => title)
+    response = email_alert_api.find_or_create_subscriber_list(
+      "tags" => massaged_attributes,
+      "title" => title,
+      "content_purpose_supergroup" => content_purpose_supergroup,
+    )
     response['subscriber_list']
   end
 
@@ -29,16 +39,28 @@ private
     )
   end
 
+  def content_purpose_supergroup
+    massaged_attributes['content_purpose_supergroup'] || default_attributes['content_purpose_supergroup']
+  end
+
   def massaged_attributes
-    attributes.dup.tap do |massaged_attributes|
+    @massaged_attributes ||= attributes.dup.tap do |massaged_attributes|
       available_choices.each do |choice|
-        facet_id = choice["facet_id"]
-        value = (massaged_attributes['filter'] || {})[facet_id]
+        key = choice["filter_key"] || choice["facet_id"]
+        value = (massaged_attributes['filter'] || {})[key]
         next unless value
 
-        massaged_attributes[facet_id] = value
+        massaged_attributes[key] = value
       end
       massaged_attributes.delete("filter")
     end
+  end
+
+  def validater
+    @validater ||= ::ValidateQuery.new(
+      massaged_attributes.merge(
+        'content_purpose_supergroup' => content_purpose_supergroup
+      )
+    )
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -24,7 +24,7 @@ private
 
   def subscriber_list
     response = email_alert_api.find_or_create_subscriber_list(
-      "tags" => massaged_attributes,
+      "tags" => tags,
       "title" => title,
       "content_purpose_supergroup" => content_purpose_supergroup,
     )
@@ -41,6 +41,20 @@ private
 
   def content_purpose_supergroup
     massaged_attributes['content_purpose_supergroup'] || default_attributes['content_purpose_supergroup']
+  end
+
+  def tags
+    @tags ||= massaged_attributes.each_with_object({}) { |(key, value), hash|
+      if is_all_field?(key)
+        hash[key[4..-1]] = { all: value }
+      else
+        hash[key] = { any: value }
+      end
+    }
+  end
+
+  def is_all_field?(key)
+    key[0..3] == 'all_'
   end
 
   def massaged_attributes

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -23,12 +23,18 @@ private
   attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :default_attributes
 
   def subscriber_list
-    response = email_alert_api.find_or_create_subscriber_list(
+    response = email_alert_api.find_or_create_subscriber_list(subscriber_list_options)
+    response['subscriber_list']
+  end
+
+  def subscriber_list_options
+    options = {
       "tags" => tags,
       "title" => title,
-      "content_purpose_supergroup" => content_purpose_supergroup,
-    )
-    response['subscriber_list']
+    }
+
+    options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
+    options
   end
 
   def title
@@ -71,10 +77,9 @@ private
   end
 
   def validater
-    @validater ||= ::ValidateQuery.new(
-      massaged_attributes.merge(
-        'content_purpose_supergroup' => content_purpose_supergroup
-      )
-    )
+    options = massaged_attributes
+    options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
+
+    @validater ||= ::ValidateQuery.new(options)
   end
 end

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -17,32 +17,8 @@ private
 
   attr_reader :filter, :subscription_list_title_prefix, :facets
 
-  def topic_names(facet)
-    filter.fetch(facet["facet_id"], []).map { |key| choice_hash_by_key(facet, key)["topic_name"] }
-  end
-
-  def topic_names_sentence(facet)
-    topic_names(facet).to_sentence
-  end
-
-  def choice_hash_by_key(facet, key)
-    facet["facet_choices"].detect { |choice| choice["key"] == key }
-  end
-
-  def selected_facets
-    facets.select { |facet| filter[facet["facet_id"]].present? }
-  end
-
-  def plural_or_single
-    if filter.fetch(facets.first["facet_id"], []).length == 1
-      "singular"
-    else
-      "plural"
-    end
-  end
-
   def prefix
-    if facets.size == 1
+    if facets.size == 1 && subscription_list_title_prefix.is_a?(Hash)
       subscription_list_title_prefix[plural_or_single].to_s
     elsif selected_facets.empty?
       subscription_list_title_prefix.to_s
@@ -51,11 +27,68 @@ private
     end
   end
 
+  def plural_or_single
+    filter.fetch(facets.first["facet_id"], []).length == 1 ? "singular" : "plural"
+  end
+
   def suffix
-    if facets.size == 1
-      topic_names_sentence(facets.first)
-    elsif selected_facets.present?
-      selected_facets.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
-    end
+    return singular_suffix if facets.size == 1
+
+    multiple_facets_suffix if selected_facets.present?
+  end
+
+  def singular_suffix
+    facet_key = facets.first['filter_key'] || facets.first['facet_id']
+    dynamic_suffix = dynamic_facet_sentence(facet_key, selected_facets.first)
+    return dynamic_suffix unless dynamic_suffix.nil?
+
+    topic_names_sentence(facets.first)
+  end
+
+  def multiple_facets_suffix
+    grouped_facets.map { |facet_key, facet_group|
+      dynamic_suffix = dynamic_facet_sentence(facet_key, facet_group.first)
+      next dynamic_suffix unless dynamic_suffix.nil?
+
+      facet_group.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
+    }.to_sentence
+  end
+
+  def topic_names_sentence(facet)
+    filter.fetch(facet["facet_id"], []).map { |key| choice_by_key(facet, key) }.to_sentence
+  end
+
+  def choice_by_key(facet, key)
+    chosen = facet.fetch("facet_choices", []).detect { |choice| choice["key"] == key }
+
+    chosen["topic_name"] if chosen
+  end
+
+  def selected_facets
+    facets.select { |facet| filter[facet["facet_id"]].present? || filter[facet["filter_key"]].present? }
+  end
+
+  def grouped_facets
+    selected_facets.group_by { |facet| facet['filter_key'] || facet['facet_id'] }
+  end
+
+  def dynamic_facet_sentence(facet_key, facet)
+    return nil unless dynamic_filter_option?(facet_key)
+
+    count = filter.fetch(facet_key, []).count
+    word = count > 1 ? facet["facet_name"] : facet["facet_name"].singularize
+    "#{count} #{word}"
+  end
+
+  def dynamic_filter_option?(filter_key)
+    # these are keys such as organisations where it is not practical to
+    # put all choices into the finder email signup content item.
+    %w(
+      world_locations
+      organisations
+      people
+      part_of_taxonomy_tree
+      document_type
+    ).include?(filter_key)
   end
 end

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -89,6 +89,7 @@ private
       organisations
       people
       part_of_taxonomy_tree
+      all_part_of_taxonomy_tree
       document_type
     ).include?(filter_key)
   end

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -39,18 +39,21 @@ private
 
   def singular_suffix
     facet_key = facets.first['filter_key'] || facets.first['facet_id']
-    dynamic_suffix = dynamic_facet_sentence(facet_key, selected_facets.first)
-    return dynamic_suffix unless dynamic_suffix.nil?
+
+    if dynamic_filter_option?(facet_key)
+      return dynamic_facet_sentence(facet_key, selected_facets.first)
+    end
 
     topic_names_sentence(facets.first)
   end
 
   def multiple_facets_suffix
     grouped_facets.map { |facet_key, facet_group|
-      dynamic_suffix = dynamic_facet_sentence(facet_key, facet_group.first)
-      next dynamic_suffix unless dynamic_suffix.nil?
-
-      facet_group.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
+      if dynamic_filter_option?(facet_key)
+        dynamic_facet_sentence(facet_key, facet_group.first)
+      else
+        facet_group.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
+      end
     }.to_sentence
   end
 
@@ -73,8 +76,6 @@ private
   end
 
   def dynamic_facet_sentence(facet_key, facet)
-    return nil unless dynamic_filter_option?(facet_key)
-
     count = filter.fetch(facet_key, []).count
     word = count > 1 ? facet["facet_name"] : facet["facet_name"].singularize
     "#{count} #{word}"

--- a/lib/validate_query.rb
+++ b/lib/validate_query.rb
@@ -1,0 +1,33 @@
+# This enables one to pass a query and check whether it is acceptable
+# by rummager. It makes a quick query against the search api and checks whether
+# the attributes throws errors.
+
+class ValidateQuery
+  def initialize(query_params = {})
+    @query_params = query_params
+  end
+
+  # returns nil or an error message
+  def validate
+    @validate ||= search_params_have_errors?
+  end
+
+private
+
+  def search_params_have_errors?
+    Services.rummager.search(rummager_params)
+    nil
+  rescue GdsApi::HTTPUnprocessableEntity => error
+    error.error_details.fetch("error", "Unprocessable request; please check your filters and try again.")
+  end
+
+  def rummager_params
+    default_params.merge(@query_params.transform_keys { |key| "filter_#{key}" })
+  end
+
+  def default_params
+    {
+      "count" => 0,
+    }
+  end
+end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -121,7 +121,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
         expect(subject).to redirect_to('http://www.example.com')
       end
 
-      it 'redirects to the correct email subscription url with hidden_params' do
+      it 'redirects to the correct email subscription url with subscriber_list_params' do
         taxonomy_signup_finder = signup_finder.tap do |content_item|
           content_item['details']['email_filter_facets'] << {
             'facet_key' => 'part_of_taxonomy_tree',
@@ -151,7 +151,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
         post :create, params: {
           slug: 'cma-cases',
-          hidden_params: { part_of_taxonomy_tree: %w(some-taxon) },
+          subscriber_list_params: { part_of_taxonomy_tree: %w(some-taxon) },
           filter: {
             'case_type' => ['ca98-and-civil-cartels'],
             'case_state' => %w(open),
@@ -181,7 +181,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
         post :create, params: {
           slug: 'cma-cases',
-          hidden_params: { part_of_taxonomy_tree: %w(some-taxon) },
+          subscriber_list_params: { part_of_taxonomy_tree: %w(some-taxon) },
           filter: {
             'case_type' => ['ca98-and-civil-cartels'],
             'case_state' => %w(open),

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -60,8 +60,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
     it 'redirects to the correct email subscription url' do
       email_alert_api_has_subscriber_list(
         "tags" => {
-          "case_type" => ['ca98-and-civil-cartels'],
-          "format" => [finder.dig('details', 'filter', 'document_type')]
+          "case_type" => { any: ['ca98-and-civil-cartels'] },
+          "format" => { any: [finder.dig('details', 'filter', 'document_type')] },
         },
         "subscription_url" => 'http://www.example.com'
       )
@@ -96,9 +96,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
         content_store_has_item('/cma-cases/email-signup', signup_finder)
         email_alert_api_has_subscriber_list(
           "tags" => {
-            "case_type" => ['ca98-and-civil-cartels'],
-            "case_state" => %w(open),
-            "format" => [finder.dig('details', 'filter', 'document_type')]
+            "case_type" => { any: ['ca98-and-civil-cartels'] },
+            "case_state" => { any: %w(open) },
+            "format" => { any: [finder.dig('details', 'filter', 'document_type')] },
           },
           "subscription_url" => 'http://www.example.com'
         )
@@ -133,10 +133,10 @@ describe EmailAlertSubscriptionsController, type: :controller do
         content_store_has_item('/cma-cases/email-signup', taxonomy_signup_finder)
         email_alert_api_has_subscriber_list(
           'tags' => {
-            'case_type' => ['ca98-and-civil-cartels'],
-            'case_state' => %w(open),
-            'format' => [finder.dig('details', 'filter', 'document_type')],
-            'part_of_taxonomy_tree[]' => ['some-taxon'],
+            'case_type' => { any: ['ca98-and-civil-cartels'] },
+            'case_state' => { any: %w(open) },
+            'format' => { any: [finder.dig('details', 'filter', 'document_type')] },
+            'part_of_taxonomy_tree[]' => { any: ['some-taxon'] },
           },
           'subscription_url' => 'http://www.example.com'
         )
@@ -165,9 +165,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
         content_store_has_item('/cma-cases/email-signup', signup_finder)
         email_alert_api_has_subscriber_list(
           'tags' => {
-            'case_type' => ['ca98-and-civil-cartels'],
-            'case_state' => %w(open),
-            'format' => [finder.dig('details', 'filter', 'document_type')],
+            'case_type' => { any: ['ca98-and-civil-cartels'] },
+            'case_state' => { any: %w(open) },
+            'format' => { any: [finder.dig('details', 'filter', 'document_type')] },
           },
           'subscription_url' => 'http://www.example.com'
         )

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 require 'gds_api/test_helpers/content_store'
 require 'gds_api/test_helpers/email_alert_api'
+require_relative "../helpers/validation_query_helper"
 
 describe EmailAlertSubscriptionsController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::EmailAlertApi
   include FixturesHelper
   include GovukContentSchemaExamples
+  include ValidateQueryHelper
+
   render_views
 
   let(:signup_finder) { cma_cases_signup_content_item }
@@ -16,7 +19,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
       it 'returns a 404, rather than 5xx' do
         content_store_does_not_have_item('/does-not-exist/email-signup')
 
-        get :new, params: { slug: 'does-not-exist' }
+        params = { slug: 'does-not-exist' }
+        stub_validation_of_valid_query(params)
+        get :new, params: params
         expect(response.status).to eq(404)
       end
     end
@@ -24,7 +29,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
     describe "finder email signup item does exist" do
       it 'returns a success' do
         content_store_has_item('/does-exist/email-signup', signup_finder)
-        get :new, params: { slug: 'does-exist' }
+        params = { slug: 'does-exist' }
+        stub_validation_of_valid_query(params)
+        get :new, params: params
 
         expect(response).to be_successful
       end
@@ -40,6 +47,11 @@ describe EmailAlertSubscriptionsController, type: :controller do
     end
 
     it "fails if the relevant filters are not provided" do
+      stub_validation_of_valid_query(
+        'filter_content_purpose_supergroup' => nil,
+        'filter_format[]' => 'mosw_report',
+      )
+
       post :create, params: { slug: 'cma-cases' }
       expect(response).to be_successful
       expect(response).to render_template('new')
@@ -53,6 +65,13 @@ describe EmailAlertSubscriptionsController, type: :controller do
         },
         "subscription_url" => 'http://www.example.com'
       )
+
+      stub_validation_of_valid_query(
+        'filter_case_type[]' => 'ca98-and-civil-cartels',
+        'filter_content_purpose_supergroup' => nil,
+        'filter_format[]' => 'mosw_report',
+      )
+
       post :create, params: {
         slug: 'cma-cases',
         filter: {
@@ -71,10 +90,10 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
       before do
         content_store_has_item('/cma-cases', finder)
-        content_store_has_item('/cma-cases/email-signup', signup_finder)
       end
 
       it 'redirects to the correct email subscription url' do
+        content_store_has_item('/cma-cases/email-signup', signup_finder)
         email_alert_api_has_subscriber_list(
           "tags" => {
             "case_type" => ['ca98-and-civil-cartels'],
@@ -83,8 +102,86 @@ describe EmailAlertSubscriptionsController, type: :controller do
           },
           "subscription_url" => 'http://www.example.com'
         )
+
+        stub_validation_of_valid_query(
+          'filter_case_state[]' => 'open',
+          'filter_case_type[]' => 'ca98-and-civil-cartels',
+          'filter_content_purpose_supergroup' => nil,
+          'filter_format[]' => 'mosw_report',
+        )
+
         post :create, params: {
           slug: 'cma-cases',
+          filter: {
+            'case_type' => ['ca98-and-civil-cartels'],
+            'case_state' => %w(open),
+          }
+        }
+
+        expect(subject).to redirect_to('http://www.example.com')
+      end
+
+      it 'redirects to the correct email subscription url with hidden_params' do
+        taxonomy_signup_finder = signup_finder.tap do |content_item|
+          content_item['details']['email_filter_facets'] << {
+            'facet_key' => 'part_of_taxonomy_tree',
+            'facet_id' => 'part_of_taxonomy_tree',
+            'facet_name' => 'Taxonomy'
+          }
+        end
+
+        content_store_has_item('/cma-cases/email-signup', taxonomy_signup_finder)
+        email_alert_api_has_subscriber_list(
+          'tags' => {
+            'case_type' => ['ca98-and-civil-cartels'],
+            'case_state' => %w(open),
+            'format' => [finder.dig('details', 'filter', 'document_type')],
+            'part_of_taxonomy_tree[]' => ['some-taxon'],
+          },
+          'subscription_url' => 'http://www.example.com'
+        )
+
+        stub_validation_of_valid_query(
+          'filter_case_state[]' => 'open',
+          'filter_case_type[]' => 'ca98-and-civil-cartels',
+          'filter_content_purpose_supergroup' => nil,
+          'filter_format[]' => 'mosw_report',
+          'filter_part_of_taxonomy_tree[]' => 'some-taxon'
+        )
+
+        post :create, params: {
+          slug: 'cma-cases',
+          hidden_params: { part_of_taxonomy_tree: %w(some-taxon) },
+          filter: {
+            'case_type' => ['ca98-and-civil-cartels'],
+            'case_state' => %w(open),
+          }
+        }
+        expect(subject).to redirect_to('http://www.example.com')
+      end
+
+
+      it 'will not include a facet that is not in the signup content item in the redirect' do
+        content_store_has_item('/cma-cases/email-signup', signup_finder)
+        email_alert_api_has_subscriber_list(
+          'tags' => {
+            'case_type' => ['ca98-and-civil-cartels'],
+            'case_state' => %w(open),
+            'format' => [finder.dig('details', 'filter', 'document_type')],
+          },
+          'subscription_url' => 'http://www.example.com'
+        )
+
+        stub_validation_of_valid_query(
+          'filter_case_state[]' => 'open',
+          'filter_case_type[]' => 'ca98-and-civil-cartels',
+          'filter_content_purpose_supergroup' => nil,
+          'filter_format[]' => 'mosw_report',
+        )
+
+        post :create, params: {
+          slug: 'cma-cases',
+          hidden_params: { part_of_taxonomy_tree: %w(some-taxon) },
           filter: {
             'case_type' => ['ca98-and-civil-cartels'],
             'case_state' => %w(open),

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -48,7 +48,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     it "fails if the relevant filters are not provided" do
       stub_validation_of_valid_query(
-        'filter_content_purpose_supergroup' => nil,
         'filter_format[]' => 'mosw_report',
       )
 
@@ -68,7 +67,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
       stub_validation_of_valid_query(
         'filter_case_type[]' => 'ca98-and-civil-cartels',
-        'filter_content_purpose_supergroup' => nil,
         'filter_format[]' => 'mosw_report',
       )
 
@@ -106,7 +104,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
         stub_validation_of_valid_query(
           'filter_case_state[]' => 'open',
           'filter_case_type[]' => 'ca98-and-civil-cartels',
-          'filter_content_purpose_supergroup' => nil,
           'filter_format[]' => 'mosw_report',
         )
 
@@ -144,7 +141,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
         stub_validation_of_valid_query(
           'filter_case_state[]' => 'open',
           'filter_case_type[]' => 'ca98-and-civil-cartels',
-          'filter_content_purpose_supergroup' => nil,
           'filter_format[]' => 'mosw_report',
           'filter_part_of_taxonomy_tree[]' => 'some-taxon'
         )
@@ -175,7 +171,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
         stub_validation_of_valid_query(
           'filter_case_state[]' => 'open',
           'filter_case_type[]' => 'ca98-and-civil-cartels',
-          'filter_content_purpose_supergroup' => nil,
           'filter_format[]' => 'mosw_report',
         )
 

--- a/spec/helpers/validation_query_helper.rb
+++ b/spec/helpers/validation_query_helper.rb
@@ -1,0 +1,30 @@
+module ValidateQueryHelper
+  def stub_valid_query
+    params = {
+      'filter_content_purpose_supergroup' => %w(news_and_communications),
+      'filter_organisations' => %w(stories),
+      'filter_people' => %w(harry-potter),
+    }
+
+    stub_query(params: params)
+  end
+
+  def stub_invalid_query
+    stub_request(:get, "#{Plek.current.find('search')}/search.json?count=0&filter_blah=news&filter_invalid_param=stories&filter_people=harry-potter")
+      .to_return(status: 422, body: { "error": "\"blah\" is not a valid filter field" }.to_json, headers: {})
+  end
+
+  def stub_validation_of_valid_query(params = {})
+    stub_query(params: params)
+  end
+
+  def stub_query(params: {}, response: {}, response_code: 200)
+    query = Rack::Utils.build_nested_query params.merge(default_params)
+    stub_request(:get, "#{Plek.current.find('search')}/search.json?#{query}")
+      .to_return(status: response_code, body: response.to_json, headers: {})
+  end
+
+  def default_params
+    { 'count' => 0 }
+  end
+end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -57,8 +57,8 @@ describe EmailAlertSignupAPI do
     before do
       email_alert_api_has_subscriber_list(
         "tags" => {
-          "format" => "test-reports",
-          "alert_type" => %w(first second),
+          "format" => { any: "test-reports" },
+          "alert_type" => { any: %w(first second) },
         },
         "subscription_url" => subscription_url
       )
@@ -68,8 +68,8 @@ describe EmailAlertSignupAPI do
       it 'returns the url email-alert-api gives back' do
         email_alert_api_has_subscriber_list(
           "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w(first second),
+            "format" => { any: "test-reports" },
+            "alert_type" => { any: %w(first second) },
           },
           "subscription_url" => subscription_url
         )
@@ -80,15 +80,15 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
             },
             "title" => "Format with report types: first ABC thing and second DEF thing",
             "content_purpose_supergroup" => nil
@@ -110,15 +110,15 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w[first],
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w[first] },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w[first],
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w[first] },
             },
             "title" => "Format with report type: first ABC thing",
             "content_purpose_supergroup" => nil
@@ -133,15 +133,15 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
             },
             "title" => "First ABC thing and second DEF thing",
             "content_purpose_supergroup" => nil,
@@ -162,13 +162,13 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
+              "format" => { any: "test-reports" },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
+              "format" => { any: "test-reports" },
             },
             "title" => "Format",
             "content_purpose_supergroup" => nil,
@@ -236,9 +236,9 @@ describe EmailAlertSignupAPI do
     before do
       email_alert_api_has_subscriber_list(
         "tags" => {
-          "format" => "test-reports",
-          "alert_type" => %w(first second),
-          "other_type" => %w(third fourth)
+          "format" => { any: "test-reports" },
+          "alert_type" => { any: %w(first second) },
+          "other_type" => { any: %w(third fourth) },
         },
         "subscription_url" => subscription_url
       )
@@ -248,8 +248,8 @@ describe EmailAlertSignupAPI do
       it 'returns the url email-alert-api gives back' do
         email_alert_api_has_subscriber_list(
           "tags" => {
-            "format" => "test-reports",
-            "alert_type" => %w(first second),
+            "format" => { any: "test-reports" },
+            "alert_type" => { any: %w(first second) },
           },
           "subscription_url" => subscription_url
         )
@@ -260,17 +260,17 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
-              "other_type" => %w(third fourth),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
+              "other_type" => { any: %w(third fourth) },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
-              "other_type" => %w(third fourth),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
+              "other_type" => { any: %w(third fourth) },
             },
             "title" => "Formats with alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
             "content_purpose_supergroup" => nil,
@@ -293,17 +293,17 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w[first],
-              "other_type" => %w[],
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w[first] },
+              "other_type" => { any: %w[] },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w[first],
-              "other_type" => %w[],
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w[first] },
+              "other_type" => { any: %w[] },
             },
             "title" => "Formats with alert type of first ABC thing",
             "content_purpose_supergroup" => nil,
@@ -318,17 +318,17 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
-              "other_type" => %w(third fourth),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
+              "other_type" => { any: %w(third fourth) },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
-              "alert_type" => %w(first second),
-              "other_type" => %w(third fourth),
+              "format" => { any: "test-reports" },
+              "alert_type" => { any: %w(first second) },
+              "other_type" => { any: %w(third fourth) },
             },
             "title" => "Alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
             "content_purpose_supergroup" => nil,
@@ -349,13 +349,13 @@ describe EmailAlertSignupAPI do
         it 'asks email-alert-api to find or create the subscriber list' do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "format" => "test-reports",
+              "format" => { any: "test-reports" },
             },
             "subscription_url" => subscription_url
           )
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {
-              "format" => "test-reports",
+              "format" => { any: "test-reports" },
             },
             "title" => "Format",
             "content_purpose_supergroup" => nil,

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -91,7 +91,6 @@ describe EmailAlertSignupAPI do
               "alert_type" => { any: %w(first second) },
             },
             "title" => "Format with report types: first ABC thing and second DEF thing",
-            "content_purpose_supergroup" => nil
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -121,7 +120,6 @@ describe EmailAlertSignupAPI do
               "alert_type" => { any: %w[first] },
             },
             "title" => "Format with report type: first ABC thing",
-            "content_purpose_supergroup" => nil
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -144,7 +142,6 @@ describe EmailAlertSignupAPI do
               "alert_type" => { any: %w(first second) },
             },
             "title" => "First ABC thing and second DEF thing",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -171,7 +168,6 @@ describe EmailAlertSignupAPI do
               "format" => { any: "test-reports" },
             },
             "title" => "Format",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -273,7 +269,6 @@ describe EmailAlertSignupAPI do
               "other_type" => { any: %w(third fourth) },
             },
             "title" => "Formats with alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -306,7 +301,6 @@ describe EmailAlertSignupAPI do
               "other_type" => { any: %w[] },
             },
             "title" => "Formats with alert type of first ABC thing",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -331,7 +325,6 @@ describe EmailAlertSignupAPI do
               "other_type" => { any: %w(third fourth) },
             },
             "title" => "Alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -358,7 +351,6 @@ describe EmailAlertSignupAPI do
               "format" => { any: "test-reports" },
             },
             "title" => "Format",
-            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -91,6 +91,7 @@ describe EmailAlertSignupAPI do
               "alert_type" => %w(first second),
             },
             "title" => "Format with report types: first ABC thing and second DEF thing",
+            "content_purpose_supergroup" => nil
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -120,6 +121,7 @@ describe EmailAlertSignupAPI do
               "alert_type" => %w[first],
             },
             "title" => "Format with report type: first ABC thing",
+            "content_purpose_supergroup" => nil
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -142,6 +144,7 @@ describe EmailAlertSignupAPI do
               "alert_type" => %w(first second),
             },
             "title" => "First ABC thing and second DEF thing",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -168,6 +171,7 @@ describe EmailAlertSignupAPI do
               "format" => "test-reports",
             },
             "title" => "Format",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -269,6 +273,7 @@ describe EmailAlertSignupAPI do
               "other_type" => %w(third fourth),
             },
             "title" => "Formats with alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -301,6 +306,7 @@ describe EmailAlertSignupAPI do
               "other_type" => %w[],
             },
             "title" => "Formats with alert type of first ABC thing",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -325,6 +331,7 @@ describe EmailAlertSignupAPI do
               "other_type" => %w(third fourth),
             },
             "title" => "Alert type of first ABC thing and second DEF thing and other type of third GHI thing and fourth JKL thing",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url
@@ -351,6 +358,7 @@ describe EmailAlertSignupAPI do
               "format" => "test-reports",
             },
             "title" => "Format",
+            "content_purpose_supergroup" => nil,
           ).and_call_original
 
           signup_api_wrapper.signup_url

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -127,6 +127,19 @@ describe EmailAlertTitleBuilder do
       end
     end
 
+    context 'when one dynamic facet is selected' do
+      let(:subscription_list_title_prefix) { 'Prefix ' }
+      let(:facets) do
+        [{ "facet_id" => "people", "facet_name" => "people" }]
+      end
+      let(:filter) do
+        { 'people' => %w(harry_potter ron_weasley) }
+      end
+
+      it { is_expected.to eq('Prefix with 2 people') }
+    end
+
+
     context 'when two facets are selected' do
       let(:filter) do
         {
@@ -137,5 +150,34 @@ describe EmailAlertTitleBuilder do
 
       it { is_expected.to eq('Prefix: with facet name one of topic name one and topic name two and facet name two of topic name three and topic name four') }
     end
+  end
+
+  context "when there are multiple facets with the same filter_key" do
+    let(:subscription_list_title_prefix) { 'News and communicatons ' }
+    let(:facets) do
+      [
+        { "facet_id" => "politicians", "facet_name" => "people", "filter_key" => "people" },
+        { "facet_id" => "people", "facet_name" => "people" },
+        { "facet_id" => "persons_of_interest", "facet_name" => "people", "filter_key" => "people" },
+        { "facet_id" => "organisations", "facet_name" => "organisations" },
+        { "facet_id" => "departments_of_interest", "facet_name" => "departments of interest", "filter_key" => "organisations" },
+        { "facet_id" => "document_type", "facet_name" => "document types" },
+        { "facet_id" => "world_locations", "facet_name" => "world locations" },
+        { "facet_id" => "level_one_taxon", "filter_key" => "part_of_taxonomy_tree", "facet_name" => "topics" },
+        { "facet_id" => "level_two_taxon", "filter_key" => "part_of_taxonomy_tree", "facet_name" => "topics" },
+        { "facet_id" => "related_to_brexit", "filter_key" => "part_of_taxonomy_tree", "filter_value" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea", "facet_name" => "topics" },
+    ]
+    end
+    let(:filter) do
+      {
+        'people' => %w(harry_potter ron_weasley dumbledore cornelius_fudge rufus_scrimgeour),
+        'organisations' => %w(ministry_of_magic gringots hogwarts),
+        'part_of_taxonomy_tree' => %w(magical_education brexit education),
+      }
+    end
+
+    it {
+      is_expected.to eq('News and communicatons with 5 people, 3 organisations, and 3 topics')
+    }
   end
 end

--- a/spec/lib/validate_query_spec.rb
+++ b/spec/lib/validate_query_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require 'validate_query'
+require_relative "../helpers/validation_query_helper"
+
+describe ValidateQuery do
+  include ValidateQueryHelper
+
+  before :each do
+    stub_valid_query
+    stub_invalid_query
+  end
+
+  describe "#validate" do
+    context "with valid params" do
+      let(:query_params) {
+        {
+          'content_purpose_supergroup' => %w(news_and_communications),
+          'organisations' => %w(stories),
+          'people' => %w(harry-potter),
+        }
+      }
+
+      subject { described_class.new(query_params) }
+
+      it "returns nil" do
+        expect(subject.validate).to eql(nil)
+      end
+    end
+
+    context "with invalid params" do
+      let(:query_params) {
+        {
+          'blah' => 'news',
+          'invalid_param' => 'stories',
+          'people' => 'harry-potter',
+        }
+      }
+      subject { described_class.new(query_params) }
+
+      it "returns an error message" do
+        expect(subject.validate).to eql("\"blah\" is not a valid filter field")
+      end
+    end
+  end
+end

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
 
-  subject(:presenter) { described_class.new(content_item(no_sort_options), values) }
-  subject(:presenter_with_sort) { described_class.new(content_item(sort_options_without_relevance), values) }
+  subject(:presenter) { described_class.new(content_item(sort_options: no_sort_options), values) }
+  subject(:presenter_with_sort) { described_class.new(content_item(sort_options: sort_options_without_relevance), values) }
+  subject(:presenter_with_email_signup) { described_class.new(content_item(email_alert_signup: email_alert_signup_options), values) }
 
   let(:no_sort_options) { nil }
 
@@ -37,6 +38,23 @@ RSpec.describe FinderPresenter do
     ]
   }
 
+  let(:email_alert_signup_options) {
+    {
+      "api_path": "/api/content/mosw-reports/email-signup",
+      "base_path": "/mosw-reports/email-signup",
+      "content_id": "12dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+      "document_type": "finder_email_signup",
+      "locale": "en",
+      "public_updated_at": "2019-01-24T10:22:17Z",
+      "schema_name": "finder_email_signup",
+      "title": "MOSW reports",
+      "withdrawn": false,
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/mosw-reports/email-signup",
+      "web_url": "/mosw-reports/email-signup"
+    }
+  }
+
   let(:values) { {} }
 
   describe "facets" do
@@ -66,6 +84,30 @@ RSpec.describe FinderPresenter do
     end
   end
 
+  describe "#email_alert_signup_url" do
+    context "with no values" do
+      it "returns the finder URL appended with /email-signup?" do
+        expect(presenter.email_alert_signup_url).to eql("https://www.gov.uk/mosw-reports/email-signup?")
+      end
+    end
+
+    context "with some values" do
+      let(:values) do
+        {
+          keyword: "legal",
+          place_of_origin: "england",
+          walk_type: "open",
+          creator: "Harry Potter",
+          unpermitted_facet: "blah_blah",
+        }
+      end
+
+      it "returns the finder URL appended with permitted query params" do
+        expect(presenter_with_email_signup.email_alert_signup_url).to eql("/mosw-reports/email-signup?place_of_origin%5B%5D=england")
+      end
+    end
+  end
+
   describe "#atom_url" do
     context "with no values" do
       it "returns the finder URL appended with .atom" do
@@ -91,35 +133,35 @@ RSpec.describe FinderPresenter do
   describe "#atom_feed_enabled?" do
     context "with no sort options and no default sort" do
       it "is true" do
-        presenter = described_class.new(content_item(no_sort_options), values)
+        presenter = described_class.new(content_item(sort_options: no_sort_options), values)
         expect(presenter.atom_feed_enabled?).to be true
       end
     end
 
     context "with default sort option set to descending public_timestamp" do
       it "is true" do
-        presenter = described_class.new(content_item(sort_options_with_public_timestamp_default), values)
+        presenter = described_class.new(content_item(sort_options: sort_options_with_public_timestamp_default), values)
         expect(presenter.atom_feed_enabled?).to be true
       end
     end
 
     context "with sort options but no default order" do
       it "is true" do
-        presenter = described_class.new(content_item(sort_options_with_relevance), values)
+        presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), values)
         expect(presenter.atom_feed_enabled?).to be true
       end
     end
 
     context "with no sort options but a changeable default order" do
       it "is false" do
-        presenter = described_class.new(content_item(no_sort_options, default_order: "relevance"), values)
+        presenter = described_class.new(content_item(sort_options: no_sort_options, default_order: "relevance"), values)
         expect(presenter.atom_feed_enabled?).to be false
       end
     end
 
     context "with no sort options but a default order of most recent first" do
       it "is true" do
-        presenter = described_class.new(content_item(no_sort_options, default_order: "-public_timestamp"), values)
+        presenter = described_class.new(content_item(sort_options: no_sort_options, default_order: "-public_timestamp"), values)
         expect(presenter.atom_feed_enabled?).to be true
       end
     end
@@ -152,7 +194,7 @@ RSpec.describe FinderPresenter do
         sort_option('Relevance', 'relevance', disabled: true)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options_with_relevance), values)
+      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), values)
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -164,7 +206,7 @@ RSpec.describe FinderPresenter do
         sort_option('Relevance', 'relevance', disabled: false)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options_with_relevance), "keywords" => "something not blank")
+      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), "keywords" => "something not blank")
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -176,7 +218,7 @@ RSpec.describe FinderPresenter do
       ].join("\n")
 
 
-      presenter = described_class.new(content_item(sort_options_without_relevance), "order" => "option_that_does_not_exist")
+      presenter = described_class.new(content_item(sort_options: sort_options_without_relevance), "order" => "option_that_does_not_exist")
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -187,7 +229,7 @@ RSpec.describe FinderPresenter do
         sort_option('Updated (oldest)', 'updated-oldest', selected: true)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options_with_default), values)
+      presenter = described_class.new(content_item(sort_options: sort_options_with_default), values)
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -198,7 +240,7 @@ RSpec.describe FinderPresenter do
         sort_option('Updated (newest)', 'updated-newest', selected: true)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options_without_relevance), "order" => "updated-newest")
+      presenter = described_class.new(content_item(sort_options: sort_options_without_relevance), "order" => "updated-newest")
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -206,10 +248,12 @@ RSpec.describe FinderPresenter do
 
 private
 
-  def content_item(sort_options, default_order: nil)
+  def content_item(sort_options: nil, email_alert_signup: nil, default_order: nil)
     finder_example = govuk_content_schema_example('finder')
     finder_example['details']['sort'] = sort_options
+    finder_example['links']['email_alert_signup'] = [email_alert_signup] if email_alert_signup
     finder_example['details']['default_order'] = default_order if default_order
+
 
     dummy_http_response = double(
       "net http response",

--- a/spec/presenters/signup_url_hidden_params_presenter_spec.rb
+++ b/spec/presenters/signup_url_hidden_params_presenter_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+RSpec.describe SignupUrlHiddenParamsPresenter do
+  include FixturesHelper
+
+  let(:signup_finder) { news_and_communications_signup_content_item }
+
+  describe '#hidden_params' do
+    it "returns empty hash if none passed in" do
+      params = {}
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder, params)
+      expect(presenter.hidden_params).to eql({})
+    end
+
+    it "returns hash with values if they are included in the content_item" do
+      signup_finder_content_item = signup_finder.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_id' => 'filter_part_of_taxonomy'
+          }
+        ]
+      end
+
+      params = { 'filter_part_of_taxonomy' => 'some-taxon' }
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
+      expect(presenter.hidden_params).to eql('filter_part_of_taxonomy' => %w(some-taxon))
+    end
+
+    it "returns hash with values if they are dynamic attributes" do
+      params = {
+        'organisations' => ["academy-for-social-justice-commissioning", "accelerated-access-review"],
+        'people' => ["sir-philip-jones", "mark-stanhope"],
+        'level_one_taxon' => ["c58fdadd-7743-46d6-9629-90bb3ccc4ef0"],
+        'related_to_brexit' => 'true'
+      }
+
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder, params)
+      expect(presenter.hidden_params).to eql(
+        'organisations' => %w(
+          academy-for-social-justice-commissioning
+          accelerated-access-review
+        ),
+        'people' => %w(sir-philip-jones mark-stanhope),
+        'part_of_taxonomy_tree' => %w(
+          c58fdadd-7743-46d6-9629-90bb3ccc4ef0
+          d6c2de5d-ef90-45d1-82d4-5f2438369eea
+        ),
+      )
+    end
+
+    it "returns empty hash if email_filter_facet includes facet_choices in the content_item" do
+      signup_finder_content_item = signup_finder.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_name' => 'filter_part_of_taxonomy',
+            'facet_choices' => [
+              {
+                "key": 'taxon',
+                "radio_button_name": 'Filter by some taxon',
+                "topic_name": 'Some taxon',
+                "prechecked": false
+              }
+            ]
+          }
+        ]
+      end
+
+      params = { 'filter_part_of_taxonomy' => 'some-taxon' }
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
+      expect(presenter.hidden_params).to eql({})
+    end
+
+    it "translates a facet id into a filter key if it is present" do
+      signup_finder_content_item = signup_finder.tap do |content_item|
+        content_item['details']['email_filter_facets'] = [
+          {
+            'facet_id' => 'some_arbitrary_facet_id',
+            'facet_name' => 'some_arbitrary_facet_name',
+            'filter_key' => 'a_filter_key_rummager_can_filter_by',
+          }
+        ]
+      end
+
+      params = { 'some_arbitrary_facet_id' => 'some-taxon' }
+      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
+      expect(presenter.hidden_params).to eql('a_filter_key_rummager_can_filter_by' => %w(some-taxon))
+    end
+  end
+end

--- a/spec/presenters/signup_url_hidden_params_presenter_spec.rb
+++ b/spec/presenters/signup_url_hidden_params_presenter_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
 
-RSpec.describe SignupUrlHiddenParamsPresenter do
+RSpec.describe SubscriberListParamsPresenter do
   include FixturesHelper
 
   let(:signup_finder) { news_and_communications_signup_content_item }
 
-  describe '#hidden_params' do
+  describe '#subscriber_list_params' do
     it "returns empty hash if none passed in" do
       params = {}
-      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder, params)
-      expect(presenter.hidden_params).to eql({})
+      presenter = described_class.new(signup_finder, params)
+      expect(presenter.subscriber_list_params).to eql({})
     end
 
     it "returns hash with values if they are included in the content_item" do
@@ -22,8 +22,8 @@ RSpec.describe SignupUrlHiddenParamsPresenter do
       end
 
       params = { 'filter_part_of_taxonomy' => 'some-taxon' }
-      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
-      expect(presenter.hidden_params).to eql('filter_part_of_taxonomy' => %w(some-taxon))
+      presenter = described_class.new(signup_finder_content_item, params)
+      expect(presenter.subscriber_list_params).to eql('filter_part_of_taxonomy' => %w(some-taxon))
     end
 
     it "returns hash with values if they are dynamic attributes" do
@@ -34,8 +34,8 @@ RSpec.describe SignupUrlHiddenParamsPresenter do
         'related_to_brexit' => 'true'
       }
 
-      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder, params)
-      expect(presenter.hidden_params).to eql(
+      presenter = described_class.new(signup_finder, params)
+      expect(presenter.subscriber_list_params).to eql(
         'organisations' => %w(
           academy-for-social-justice-commissioning
           accelerated-access-review
@@ -66,8 +66,8 @@ RSpec.describe SignupUrlHiddenParamsPresenter do
       end
 
       params = { 'filter_part_of_taxonomy' => 'some-taxon' }
-      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
-      expect(presenter.hidden_params).to eql({})
+      presenter = described_class.new(signup_finder_content_item, params)
+      expect(presenter.subscriber_list_params).to eql({})
     end
 
     it "translates a facet id into a filter key if it is present" do
@@ -82,8 +82,8 @@ RSpec.describe SignupUrlHiddenParamsPresenter do
       end
 
       params = { 'some_arbitrary_facet_id' => 'some-taxon' }
-      presenter = SignupUrlHiddenParamsPresenter.new(signup_finder_content_item, params)
-      expect(presenter.hidden_params).to eql('a_filter_key_rummager_can_filter_by' => %w(some-taxon))
+      presenter = described_class.new(signup_finder_content_item, params)
+      expect(presenter.subscriber_list_params).to eql('a_filter_key_rummager_can_filter_by' => %w(some-taxon))
     end
   end
 end

--- a/spec/presenters/signup_url_hidden_params_presenter_spec.rb
+++ b/spec/presenters/signup_url_hidden_params_presenter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SubscriberListParamsPresenter do
           accelerated-access-review
         ),
         'people' => %w(sir-philip-jones mark-stanhope),
-        'part_of_taxonomy_tree' => %w(
+        'all_part_of_taxonomy_tree' => %w(
           c58fdadd-7743-46d6-9629-90bb3ccc4ef0
           d6c2de5d-ef90-45d1-82d4-5f2438369eea
         ),

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -23,6 +23,10 @@ module FixturesHelper
     JSON.parse(File.read(fixtures_path + "/cma_cases_signup_content_item.json"))
   end
 
+  def news_and_communications_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/news_and_communications_signup_content_item.json"))
+  end
+
   def cma_cases_with_multi_facets_signup_content_item
     JSON.parse(File.read(fixtures_path + "/cma_cases_with_multi_facets_signup_content_item.json"))
   end


### PR DESCRIPTION
https://trello.com/c/TnK2c8fF/169-add-the-ability-to-sign-up-for-emails-on-the-news-and-communications-finder?menu=filter&filter=label:Finders

This PR enables users to subscribe to emails from the news and communications finder.

In order to enable this the following changes were necessary:

- Add default filters to email subscriptions. For example, content_purpose_supergroup=news_and_communications is now a possible filter, and is set by default from the news and communications signup content item.
- Add an email signup content item
- Permit sending dynamic filters (with no specified choices) to the email alert api.

A number of minor changes were also needed. I've broken it up into smaller commits which will hopefully help with reviewing.

Before we merge, we will need to bump finder frontend's version of [gds-api-adapters](https://github.com/alphagov/gds-api-adapters/pull/893) to`57.2.4` (https://github.com/alphagov/gds-api-adapters/pull/898 needs to be merged). Additionally we'll need to deploy https://github.com/alphagov/email-alert-api/pull/776 to permit subscriptions to supergroups.

## Screenshots

![screen shot 2019-01-28 at 12 21 17](https://user-images.githubusercontent.com/8124374/51852885-f51fbe00-231e-11e9-86ff-84d41111a63b.png)
![screen shot 2019-01-28 at 12 21 25](https://user-images.githubusercontent.com/8124374/51852896-f8b34500-231e-11e9-9bae-7acb9c8208ea.png)
![screen shot 2019-01-28 at 12 21 09](https://user-images.githubusercontent.com/8124374/51852890-f6e98180-231e-11e9-8282-11e0c3bddc3e.png)
