### PR TITLE
Tracking not working when updated results in form change

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -102,11 +102,16 @@
         function(){
           var newPath = window.location.pathname + "?" + $.param(this.state);
           history.pushState(this.state, '', newPath);
+          this.trackingInit();
         }.bind(this)
       )
     }
     this.trackPageView();
   };
+
+  LiveSearch.prototype.trackingInit = function() {
+    GOVUK.modules.start($('.js-live-search-results-block'));
+  }
 
   LiveSearch.prototype.trackPageView = function trackPageView() {
     if (this.canTrackPageview()) {

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -319,6 +319,7 @@ Then(/^I see the most viewed articles first$/) do
     expect(page).to have_content('16 November 2018')
   end
 
+  expect(page).to have_css("a[data-track-category='navFinderLinkClicked']")
   expect(page).to have_content('sorted by Most viewed')
 end
 
@@ -331,6 +332,7 @@ Then(/^I see services in alphabetical order$/) do
     expect(page).to have_content('Register a magical spell')
   end
 
+  expect(page).to have_css("a[data-track-category='navFinderLinkClicked']")
   expect(page).to have_content('sorted by A-Z')
 end
 

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -185,11 +185,14 @@ describe("liveSearch", function(){
       var promise = jasmine.createSpyObj('promise', ['done']);
       spyOn(liveSearch, 'updateResults').and.returnValue(promise);
       spyOn(GOVUK.analytics, 'trackPageview');
+      spyOn(liveSearch, 'trackingInit');
+
       liveSearch.state = [];
 
       liveSearch.formChange();
       promise.done.calls.mostRecent().args[0]();
 
+      expect(liveSearch.trackingInit).toHaveBeenCalled();
       expect(GOVUK.analytics.trackPageview).toHaveBeenCalled();
       var trackArgs = GOVUK.analytics.trackPageview.calls.first().args[0];
       expect(trackArgs.split('?')[1], 'field=sheep');


### PR DESCRIPTION
- When a change is made in the form, js-live-search-results-block, tracking stops working.
- When a form change is triggered, the JavaScript modules need reinitializing to be able to
add tracking again.

Trello: https://trello.com/c/q1W29H42