### PR TITLE
Sort taxons in taxonomy registry

### DIFF
--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -34,16 +34,17 @@ module Registries
 
     def format_child_taxons(taxon)
       children = taxon.dig('links', 'child_taxons') || []
-      children.map { |child_taxon|
+      formatted_children = children.map { |child_taxon|
         format_taxon(child_taxon, taxon['content_id'])
       }
+
+      formatted_children.sort_by { |child_taxon| child_taxon['title'] }
     end
 
     def fetch_level_one_taxons_from_api
       taxons = fetch_taxon.dig('links', 'level_one_taxons') || []
-      taxons.map { |taxon|
-        fetch_taxon(taxon['base_path'])
-      }
+      sorted = taxons.sort_by { |taxon| taxon['title'] }
+      sorted.map { |taxon| fetch_taxon(taxon['base_path']) }
     end
 
     def fetch_taxon(base_path = '/')


### PR DESCRIPTION
https://trello.com/c/9uUwpGuf/293-sort-topics-in-drop-down-facet

This sorts taxons for the taxonomy facet. In testing users usually assume options in a select field are alphabetical. This makes it so.

Check it out here: https://finder-frontend-pr-825.herokuapp.com/news-and-communications

![screen shot 2019-01-29 at 14 46 53](https://user-images.githubusercontent.com/8124374/51916220-c401c500-23d4-11e9-82e4-708a00e55b37.png)
![screen shot 2019-01-29 at 14 46 44](https://user-images.githubusercontent.com/8124374/51916221-c401c500-23d4-11e9-9639-49cd8f869cd1.png)
