### PR TITLE
[DO NOT MERGE] Add new feedback form to business finder

### DIFF
--- a/app/assets/javascripts/modules/feedback.js
+++ b/app/assets/javascripts/modules/feedback.js
@@ -1,0 +1,71 @@
+window.GOVUK = window.GOVUK || {};
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (GOVUK) {
+  "use strict";
+
+  var jsHiddenClass = 'js-hidden';
+
+  GOVUK.Modules.BusinessFinderFeedback = function () {
+
+    this.start = function ($this) {
+
+      var $form = $this.find('.js-feedback-form');
+      var $promptQuestions = $this.find('.js-prompt');
+      var $openFormButton = $this.find('.js-open-form');
+      var $submitMessage = $this.find('.js-submit-message');
+
+      $openFormButton.on('click', function(e) {
+        e.preventDefault();
+        $promptQuestions.toggleClass(jsHiddenClass);
+        $form.toggleClass(jsHiddenClass);
+        $form.find('textarea')[0].focus();
+      });
+
+      $form.on('submit', function(e) {
+        e.preventDefault();
+        $.ajax({
+          type: "POST",
+          url: $form.attr('action'),
+          dataType: "json",
+          data: $form.serialize(),
+          beforeSend: disableSubmitFormButton($form),
+          timeout: 6000
+        }).done(function () {
+          trackEvent($form);
+          $form.toggleClass(jsHiddenClass);
+          $submitMessage.toggleClass(jsHiddenClass).focus();
+          enableSubmitFormButton($form);
+        }).fail(function () {
+          trackEvent($form);
+          showError($form);
+          enableSubmitFormButton($form);
+        });
+      });
+    };
+
+    function trackEvent($form) {
+      var trackEventParams = {
+        category: $form.data('track-category'),
+        action: $form.data('track-action')
+      }
+
+      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action);
+      }
+    }
+
+    function disableSubmitFormButton ($form) {
+      $form.find('button[type="submit"]').prop('disabled', true);
+    }
+
+    function enableSubmitFormButton ($form) {
+      $form.find('button[type="submit"]').removeAttr('disabled');
+    }
+
+    function showError ($form) {
+      var $errorBox = $form.find('#feedback-error').parent();
+      $errorBox.removeClass(jsHiddenClass).focus();
+    }
+  };
+})(window.GOVUK);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -310,6 +310,35 @@
     }
   }
 
+  .feedback-form {
+    display: none;
+
+    .js-enabled & {
+      @include core-19;
+      display: block;
+      background-color: $grey-3;
+      margin-top: govuk-spacing(6);
+      padding: govuk-spacing(4);
+    }
+
+    .feedback-form__question {
+      @include bold-19;
+    }
+
+    .feedback-form__option {
+      margin-right: govuk-spacing(2);
+    }
+
+    .feedback-form__message-container {
+      outline: 0;
+
+      .feedback-form__message {
+        @include govuk-font($size: 19);
+        margin-bottom: govuk-spacing(4);
+      }
+    }
+  }
+
   .facet-tags {
     margin-top: $gutter-one-third;
     margin-bottom: $gutter;

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -14,6 +14,14 @@ class FinderPresenter
     @keywords = values["keywords"].presence
   end
 
+  def show_feedback_form?
+    @slug.eql?('/find-eu-exit-guidance-business')
+  end
+
+  def contact_form_link
+    "If the problem persists, we have other ways for you to provide feedback on the <a href=\"/contact\">contact page</a>".html_safe
+  end
+
   def phase_message
     content_item['details']['beta_message'] || content_item['details']['alpha_message']
   end

--- a/app/views/finders/_feedback_form.html.erb
+++ b/app/views/finders/_feedback_form.html.erb
@@ -1,0 +1,48 @@
+<div class="feedback-form" data-module="business-finder-feedback">
+  <div class="js-prompt" data-module="track-click">
+    <a
+      class="feedback-form__option js-open-form"
+      href="/contact/govuk"
+      aria-expanded="false"
+      role="button"
+      aria-controls="business-finder-feedback"
+      data-track-category="businessFinderFeedback"
+      data-track-action="missingContentFeedback"><%= t('finders.feedback.did_you_find') %></a>
+  </div>
+
+  <form
+    action="/contact/govuk/content_improvement"
+    method="post"
+    id="business-finder-feedback"
+    tabindex="-1"
+    data-track-category="BusinessFinderFeedback"
+    data-track-action="GOV.UK Send Form"
+    class="js-hidden js-feedback-form">
+
+      <div class="js-hidden">
+        <%= render "govuk_publishing_components/components/error_summary", {
+          id: "feedback-error",
+          title: "Sorry, we’re unable to receive your message right now.",
+          description: finder.contact_form_link,
+        } %>
+      </div>
+
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t('finders.feedback.give_details')
+        },
+        name: "description"
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Send"
+      } %>
+  </form>
+
+    <div class="js-submit-message js-hidden feedback-form__message-container" tabindex="-1">
+      <p class="feedback-form__message"><%= t('finders.feedback.success_message') %></p>
+      <p class="feedback-form__message email-link">
+        <%= link_to "Subscribe to receive email alerts", finder.email_alert_signup_url %>
+        when new information is published for your business area.
+    </p>
+  </div>
+</div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -61,40 +61,49 @@
   <% end %>
 </header>
 
-<form method="get" action="<%= finder.slug %>" class="js-live-search-form">
-  <div class="grid-row">
-    <div class="column-third">
-      <%= render finder.facets %>
-    </div>
+<div class="grid-row">
+  <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+      <div class="column-third">
+        <%= render finder.facets %>
+      </div>
 
-    <div class="column-two-thirds">
-      <div class='js-live-search-results-block'>
-        <div class="filtered-results">
-          <div aria-live='assertive' id='js-search-results-info' data-module="remove-filter">
-            <% if finder.show_generic_description? %>
-              <%= render_mustache('result_count_generic', @results.to_hash) %>
-            <% else %>
-              <%= render_mustache('result_count', @results.to_hash) %>
-            <% end %>
-          </div>
-
-          <% if finder.sort.present? %>
-            <div class="govuk-form-group">
-              <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
-              <%= select_tag 'order', finder.sort_options,
-                             class: 'govuk-select js-order-results',
-                             'aria-controls': 'js-search-results-info',
-                             data: { 'default-sort-option' => finder.default_sort_option_value,
-                                     'relevance-sort-option' => finder.relevance_sort_option_value,
-                                     'module' => 'track-select-change'} %>
+      <div class="column-two-thirds">
+        <div class='js-live-search-results-block'>
+          <div class="filtered-results">
+            <div aria-live='assertive' id='js-search-results-info' data-module="remove-filter">
+              <% if finder.show_generic_description? %>
+                <%= render_mustache('result_count_generic', @results.to_hash) %>
+              <% else %>
+                <%= render_mustache('result_count', @results.to_hash) %>
+              <% end %>
             </div>
-          <% end %>
 
-          <div id='js-results'>
-            <%= render_mustache('results', @results.to_hash) %>
+            <% if finder.sort.present? %>
+              <div class="govuk-form-group">
+                <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
+                <%= select_tag 'order', finder.sort_options,
+                  class: 'govuk-select js-order-results',
+                  'aria-controls': 'js-search-results-info',
+                  data: { 'default-sort-option' => finder.default_sort_option_value,
+                          'relevance-sort-option' => finder.relevance_sort_option_value,
+                          'module' => 'track-select-change'} %>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>
+  </form>
+  <div class="column-two-thirds">
+    <div class='js-live-search-results-block'>
+      <div class="filtered-results results-info">
+        <div id='js-results'>
+          <%= render_mustache('results', @results.to_hash) %>
+        </div>
+      </div>
     </div>
+    <% if finder.show_feedback_form? %>
+      <%= render partial: 'feedback_form' %>
+    <% end %>
   </div>
-</form>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,3 +27,7 @@ en:
     facet_disclosure:
       more: "Show more search options"
       fewer: "Show fewer search options"
+    feedback:
+      did_you_find: "Tell us if you can't find what you're looking for"
+      give_details: "What are you looking for?"
+      success_message: "Your message was sent."

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -14,7 +14,7 @@ end
 
 Then(/I see no results$/) do
   expect(page).to have_content('0 reports')
-  expect(page).to have_css('.filtered-results .document', count: 0)
+  expect(page).to have_css('.results-info .document', count: 0)
 end
 
 And(/there is no keyword search box$/) do
@@ -25,10 +25,10 @@ Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 
   expect(page).to have_content('2 reports')
-  expect(page).to have_css('.filtered-results .document', count: 2)
+  expect(page).to have_css('.results-info .document', count: 2)
   expect(page).to have_css('.gem-c-metadata')
 
-  within '.filtered-results .document:nth-child(1)' do
+  within '.results-info .document:nth-child(1)' do
     expect(page).to have_link(
       'West London wobbley walk',
       href: '/mosw-reports/west-london-wobbley-walk',
@@ -40,7 +40,7 @@ Then(/^I can get a list of all documents with matching metadata$/) do
   visit_filtered_finder('walk_type' => 'hopscotch')
 
   expect(page).to have_content('1 report')
-  expect(page).to have_css('.filtered-results .document', count: 1)
+  expect(page).to have_css('.results-info .document', count: 1)
 end
 
 When(/^I view a list of news and communications$/) do
@@ -75,7 +75,7 @@ When(/^I search documents by keyword$/) do
 end
 
 Then(/^I see all documents which contain the keywords$/) do
-  within ".filtered-results" do
+  within ".results-info" do
     expect(page).to have_css("a", text: @keyword_search)
   end
 end
@@ -96,7 +96,7 @@ Then(/^I can see documents which are marked as being in history mode$/) do
 end
 
 Then(/^I can see documents which have government metadata$/) do
-  within '.filtered-results .document:nth-child(1)' do
+  within '.results-info .document:nth-child(1)' do
     expect(page).to have_content('Updated:')
     expect(page).to have_css('dl time[datetime="2007-02-14"]')
 
@@ -113,14 +113,14 @@ end
 
 Then(/^I can get a list of all documents with good metadata$/) do
   visit finder_path('mosw-reports')
-  expect(page).to have_css('.filtered-results .document', count: 2)
+  expect(page).to have_css('.results-info .document', count: 2)
 
-  within '.filtered-results .document:nth-child(1)' do
+  within '.results-info .document:nth-child(1)' do
     expect(page).to have_content('Backward')
     expect(page).not_to have_content('England')
   end
 
-  within '.filtered-results .document:nth-child(2)' do
+  within '.results-info .document:nth-child(2)' do
     expect(page).to have_content('Northern Ireland')
     expect(page).not_to have_content('Hopscotch')
   end
@@ -280,7 +280,7 @@ Then(/^I only see documents that match the checkbox filter$/) do
   expect(page).to have_css('.facet-tags__preposition', text: "That Is")
   expect(page).to have_css('.facet-tag__text', text: "Open")
 
-  within ".filtered-results .document:nth-child(1)" do
+  within ".results-info .document:nth-child(1)" do
     expect(page).to have_content("Big Beer Co / Salty Snacks Ltd merger inquiry")
     expect(page).to_not have_content("Bakery market investigation")
   end
@@ -310,12 +310,12 @@ When(/^I filter the results$/) do
 end
 
 Then(/^I see the most viewed articles first$/) do
-  within '.filtered-results .document:nth-child(1)' do
+  within '.results-info .document:nth-child(1)' do
     expect(page).to have_content('Press release from Hogwarts')
     expect(page).to have_content('25 December 2017')
   end
 
-  within '.filtered-results .document:nth-child(2)' do
+  within '.results-info .document:nth-child(2)' do
     expect(page).to have_content('16 November 2018')
   end
 
@@ -324,11 +324,11 @@ Then(/^I see the most viewed articles first$/) do
 end
 
 Then(/^I see services in alphabetical order$/) do
-  within '.filtered-results .document:nth-child(1)' do
+  within '.results-info .document:nth-child(1)' do
     expect(page).to have_content('Apply for your full broomstick licence')
   end
 
-  within '.filtered-results .document:nth-child(2)' do
+  within '.results-info .document:nth-child(2)' do
     expect(page).to have_content('Register a magical spell')
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/a9WXTd6f/64-build-a-feedback-component-that-sits-at-the-bottom-of-finder-results

Left to do before this is production-ready:
- Confirm tracking events are correct/what we want
- Consider users with JS disabled
- Write tests
- Think about making it an actual component in finder-frontend