### PR TITLE
Fix advanced search when searching with dates

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -34,7 +34,7 @@ class Facet
 private
 
   def and_word_connectors
-    { two_words_connector: ' and ' }
+    { words_connector: ' and ', two_words_connector: ' and ' }
   end
 
   def or_word_connectors

--- a/features/advanced_search.feature
+++ b/features/advanced_search.feature
@@ -15,6 +15,12 @@ Feature: Advanced Search
     Then I only see documents tagged to the taxon tree within the supergroup
     And The correct metadata is displayed for the search results
 
+  Scenario: Filters documents by taxon, supergroup and dates
+    Given a collection of tagged documents with dates in supergroup 'news_and_communications'
+    When I filter by taxon, supergroup and dates
+    Then I only see documents tagged to the taxon tree within the supergroup
+    And the correct metadata is displayed for the dates
+
   Scenario: Filters documents by taxon, supergroup and subgroups
     Given a collection of tagged documents in supergroup 'news_and_communications' and subgroups 'news,updates_and_alerts'
     When I filter by taxon, supergroup and subgroups

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -32,6 +32,9 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
   )
 
   case categorisation.strip
+  when /^with dates in supergroup '(\w+)'$/
+    search_params["filter_content_store_document_type"] = GovukDocumentTypes.supergroup_document_types($1)
+    search_params["filter_public_timestamp"] = "from:2005-01-01,to:2025-01-01"
   when /^in supergroup '(\w+)'$/
     search_params["filter_content_store_document_type"] = GovukDocumentTypes.supergroup_document_types($1)
   when /^in supergroup '(\w+)' and subgroups '([\w,]+)'$/
@@ -70,6 +73,10 @@ When(/^I filter by taxon and by supergroup$/) do
   visit "/search/advanced?topic=/taxon&group=news_and_communications"
 end
 
+When(/^I filter by taxon, supergroup and dates$/) do
+  visit "/search/advanced?topic=/taxon&group=news_and_communications&public_timestamp%5Bfrom%5D=2005&public_timestamp%5Bto%5D=2025"
+end
+
 When(/^I filter by taxon, supergroup and subgroups$/) do
   visit "/search/advanced?topic=/taxon&group=news_and_communications&subgroup[]=news&subgroup[]=updates_and_alerts"
 end
@@ -95,6 +102,12 @@ end
 Then(/^The correct metadata is displayed for the search results$/) do
   expect(page).to have_css(".gem-c-document-list__attribute", text: "Guidance")
   expect(page).not_to have_css(".gem-c-document-list__attribute", text: "Guide")
+end
+
+And(/^the correct metadata is displayed for the dates$/) do
+  within(".result-info") do
+    expect(page).to have_content("2 results in updates and alerts, news, speeches and statements, and decisions and published between 1 January 2005 and 1 January 2025")
+  end
 end
 
 Then(/^The page is not found$/) do


### PR DESCRIPTION
At present, if you fill in an [advanced search finder](https://www.gov.uk/search/advanced?topic=%2Feducation&group=research_and_statistics) with values for both the "before" and "after" publication dates then the search will fail.  

The word connector on the facet didn't seem to be set up quite right, so when it tries to render `Between '2005' _and_ '2025'`, the _and_ is actually `nil` at the moment.

You can test the fix at: https://finder-frontend-pr-841.herokuapp.com/search/advanced?public_timestamp%5Bfrom%5D=2005&public_timestamp%5Bto%5D=2014&topic=%2Feducation&group=research_and_statistics

Fixes: https://sentry.io/govuk/app-finder-frontend/issues/846706923/?query=is%3Aunresolved