### PR TITLE
Remove news-and-comms finder from dev

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -152,7 +152,6 @@ private
   end
 
   FINDERS_IN_DEVELOPMENT = {
-    "/news-and-communications" => "news_and_communications",
     "/guidance-and-regulation" => "guidance_and_regulation",
     "/statistics" => "statistics",
     "/services" => "services",


### PR DESCRIPTION
This can be merged when we've published the content item.