### PR TITLE
Allow Atom feeds on more things

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -4,6 +4,8 @@ class FinderPresenter
 
   attr_reader :content_item, :name, :slug, :organisations, :values, :keywords
 
+  MOST_RECENT_FIRST = "-public_timestamp".freeze
+
   def initialize(content_item, values = {})
     @content_item = content_item
     @name = content_item['title']
@@ -118,6 +120,11 @@ class FinderPresenter
       &.parameterize
   end
 
+  def default_sort_option_key
+    default_sort_option
+      &.dig('key')
+  end
+
   def relevance_sort_option
     sort
       &.detect { |option| %w(relevance -relevance).include?(option['key']) }
@@ -203,9 +210,9 @@ class FinderPresenter
 
   def atom_feed_enabled?
     if sort_options.present?
-      default_sort_option.blank?
+      default_sort_option.blank? || default_sort_option_key == MOST_RECENT_FIRST
     else
-      default_order.blank?
+      default_order.blank? || default_order == MOST_RECENT_FIRST
     end
   end
 


### PR DESCRIPTION
When the default order is set to `-public_timestamp`, this matches the behaviour of an atom feed so we should allow this.

I've also added some tests around this behaviour so that we can be more confident about changing it in future.  I'm not sure it's quite right to expect the atom feed to behave exactly like search results in a finder.