### PR TITLE
Switch production to dalli_store for caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'chronic', '~> 0.10.2'
+gem 'dalli'
 gem 'gds-api-adapters', '~> 57.3'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 1.11.2'
@@ -37,7 +38,6 @@ end
 
 group :test do
   gem 'cucumber-rails', '~> 1.6.0', require: false
-  gem 'dalli', '~> 2.7.9'
   gem 'govuk-content-schema-test-helpers', '~> 1.6'
   gem 'govuk_test'
   gem 'launchy', '~> 2.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ DEPENDENCIES
   binding_of_caller
   chronic (~> 0.10.2)
   cucumber-rails (~> 1.6.0)
-  dalli (~> 2.7.9)
+  dalli
   gds-api-adapters (~> 57.3)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint (~> 3.10.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,6 +6,7 @@ FinderFrontend::Application.configure do
   end
 
   config.cache_classes = true
+  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true }
   config.eager_load = true
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-bundle install
+bundle check || bundle install
 
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \


### PR DESCRIPTION
We're currently using the file_store cache for some things, and we should switch to memcached. https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore

We're going with `:dalli_store` over `:mem_cache_store` as this is consistent with [other](https://github.com/alphagov/government-frontend/blob/e88ccf3af60175b45471571c0688a70f764da860/config/environments/production.rb#L61) [GOV.UK](https://github.com/alphagov/local-links-manager/blob/a82eb10b1b72792ebdf0ef8204214e9c42521262/config/environments/production.rb#L52) [apps](https://github.com/alphagov/publishing-api/blob/76679ce5fc1d300408a80a9bc1a14e30b6f24151/config/environments/production.rb#L55).

~We need to make sure that the corresponding puppet PR has been deployed before merging this.~ . This has now been deployed

https://github.com/alphagov/govuk-puppet/pull/8618