### PR TITLE
Looping and reloading question pages

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -23,7 +23,7 @@ private
   def raw_finder
     # FIXME: stop caching this once the app has migrated to AWS
     @raw_finder ||= begin
-      item_hash = Rails.cache.fetch("QaController/#{slug}", expires_in: 5.minutes) do
+      item_hash = Rails.cache.fetch("QaController/#{slug}", expires_in: 15.minutes) do
         Services.content_store.content_item(slug).to_hash
       end
 


### PR DESCRIPTION
- Timeouts are taking the users to the first page because of caching.
- This was resolved by adding a caching limit and this limit is not long enough, therefore this issue
still persists, therefore the caching limit has been increased to 15.
- Migrating the application to AWS will solve this issue without the need
for caching.

Trello: https://trello.com/c/cg8UDuJU