### PR TITLE
Skip search results that cannot be atom entries

### DIFF
--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -8,9 +8,9 @@ class AtomPresenter
   end
 
   def entries
-    finder.results.documents.map { |d|
-      EntryPresenter.new(d)
-    }
+    finder.results.documents
+    .reject { |d| d.public_timestamp.blank? }
+    .map { |d| EntryPresenter.new(d) }
   end
 
   def updated_at


### PR DESCRIPTION
Some Whitehall content doesn't have a public timestamp: https://www.gov.uk/api/search.json?filter_link=/government/organisations/advisory-committee-on-business-appointments/about&fields=public_timestamp

This still ends up in our search results, but breaks atom feeds ( http://gov.uk/government/organisations/latest.atom?organisations%5B%5D=committee-on-radioactive-waste-management&page=2 is a current issue, but is time specific obvs )

This results in errors like: https://sentry.io/govuk/app-finder-frontend/issues/866192258/?environment=production