### PR TITLE
Memoize cache response for registries

### DIFF
--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -7,7 +7,7 @@ module Registries
     end
 
     def taxonomy_tree
-      Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+      @taxonomy_tree ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
         taxonomy_tree_as_hash
       end
     rescue GdsApi::HTTPServerError

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -14,7 +14,7 @@ module Registries
   private
 
     def cached_locations
-      Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+      @cached_locations ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
         locations
       end
     rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway


### PR DESCRIPTION
We're currently hitting the cache for each request here.  It's better in memory once we've got it.

![snippet of cache reads for the world locations registry](https://user-images.githubusercontent.com/773037/52130204-7635c880-2631-11e9-9932-94fa431d18ed.png)
