### PR TITLE
Adds different category of GA event for deselect of checkbox facet

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -83,13 +83,11 @@
 
   OptionSelect.prototype.fireChangedAnalyticsEvent = function fireChangedAnalyticsEvent(event){
     var $targetCheckbox = $(event.target);
-    if($targetCheckbox.is(':checked')){
-        var category = $targetCheckbox.data("track-category");
-        var action = $targetCheckbox.data("track-action");
-        var label = $targetCheckbox.data("track-label");
-        var value = $targetCheckbox.data("track-value");
-        GOVUK.analytics.trackEvent(category, action, { label: label, value: value });
-    }
+    var action = $targetCheckbox.data("track-action");
+    var label = $targetCheckbox.data("track-label");
+    var value = $targetCheckbox.data("track-value");
+    var category = $targetCheckbox.is(':checked') ? "filterClicked" : "filterRemoved";
+    GOVUK.analytics.trackEvent(category, action, { label: label, value: value });
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -24,6 +24,9 @@
       // Attach listener to update checked count
       this.$options.on('change', this.updateCheckedCount.bind(this));
 
+      // Attach listener to conditionally fire GA event
+      this.$options.on('change', this.fireChangedAnalyticsEvent.bind(this));
+
       // Replace div.container-head with a button
       this.replaceHeadWithButton();
 
@@ -76,6 +79,17 @@
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){
     this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
+  };
+
+  OptionSelect.prototype.fireChangedAnalyticsEvent = function fireChangedAnalyticsEvent(event){
+    var $targetCheckbox = $(event.target);
+    if($targetCheckbox.is(':checked')){
+        var category = $targetCheckbox.data("track-category");
+        var action = $targetCheckbox.data("track-action");
+        var label = $targetCheckbox.data("track-label");
+        var value = $targetCheckbox.data("track-value");
+        GOVUK.analytics.trackEvent(category, action, { label: label, value: value });
+    }
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){

--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -13,7 +13,6 @@ class SelectFacet < FilterableFacet
         label: allowed_value['label'],
         id: "#{key}-#{allowed_value['value']}",
         data_attributes: {
-          track_category: "filterClicked",
           track_action: name,
           track_label: allowed_value['label'],
         },

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -1,6 +1,5 @@
 <% title_id = "option-select-title-#{title.parameterize}" %>
 <div class="app-c-option-select"
-  <% if options.any? { |option| option[:data_attributes] } %>data-module="track-click"<% end %>
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
 >

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -346,4 +346,34 @@ describe('GOVUK.OptionSelect', function() {
 
   });
 
+
+  describe('fireChangedAnalyticsEvent', function(){
+
+    beforeEach(function(){
+      GOVUK.analytics = {
+        trackEvent: function(){}
+      }
+
+      spyOn(GOVUK.analytics, 'trackEvent');
+    });
+
+    it('fires a Google Analytics event for the change event if the checkbox is checked', function(){
+      $optionSelectHTML.find(":input").trigger("click");
+      expect($optionSelectHTML.find(":input").is(":checked")).toBe(true);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+    });
+
+    it('does not fire a Google Analytics event for the change event if the checkbox is unchecked', function(){
+      $optionSelectHTML.find(":input").trigger("click");
+      expect($optionSelectHTML.find(":input").is(":checked")).toBe(true);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+
+      GOVUK.analytics.trackEvent.calls.reset();
+
+      $optionSelectHTML.find(":input").trigger("click");
+      expect($optionSelectHTML.find(":input").is(":checked")).toBe(false);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledTimes(0);
+    });
+  });
+
 });

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -11,7 +11,7 @@ describe('GOVUK.OptionSelect', function() {
       '<div class="options-container">'+
         '<div class="js-auto-height-inner">'+
           '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="aerospace" id="aerospace" type="checkbox" class="govuk-checkboxes__input">'+
+            '<input name="market_sector[]" value="aerospace" id="aerospace" type="checkbox" class="govuk-checkboxes__input" data-track-action="market-sector" data-track-label="aerospace" data-track-value="1">'+
             '<label class="govuk-label govuk-checkboxes__label" for="aerospace">Aerospace</label>'+
           '</div>'+
           '<div class="gem-c-checkbox govuk-checkboxes__item">'+
@@ -355,24 +355,25 @@ describe('GOVUK.OptionSelect', function() {
       }
 
       spyOn(GOVUK.analytics, 'trackEvent');
+
+      $checkbox = $optionSelectHTML.find(":input#aerospace");
     });
 
-    it('fires a Google Analytics event for the change event if the checkbox is checked', function(){
-      $optionSelectHTML.find(":input").trigger("click");
-      expect($optionSelectHTML.find(":input").is(":checked")).toBe(true);
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+    it('fires a filterClicked Google Analytics event for the change event if the checkbox is checked', function(){
+      $checkbox.trigger("click");
+      expect($checkbox.is(":checked")).toBe(true);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("filterClicked", "market-sector", { label: "aerospace", value: 1 });
     });
 
-    it('does not fire a Google Analytics event for the change event if the checkbox is unchecked', function(){
-      $optionSelectHTML.find(":input").trigger("click");
-      expect($optionSelectHTML.find(":input").is(":checked")).toBe(true);
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+    it('fires a filterRemoved Google Analytics event for the change event if the checkbox is unchecked', function(){
+      $checkbox.trigger("click");
+      expect($checkbox.is(":checked")).toBe(true);
 
       GOVUK.analytics.trackEvent.calls.reset();
 
-      $optionSelectHTML.find(":input").trigger("click");
-      expect($optionSelectHTML.find(":input").is(":checked")).toBe(false);
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledTimes(0);
+      $checkbox.trigger("click");
+      expect($checkbox.is(":checked")).toBe(false);
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith("filterRemoved", "market-sector", { label: "aerospace", value: 1 });
     });
   });
 


### PR DESCRIPTION
The tracking event was firing when checkboxes were being deselected
The first commit made it not fire the GA event at all on deselect
The second commit was made after a discussion and decision to make it fire a _different_ event on deselect. It will now fire an event with category 'filterClicked' on select and 'filterRemoved' on deselect. All other values for the event will stay the same

Trello: https://trello.com/c/l6kGfBhh/230-add-missing-facet-tag-email-alert-tracking-and-checkbox-issue