### PR TITLE
Power owning organisation breadcrumbs from rummager

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -64,16 +64,9 @@ private
   end
 
   def fetch_breadcrumbs
-    parent_content_item = {}
-    unless params.dig("parent_path").to_s.empty?
-      begin
-        parent_content_item = Services.content_store.content_item(params["parent_path"])
-      rescue GdsApi::HTTPNotFound
-        # parent_path is user input so we don't mind if it's bad
-        GovukStatsd.increment("breadcrumb.parent_path_not_found")
-      end
-    end
-    FinderBreadcrumbsPresenter.new(parent_content_item, @content_item)
+    parent_slug = params["parent"]
+    org_info = org_registry[parent_slug] if parent_slug.present?
+    FinderBreadcrumbsPresenter.new(org_info, @content_item)
   end
 
   def finder_presenter_class
@@ -86,5 +79,9 @@ private
 
   def result_set_presenter_class
     ResultSetPresenter
+  end
+
+  def org_registry
+    @org_registry ||= Registries::OrganisationsRegistry.new
   end
 end

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -1,0 +1,39 @@
+module Registries
+  class OrganisationsRegistry
+    CACHE_KEY = "registries/organisations".freeze
+
+    def [](slug)
+      organisations[slug]
+    end
+
+    def organisations
+      @organisations ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        organisations_as_hash
+      end
+    rescue GdsApi::HTTPServerError
+      GovukStatsd.increment("registries.organisations_api_errors")
+      {}
+    end
+
+  private
+
+    def organisations_as_hash
+      fetch_organisations_from_rummager
+        .reject { |result| result['slug'].empty? || result['title'].empty? }
+        .each_with_object({}) { |result, orgs|
+          slug = result['slug']
+          orgs[slug] = result.slice('title', 'slug')
+        }
+    end
+
+    def fetch_organisations_from_rummager
+      params = {
+        filter_format: 'organisation',
+        fields: %w(title slug),
+        count: 1500
+      }
+      response = Services.rummager.search(params)
+      response['results']
+    end
+  end
+end

--- a/app/presenters/finder_breadcrumbs_presenter.rb
+++ b/app/presenters/finder_breadcrumbs_presenter.rb
@@ -1,22 +1,31 @@
 class FinderBreadcrumbsPresenter
-  def initialize(parent_content_item, finder_content_item)
-    @parent_content_item = parent_content_item
+  attr_reader :organisation, :finder_name
+
+  def initialize(organisation, finder_content_item)
+    @organisation = organisation
     @finder_name = finder_content_item.dig("title")
   end
 
   def breadcrumbs
-    return nil unless @parent_content_item.dig("document_type") == "organisation"
+    return nil unless organisation.present?
 
     crumbs = [{ title: "Home", url: "/" }]
     crumbs << { title: 'Organisations', url: '/government/organisations' }
-    if @parent_content_item.dig("title").present?
-      crumbs << { title: @parent_content_item.dig("title"), url: @parent_content_item.dig("base_path") }
+
+    if organisation_is_valid?
+      crumbs << { title: organisation["title"], url: "/government/organisations/#{organisation['slug']}" }
     end
 
-    if @finder_name.present?
-      crumbs << { title: @finder_name, is_current_page: true }
+    if finder_name.present?
+      crumbs << { title: finder_name, is_current_page: true }
     end
 
     crumbs
+  end
+
+private
+
+  def organisation_is_valid?
+    organisation.present? && %w(title slug).all? { |key| organisation[key].present? }
   end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -226,17 +226,17 @@ end
 Given(/^an organisation finder exists$/) do
   content_store_has_government_finder
   stub_rummager_api_request_with_government_results
-  content_store_has_attorney_general_organisation
+  stub_rummager_api_request_with_organisation_links
 
-  visit finder_path('government/policies/benefits-reform', parent_path: '/government/organisations/attorney-generals-office')
+  visit finder_path('government/policies/benefits-reform', parent: 'attorney-generals-office')
 end
 
 Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   content_store_has_government_finder
   stub_rummager_api_request_with_government_results
-  content_store_is_missing_path
+  stub_rummager_api_request_with_organisation_links
 
-  visit finder_path('government/policies/benefits-reform', parent_path: '/bernard-cribbins')
+  visit finder_path('government/policies/benefits-reform', parent: 'bernard-cribbins')
 end
 
 Then(/^I can see a breadcrumb for home$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -27,6 +27,12 @@ module DocumentHelper
     )
   end
 
+  def stub_rummager_api_request_with_organisation_links
+    stub_request(:get, rummager_all_org_links_url).to_return(
+      body: organisation_link_results,
+    )
+  end
+
   def stub_rummager_api_request_with_government_results
     stub_request(:get, rummager_all_documents_url).to_return(
       body: government_documents_json,
@@ -150,14 +156,6 @@ module DocumentHelper
       base_path,
       govuk_content_schema_example('policies_finder').to_json
     )
-  end
-
-  def content_store_has_attorney_general_organisation
-    content_store_has_item('/government/organisations/attorney-generals-office', govuk_content_schema_example('attorney_general', 'organisation').to_json)
-  end
-
-  def content_store_is_missing_path
-    content_store_does_not_have_item('/bernard-cribbins')
   end
 
   def search_params(params = {})
@@ -288,6 +286,14 @@ module DocumentHelper
 
     stub_request(:get, cma_case_documents_filtered_by_supergroup).to_return(
       body: filtered_cma_case_documents_json,
+    )
+  end
+
+  def rummager_all_org_links_url
+    simple_rummager_url(
+      "count" => 1500,
+      "fields" => %w(slug title),
+      "filter_format" => "organisation"
     )
   end
 
@@ -447,6 +453,31 @@ module DocumentHelper
 
   def whitehall_admin_world_locations_api_url
     "#{Plek.current.find('whitehall-admin')}/api/world-locations"
+  end
+
+  def organisation_link_results
+    %|{
+      "results": [
+        {
+          "title": "HM Revenue & Customs",
+          "slug": "hm-revenue-customs",
+          "_id": "/government/organisations/hm-revenue-customs",
+          "elasticsearch_type": "edition",
+          "document_type": "edition"
+        },
+        {
+          "title": "Attorney General's Office",
+          "slug": "attorney-generals-office",
+          "_id": "/government/organisations/companies-house",
+          "elasticsearch_type": "edition",
+          "document_type": "edition"
+        }
+      ],
+      "total": 1072,
+      "start": 0,
+      "aggregates": {},
+      "suggested_queries": []
+    }|
   end
 
   def aaib_reports_search_results

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -4,6 +4,10 @@ module RummagerUrlHelper
     "#{Plek.current.find('search')}/batch_search.json?#{query}"
   end
 
+  def simple_rummager_url(params)
+    "#{Plek.current.find('search')}/search.json?#{params.to_query}"
+  end
+
   def mosw_search_params
     base_search_params.merge(
       "fields" => mosw_search_fields.join(","),

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Registries::OrganisationsRegistry do
+  let(:slug) { 'ministry-of-magic' }
+  let(:rummager_params) {
+    {
+      "count" => 1500,
+      "fields" => %w(slug title),
+      "filter_format" => "organisation"
+    }
+  }
+  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+
+  describe "when rummager is available" do
+    before do
+      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      clear_cache
+    end
+
+    it "will fetch organisation breadcrumb information by slug" do
+      organisation = described_class.new[slug]
+      expect(organisation).to eq(
+        'title' => 'Ministry of Magic',
+        'slug' => slug
+      )
+    end
+  end
+
+  describe "when rummager is unavailable" do
+    before do
+      rummager_is_unavailable
+      clear_cache
+    end
+
+    it "will return an (uncached) empty hash" do
+      organisation = described_class.new[slug]
+      expect(organisation).to be_nil
+      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+    end
+  end
+
+  def rummager_is_unavailable
+    stub_request(:get, rummager_url).to_return(status: 500)
+  end
+
+  def clear_cache
+    Rails.cache.delete(described_class::CACHE_KEY)
+  end
+
+  def rummager_results
+    %|{
+      "results": [
+        {
+          "title": "Ministry of Magic",
+          "slug": "ministry-of-magic",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Attorney General's Office",
+          "slug": "attorney-generals-office",
+          "_id": "/government/organisations/companies-house"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "aggregates": {},
+      "suggested_queries": []
+    }|
+  end
+end


### PR DESCRIPTION
At present we're fetching a content item to check whether the supplied parent path is a valid organisation.  This was OK when we implemented this initially, but it can be quite slow now because of the latency to content store, and may even cause the page to time out altogether which isn't great.

Because of that, I'm adding another registry to store all the slugs and titles of the organisations that we support.  We can look the `parent` slug up against that and only have to refresh it every so often.  The query for all orgs takes about 0.09 seconds for Rummager to process so shouldn't adversely impact the request that has to populate the cache.

I changed the name of the param to `parent` from `parent_path` as it's no longer a path.

Example URLs:
- https://finder-frontend-pr-850.herokuapp.com/news-and-communications (just a home breadcrumb)
- https://finder-frontend-pr-850.herokuapp.com/news-and-communications?parent=ministry-of-silly-walks (just a home breadcrumb)
- https://finder-frontend-pr-850.herokuapp.com/news-and-communications?parent=ministry-of-defence (org breadcrumb)

https://trello.com/c/3OdXjIoE/321-make-org-breadcrumbs-independent-of-content-store