### PR TITLE
Cache finder content items for 5 minutes

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -24,7 +24,9 @@ private
     if development_env_finder_json
       JSON.parse(File.read(development_env_finder_json))
     else
-      Services.content_store.content_item(base_path)
+      Rails.cache.fetch("finder_api#{base_path}", expires_in: 5.minutes) do
+        Services.content_store.content_item(base_path).to_h
+      end
     end
   end
 

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -4,17 +4,11 @@ require 'gds_api/email_alert_api'
 
 module Services
   def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(
-      Plek.find("content-store"),
-      disable_cache: Rails.env.development?
-    )
+    @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(
-      Plek.find("search"),
-      disable_cache: Rails.env.development?
-    )
+    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end
 
   def self.email_alert_api


### PR DESCRIPTION
This will help level out the latency issues for most users. We're going to be adding a lot of traffic to finder frontend, so we should keep it as fast as we can.

We need the content item to render the finder, so it's OK to error if the request times out.

Content items used to be cached everywhere until https://github.com/alphagov/gds-api-adapters/pull/848.  This was a good idea for most content, but less suited to static things like finders.

The QA controller also does this: https://github.com/alphagov/finder-frontend/blob/master/app/controllers/qa_controller.rb#L27

Finder content items rarely change, so this should be OK.