### PR TITLE
Bug fix for sorting dropdown when filtering by keywords

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -199,8 +199,10 @@
   LiveSearch.prototype.selectRelevanceSortOption = function selectRelevanceSortOption() {
     var relevanceSortOption = this.$orderSelect.data('relevance-sort-option');
 
-    this.$orderSelect.val(relevanceSortOption);
-    this.state = this.$form.serializeArray();
+    if (relevanceSortOption) {
+      this.$orderSelect.val(relevanceSortOption);
+      this.state = this.$form.serializeArray();
+    }
   };
 
   LiveSearch.prototype.insertRelevanceOption = function insertRelevanceOption() {

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -156,3 +156,10 @@ Feature: Filtering documents
     Given a collection of documents exist that can be filtered by checkbox
     When I use a checkbox filter and another disallowed filter
     Then I can sign up to email alerts for allowed filters
+
+  @javascript
+  Scenario: Filter documents by keywords and sort by most relevant
+    When I view the news and communications finder
+    And I fill in some keywords
+    Then I see most relevant order selected
+

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -350,6 +350,10 @@ Then(/^I see services in alphabetical order$/) do
   expect(page).to have_content('sorted by A-Z')
 end
 
+Then(/^I see most relevant order selected$/) do
+  expect(page).to have_select('order', selected: "Relevance")
+end
+
 And(/^I see the facet tag$/) do
   within '.facet-tags' do
     expect(page).to have_link("✕")

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -142,6 +142,11 @@ describe("liveSearch", function(){
       expect(liveSearch.$resultsBlock.mustache).not.toHaveBeenCalled();
     });
 
+    it('should have an order state selected when keywords are present', function(){
+      liveSearch.state = 'find-eu-exit-guidance-business.json?keywords=123';
+      expect(liveSearch.$orderSelect.val()).not.toBe(null);
+    });
+
     it('should update the results if the state of these results matches the state of the page', function(){
       liveSearch.state = {search: 'state'};
       spyOn(liveSearch.$resultsBlock, 'mustache');


### PR DESCRIPTION
- Define order when keyword filtering is used to render new results.

Before:
![screen shot 2019-02-05 at 14 59 04](https://user-images.githubusercontent.com/6651749/52281783-ba3d0c00-2956-11e9-8941-742d6bce5ba8.png)

After:
![screen shot 2019-02-05 at 14 59 43](https://user-images.githubusercontent.com/6651749/52281797-c1fcb080-2956-11e9-958b-be760c7273d5.png)
