### PR TITLE
Permit non whitespaced email title prefixes

### DIFF
--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -10,7 +10,7 @@ class EmailAlertTitleBuilder
   end
 
   def call
-    (prefix.to_s + suffix.to_s).upcase_first
+    "#{prefix.to_s.strip} #{suffix}".strip.upcase_first
   end
 
 private
@@ -23,7 +23,7 @@ private
     elsif selected_facets.empty?
       subscription_list_title_prefix.to_s
     elsif subscription_list_title_prefix
-      "#{subscription_list_title_prefix}with "
+      "#{subscription_list_title_prefix.strip} with"
     end
   end
 

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -20,7 +20,7 @@ describe EmailAlertTitleBuilder do
 
   context 'when there is one facet' do
     let(:subscription_list_title_prefix) do
-      { 'singular' => 'Prefix: ', 'plural' => 'Prefixes: ' }
+      { 'singular' => 'Prefix:', 'plural' => 'Prefixes:' }
     end
     let(:facets) do
       [
@@ -48,7 +48,7 @@ describe EmailAlertTitleBuilder do
     context 'when no choice is selected' do
       let(:filter) { {} }
 
-      it { is_expected.to eq('Prefixes: ') }
+      it { is_expected.to eq('Prefixes:') }
     end
 
     context 'when one choice is selected' do
@@ -110,7 +110,7 @@ describe EmailAlertTitleBuilder do
     context 'when no choice is selected' do
       let(:filter) { {} }
 
-      it { is_expected.to eq('Prefix: ') }
+      it { is_expected.to eq('Prefix:') }
     end
 
     context 'when one facet is selected' do


### PR DESCRIPTION
Email sign up pages have prefixes like `"News and communications: "`

But the prefixes often have whitespaces at the end. This looks a bit odd, so this computes whether the whitespace is needed at the end.

See `subscription_list_title_prefix` on https://www.gov.uk/api/content/cma-cases/email-signup.
See also https://github.com/alphagov/rummager/pull/1419/files#diff-f74339b4005b4bfdbf8d693f5da78c6bR16