### PR TITLE
Suppress filterClicked analytics event when removing facet tag

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -30,7 +30,7 @@
 
       this.$form.find('input[type=checkbox], input[type=text], input[type=radio], select').on('change',
         function(e) {
-          if (e.target.type == "text") {
+          if (e.target.type == "text" && !e.suppressAnalytics) {
             LiveSearch.prototype.fireTextAnalyticsEvent(e);
           }
           this.formChange(e)

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -35,7 +35,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var currentVal = $input.val();
         var newVal = $.trim(currentVal.replace(removeFilterValue, ''));
 
-        $input.val(newVal).trigger('change');
+        $input.val(newVal).trigger({
+          type: "change",
+          suppressAnalytics: true
+        });
       }
       else if (elementType == 'OPTION') {
         $('#' + removeFilterFacet).val("").trigger('change');

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -183,14 +183,11 @@ describe("liveSearch", function(){
     it("should update save state and update results when checkbox is changed", function(){
       var promise = jasmine.createSpyObj('promise', ['done']);
       spyOn(liveSearch, 'updateResults').and.returnValue(promise);
-      //spyOn(liveSearch, 'pageTrack').and.returnValue(promise);
       $form.find('input[name="field"]').prop('checked', false);
 
       liveSearch.formChange();
       expect(liveSearch.state).toEqual([{name: 'published_at', value: '2004'}]);
       expect(liveSearch.updateResults).toHaveBeenCalled();
-      promise.done.calls.mostRecent().args[0]();
-      //expect(liveSearch.pageTrack).toHaveBeenCalled();
     });
 
     it("should trigger analytics trackpage when checkbox is changed", function(){

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -42,6 +42,12 @@ describe('remove-filter', function () {
    '</div>'
   );
 
+  var $facetTagDate = $(
+    '<div data-module="remove-filter">' +
+    '<a href="/news-and-communications?[][]=from&amp;[][]=2018&amp;[][]=to&amp;[][]=" class="remove-filter" role="button" aria-label="Remove filter  1 January 2018" data-module="remove-filter-link" data-facet="public_timestamp" data-value="2018" data-name="public_timestamp[from]">✕</a>' +
+    '</div>'
+  );
+
   var $facets =
     '<select id="level_one_taxon" name="level_one_taxon">' +
       '<option value="">All topics</option>' +
@@ -49,6 +55,9 @@ describe('remove-filter', function () {
     '</select>' +
     '<div id="keywords">'+
       '<input name="keywords" value="" id="finder-keyword-search" type="text">' +
+    '</div>' +
+    '<div>'+
+      '<input name="public_timestamp[from]" value="" id="public_timestamp[from]" type="text">' +
     '</div>' +
     '<div id="related_to_brexit">' +
       '<input type="checkbox" name="related_to_brexit" value="true" data-module="track-click">' +


### PR DESCRIPTION
This commit suppresses the `filterClicked` event from firing when a facet tag is removed which corresponds to a text input type (i.e. keywords, published before / after).

Solo: @karlbaker02

https://finder-frontend-pr-857.herokuapp.com/news-and-communications

Trello: https://trello.com/c/FA9IOPMG