### PR TITLE
Cache all content item requests in finder-frontend

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -23,9 +23,7 @@ private
   def raw_finder
     # FIXME: stop caching this once the app has migrated to AWS
     @raw_finder ||= begin
-      item_hash = Rails.cache.fetch("QaController/#{slug}", expires_in: 5.minutes) do
-        Services.content_store.content_item(slug).to_hash
-      end
+      item_hash = Services.cached_content_item(slug)
 
       item_hash.with_indifferent_access
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
   def index
     search_params = SearchParameters.new(params)
 
-    @content_item = Services.content_store.content_item("/search").to_hash
+    @content_item = Services.cached_content_item("/search")
     if search_params.no_search? && params[:format] != "json"
       render(action: 'no_search_term') && return
     end

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -14,7 +14,7 @@ class AdvancedSearchFinderApi < FinderApi
   end
 
   def taxon
-    @taxon ||= Services.content_store.content_item(filter_params[TAXON_SEARCH_FILTER])
+    @taxon ||= Services.cached_content_item(filter_params[TAXON_SEARCH_FILTER])
   rescue GdsApi::HTTPNotFound
     raise_on_missing_taxon_at_path
   end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -24,9 +24,7 @@ private
     if development_env_finder_json
       JSON.parse(File.read(development_env_finder_json))
     else
-      Rails.cache.fetch("finder_api#{base_path}", expires_in: 5.minutes) do
-        Services.content_store.content_item(base_path).to_h
-      end
+      Services.cached_content_item(base_path)
     end
   end
 

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -48,7 +48,7 @@ module Registries
     end
 
     def fetch_taxon(base_path = '/')
-      GdsApi.content_store.content_item base_path
+      Services.cached_content_item(base_path)
     end
   end
 end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -7,6 +7,12 @@ module Services
     @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
   end
 
+  def self.cached_content_item(base_path)
+    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 5.minutes) do
+      content_store.content_item(base_path).to_h
+    end
+  end
+
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end


### PR DESCRIPTION
All of these things call content items that can be cached, so I'm expanding the cache from just finders and the qa pages to include search, the advanced search finders and the topic taxonomy registry.

The biggest change is that we'll be caching taxon pages that are used in the advanced search finders.  This will potentially use more memory than all of the other cached content items combined because there are more taxons. 

On the upside, there are relatively few heavily used taxons in the advanced search finder, so they will come and go. 

We've [got a dashboard](https://grafana.publishing.service.gov.uk/dashboard/db/memcached-usage-on-finders?orgId=1) that we can use to check whether things are starting to get ejected from memcached.  If so, we'll drop the taxons from the cache.

There are approx 4000 live taxons at present, with content items somewhere between 100k and 4k in size.  Worst case is that all of them at 100k and all in the cache at once (uncompressed), then we'd need 400MB RAM to store them without ejections.  We allow memcache to use 12% of the machine RAM which works out to 720MB, so we _should_ be well under.

https://finder-frontend-pr-860.herokuapp.com/cma-cases
https://finder-frontend-pr-860.herokuapp.com/news-and-communications
https://finder-frontend-pr-860.herokuapp.com/search
https://finder-frontend-pr-860.herokuapp.com/search/advanced?topic=%2Fhealth-and-social-care&group=news_and_communications
https://finder-frontend-pr-860.herokuapp.com/prepare-business-uk-leaving-eu


