### PR TITLE
Fix tracking bug where showing incorrect result count

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -105,10 +105,10 @@
           var newPath = window.location.pathname + "?" + $.param(this.state);
           history.pushState(this.state, '', newPath);
           this.trackingInit();
+          this.trackPageView();
         }.bind(this)
       )
     }
-    this.trackPageView();
   };
 
   LiveSearch.prototype.trackingInit = function() {


### PR DESCRIPTION
when the pageview event is fired after changing filter/sort.
dimension 27 should contain the number of results.

Currently it shows the number of results for the previous page view.

This is because the event pageview event is fired before
the results are received (the promise for updateResults has not resolved).

Moving triggering the pageview event into the `done` handler for updateResults.

Trello: https://trello.com/c/lEgaXNX7/98-bug-with-finder-event-tracking