### PR TITLE
Send reject_content_purpose_supergroup to email-alert-api

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -60,7 +60,7 @@ private
     EmailAlertSignupAPI.new(
       email_alert_api: Services.email_alert_api,
       attributes: email_signup_attributes,
-      default_attributes: default_filters,
+      default_attributes: { filter: default_filters, reject: default_rejects },
       subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
       available_choices: signup_presenter.choices,
     )
@@ -84,5 +84,9 @@ private
 
   def default_filters
     content['details'].fetch('filter', {})
+  end
+
+  def default_rejects
+    content['details'].fetch('reject', {})
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -7,7 +7,7 @@ class EmailAlertSignupAPI
     @attributes = dependencies.fetch(:attributes)
     @subscription_list_title_prefix = dependencies.fetch(:subscription_list_title_prefix)
     @available_choices = dependencies.fetch(:available_choices)
-    @default_attributes = dependencies.fetch(:default_attributes, {})
+    @default_attributes = dependencies.fetch(:default_attributes, filter: {}, reject: {})
   end
 
   def signup_url
@@ -34,6 +34,7 @@ private
     }
 
     options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
+    options["reject_content_purpose_supergroup"] = reject_content_purpose_supergroup if reject_content_purpose_supergroup.present?
     options
   end
 
@@ -46,7 +47,11 @@ private
   end
 
   def content_purpose_supergroup
-    massaged_attributes['content_purpose_supergroup'] || default_attributes['content_purpose_supergroup']
+    massaged_attributes['content_purpose_supergroup'] || default_attributes[:filter]['content_purpose_supergroup']
+  end
+
+  def reject_content_purpose_supergroup
+    massaged_attributes['reject_content_purpose_supergroup'] || default_attributes[:reject]['content_purpose_supergroup']
   end
 
   def tags


### PR DESCRIPTION
https://trello.com/c/ylw7DDQa/329-enable-email-alert-api-to-reject-a-content-purpose-supergroup

This enables one to reject content_purpose_supergroups in email alert subscriptions, like we can with rummager queries.

We'll need to bump the gem in finder-frontend before merging this (https://github.com/alphagov/gds-api-adapters/pull/905). Also need to deploy email-alert-api.