### PR TITLE
Fix facet tag space key bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
+//= require govuk_publishing_components/dependencies
 //
 //= require support
 //

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -23,7 +23,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var inputType = $input.prop('type');
 
       setInputState(elementType, inputType, $input, removeFilterValue, removeFilterFacet);
-      fireRemoveTagTrackingEvent(removeFilterValue, removeFilterFacet)
+      fireRemoveTagTrackingEvent(removeFilterValue, removeFilterFacet);
     }
 
     function setInputState(elementType, inputType, $input, removeFilterValue, removeFilterFacet) {
@@ -40,7 +40,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       else if (elementType == 'OPTION') {
         $('#' + removeFilterFacet).val("").trigger('change');
       }
-    };
+    }
 
     function getSelectorForInput(removeFilterName, removeFilterValue) {
       if (!!removeFilterName) {
@@ -61,5 +61,5 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         { label: label }
       );
     }
-  }
+  };
 })(window, window.GOVUK);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -373,7 +373,7 @@
     margin-left: 0;
 
     .js-enabled & {
-      margin-left: 10px;
+      margin-left: 5px;
     }
   }
 
@@ -382,10 +382,18 @@
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     padding: 8px;
+    border-radius: 5px;
     font-weight: bold;
+    @include bold-16;
+    text-align: left;
+    cursor: pointer;
     color: #000;
     text-decoration: none;
+    background: none;
+    border: 0;
 
     .js-enabled & {
       display: inline-block;

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -26,10 +26,7 @@ private
   attr_reader :fragment, :filter_params, :base_url
 
   def remove_filter_link(value)
-    filtered_params = filter_parameters(value)
-
     {
-      href: "#{base_url}?#{Rack::Utils.build_nested_query(filtered_params)}",
       data: {
         facet: value['parameter_key'],
         name: value['name'],

--- a/app/views/finders/_applied_filter.mustache
+++ b/app/views/finders/_applied_filter.mustache
@@ -4,14 +4,13 @@
     <p class="facet-tags__preposition">{{{preposition}}}</p>
     <div class="facet-tag">
       <p class="facet-tag__text">{{{text}}}</p>
-      <a href="{{link.href}}"
+      <button type="button"
         class="facet-tag__remove"
-        role="button"
         aria-label="Remove filter {{{text}}}"
         data-module="remove-filter-link"
         data-facet="{{{link.data.facet}}}"
         data-value="{{{link.data.value}}}"
-        data-name="{{{link.data.name}}}">&#x2715;</a>
+        data-name="{{{link.data.name}}}">&#x2715;</button>
     </div>
   </div>
   {{/.}}

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -145,7 +145,7 @@ Feature: Filtering documents
     When I view the news and communications finder
     And I fill in some keywords
     And I click the Keyword1 remove control
-    Then The keyword textbox is empty
+    Then The keyword textbox only contains Keyword2
 
   Scenario: Subscribing to email alerts
     Given a collection of documents exist that can be filtered by checkbox

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -132,7 +132,7 @@ Feature: Filtering documents
   Scenario Outline: Removing checkbox filter
     When I view the news and communications finder
     And I click button <filter> and select facet <facet>
-    And I click the <facet> remove link
+    And I click the <facet> remove control
     Then The <checkbox_element> checkbox in deselected
     Examples:
       | facet              | filter           | checkbox_element                |
@@ -144,7 +144,7 @@ Feature: Filtering documents
   Scenario: Removing keyword filter
     When I view the news and communications finder
     And I fill in some keywords
-    And I click the Keyword1 remove link
+    And I click the Keyword1 remove control
     Then The keyword textbox is empty
 
   Scenario: Subscribing to email alerts

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -378,11 +378,23 @@ And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
 end
 
 And(/^I click the (.*) remove control$/) do |filter|
+  #expect(page).to have_css(".js-enabled")
+  page.execute_script("removeFilter = new GOVUK.Modules.RemoveFilter(); removeFilter.start();")
   find("p", text: filter).sibling('button').click
-  expect(page).to_not have_selector(:css, "[aria-label='Remove filter #{filter}']")
+
+  page.execute_script("$('[aria-label=\"Remove filter #{filter}\"]').click();")
+
+  check = page.evaluate_script("$('.facet-tags').html()")
+  #check = page.evaluate_script("$('body').attr('class')")
+  puts(check)
 end
 
 Then(/^The (.*) checkbox in deselected$/) do |checkbox|
+  #check = page.evaluate_script("$('##{checkbox}').parent().html();")
+  #puts(check)
+  #check = page.evaluate_script("document.getElementById('#{checkbox}').checked;")
+  #puts(check)
+
   expect(page.find("##{checkbox}", visible: :all)).to_not be_checked
 end
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -356,10 +356,10 @@ end
 
 And(/^I see the facet tag$/) do
   within '.facet-tags' do
-    expect(page).to have_link("✕")
+    expect(page).to have_button("✕")
     expect(page).to have_content("Open")
-    expect(page).to have_css("a[data-module='remove-filter-link']")
-    expect(page).to have_css("a[aria-label='Remove filter Open']")
+    expect(page).to have_css("[data-module='remove-filter-link']")
+    expect(page).to have_css("[aria-label='Remove filter Open']")
   end
 end
 
@@ -377,8 +377,9 @@ And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
   find('label', text: facet).click
 end
 
-And(/^I click the (.*) remove link$/) do |filter|
-  find("p", text: filter).sibling('a').click
+And(/^I click the (.*) remove control$/) do |filter|
+  find("p", text: filter).sibling('button').click
+  expect(page).to_not have_selector(:css, "[aria-label='Remove filter #{filter}']")
 end
 
 Then(/^The (.*) checkbox in deselected$/) do |checkbox|

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -377,24 +377,16 @@ And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
   find('label', text: facet).click
 end
 
-And(/^I click the (.*) remove control$/) do |filter|
-  #expect(page).to have_css(".js-enabled")
-  page.execute_script("removeFilter = new GOVUK.Modules.RemoveFilter(); removeFilter.start();")
-  find("p", text: filter).sibling('button').click
+When(/^I click the (.*) remove control$/) do |filter|
+  expect(page).to have_css(".js-enabled")
 
-  page.execute_script("$('[aria-label=\"Remove filter #{filter}\"]').click();")
+  button = page.find("p[class='facet-tag__text']", text: filter).sibling("button[data-module='remove-filter-link']")
+  button.click
 
-  check = page.evaluate_script("$('.facet-tags').html()")
-  #check = page.evaluate_script("$('body').attr('class')")
-  puts(check)
+  expect(page).to_not have_selector("p[class='facet-tag__text']", text: filter)
 end
 
 Then(/^The (.*) checkbox in deselected$/) do |checkbox|
-  #check = page.evaluate_script("$('##{checkbox}').parent().html();")
-  #puts(check)
-  #check = page.evaluate_script("document.getElementById('#{checkbox}').checked;")
-  #puts(check)
-
   expect(page.find("##{checkbox}", visible: :all)).to_not be_checked
 end
 
@@ -404,6 +396,10 @@ end
 
 Then(/^The keyword textbox is empty$/) do
   expect(page).to have_field('Search', with: '')
+end
+
+Then(/^The keyword textbox only contains (.*)$/) do |filter|
+  expect(page).to have_field('Search', with: filter)
 end
 
 When(/^I use a checkbox filter and another disallowed filter$/) do

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -9,36 +9,36 @@ describe('remove-filter', function () {
   GOVUK.analytics = GOVUK.analytics || {}
   var $checkbox = $(
   '<div data-module="remove-filter">' +
-    '<a href="/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter Brexit" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-name="">✕</a>' +
+    '<button href="/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter Brexit" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-name="">✕</button>' +
   '</div>');
 
   var $oneTextQuery = $(
     '<div data-module="remove-filter">' +
-      '<a href="/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-name="keywords">✕</a>' +
+      '<button href="/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-name="keywords">✕</button>' +
     '</div>'
   );
 
   var $multipleTextQueries = $(
     '<div data-module="remove-filter">' +
-      '<a href="/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-name="keywords">✕</a>' +
+      '<button href="/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-name="keywords">✕</button>' +
     '</div>'
   );
 
   var $dropdown = $(
     '<div data-module="remove-filter">' +
-      '<a href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</a>' +
+      '<button href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</button>' +
     '</div>'
   );
 
   var $facetTagOne = $(
       '<div data-module="remove-filter">' +
-      '<a href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="aa3a9702-da22-487f-86c1-8334a730e558" data-name="">✕</a>' +
+      '<button href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="aa3a9702-da22-487f-86c1-8334a730e558" data-name="">✕</button>' +
       '</div>'
   );
 
   var $facetTagTwo = $(
    '<div data-module="remove-filter">' +
-     '<a href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</a>' +
+     '<button href="/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</button>' +
    '</div>'
   );
 
@@ -155,5 +155,5 @@ describe('remove-filter', function () {
 });
 
 function triggerRemoveFilterClick(element) {
-  element.find('a[data-module=remove-filter-link]').trigger('click');
+  element.find('button[data-module=remove-filter-link]').trigger('click');
 }


### PR DESCRIPTION
![screen shot 2019-02-07 at 09 54 13](https://user-images.githubusercontent.com/861310/52403317-59c8de80-2abe-11e9-98b2-ca76276487c3.png)

When using the space key on a facet tag the required action was occurring but also causing the link to be activated, reloading the page with an incorrect URL (separate issue, the link wasn't being generated quite right).

This was because the link had `role="button"` on it (correct) but this was causing both the JS to fire and the default action (weirdly difficult to prevent using standard methods e.g. `event.preventDefault`). See the first 'note' section here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role

Solution is to turn this into an actual button, works fine now. Also restyled the button slightly to cover the full area of the facet tag, to make clicking on it easier.

Example URL: https://finder-frontend-pr-864.herokuapp.com/news-and-communications
Trello card: https://trello.com/c/yzUrDbq5/263-fix-facet-tag-bug-with-keyboard-interaction