### PR TITLE
Permit allowed_values to be nil

### DIFF
--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -1,6 +1,6 @@
 class SelectFacet < FilterableFacet
   def allowed_values
-    facet['allowed_values']
+    facet['allowed_values'] || []
   end
 
   def options(controls, key)


### PR DESCRIPTION
If `allowed_values` is nil, this can cause issues with methods that use `allowed_values` expecting it to be an array. 

This is not a required field for a finder content item, so we should have a default value.