### PR TITLE
Fix tracking on facet tag removal.

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -11,6 +11,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     function toggleFilter(e) {
       e.preventDefault();
+      e.stopPropagation();
 
       var removeFilterName = $(this).data('name');
       var removeFilterValue = $(this).data('value');


### PR DESCRIPTION
We had a race condition where we could not tell if the `facetTagRemoved`
GA event would be sent or if the data would be reloaded first.

We need the `facetTagRemoved` to fire first because we need it to contain the
number of items displayed when the user clicked on the link.

In an attempt to stop the form submission, I added an `e.stopPropogation()`.

It didn't stop the form from being submitted but `seems` to have allowed the
GA event to happen before the data gets re-loaded, which is the behaviour we are
looking for.

I say `seems` here because it's a race condition that only happened rarely.

Trello: https://trello.com/c/lEgaXNX7/98-bug-with-finder-event-tracking