### PR TITLE
Add applied filters to Atom feed titles

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -28,7 +28,7 @@ class FindersController < ApplicationController
           render 'finders/show-redirect'
         elsif finder.atom_feed_enabled?
           expires_in(ATOM_FEED_MAX_AGE, public: true)
-          @feed = AtomPresenter.new(finder)
+          @feed = AtomPresenter.new(finder, results)
         else
           render plain: 'Not found', status: :not_found
         end
@@ -41,7 +41,7 @@ class FindersController < ApplicationController
 private
 
   def results
-    result_set_presenter_class.new(finder, filter_params, view_context)
+    @results ||= result_set_presenter_class.new(finder, filter_params, view_context)
   end
 
   def finder

--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -1,10 +1,19 @@
 class AtomPresenter
-  def initialize(finder)
+  def initialize(finder, results)
     @finder = finder
+    @results = results
   end
 
   def title
+    return "#{finder.name} #{filters_applied.join(' ')}" if filters_applied.present?
+
     finder.name
+  end
+
+  def filters_applied
+    @filters_applied ||= results.selected_filter_descriptions.map { |filters|
+      filters.map { |filter| "#{filter[:preposition].downcase} #{filter[:text]}" }
+    }.flatten
   end
 
   def entries
@@ -19,5 +28,5 @@ class AtomPresenter
 
 private
 
-  attr_reader :finder
+  attr_reader :finder, :results
 end

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe AtomPresenter do
+  subject(:instance) { described_class.new(finder, results) }
+
+  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context) }
+
+  let(:finder) do
+    double(
+      FinderPresenter,
+      slug: "/news-and-communications",
+      name: 'News and communications',
+      results: result_set,
+      document_noun: 'case',
+      total: 20,
+      filters: a_facet_collection.filters,
+      facets: a_facet_collection,
+      keywords: '',
+      atom_url: "/a-finder.atom",
+      default_documents_per_page: 10,
+      values: {},
+      pagination: { 'current_page' => 1, 'total_pages' => 2 },
+      sort: {},
+    )
+  end
+
+  let(:filter_params) { double(:filter_params, keywords: '') }
+  let(:view_context) { double(:view_context) }
+
+  let(:a_facet) do
+    double(
+      SelectFacet,
+      key: 'key_1',
+      sentence_fragment: {
+        'key' => 'key_1',
+        'type' => 'text',
+        'preposition' => 'About',
+        'values' => first_facet_values,
+        'word_connectors' => { words_connector: 'and' }
+      },
+      has_filters?: true,
+      value: ['brexit', 'harry-potter']
+    )
+  end
+
+  let(:first_facet_values) do
+    [{ 'label' => 'Brexit' }, { 'label' => 'Harry Potter' }]
+  end
+
+  let(:second_facet_values) do
+    [{ 'label' => 'Farming' }, { 'label' => 'Chemicals' }]
+  end
+
+  let(:a_date_facet) do
+    double(
+      SelectFacet,
+      'key' => 'closed_date',
+      sentence_fragment: nil,
+      has_filters?: false,
+      'word_connectors' => { words_connector: 'or' }
+    )
+  end
+
+  let(:result_set) do
+    ResultSet.new((1..20).map { document }, 20)
+  end
+
+  let(:another_facet) do
+    double(
+      SelectFacet,
+      key: 'key_2',
+      preposition: 'About',
+      sentence_fragment: {
+        'key' => 'key_2',
+        'type' => 'text',
+        'preposition' => 'Related to',
+        'values' => second_facet_values,
+        'word_connectors' => { words_connector: 'or' }
+      },
+      has_filters?: true,
+      value: %w[farming chemicals],
+      'word_connectors' => { words_connector: 'or' }
+    )
+  end
+
+  let(:a_date_facet) do
+    double(SelectFacet, has_filters?: false)
+  end
+
+  let(:a_facet_collection) do
+    double(
+      FacetCollection,
+      filters: [a_facet, another_facet, a_date_facet]
+    )
+  end
+
+  let(:document) do
+    double(
+      Document,
+      updated_at: "2019-02-07T12:21:00Z",
+      public_timestamp: "2019-02-01T12:21:00Z",
+    )
+  end
+
+  describe "#title" do
+    it "provides the finder title with filters applied" do
+      expect(instance.title).to eql("News and communications about Brexit and Harry Potter related to Farming or Chemicals")
+    end
+
+    context "no facets selected" do
+      let(:first_facet_values) { [] }
+      let(:second_facet_values) { [] }
+
+      it "provides the finder title from the content item when no filters are applied" do
+        expect(instance.title).to eql("News and communications")
+      end
+    end
+  end
+
+  describe "#entries" do
+    it "provides an array of EntryPresenter documents" do
+      expect(instance.entries).to all(be_an(EntryPresenter))
+    end
+  end
+
+  describe "#updated_at" do
+    it "provides the date of the most recent document update" do
+      expect(instance.updated_at.to_s).to eql("2019-02-01 12:21:00 UTC")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/LRaN1SUq/338-to-fix-the-atom-subscription-labels-to-show-brexit-related-content

This adds humanised filters to a finder atom feed title.

News and communications with the filter related_to_brexit=true will have an atom feed title of: "News and communications about Brexit".

To test manually:

1. Go to https://finder-frontend-pr-869.herokuapp.com/news-and-communications
2. Select some filters
3. Click the feed link, or go directly to https://finder-frontend-pr-869.herokuapp.com/news-and-communications.atom with the path set.

[Or just see the title from this link](https://finder-frontend-pr-869.herokuapp.com/news-and-communications.atom?level_one_taxon=20086ead-41fc-49cf-8a62-d4e1126f41fc&level_two_taxon=6bf58181-7ebe-4599-8a93-281f9b7af810&order=updated-newest&organisations%5B%5D=academy-for-social-justice-commissioning&organisations%5B%5D=accelerated-access-review&people%5B%5D=mark-stanhope&people%5B%5D=sir-philip-jones&people%5B%5D=andrew-pulford&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&world_locations%5B%5D=afghanistan&world_locations%5B%5D=albania)