### PR TITLE
Allow creation of email subscription with only default rejected filters applied

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -40,7 +40,7 @@ private
   end
 
   def has_default_filters?
-    default_filters.present? && default_filters.any?
+    default_filters.present? && default_filters.any? || default_rejects.present? && default_rejects.any?
   end
 
   def chosen_options

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -84,6 +84,7 @@ private
   def validater
     options = massaged_attributes
     options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
+    options["reject_content_purpose_supergroup"] = reject_content_purpose_supergroup if reject_content_purpose_supergroup.present?
 
     @validater ||= ::ValidateQuery.new(options)
   end

--- a/lib/validate_query.rb
+++ b/lib/validate_query.rb
@@ -22,7 +22,9 @@ private
   end
 
   def rummager_params
-    default_params.merge(@query_params.transform_keys { |key| "filter_#{key}" })
+    default_params.merge(@query_params.transform_keys { |key|
+      key.start_with?("reject") ? key : "filter_#{key}"
+    })
   end
 
   def default_params

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -46,6 +46,59 @@ describe EmailAlertSubscriptionsController, type: :controller do
       content_store_has_item('/cma-cases/email-signup', signup_finder)
     end
 
+    context "finder has default rejects" do
+      let(:signup_finder) {
+        cma_cases_signup_content_item.to_hash.merge("details" => {
+          "reject" => { "content_purpose_supergroup" => 'other' },
+        })
+      }
+
+      it "does not fail if no other attributes are provided" do
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => { any: %w(mosw_report) },
+          },
+          "reject_content_purpose_supergroup" => 'other',
+          "subscription_url" => 'http://www.example.com',
+        )
+
+        stub_validation_of_valid_query(
+          'filter_format[]' => 'mosw_report',
+          'reject_content_purpose_supergroup' => 'other',
+        )
+
+        post :create, params: { slug: 'cma-cases' }
+        expect(subject).to redirect_to('http://www.example.com')
+      end
+    end
+
+    context "finder has default filters" do
+      let(:signup_finder) {
+        cma_cases_signup_content_item.to_hash.merge("details" => {
+          "filter" => { "content_purpose_supergroup" => 'news-and-communications' },
+        })
+      }
+
+      it "does not fail if no other attributes are provided" do
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "format" => { any: %w(mosw_report) },
+          },
+          "content_purpose_supergroup" => 'news-and-communications',
+          "subscription_url" => 'http://www.example.com',
+        )
+
+        stub_validation_of_valid_query(
+          'filter_format[]' => 'mosw_report',
+          'filter_content_purpose_supergroup' => 'news-and-communications',
+        )
+
+        post :create, params: { slug: 'cma-cases' }
+        expect(subject).to redirect_to('http://www.example.com')
+      end
+    end
+
+
     it "fails if the relevant filters are not provided" do
       stub_validation_of_valid_query(
         'filter_format[]' => 'mosw_report',


### PR DESCRIPTION
https://trello.com/c/ylw7DDQa/329-enable-email-alert-api-to-reject-a-content-purpose-supergroup

This allows one to subscribe to the All Content feed without applying any filters, if there is a default rejection filter applied via the content item.