### PR TITLE
Persist parent param on finders

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -13,6 +13,7 @@ class FindersController < ApplicationController
         @results = results
         @content_item = raw_finder
         @breadcrumbs = fetch_breadcrumbs
+        @parent = parent
       end
       format.json do
         if %w[finder search].include? finder_api.content_item['document_type']
@@ -83,5 +84,9 @@ private
 
   def org_registry
     @org_registry ||= Registries::OrganisationsRegistry.new
+  end
+
+  def parent
+    params.fetch(:parent, '')
   end
 end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -63,6 +63,7 @@
 
 <div class="grid-row">
   <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+    <input type="hidden" name="parent" value="<%= @parent %>">
     <div class="column-third">
       <%= render finder.facets %>
     </div>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -72,6 +72,9 @@ Feature: Filtering documents
     And I can see a breadcrumb for all organisations
     And I can see a breadcrumb for the organisation
     And I can see a breadcrumb that not a link for the finder
+    And I sort by most viewed
+    And I filter the results
+    Then I can see a breadcrumb for the organisation
 
   Scenario: Visit a finder from an organisation handling breadcrumb failures
     Given an organisation finder exists but a bad breadcrumb path is given

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -123,6 +123,7 @@ end
 Given(/^a government finder exists$/) do
   content_store_has_government_finder
   stub_rummager_api_request_with_government_results
+  stub_organisations_registry_request
 end
 
 Then(/^I can see the government header$/) do
@@ -288,16 +289,16 @@ end
 
 Given(/^an organisation finder exists$/) do
   content_store_has_government_finder
+  stub_organisations_registry_request
   stub_rummager_api_request_with_government_results
-  stub_rummager_api_request_with_organisation_links
 
-  visit finder_path('government/policies/benefits-reform', parent: 'attorney-generals-office')
+  visit finder_path('government/policies/benefits-reform', parent: 'ministry-of-magic')
 end
 
 Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   content_store_has_government_finder
+  stub_organisations_registry_request
   stub_rummager_api_request_with_government_results
-  stub_rummager_api_request_with_organisation_links
 
   visit finder_path('government/policies/benefits-reform', parent: 'bernard-cribbins')
 end
@@ -323,11 +324,11 @@ And(/^no breadcrumb for all organisations$/) do
 end
 
 Then(/^I can see a breadcrumb for the organisation$/) do
-  expect(page).to have_link("Attorney General's Office", href: "/government/organisations/attorney-generals-office")
-  expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Attorney General's Office")
-  expect(page).to have_css("a[data-track-action='3']", text: "Attorney General's Office")
-  expect(page).to have_css("a[data-track-label='/government/organisations/attorney-generals-office']", text: "Attorney General's Office")
-  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Attorney General\\'s Office\"}']", text: "Attorney General's Office")
+  expect(page).to have_link("Ministry of Magic", href: "/government/organisations/ministry-of-magic")
+  expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Ministry of Magic")
+  expect(page).to have_css("a[data-track-action='3']", text: "Ministry of Magic")
+  expect(page).to have_css("a[data-track-label='/government/organisations/ministry-of-magic']", text: "Ministry of Magic")
+  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Ministry of Magic\"}']", text: "Ministry of Magic")
 end
 
 Then(/^I can see a breadcrumb that not a link for the finder$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -29,16 +29,12 @@ module DocumentHelper
     )
   end
 
-  def stub_rummager_api_request_with_organisation_links
-    stub_request(:get, rummager_all_org_links_url).to_return(
-      body: organisation_link_results,
-    )
-  end
-
   def stub_rummager_api_request_with_government_results
-    stub_request(:get, rummager_all_documents_url).to_return(
-      body: government_documents_json,
-    )
+    stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
+      .with(query: hash_including({}))
+      .to_return(
+        body: government_documents_json,
+      )
   end
 
   def stub_rummager_api_request_with_10_government_results
@@ -79,6 +75,12 @@ module DocumentHelper
         "filter_sector_business_area[0]" => "aerospace",
       )
     ).to_return(body: filtered_business_readiness_results_json)
+  end
+
+  def stub_all_rummager_api_requests_with_all_documents_results
+    stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
+        .with(query: hash_including({}))
+        .to_return(body: all_documents_json)
   end
 
   def stub_all_rummager_api_requests_with_news_and_communication_results
@@ -174,10 +176,20 @@ module DocumentHelper
 
   def content_store_has_government_finder
     base_path = '/government/policies/benefits-reform'
-    content_store_has_item(
-      base_path,
-      govuk_content_schema_example('finder').merge('base_path' => base_path).to_json
-    )
+    finder = govuk_content_schema_example('finder').merge('base_path' => base_path)
+    finder['details']["sort"] = [
+      {
+        "name": "Most viewed",
+        "key": "-popularity"
+      },
+      {
+        "name": "Relevance",
+        "key": "-relevance",
+        "default": true
+      }
+    ]
+
+    content_store_has_item(base_path, finder.to_json)
   end
 
   def content_store_has_services_finder


### PR DESCRIPTION
Previously the breadcrumbs would be removed on page reload if you changed any search facets. This change will ensure that the breadcrumbs are now persisted.

Authors: Fli.* & Bill

https://trello.com/c/2eWij236/354-bug-disappearing-breadcrumb-from-org-pages