### PR TITLE
Remove autoselection of relevance sort option when keywords change

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -183,10 +183,6 @@
     if (keywordsCleared) {
       liveSearch.selectDefaultSortOption();
     }
-
-    if (keywordsChanged) {
-      liveSearch.selectRelevanceSortOption();
-    }
   };
 
   LiveSearch.prototype.selectDefaultSortOption = function selectDefaultSortOption() {

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -165,5 +165,5 @@ Feature: Filtering documents
   Scenario: Filter documents by keywords and sort by most relevant
     When I view the news and communications finder
     And I fill in some keywords
+    And I sort by most relevant
     Then I see most relevant order selected
-

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -350,6 +350,10 @@ When(/^I sort by A-Z$/) do
   select 'A-Z', from: 'Sort by'
 end
 
+When(/^I sort by most relevant$/) do
+  select 'Relevance', from: 'Sort by'
+end
+
 When(/^I filter the results$/) do
   click_on 'Filter results'
 end


### PR DESCRIPTION
This feature is no longer required as it was reported as a bug.

Steps to reproduce:

1. Go to https://www-origin.integration.publishing.service.gov.uk/transparency-and-freedom-of-information-releases?keywords=electric&order=updated-oldest
2. See that sort order is 'relevance' not 'updated-oldest'

Trello: https://trello.com/c/MyDEY060/348-update-url-when-sort-order-changes-to-relevance