### PR TITLE
Don't use memcached on heroku apps

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ FinderFrontend::Application.configure do
   end
 
   config.cache_classes = true
-  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true }
+  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true } unless ENV['HEROKU_APP_NAME']
   config.eager_load = true
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true


### PR DESCRIPTION
Heroku spends a lot of time looking for cached values in a memcached instance that doesn't exist.  By omitting this line, we'll use the default rails cache type which is `filestore`.

Memcached exists in GOV.UK production environments

```
2019-02-14T17:00:23.894121+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:23.975140+00:00 app[web.1]: 127.0.0.1:11211 failed (count: 1) Errno::ECONNREFUSED: Connection refused - send
2019-02-14T17:00:23.975234+00:00 app[web.1]: 127.0.0.1:11211 is down
2019-02-14T17:00:23.975792+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:24.289790+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.039718+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.050949+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.051286+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.187824+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.187965+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.292349+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.292983+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.355744+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.355872+00:00 app[web.1]: DalliError: No server available
2019-02-14T17:00:25.434192+00:00 app[web.1]: DalliError: No server available
...
```