### PR TITLE
Fix small checkbox hit area

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -109,7 +109,7 @@
   .govuk-checkboxes__item {
     min-height: 26px;
     margin-bottom: 10px;
-    padding: 0 0 0 30px;
+    padding: 0 0 0 26px;
   }
 
   .govuk-checkboxes__item:last-child,
@@ -125,7 +125,7 @@
   }
 
   .govuk-checkboxes__label {
-    padding: 8px 5px 2px;
+    padding: 8px 5px 2px 9px;
     font-size: 16px;
   }
 


### PR DESCRIPTION
Adjusts the padding around the label of the small checkboxes in option selects so that there is no gap that cannot be clicked on.

Problem:

![image](https://user-images.githubusercontent.com/861310/52850174-c4a39680-310a-11e9-8386-d0a35dcd85ff.png)

Fix:

![screen shot 2019-02-15 at 10 18 45](https://user-images.githubusercontent.com/861310/52850326-1e0bc580-310b-11e9-8bdf-b20f583fa1fa.png)



Fixes https://github.com/alphagov/govuk_publishing_components/issues/696
