### PR TITLE
Dynamic values in email subscription titles

### DIFF
--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -5,7 +5,10 @@ module Registries
     def all
       @all ||= {
         'world_locations' => world_locations,
-        'part_of_taxonomy_tree' => topic_taxonomy
+        'all_part_of_taxonomy_tree' => topic_taxonomy,
+        'part_of_taxonomy_tree' => topic_taxonomy,
+        'people' => people,
+        'organisations' => organisations,
       }
     end
 
@@ -17,6 +20,14 @@ module Registries
 
     def topic_taxonomy
       @topic_taxonomy ||= TopicTaxonomyRegistry.new
+    end
+
+    def people
+      @people ||= PeopleRegistry.new
+    end
+
+    def organisations
+      @organisations ||= OrganisationsRegistry.new
     end
   end
 end

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -1,0 +1,38 @@
+module Registries
+  class PeopleRegistry
+    CACHE_KEY = "registries/people".freeze
+
+    def [](slug)
+      people[slug]
+    end
+
+    def people
+      @people ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        people_as_hash
+      end
+    rescue GdsApi::HTTPServerError
+      GovukStatsd.increment("registries.people_api_errors")
+      {}
+    end
+
+  private
+
+    def people_as_hash
+      fetch_people_from_rummager
+        .reject { |result| result['slug'].empty? || result['title'].empty? }
+        .each_with_object({}) { |result, orgs|
+          slug = result['slug']
+          orgs[slug] = result.slice('title', 'slug')
+        }
+    end
+
+    def fetch_people_from_rummager
+      params = {
+        filter_format: 'person',
+        fields: %w(title slug),
+        count: 1500
+      }
+      Services.rummager.search_enum(params, page_size: 1500)
+    end
+  end
+end

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -166,4 +166,3 @@ Feature: Filtering documents
     When I view the news and communications finder
     And I fill in some keywords
     Then I see most relevant order selected
-

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -44,18 +44,40 @@ Then(/^I can get a list of all documents with matching metadata$/) do
 end
 
 When(/^I view a list of news and communications$/) do
-  topic_taxonomy_has_taxons(%w[Taxon_1 Taxon_2])
+  topic_taxonomy_has_taxons([
+    {
+      content_id: "Taxon_1",
+      title: "Taxon_1"
+    },
+    {
+      content_id: "Taxon_2",
+      title: "Taxon_2"
+    }
+  ])
   content_store_has_news_and_communications_finder
   stub_whitehall_api_world_location_request
+  stub_people_registry_request
+  stub_organisations_registry_request
   stub_rummager_api_request_with_news_and_communication_results
   visit finder_path('news-and-communications')
 end
 
 When(/^I view the news and communications finder$/) do
-  topic_taxonomy_has_taxons(%w[Taxon_1 Taxon_2])
+  topic_taxonomy_has_taxons([
+    {
+      content_id: "Taxon_1",
+      title: "Taxon_1"
+    },
+    {
+      content_id: "Taxon_2",
+      title: "Taxon_2"
+    }
+  ])
   content_store_has_news_and_communications_finder
   stub_whitehall_api_world_location_request
   stub_all_rummager_api_requests_with_news_and_communication_results
+  stub_people_registry_request
+  stub_organisations_registry_request
   visit finder_path('news-and-communications')
 end
 
@@ -64,6 +86,8 @@ When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons
   content_store_has_services_finder
   stub_rummager_api_request_with_services_results
+  stub_people_registry_request
+  stub_organisations_registry_request
 
   visit finder_path('services')
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,12 +1,14 @@
 require_relative '../../lib/govuk_content_schema_examples'
 require_relative "../../spec/helpers/taxonomy_spec_helper"
 require_relative "../../spec/helpers/validation_query_helper"
+require_relative "../../spec/helpers/registry_spec_helper"
 require 'gds_api/test_helpers/email_alert_api'
 require 'gds_api/test_helpers/content_store'
 
 module DocumentHelper
   include GovukContentSchemaExamples
   include TaxonomySpecHelper
+  include RegistrySpecHelper
   include ValidateQueryHelper
   include GdsApi::TestHelpers::EmailAlertApi
   include GdsApi::TestHelpers::ContentStore

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -41,7 +41,7 @@ private
     facet_key = facets.first['filter_key'] || facets.first['facet_id']
 
     if dynamic_filter_option?(facet_key)
-      return dynamic_facet_sentence(facet_key, selected_facets.first)
+      return dynamic_facet_sentence(facet_key, selected_facets.first["facet_name"])
     end
 
     topic_names_sentence(facets.first)
@@ -50,7 +50,7 @@ private
   def multiple_facets_suffix
     grouped_facets.map { |facet_key, facet_group|
       if dynamic_filter_option?(facet_key)
-        dynamic_facet_sentence(facet_key, facet_group.first)
+        dynamic_facet_sentence(facet_key, facet_group.first["facet_name"])
       else
         facet_group.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
       end
@@ -75,10 +75,44 @@ private
     selected_facets.group_by { |facet| facet['filter_key'] || facet['facet_id'] }
   end
 
-  def dynamic_facet_sentence(facet_key, facet)
-    count = filter.fetch(facet_key, []).count
-    word = count > 1 ? facet["facet_name"] : facet["facet_name"].singularize
-    "#{count} #{word}"
+  def dynamic_facet_sentence(facet_key, facet_name)
+    registry              = registry(facet_key)
+    all_values            = filter_values(facet_key, registry)
+    values, blank_values  = all_values.partition(&:present?)
+    total_values          = all_values.count
+    word                  = total_values > 1 ? facet_name : facet_name.singularize
+
+    return "#{total_values} #{word}" if registry.nil? || values.count.zero?
+
+    return "#{word} of #{values.to_sentence}" if blank_values.count.zero?
+
+    other_word = blank_values.count > 1 ? facet_name : facet_name.singularize
+    values_with_unknown_others = values.concat(["#{blank_values.count} other #{other_word}"])
+
+    "#{word} of #{values_with_unknown_others.to_sentence}"
+  end
+
+  def filter_values(facet_key, registry)
+    filter.fetch(facet_key, []).map { |value|
+      find_title_by_slug(value, registry)
+    }
+  end
+
+  def find_title_by_slug(slug, registry)
+    return "" if registry.nil?
+
+    return "Brexit" if is_brexit?(registry, slug)
+
+    item = registry[slug] || {}
+    item.fetch("title", "")
+  end
+
+  def registry(facet_key)
+    registries.all[facet_key]
+  end
+
+  def registries
+    @registries ||= Registries::BaseRegistries.new
   end
 
   def dynamic_filter_option?(filter_key)
@@ -92,5 +126,9 @@ private
       all_part_of_taxonomy_tree
       document_type
     ).include?(filter_key)
+  end
+
+  def is_brexit?(registry, content_id)
+    registry.is_a?(Registries::TopicTaxonomyRegistry) && content_id == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
   end
 end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require "helpers/taxonomy_spec_helper"
+require "helpers/registry_spec_helper"
 require 'gds_api/test_helpers/content_store'
 require 'gds_api/test_helpers/email_alert_api'
 require_relative "../helpers/validation_query_helper"
@@ -9,10 +11,32 @@ describe EmailAlertSubscriptionsController, type: :controller do
   include FixturesHelper
   include GovukContentSchemaExamples
   include ValidateQueryHelper
+  include TaxonomySpecHelper
+  include RegistrySpecHelper
 
   render_views
 
   let(:signup_finder) { cma_cases_signup_content_item }
+  let(:content_id_one) { "magical-education" }
+  let(:content_id_two) { "herbology" }
+  let(:top_level_taxon_one_title) { "Magical Education" }
+  let(:top_level_taxon_two_title) { "Herbology" }
+
+  before :each do
+    topic_taxonomy_has_taxons([
+      {
+        content_id: content_id_one,
+        title: top_level_taxon_one_title
+      },
+      {
+        content_id: content_id_two,
+        title: top_level_taxon_two_title
+      }
+    ])
+
+    stub_people_registry_request
+    stub_organisations_registry_request
+  end
 
   describe 'GET #new' do
     describe "finder email signup item doesn't exist" do

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -1,0 +1,64 @@
+module RegistrySpecHelper
+  def stub_people_registry_request
+    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    .with(query: {
+        count: 1500,
+        start: 0,
+        fields: %w(slug title),
+        filter_format: %(person),
+    })
+    .to_return(body: { results: [
+        {
+          "title": "Harry Potter",
+          "slug": "harry-potter",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Albus Dumbledore",
+          "slug": "albus-dumbledore",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Ron Weasley",
+          "slug": "ron-weasley",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Cornelius Fudge",
+          "slug": "cornelius-fudge",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Rufus Scrimgeour",
+          "slug": "rufus-scrimgeour",
+          "_id": "/government/people/rufus-scrimgeour"
+        }
+    ] }.to_json)
+  end
+
+  def stub_organisations_registry_request
+    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    .with(query: {
+      count: 1500,
+      fields: %w(slug title),
+      filter_format: %(organisation),
+    })
+    .to_return(body: { results: [
+        {
+          "title": "Ministry of Magic",
+          "slug": "ministry-of-magic",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Gringots",
+          "slug": "gringots",
+          "_id": "/government/organisations/gringots"
+        },
+        {
+          "title": "Department of Mysteries",
+          "slug": "department-of-mysteries",
+          "_id": "/government/organisations/department-of-mysteries"
+        }
+    ] }.to_json)
+  end
+end

--- a/spec/helpers/taxonomy_spec_helper.rb
+++ b/spec/helpers/taxonomy_spec_helper.rb
@@ -6,20 +6,33 @@ module TaxonomySpecHelper
   CONTENT_ID_1 = SecureRandom.uuid.freeze
   CONTENT_ID_2 = SecureRandom.uuid.freeze
 
+  def default_taxons
+    [
+      {
+        content_id: CONTENT_ID_1,
+        title: 'Herbology',
+      },
+      {
+        content_id: CONTENT_ID_2,
+        title: 'Magical Education',
+      }
+    ]
+  end
+
   def topic_taxonomy_api_is_unavailable
     content_store_isnt_available
   end
 
-  def topic_taxonomy_has_taxons(taxon_ids = [CONTENT_ID_1, CONTENT_ID_2])
+  def topic_taxonomy_has_taxons(topics = default_taxons)
     clear_taxon_cache
 
     taxons = []
 
-    taxon_ids.map { |id|
-      taxon = level_one_taxon(id)
+    topics.map { |topic|
+      taxon = level_one_taxon(topic)
       taxons.unshift(taxon)
 
-      content_store_has_item("/#{id}", taxon)
+      content_store_has_item("/#{topic[:content_id]}", taxon)
     }
 
     content_store_has_item("/", root_taxon(taxons))
@@ -43,11 +56,11 @@ module TaxonomySpecHelper
     }
   end
 
-  def level_one_taxon(content_id)
+  def level_one_taxon(topic)
     {
-      'base_path' => "/#{content_id}",
-      'title' => content_id,
-      'content_id' => content_id,
+      'base_path' => "/#{topic[:content_id]}",
+      'title' => topic[:title],
+      'content_id' => topic[:content_id],
       'links' => {
         'child_taxons' => [{
           'base_path' => "/subtaxon",

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Registries::PeopleRegistry do
+  let(:slug) { 'cornelius-fudge' }
+  let(:default_rummager_params) {
+    {
+      "count" => 1500,
+      "fields" => %w(slug title),
+      "filter_format" => "person"
+    }
+  }
+  let(:rummager_params) { default_rummager_params.merge("start" => 0) }
+  let(:second_rummager_params) { default_rummager_params.merge("start" => 1) }
+  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:second_rummager_url) { "#{Plek.current.find('search')}/search.json?#{second_rummager_params.to_query}" }
+
+  describe "when rummager is available" do
+    before do
+      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      stub_request(:get, second_rummager_url).to_return(body: { "results": [] }.to_json)
+      clear_cache
+    end
+
+    it "will fetch person breadcrumb information by slug" do
+      person = described_class.new[slug]
+      expect(person).to eq(
+        'title' => 'Cornelius Fudge',
+        'slug' => slug
+      )
+    end
+  end
+
+  describe "when rummager is unavailable" do
+    before do
+      rummager_is_unavailable
+      clear_cache
+    end
+
+    it "will return an (uncached) empty hash" do
+      person = described_class.new[slug]
+      expect(person).to be_nil
+      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+    end
+  end
+
+  def rummager_is_unavailable
+    stub_request(:get, rummager_url).to_return(status: 500)
+  end
+
+  def clear_cache
+    Rails.cache.delete(described_class::CACHE_KEY)
+  end
+
+  def rummager_results
+    %|{
+      "results": [
+        {
+          "title": "Cornelius Fudge",
+          "slug": "cornelius-fudge",
+          "_id": "a field that we're not using"
+        },
+        {
+          "title": "Rufus Scrimgeour",
+          "slug": "rufus-scrimgeour",
+          "_id": "/government/people/companies-house"
+        }
+      ],
+      "total": 2,
+      "start": 0,
+      "aggregates": {},
+      "suggested_queries": []
+    }|
+  end
+end

--- a/spec/lib/registries/topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/topic_taxonomy_registry_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
 
   let(:content_id_one) { SecureRandom.uuid }
   let(:content_id_two) { SecureRandom.uuid }
-  let(:top_level_taxon_one) { level_one_taxon(content_id_one) }
-  let(:top_level_taxon_two) { level_one_taxon(content_id_two) }
+  let(:top_level_taxon_one) { level_one_taxon(content_id: content_id_one, title: content_id_one) }
+  let(:top_level_taxon_two) { level_one_taxon(content_id: content_id_two, title: content_id_two) }
 
   describe "when topic taxonomy API is unavailable" do
     it "will return an (uncached) empty hash" do
@@ -23,7 +23,16 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
   describe "when topic taxonomy api is available" do
     before :each do
       clear_taxon_cache
-      topic_taxonomy_has_taxons([content_id_one, content_id_two])
+      topic_taxonomy_has_taxons([
+        {
+          content_id: content_id_one,
+          title: content_id_one
+        },
+        {
+          content_id: content_id_two,
+          title: content_id_two
+        }
+      ])
     end
 
     after { clear_taxon_cache }

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -5,7 +5,16 @@ describe TaxonFacet do
   include TaxonomySpecHelper
 
   before do
-    topic_taxonomy_has_taxons(%w(allowed-value-1 allowed-value-2))
+    topic_taxonomy_has_taxons([
+      {
+        content_id: "allowed-value-1",
+        title: "allowed-value-1"
+      },
+      {
+        content_id: "allowed-value-2",
+        title: "allowed-value-2"
+      }
+    ])
   end
 
   let(:allowed_values) {


### PR DESCRIPTION
When a user signs up for an email subscription, we generate a subscriber list for the user with their selected filters. We also send email-alert-api a title for the subscriber list.

This adds more detail to the title if the filters are dynamic (filters without allowed fields set in the content item, such as organisations, people, and so on, which are populated at runtime from other sources). Examples of a title we generate below.

Before:

"News with 3 people and 2 organisations"

After:

"News with people of Harry Potter, Ron Weasley, and 1 other, and organisations of HM Treasury and Cabinet Office"

It is possible to display the actual values rather than the counts because we now
have registries - cached collections of people, organisations, world locations, etc. -
that we can use to lookup a beautified value for a given slug.

Authors: Felicity and Bill

https://trello.com/c/J6ZHmdgi/349-improve-email-signups-description
