### PR TITLE
Remove H3s from finder results list

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -18,6 +18,54 @@
   @extend %site-width-container;
 }
 
+.document {
+  border-bottom: solid 1px $border-colour;
+  padding: $gutter-half 0;
+
+  &:first-child {
+    padding-top:0;
+    margin-top:-2px;
+  }
+
+  .document__link {
+    @include bold-19;
+    margin: 0;
+    text-decoration: none;
+
+    &.document-heading--pinned {
+      @include govuk-font($size: 24, $weight: bold);
+    }
+  }
+
+  dl {
+    margin: 0;
+
+    dt, dd {
+      @include core-14;
+      margin-left: 0;
+    }
+
+    dt {
+      display: none;
+
+      &.metadata-date-label {
+        @include inline-block;
+      }
+    }
+
+    dd {
+      margin-right: $gutter-one-third;
+      @include inline-block;
+    }
+  }
+
+  p.historic {
+    @include core-14;
+    padding: 0 0 3px;
+    color: $secondary-text-colour;
+  }
+}
+
 #finder-frontend {
   margin-bottom: $gutter * 1.5;
 
@@ -278,57 +326,6 @@
       .filtered-results__facet-heading {
         @include govuk-font($size: 24, $weight: bold);
         margin-bottom: $gutter-half;
-      }
-    }
-
-    .document {
-      border-bottom: solid 1px $border-colour;
-      padding: $gutter-half 0;
-
-      &:first-child {
-        padding-top:0;
-        margin-top:-2px;
-      }
-
-      h3 {
-        @include bold-19;
-        margin: 0;
-
-        a {
-          text-decoration: none;
-        }
-
-        &.document-heading--pinned {
-          @include govuk-font($size: 24, $weight: bold);
-        }
-      }
-
-      dl {
-        margin: 0;
-
-        dt, dd {
-          @include core-14;
-          margin-left: 0;
-        }
-
-        dt {
-          display: none;
-
-          &.metadata-date-label {
-            @include inline-block;
-          }
-        }
-
-        dd {
-          margin-right: $gutter-one-third;
-          @include inline-block;
-        }
-      }
-
-      p.historic {
-        @include core-14;
-        padding: 0 0 3px;
-        color: $secondary-text-colour;
       }
     }
   }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -26,7 +26,7 @@ header {
   margin-top: 20px;
   clear: both;
 
-  h3, dl, dd, ul, li {
+  a, dl, dd, ul, li {
     margin: 0;
   }
   ul {
@@ -38,7 +38,8 @@ header {
     border-bottom: 1px solid $border-colour;
     list-style: none;
   }
-  h3 {
+  a {
+    font-weight: bold;
     margin-bottom: 5px;
   }
   dt {

--- a/app/views/advanced_search_finder/_results.mustache
+++ b/app/views/advanced_search_finder/_results.mustache
@@ -10,15 +10,14 @@
     {{! The following elements use BEM styles from the govuk_publishing_components/document-list component
     for visual consistency, this might prove to be a maintenance headache in which case it would be better
     to port the styles to the advanced-search sass file. }}
-    <li class="gem-c-document-list__item">
-      <h3 class="gem-c-document-list__item-title">
-        <a href='{{document.link}}'
-           data-track-category='navFinderLinkClicked'
-           data-track-action='{{finder_name}}.{{document_index}}'
-           data-track-label='{{document.link}}'
-           data-track-options='{"dimension28":"{{page_count}}","dimension29":"{{document.title}}"}'
-        >{{document.title}}</a>
-      </h3>
+    <li class="document">
+      <a href='{{document.link}}'
+        class="document__link"
+          data-track-category='navFinderLinkClicked'
+          data-track-action='{{finder_name}}.{{document_index}}'
+          data-track-label='{{document.link}}'
+          data-track-options='{"dimension28":"{{page_count}}","dimension29":"{{document.title}}"}'
+      >{{document.title}}</a>
       {{#document.summary}}
         <p>{{document.summary}}</p>
       {{/document.summary}}

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -6,7 +6,6 @@
 {{/atom_url}}
 
 <ul data-module="track-click">
-
   {{#display_grouped_results }}
     {{#documents_by_facets}}
       {{> finders/_grouped_results }}

--- a/app/views/finders/_results_document.mustache
+++ b/app/views/finders/_results_document.mustache
@@ -1,12 +1,11 @@
 <li class="document">
-  <h3 {{#document.promoted}}class="document-heading--pinned"{{/document.promoted}}>
-    <a href='{{document.link}}'
-        data-track-category='navFinderLinkClicked'
-        data-track-action='{{finder_name}}.{{document_index}}'
-        data-track-label='{{document.link}}'
-        data-track-options='{"dimension28":"{{page_count}}","dimension29":"{{document.title}}"}'
-    >{{document.title}}</a>
-  </h3>
+  <a href='{{document.link}}'
+      class="{{#document.promoted}}document-heading--pinned{{/document.promoted}} document__link"
+      data-track-category='navFinderLinkClicked'
+      data-track-action='{{finder_name}}.{{document_index}}'
+      data-track-label='{{document.link}}'
+      data-track-options='{"dimension28":"{{page_count}}","dimension29":"{{document.title}}"}'
+  >{{document.title}}</a>
   {{#document.summary}}
     <p>{{document.summary}}</p>
   {{/document.summary}}

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -241,7 +241,7 @@ describe("liveSearch", function(){
       liveSearch.resultCache["the=first"] = dummyResponse;
       liveSearch.state = { the: "first" };
       liveSearch.displayResults(dummyResponse, $.param(liveSearch.state));
-      expect($results.find('h3').text()).toMatch('Test report');
+      expect($results.find('a').text()).toMatch('Test report');
       expect($count.find('.result-count').text()).toMatch(/^\s*1\s*/);
     });
 


### PR DESCRIPTION
The finder results lists render each document title as a H3. This is noisy for screenreader users, especially when navigating by heading. This PR changes the headings to links instead, bringing it in line with the document list component which it copies styling from. 

**Note: there should be no visual change.**

## Before
<img width="647" alt="screen shot 2019-02-18 at 13 56 09" src="https://user-images.githubusercontent.com/29889908/52955621-0a6b9380-3385-11e9-950e-ed078b45ac23.png">

## After
<img width="647" alt="screen shot 2019-02-18 at 13 57 31" src="https://user-images.githubusercontent.com/29889908/52955660-22431780-3385-11e9-9513-110dc92f0ad0.png">

## Before (print styles)
<img width="668" alt="screen shot 2019-02-18 at 13 59 00" src="https://user-images.githubusercontent.com/29889908/52955739-60403b80-3385-11e9-8c50-d12afb50ab93.png">

## After (print styles)
<img width="661" alt="screen shot 2019-02-18 at 13 59 05" src="https://user-images.githubusercontent.com/29889908/52955747-66361c80-3385-11e9-93d7-6fd3852de875.png">

Links to test:
- https://finder-frontend-pr-889.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-889.herokuapp.com/news-and-communications
- https://finder-frontend-pr-889.herokuapp.com/search/advanced?group=services&topic=%2Feducation

Note: this PR doesn't cover updating the [GOV.UK search page](https://www.gov.uk/search?q=student). This proved more complicated to update - we can revisit this in a separate PR.
