### PR TITLE
Show all values for People, Organisations and World Locations regardless of applied filters

### DIFF
--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -15,6 +15,10 @@ module Registries
       {}
     end
 
+    def values
+      organisations
+    end
+
   private
 
     def organisations_as_hash
@@ -30,7 +34,8 @@ module Registries
       params = {
         filter_format: 'organisation',
         fields: %w(title slug acronym),
-        count: 1500
+        count: 1500,
+        order: 'title'
       }
       response = Services.rummager.search(params)
       response['results']

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -1,6 +1,6 @@
 module Registries
   class PeopleRegistry
-    CACHE_KEY = "registries/people".freeze
+    CACHE_KEY = "#{NAMESPACE}/people".freeze
 
     def [](slug)
       people[slug]
@@ -13,6 +13,10 @@ module Registries
     rescue GdsApi::HTTPServerError
       GovukStatsd.increment("registries.people_api_errors")
       {}
+    end
+
+    def values
+      people
     end
 
   private
@@ -30,7 +34,8 @@ module Registries
       params = {
         filter_format: 'person',
         fields: %w(title slug),
-        count: 1500
+        count: 1500,
+        order: 'title'
       }
       Services.rummager.search_enum(params, page_size: 1500)
     end

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -11,6 +11,10 @@ module Registries
       end
     end
 
+    def values
+      cached_locations
+    end
+
   private
 
     def cached_locations

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -182,3 +182,11 @@ Feature: Filtering documents
     When I view the business readiness finder
     And I click button "Sector / Business Area" and select facet Aerospace
     Then I see results grouped by primary facet value
+
+  Scenario: Dynamic facets continue to show all options on page reload
+    When I view the news and communications finder
+    And I select a Person
+    And I reload the page
+    Then I should see all people in the people facet
+    And I should see all organisations in the organisation facet
+    And I should see all world locations in the world location facet

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -445,6 +445,36 @@ And(/^I select a taxon$/) do
   select('Taxon_1', from: 'Topic')
 end
 
+And(/^I select a Person$/) do
+  check('Rufus Scrimgeour')
+end
+
+And(/^I reload the page$/) do
+  visit [current_path, page.driver.request.env['QUERY_STRING']].reject(&:blank?).join('?')
+end
+
+Then(/^I should see all people in the people facet$/) do
+  expect(page).to have_css('input[id^="people-"]', count: 5)
+  find('label', text: 'Albus Dumbledore')
+  find('label', text: 'Cornelius Fudge')
+  find('label', text: 'Harry Potter')
+  find('label', text: 'Ron Weasley')
+  find('label', text: 'Rufus Scrimgeour')
+end
+
+And(/^I should see all organisations in the organisation facet$/) do
+  expect(page).to have_css('input[id^="organisations-"]', count: 3)
+  find('label', text: 'Department of Mysteries')
+  find('label', text: 'Gringots')
+  find('label', text: 'Ministry of Magic')
+end
+
+Then(/^I should see all world locations in the world location facet$/) do
+  expect(page).to have_css('input[id^="world_locations-"]', count: 2)
+  find('label', text: 'Azkaban')
+  find('label', text: 'Tracy Island')
+end
+
 And(/^I select a World Location$/) do
   click_on('World location')
   check('Azkaban')

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -299,6 +299,7 @@ Given(/^an organisation finder exists$/) do
   content_store_has_government_finder
   stub_organisations_registry_request
   stub_rummager_api_request_with_government_results
+  stub_people_registry_request
 
   visit finder_path('government/policies/benefits-reform', parent: 'ministry-of-magic')
 end
@@ -307,6 +308,7 @@ Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   content_store_has_government_finder
   stub_organisations_registry_request
   stub_rummager_api_request_with_government_results
+  stub_people_registry_request
 
   visit finder_path('government/policies/benefits-reform', parent: 'bernard-cribbins')
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -354,7 +354,8 @@ module DocumentHelper
     simple_rummager_url(
       "count" => 1500,
       "fields" => %w(slug title acronym),
-      "filter_format" => "organisation"
+      "filter_format" => "organisation",
+      "order" => 'title'
     )
   end
 
@@ -528,16 +529,16 @@ module DocumentHelper
     %|{
       "results": [
         {
-          "title": "HM Revenue & Customs",
-          "slug": "hm-revenue-customs",
-          "_id": "/government/organisations/hm-revenue-customs",
+          "title": "Attorney General's Office",
+          "slug": "attorney-generals-office",
+          "_id": "/government/organisations/companies-house",
           "elasticsearch_type": "edition",
           "document_type": "edition"
         },
         {
-          "title": "Attorney General's Office",
-          "slug": "attorney-generals-office",
-          "_id": "/government/organisations/companies-house",
+          "title": "HM Revenue & Customs",
+          "slug": "hm-revenue-customs",
+          "_id": "/government/organisations/hm-revenue-customs",
           "elasticsearch_type": "edition",
           "document_type": "edition"
         }
@@ -1448,12 +1449,28 @@ module DocumentHelper
     %|{
       "results": [
         {
+          "id": "https://www.gov.uk/api/world-locations/azkaban",
+          "title": "Azkaban",
+          "format": "World location",
+          "updated_at": "2018-04-27T14:41:52.000+01:00",
+          "web_url": "https://www.gov.uk/world/azkaban",
+          "analytics_identifier": "WL1",
+          "details": {
+            "slug": "azkaban",
+            "iso2": "AK"
+          },
+          "organisations": {
+            "id": "https://www.gov.uk/api/world-locations/azkaban/organisations",
+            "web_url": "https://www.gov.uk/world/azkaban#organisations"
+          }
+        },
+        {
           "id": "https://www.gov.uk/api/world-locations/tracy-island",
           "title": "Tracy Island",
           "format": "World location",
           "updated_at": "2018-04-27T14:41:52.000+01:00",
           "web_url": "https://www.gov.uk/world/tracy-island",
-          "analytics_identifier": "WL1",
+          "analytics_identifier": "WL2",
           "details": {
             "slug": "tracy-island",
             "iso2": "TI"

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -10,23 +10,23 @@ module RegistrySpecHelper
     })
     .to_return(body: { results: [
       {
-        "title": "Harry Potter",
-        "slug": "harry-potter",
-        "_id": "a field that we're not using"
-      },
-      {
         "title": "Albus Dumbledore",
         "slug": "albus-dumbledore",
         "_id": "a field that we're not using"
       },
       {
-        "title": "Ron Weasley",
-        "slug": "ron-weasley",
+        "title": "Cornelius Fudge",
+        "slug": "cornelius-fudge",
         "_id": "a field that we're not using"
       },
       {
-        "title": "Cornelius Fudge",
-        "slug": "cornelius-fudge",
+        "title": "Harry Potter",
+        "slug": "harry-potter",
+        "_id": "a field that we're not using"
+      },
+      {
+        "title": "Ron Weasley",
+        "slug": "ron-weasley",
         "_id": "a field that we're not using"
       },
       {

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -2,37 +2,38 @@ module RegistrySpecHelper
   def stub_people_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {
-        count: 1500,
-        start: 0,
-        fields: %w(slug title),
-        filter_format: %(person),
+      count: 1500,
+      start: 0,
+      fields: %w(slug title),
+      filter_format: %(person),
+      order: 'title'
     })
     .to_return(body: { results: [
-        {
-          "title": "Harry Potter",
-          "slug": "harry-potter",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Albus Dumbledore",
-          "slug": "albus-dumbledore",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Ron Weasley",
-          "slug": "ron-weasley",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Cornelius Fudge",
-          "slug": "cornelius-fudge",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Rufus Scrimgeour",
-          "slug": "rufus-scrimgeour",
-          "_id": "/government/people/rufus-scrimgeour"
-        }
+      {
+        "title": "Harry Potter",
+        "slug": "harry-potter",
+        "_id": "a field that we're not using"
+      },
+      {
+        "title": "Albus Dumbledore",
+        "slug": "albus-dumbledore",
+        "_id": "a field that we're not using"
+      },
+      {
+        "title": "Ron Weasley",
+        "slug": "ron-weasley",
+        "_id": "a field that we're not using"
+      },
+      {
+        "title": "Cornelius Fudge",
+        "slug": "cornelius-fudge",
+        "_id": "a field that we're not using"
+      },
+      {
+        "title": "Rufus Scrimgeour",
+        "slug": "rufus-scrimgeour",
+        "_id": "/government/people/rufus-scrimgeour"
+      }
     ] }.to_json)
   end
 
@@ -42,25 +43,26 @@ module RegistrySpecHelper
       count: 1500,
       fields: %w(slug title acronym),
       filter_format: %(organisation),
+      order: 'title'
     })
     .to_return(body: { results: [
-        {
-          "title": "Ministry of Magic",
-          "slug": "ministry-of-magic",
-          "acronym": "MOM",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Gringots",
-          "acronym": "GRI",
-          "slug": "gringots",
-          "_id": "/government/organisations/gringots"
-        },
-        {
-          "title": "Department of Mysteries",
-          "slug": "department-of-mysteries",
-          "_id": "/government/organisations/department-of-mysteries"
-        }
+      {
+        "title": "Department of Mysteries",
+        "slug": "department-of-mysteries",
+        "_id": "/government/organisations/department-of-mysteries"
+      },
+      {
+        "title": "Gringots",
+        "acronym": "GRI",
+        "slug": "gringots",
+        "_id": "/government/organisations/gringots"
+      },
+      {
+        "title": "Ministry of Magic",
+        "slug": "ministry-of-magic",
+        "acronym": "MOM",
+        "_id": "a field that we're not using"
+      }
     ] }.to_json)
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Registries::BaseRegistries do
   it "fetches all registries" do
     expect(subject.all).to have_key('world_locations')
     expect(subject.all).to have_key('part_of_taxonomy_tree')
+    expect(subject.all).to have_key('organisations')
+    expect(subject.all).to have_key('people')
   end
 
   it "provides world_locations registry" do

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Registries::OrganisationsRegistry do
     {
       "count" => 1500,
       "fields" => %w(slug title acronym),
-      "filter_format" => "organisation"
+      "filter_format" => "organisation",
+      "order" => 'title'
     }
   }
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -27,6 +28,13 @@ RSpec.describe Registries::OrganisationsRegistry do
         'acronym' => 'MOM',
         'slug' => slug
       )
+    end
+
+    it "will return all organisations by title ascending" do
+      organisations = described_class.new.values
+
+      expect(organisations.length).to eql(3)
+      expect(organisations.keys).to eql(%w(department-of-mysteries gringots ministry-of-magic))
     end
   end
 
@@ -55,14 +63,14 @@ RSpec.describe Registries::OrganisationsRegistry do
     %|{
       "results": [
         {
-          "title": "Ministry of Magic",
-          "slug": "ministry-of-magic",
-          "_id": "a field that we're not using"
-        },
-        {
           "title": "Attorney General's Office",
           "slug": "attorney-generals-office",
           "_id": "/government/organisations/companies-house"
+        },
+        {
+          "title": "Ministry of Magic",
+          "slug": "ministry-of-magic",
+          "_id": "a field that we're not using"
         }
       ],
       "total": 2,

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Registries::PeopleRegistry do
     {
       "count" => 1500,
       "fields" => %w(slug title),
-      "filter_format" => "person"
+      "filter_format" => "person",
+      "order" => 'title'
     }
   }
   let(:rummager_params) { default_rummager_params.merge("start" => 0) }
@@ -27,6 +28,13 @@ RSpec.describe Registries::PeopleRegistry do
         'title' => 'Cornelius Fudge',
         'slug' => slug
       )
+    end
+
+    it "will return all people ordered by title ascending" do
+      people = described_class.new.values
+
+      expect(people.length).to eql(2)
+      expect(people.keys).to eql(%w(cornelius-fudge rufus-scrimgeour))
     end
   end
 

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe Registries::WorldLocationsRegistry do
         'slug' => slug
       )
     end
+
+    it "will return all world locations" do
+      world_locations = registry.values
+
+      expect(world_locations.length).to eql(3)
+      expect(world_locations.keys).to eql(%w(hogwarts privet-drive diagon-alley))
+    end
   end
 
   describe "when world locations API is unavailable" do


### PR DESCRIPTION
This PR updates finders to show all available _People_, _Organisations_ and _World Locations_ values in dynamic facets, regardless of whether these values are applicable to the currently selected facets.

The reason behind this is to ensure that we don't give the appearance of les options being available for these facets than there actually are, and also to ensure that we don't incorrectly constrain a user's search as they select and de-select filters - something which can happen right now, as the facets aren't reloaded on-the-fly with JS enabled but instead only on page load/reload.

Further information can be found at https://trello.com/c/Bc9UKt5W.

Solo: @karlbaker02

https://finder-frontend-pr-890.herokuapp.com/news-and-communications