### PR TITLE
Add acronyms to organisations registry

### DIFF
--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -22,14 +22,14 @@ module Registries
         .reject { |result| result['slug'].empty? || result['title'].empty? }
         .each_with_object({}) { |result, orgs|
           slug = result['slug']
-          orgs[slug] = result.slice('title', 'slug')
+          orgs[slug] = result.slice('title', 'slug', 'acronym')
         }
     end
 
     def fetch_organisations_from_rummager
       params = {
         filter_format: 'organisation',
-        fields: %w(title slug),
+        fields: %w(title slug acronym),
         count: 1500
       }
       response = Services.rummager.search(params)

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -321,7 +321,7 @@ module DocumentHelper
   def rummager_all_org_links_url
     simple_rummager_url(
       "count" => 1500,
-      "fields" => %w(slug title),
+      "fields" => %w(slug title acronym),
       "filter_format" => "organisation"
     )
   end

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -40,17 +40,19 @@ module RegistrySpecHelper
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {
       count: 1500,
-      fields: %w(slug title),
+      fields: %w(slug title acronym),
       filter_format: %(organisation),
     })
     .to_return(body: { results: [
         {
           "title": "Ministry of Magic",
           "slug": "ministry-of-magic",
+          "acronym": "MOM",
           "_id": "a field that we're not using"
         },
         {
           "title": "Gringots",
+          "acronym": "GRI",
           "slug": "gringots",
           "_id": "/government/organisations/gringots"
         },

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -1,11 +1,14 @@
 require 'spec_helper'
+require 'helpers/registry_spec_helper'
 
 RSpec.describe Registries::OrganisationsRegistry do
+  include RegistrySpecHelper
+
   let(:slug) { 'ministry-of-magic' }
   let(:rummager_params) {
     {
       "count" => 1500,
-      "fields" => %w(slug title),
+      "fields" => %w(slug title acronym),
       "filter_format" => "organisation"
     }
   }
@@ -13,14 +16,15 @@ RSpec.describe Registries::OrganisationsRegistry do
 
   describe "when rummager is available" do
     before do
-      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      stub_organisations_registry_request
       clear_cache
     end
 
-    it "will fetch organisation breadcrumb information by slug" do
+    it "will fetch organisation information by slug" do
       organisation = described_class.new[slug]
       expect(organisation).to eq(
         'title' => 'Ministry of Magic',
+        'acronym' => 'MOM',
         'slug' => slug
       )
     end


### PR DESCRIPTION
This adds an additional field (acronyms) to the results
we fetch and cache from rummager for the organisations
registry.

Later we will use this extra field to allow users
to filter by looking for an acronym in the autocomplete
facet. This just adds them to the registry.

https://trello.com/c/Ql3rrz9O/374-allow-users-to-filter-orgs-using-abbreviations