### PR TITLE
Fli.* - display message if finder returns zero results

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -25,6 +25,7 @@ class ResultSetPresenter
       pluralised_document_noun: document_noun.pluralize(total),
       applied_filters: selected_filter_descriptions,
       documents: documents,
+      zero_results: total.zero?,
       page_count: documents.count,
       finder_name: finder.name,
       any_filters_applied: any_filters_applied?,

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -43,7 +43,6 @@
   <div class='no-results'>
     <h2 class='gem-c-heading'>There are no matching results.</h2>
     <p>Try making your search broader.</p>
-    {{results}}
   </div>
 {{/zero_results}}
 

--- a/app/views/finders/_results.mustache
+++ b/app/views/finders/_results.mustache
@@ -39,4 +39,12 @@
   {{/documents}}
 </ul>
 
+{{#zero_results}}
+  <div class='no-results'>
+    <h2 class='gem-c-heading'>There are no matching results.</h2>
+    <p>Try making your search broader.</p>
+    {{results}}
+  </div>
+{{/zero_results}}
+
 {{{next_and_prev_links}}}

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -26,12 +26,14 @@ Feature: Filtering documents
     Given a collection of documents exist
     When I search documents by keyword
     Then I see all documents which contain the keywords
+    And there is not a zero results message
 
   Scenario: Hiding keyword search
     Given no results
     When I view the finder with no keywords and no facets
     Then I see no results
     And there is no keyword search box
+    And there is a helpful message
 
   Scenario: Visit a government finder
     Given a government finder exists

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -33,7 +33,7 @@ Feature: Filtering documents
     When I view the finder with no keywords and no facets
     Then I see no results
     And there is no keyword search box
-    And there is a helpful message
+    And there is a zero results message
 
   Scenario: Visit a government finder
     Given a government finder exists

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -21,6 +21,14 @@ And(/there is no keyword search box$/) do
   expect(page).to_not have_css('#finder-keyword-search')
 end
 
+And(/there is a helpful message$/) do
+  expect(page).to have_content('no matching results')
+end
+
+And(/there is not a zero results message$/) do
+  expect(page).to_not have_content('no matching results')
+end
+
 Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -21,7 +21,7 @@ And(/there is no keyword search box$/) do
   expect(page).to_not have_css('#finder-keyword-search')
 end
 
-And(/there is a helpful message$/) do
+And(/there is a zero results message$/) do
   expect(page).to have_content('no matching results')
 end
 


### PR DESCRIPTION
added a message to be displayed if a particular query returns zero results.

added to existing cucumber tests to validate absence or presence of this message.

story card: https://trello.com/c/uA82ETNg/368-display-a-message-when-a-finder-returns-0-results

Example page: https://finder-frontend-pr-892.herokuapp.com/news-and-communications?keywords=&level_one_taxon=ba951b09-5146-43be-87af-44075eac3ae9&level_two_taxon=&people%5B%5D=george-zambellas&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest