### PR TITLE
Exclude date metadata from results that are services

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -64,6 +64,7 @@ private
       description
       public_timestamp
       popularity
+      content_purpose_supergroup
     )
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -63,6 +63,8 @@ private
   end
 
   def date_metadata
+    return [] if @content_purpose_supergroup == 'services'
+
     date_metadata_keys
       .map(&method(:build_date_metadata))
       .select(&method(:metadata_value_present?))

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -143,6 +143,7 @@ module RummagerUrlHelper
       description
       public_timestamp
       popularity
+      content_purpose_supergroup
     )
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -38,7 +38,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
+        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
 
         stub_request(:get, url)
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -125,7 +125,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
+        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
           to_return(status: 200, body: rummager_response, headers: {})
       end
 

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -58,7 +58,7 @@ describe SearchQueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup",
       )
     end
   end
@@ -85,7 +85,7 @@ describe SearchQueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,alpha,beta",
       )
     end
 
@@ -102,7 +102,7 @@ describe SearchQueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,zeta,beta",
         )
       end
     end


### PR DESCRIPTION
This excludes the date published/updated metadata from the
result items that are part of the services supergroup.

This is for the all content finder but should be the case for all results that are services. 

https://trello.com/c/GlElZKVa/379-remove-updated-metadata-from-results-that-are-doc-types-within-services-supergroup