### PR TITLE
[DO NOT MERGE] [WIP] Prototype make finders more accessible

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -16,6 +16,8 @@
     this.$resultsCount = options.$results.find('#js-result-count');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
+    this.$clearlink = $('.js-clear-facets');
+
     this.$emailLink = $("p.email-link a");
 
     this.emailSignupHref = this.$emailLink.attr('href');
@@ -46,6 +48,13 @@
             this.formChange(e);
             e.preventDefault();
           }
+        }.bind(this)
+      );
+
+      this.$clearlink.on('click',
+        function(e) {
+          e.preventDefault();
+          this.resetFacets();
         }.bind(this)
       );
 
@@ -102,6 +111,36 @@
         }.bind(this)
       )
     }
+  };
+
+  LiveSearch.prototype.resetFacets = function resetFacets() {
+    var facets = this.state.filter(function(item) { return item.value !== "" && item.name !== "order"; });
+
+    facets.forEach(function(facet) {
+      var $input = $("[name='" + facet.name + "']");
+      var inputType = $input.prop('type');
+      var inputId = $input.attr('id');
+      var isAutoComplete = !!$('#' + inputId).length;
+      var autocompleteId = inputId.replace('-select', ''); // autocompletes always have -select on the end
+
+      if (inputType == 'checkbox') {
+        $input.prop("checked", false);
+        $input.trigger('change');
+      }
+      else if (inputType == 'text' || inputType == 'search') {
+        $input.val('');
+      }
+      else {
+        if (isAutoComplete) {
+          setTimeout(function(){
+            $('#' + autocompleteId + '__list').html('');
+          },150);
+        }
+        $input.val('').change();
+      }
+    });
+
+    this.formChange();
   };
 
   LiveSearch.prototype.trackingInit = function() {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -240,7 +240,6 @@
       @include core-16;
       vertical-align: baseline;
       margin: 0 0 $gutter 0;
-      border-bottom: solid 1px govuk-colour("black");
 
       .result-count {
         @include bold-27;
@@ -422,6 +421,14 @@
       display: inline-block;
     }
   }
+}
+
+.clear-search {
+  display: none;
+}
+
+.js-enabled .clear-search--active {
+  display: inline-block;
 }
 
 .facet-toggle {

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -154,7 +154,7 @@ private
   # Add a finder with the base path as a key and the finder name
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
-  FINDERS_IN_DEVELOPMENT = {}.freeze
+  FINDERS_IN_DEVELOPMENT = {'/news-and-communications' => 'news_and_communications'}.freeze
 
   def development_env_finder_json
     return development_json if is_development_json?

--- a/app/views/finders/_autocomplete_facet.html.erb
+++ b/app/views/finders/_autocomplete_facet.html.erb
@@ -1,7 +1,6 @@
 <%= render "govuk_publishing_components/components/accessible_autocomplete", {
     id: autocomplete_facet.key,
     multiple: true,
-    hide_facets: true,
     label: {
         text: autocomplete_facet.name
     },

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -15,6 +15,10 @@
     </a>
 
     <div id="facet-wrapper" class="facet-toggle__content--hidden">
+      <div class="govuk-form-group clear-search clear-search--active js-clear-facets">
+        <a href="#">Clear all search options</a>
+      </div>
+
       <%= render facet_collection.filters %>
     </div>
   </div>

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -2,10 +2,5 @@
   <span class="result-count">
     {{total}} {{{pluralised_document_noun}}}
   </span>
-  <div class="facet-tags" data-module="track-click">
-    {{#applied_filters}}
-        {{> finders/_applied_filter}}
-    {{/applied_filters}}
-  </div>
   {{{sort_options}}}
 </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -75,6 +75,7 @@
           </div>
 
           <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
+
           <% if finder.sort %>
             <div class="govuk-form-group">
               <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -151,6 +151,14 @@ Feature: Filtering documents
     And I click the Keyword1 remove control
     Then The keyword textbox only contains Keyword2
 
+  @javascript
+  Scenario: Clearing all search facets
+    When I view the news and communications finder
+    And I fill in some keywords
+    And I use a checkbox filter
+    And I sort by most relevant
+    Then I can clear all facets
+
   Scenario: Subscribing to email alerts
     Given a collection of documents exist that can be filtered by checkbox
     When I use a checkbox filter

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -453,6 +453,13 @@ When(/^I click the (.*) remove control$/) do |filter|
   expect(page).to_not have_selector("p[class='facet-tag__text']", text: filter)
 end
 
+Then(/^I can clear all facets$/) do
+  click_on "Clear all search options"
+
+  expect(page).to have_selector("[keywords][value='']")
+  #expect(page).to have_field('Your name', with: 'John')
+end
+
 Then(/^The (.*) checkbox in deselected$/) do |checkbox|
   expect(page.find("##{checkbox}", visible: :all)).to_not be_checked
 end


### PR DESCRIPTION
- remove facet tags from news and comms finder
- allow autocomplete multiple to have its own facet tags
- add 'clear all search options' option

Try it: https://finder-frontend-pr-900.herokuapp.com/news-and-communications

Trello card: https://trello.com/c/ppFUeOhY/385-improve-facet-search-accessibility
