### PR TITLE
Add statsd monitoring for external request time

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -78,9 +78,11 @@ private
       params: filter_params,
     ).call
 
-    merge_and_deduplicate(
-      Services.rummager.batch_search(queries).to_hash
-    )
+    GovukStatsd.time("rummager.finder_batch_search") do
+      merge_and_deduplicate(
+        Services.rummager.batch_search(queries).to_hash
+      )
+    end
   end
 
   def augment_content_item_with_results(content_item, search_response)

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -18,12 +18,14 @@ module Registries
   private
 
     def organisations_as_hash
-      fetch_organisations_from_rummager
-        .reject { |result| result['slug'].empty? || result['title'].empty? }
-        .each_with_object({}) { |result, orgs|
-          slug = result['slug']
-          orgs[slug] = result.slice('title', 'slug', 'acronym')
-        }
+      GovukStatsd.time("registries.organisations.request_time") do
+        fetch_organisations_from_rummager
+          .reject { |result| result['slug'].empty? || result['title'].empty? }
+          .each_with_object({}) { |result, orgs|
+            slug = result['slug']
+            orgs[slug] = result.slice('title', 'slug', 'acronym')
+          }
+      end
     end
 
     def fetch_organisations_from_rummager

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -18,12 +18,14 @@ module Registries
   private
 
     def people_as_hash
-      fetch_people_from_rummager
-        .reject { |result| result['slug'].empty? || result['title'].empty? }
-        .each_with_object({}) { |result, orgs|
-          slug = result['slug']
-          orgs[slug] = result.slice('title', 'slug')
-        }
+      GovukStatsd.time("registries.people.request_time") do
+        fetch_people_from_rummager
+          .reject { |result| result['slug'].empty? || result['title'].empty? }
+          .each_with_object({}) { |result, orgs|
+            slug = result['slug']
+            orgs[slug] = result.slice('title', 'slug')
+          }
+      end
     end
 
     def fetch_people_from_rummager

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -18,9 +18,11 @@ module Registries
   private
 
     def taxonomy_tree_as_hash
-      fetch_level_one_taxons_from_api.each_with_object({}) { |taxon, taxonomy|
-        taxonomy[taxon['content_id']] = format_taxon(taxon)
-      }
+      GovukStatsd.time("registries.topic_taxonomy.request_time") do
+        fetch_level_one_taxons_from_api.each_with_object({}) { |taxon, taxonomy|
+          taxonomy[taxon['content_id']] = format_taxon(taxon)
+        }
+      end
     end
 
     def format_taxon(taxon, parent_id = nil)

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -27,9 +27,11 @@ module Registries
     end
 
     def locations
-      fetch_locations.each_with_object({}) { |hash, result_hash|
-        result_hash[hash['slug']] = hash
-      }
+      GovukStatsd.time("registries.world_locations.request_time") do
+        fetch_locations.each_with_object({}) { |hash, result_hash|
+          result_hash[hash['slug']] = hash
+        }
+      end
     end
 
     def fetch_locations

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -9,7 +9,9 @@ module Services
 
   def self.cached_content_item(base_path)
     Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 5.minutes) do
-      content_store.content_item(base_path).to_h
+      GovukStatsd.time("content_store.fetch_request_time") do
+        content_store.content_item(base_path).to_h
+      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/hQFZm8VG/356-instrument-and-monitor-our-pages-on-finder-frontend

The new finders we're adding will probably lead to more traffic to this application. This change will make it possible for us to monitor the execution of requests to the external dependencies of finder-frontend. This will help us understand the impact of external requests and cache timeouts on end users. 

The stats will be sent to graphite [1].

We plan to put the output of this into the Finder Frontend application dashboard in Grafana.

[1] https://docs.publishing.service.gov.uk/manual/tools.html#graphite

See individual commits for details.