### PR TITLE
Add metadata fields to statistics finder.

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -48,7 +48,7 @@
     dt {
       display: none;
 
-      &.metadata-date-label {
+      &.metadata-label {
         @include inline-block;
       }
     }

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -163,7 +163,9 @@ private
   # Add a finder with the base path as a key and the finder name
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
-  FINDERS_IN_DEVELOPMENT = {}.freeze
+  FINDERS_IN_DEVELOPMENT = {
+    "/statistics" => "statistics",
+  }.freeze
 
   def development_env_finder_json
     return development_json if is_development_json?

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -107,7 +107,7 @@ class FinderPresenter
   end
 
   def text_metadata_keys
-    metadata.select { |f| f.type == "text" }.map(&:key)
+    metadata.select { |f| %w[text autocomplete].include?(f.type) }.map(&:key)
   end
 
   def default_sort_option
@@ -201,8 +201,7 @@ class FinderPresenter
   end
 
   def display_key_for_metadata_key(key)
-    case key
-    when 'organisations'
+    if %w[organisations document_collections].include?(key)
       'title'
     else
       'label'

--- a/app/views/finders/_document.mustache
+++ b/app/views/finders/_document.mustache
@@ -13,12 +13,12 @@
     {{#document.show_metadata}}
       {{#document.metadata}}
         {{#is_text}}
-          <dt class='metadata-text-label'>{{label}}:</dt>
+          <dt class='metadata-label'>{{label}}:</dt>
           <dd class='metadata-text-value'>{{value}}</dd>
         {{/is_text}}
 
         {{#is_date}}
-          <dt class='metadata-date-label'>{{label}}:</dt>
+          <dt class='metadata-label'>{{label}}:</dt>
           <dd class='metadata-date-value'><time datetime='{{machine_date}}'>{{human_date}}</time></dd>
         {{/is_date}}
       {{/document.metadata}}

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -57,6 +57,42 @@
     ],
     "facets":[
       {
+        "key": "release_timestamp",
+        "name": "release_timestamp",
+        "short_name": "Release date",
+        "preposition": "from",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "statistics_announcement_state",
+        "name": "State",
+        "short_name": "State",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "display_type",
+        "name": "content_store_document_type",
+        "short_name": "Document type",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "document_collections",
+        "name": "document_collections",
+        "short_name": "Part of a collection",
+        "preposition": "from",
+        "type": "autocomplete",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
         "filter_key": "all_part_of_taxonomy_tree",
         "keys": ["level_one_taxon", "level_two_taxon"],
         "name": "topic",
@@ -69,7 +105,7 @@
       {
         "key": "organisations",
         "name": "Organisation",
-        "short_name": "From",
+        "short_name": "Organisation",
         "preposition": "from",
         "type": "autocomplete",
         "display_as_result_metadata": true,
@@ -93,7 +129,7 @@
         "allowed_values": [
           {
             "text": "Published",
-            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]",
+            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]"
           },
           {
             "text": "Upcoming",


### PR DESCRIPTION
Add metadata fields to statistics finder.

Adds Document Type and Publishing orgs as metadata.
Adds Updated date and collection to 'published' statistics.
Adds Release date and cancelled/confirmed state to 'upcoming' stats

The search api only indexes 'updated date' and 'collection' metadata
on 'published' stats and 'release date' and 'state' on 'upcoming'
stats so no extra logic is needed.

See Trello: https://trello.com/c/XLdskaKe/382-make-stats-results-metadata-match-existing-metadata

![image](https://user-images.githubusercontent.com/6050162/53106746-8d2e5300-352b-11e9-8da2-4130f19ce8cd.png)
