### PR TITLE
Adds a landmark to the search results region or search filters sidebar

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -64,11 +64,11 @@
 <div class="grid-row">
   <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
     <input type="hidden" name="parent" value="<%= @parent %>">
-    <div class="column-third">
+    <div class="column-third" role="search" aria-label="<%= finder.name %>">
       <%= render finder.facets %>
     </div>
 
-    <div class="column-two-thirds">
+    <div class="column-two-thirds" role="region" aria-label="<%= finder.name %> search results">
       <div class='js-live-search-results-block'>
         <div class="filtered-results">
           <div aria-live='assertive' id='js-search-results-info' data-module="remove-filter">

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -199,3 +199,8 @@ Feature: Filtering documents
     And I press tab key to navigate
     Then I should see a "Skip to results" link
     And the page has results region
+
+  Scenario: Results should be a landmark to allow screenreaders to jump to it quickly
+    When I view the news and communications finder
+    Then the page has a landmark to the search results
+    And the page has a landmark to the search filters

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -571,3 +571,11 @@ end
 Then(/^the page has results region$/) do
   expect(page).to have_css('[id="js-results"]')
 end
+
+Then(/^the page has a landmark to the search results$/) do
+  expect(page).to have_css('[class="column-two-thirds"][role="region"][aria-label$="search results"]')
+end
+
+Then(/^the page has a landmark to the search filters$/) do
+  expect(page).to have_css('.column-third[role="search"][aria-label]')
+end


### PR DESCRIPTION
Screen reader users should be able to easily navigate to the search
results region or the search/filters sidebar of the page by using landmarks.

Demo page: https://finder-frontend-pr-906.herokuapp.com/news-and-communications

Trello card: https://trello.com/c/HrwDU1do/387-improve-page-navigation-for-keyboard-users-and-screen-readers

