### PR TITLE
Add filter to option select component

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -47,6 +47,14 @@
     }
   }
 
+  .app-c-option-select__filter {
+    display: none;
+
+    .govuk-form-group {
+      margin-bottom: $gutter-one-third;
+    }
+  }
+
   .js-enabled & {
     padding: 0 0 1px;
 
@@ -102,6 +110,10 @@
         }
       }
     }
+
+    .app-c-option-select__filter {
+      display: block;
+    }
   }
 
   // This is a temporary overwrite for checkboxes
@@ -124,9 +136,12 @@
     height: 26px;
   }
 
+  .govuk-label {
+    font-size: 16px;
+  }
+
   .govuk-checkboxes__label {
     padding: 8px 5px 2px 9px;
-    font-size: 16px;
   }
 
   .govuk-checkboxes__input + .govuk-checkboxes__label::before {
@@ -142,5 +157,4 @@
     height: 5px;
     border-width: 0 0 3px 3px;
   }
-
 }

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -10,8 +10,26 @@
   </div>
   <div role="group" aria-labelledby="<%= title_id %>" class="options-container" id="<%= options_container_id %>">
     <div class="js-auto-height-inner">
+      <%
+        checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
+        checkboxes_count_id = checkboxes_id + "-count"
+      %>
+      <% if local_assigns.include?(:show_filter) %>
+        <div class="app-c-option-select__filter">
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Filter " + title
+            },
+            name: "filter",
+            controls: checkboxes_id,
+            describedby: checkboxes_count_id
+          } %>
+          <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
+        </div>
+      <% end %>
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "#{key}[]",
+        id: checkboxes_id,
         heading: "Please select all that apply",
         visually_hide_heading: true,
         no_hint_text: true,

--- a/app/views/components/docs/option-select.yml
+++ b/app/views/components/docs/option-select.yml
@@ -13,6 +13,14 @@ accessibility_criteria: |
   - have a margin to the right when the box is scrollable so that users can interact with a scrollbar without accidentally clicking an option
   - only include an `aria-controls` attribute if an element with the ID specified exists on the page
   - be [grouped with a label](https://www.w3.org/WAI/GL/wiki/Using_grouping_roles_to_identify_related_form_controls)
+
+  The option select filter must:
+
+  - be focusable with a keyboard
+  - indicate when it has keyboard focus
+  - inform the user that is it an editable field
+  - inform the user when there are matches, or if there are no matches
+  - inform the user as the number of matches changes
 examples:
   default:
     data:
@@ -70,7 +78,6 @@ examples:
       options:
       - value: potatoes
         label: Potatoes
-        name: potatoes
         checked: true
       - value: carrots
         label: Carrots
@@ -147,3 +154,97 @@ examples:
           track_label: "high_heels"
           track_options:
             dimension28: 1
+  with_filter:
+    description: Adds a filter to allow users to narrow the checkboxes down. Checkboxes will only show if they match what the user has typed, or if they are already checked. The filter is case insensitive and strips out punctuation characters and duplicate whitespace, and sees '&' and 'and' as the same, to make filtering easier.
+    data:
+      key: filter_demo
+      title: Countries
+      options_container_id: list_of_countries_to_filter
+      show_filter: true
+      options:
+      - value: afghanistan
+        label: Afghanistan
+        id: afghanistan
+      - value: albania
+        label: Albania
+        id: albania
+      - value: algeria
+        label: Algeria
+        id: algeria
+        checked: true
+      - value: american_samoa
+        label: American Samoa
+        id: american_samoa
+      - value: andorra
+        label: Andorra
+        id: andorra
+        checked: true
+      - value: angola
+        label: Angola
+        id: angola
+      - value: anguilla
+        label: Anguilla
+        id: anguilla
+      - value: antigua_and_barbuda
+        label: Antigua and Barbuda
+        id: antigua_and_barbuda
+      - value: argentina
+        label: Argentina
+        id: argentina
+      - value: armenia
+        label: Armenia
+        id: armenia
+      - value: aruba
+        label: Aruba
+        id: aruba
+      - value: australia
+        label: Australia
+        id: australia
+      - value: austria
+        label: Austria
+        id: austria
+      - value: azerbaijan
+        label: Azerbaijan
+        id: azerbaijan
+      - value: bahamas
+        label: Bahamas
+        id: bahamas
+      - value: bahrain
+        label: Bahrain
+        id: bahrain
+      - value: bangladesh
+        label: Bangladesh
+        id: bangladesh
+      - value: barbados
+        label: Barbados
+        id: barbados
+      - value: belarus
+        label: Belarus
+        id: belarus
+      - value: belgium
+        label: Belgium
+        id: belgium
+      - value: belize
+        label: Belize
+        id: belize
+      - value: benin
+        label: Benin
+        id: benin
+      - value: bermuda
+        label: Bermuda
+        id: bermuda
+      - value: bhutan
+        label: Bhutan
+        id: bhutan
+      - value: bolivia
+        label: Bolivia
+        id: bolivia
+      - value: cote
+        label: Cote d’Ivoire
+        id: cote
+      - value: sthelena
+        label: St Helena, Ascension and Tristan da Cunha
+        id: sthelena
+      - value: trinidad
+        label: Trinidad & Tobago
+        id: trinidad

--- a/app/views/finders/_select_facet.html.erb
+++ b/app/views/finders/_select_facet.html.erb
@@ -6,7 +6,7 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => select_facet.key,
     :options => select_facet.options("js-search-results-info", select_facet.key),
-    :closed_on_load => close_facet,
+    :closed_on_load => close_facet
   }
   %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  components:
+    option_select:
+      found_single: "option found"
+      found_multiple: "options found"
   time:
     formats:
       as_date: "%d %B %Y"

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -87,6 +87,15 @@ describe 'components/_option-select.html.erb', type: :view do
     expect(rendered).to have_selector('.app-c-option-select[data-closed-on-load="true"]')
   end
 
+  it "can show a filter control" do
+    arguments = option_select_arguments
+    arguments[:show_filter] = true
+    render_component(arguments)
+
+    expect(rendered).to have_selector('.app-c-option-select .gem-c-input[name="filter"]')
+    expect(rendered).to have_selector('.app-c-option-select__count')
+  end
+
   def expect_label_and_checked_checkbox(label, id, value)
     expect_label_and_checkbox(label, id, value, true)
   end

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -10,45 +10,84 @@ describe('GOVUK.OptionSelect', function() {
       '</div>'+
       '<div class="options-container">'+
         '<div class="js-auto-height-inner">'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="aerospace" id="aerospace" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="aerospace">Aerospace</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="agriculture-environment-and-natural-resources" id="agriculture-environment-and-natural-resources" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="agriculture-environment-and-natural-resources">Agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment and natural resources.</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="building-and-construction" id="building-and-construction" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="building-and-construction">Building and construction</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="chemicals" id="chemicals" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="chemicals">Chemicals</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="clothing-footwear-and-fashion" id="clothing-footwear-and-fashion" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="clothing-footwear-and-fashion">Clothing, footwear and fashion</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="defence" id="defence" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="defence">Defence</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="distribution-and-service-industries" id="distribution-and-service-industries" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="distribution-and-service-industries">Distribution and Service Industries</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="electronics-industry" id="electronics-industry" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="electronics-industry">Electronics Industry</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="energy" id="energy" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="energy">Energy</label>'+
-          '</div>'+
-          '<div class="gem-c-checkbox govuk-checkboxes__item">'+
-            '<input name="market_sector[]" value="engineering" id="engineering" type="checkbox" class="govuk-checkboxes__input">'+
-            '<label class="govuk-label govuk-checkboxes__label" for="engineering">Engineering</label>'+
+          '<div id="checkboxes-9b7ecc25" class="gem-c-checkboxes govuk-form-group" data-module="checkboxes">'+
+            '<fieldset class="govuk-fieldset">'+
+              '<legend class="govuk-fieldset__legend govuk-fieldset__legend--m gem-c-checkboxes__legend--hidden">Please select all that apply</legend>'+
+              '<ul class="govuk-checkboxes gem-c-checkboxes__list">'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="aerospace" value="aerospace" class="govuk-checkboxes__input" />'+
+                    '<label for="aerospace" class="govuk-label govuk-checkboxes__label">Aerospace</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="agriculture-environment-and-natural-resources" value="agriculture-environment-and-natural-resources" class="govuk-checkboxes__input" />'+
+                    '<label for="agriculture-environment-and-natural-resources" class="govuk-label govuk-checkboxes__label">Agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment and natural resources.</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="building-and-construction" value="building-and-construction" class="govuk-checkboxes__input" />'+
+                    '<label for="building-and-construction" class="govuk-label govuk-checkboxes__label">Building and construction</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="chemicals" value="chemicals" class="govuk-checkboxes__input" />'+
+                    '<label for="chemicals" class="govuk-label govuk-checkboxes__label">Chemicals</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="clothing-footwear-and-fashion" value="clothing-footwear-and-fashion" class="govuk-checkboxes__input" />'+
+                    '<label for="clothing-footwear-and-fashion" class="govuk-label govuk-checkboxes__label">Clothing, footwear and fashion</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="defence" value="defence" class="govuk-checkboxes__input" />'+
+                    '<label for="defence" class="govuk-label govuk-checkboxes__label">Defence</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="distribution-and-service-industries" value="distribution-and-service-industries" class="govuk-checkboxes__input" />'+
+                    '<label for="distribution-and-service-industries" class="govuk-label govuk-checkboxes__label">Distribution &amp; Service Industries</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="electronics-industry" value="electronics-industry" class="govuk-checkboxes__input" />'+
+                    '<label for="electronics-industry" class="govuk-label govuk-checkboxes__label">Electronics Industry</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="energy" value="energy" class="govuk-checkboxes__input" />'+
+                    '<label for="energy" class="govuk-label govuk-checkboxes__label">Energy</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="engineering" value="engineering" class="govuk-checkboxes__input" />'+
+                    '<label for="engineering" class="govuk-label govuk-checkboxes__label">Engineering</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="thatdepartment" value="thatdepartment" class="govuk-checkboxes__input" />'+
+                    '<label for="thatdepartment" class="govuk-label govuk-checkboxes__label">Closed organisation: Department for Fisheries, War Widows\' pay, Farmers’ rights - sheep and goats, Farmer\'s rights – cows & llamas</label>'+
+                  '</div>'+
+                '</li>'+
+                '<li class="gem-c-checkboxes__list-item">'+
+                  '<div class="gem-c-checkbox govuk-checkboxes__item">'+
+                    '<input type="checkbox" name="market_sector[]" id="militarycourts" value="militarycourts" class="govuk-checkboxes__input" />'+
+                    '<label for="militarycourts" class="govuk-label govuk-checkboxes__label">1st and 2nd Military Courts</label>'+
+                  '</div>'+
+                '</li>'+
+              '</ul>'+
+            '</fieldset>'+
           '</div>'+
         '</div>'+
       '</div>';
@@ -294,7 +333,144 @@ describe('GOVUK.OptionSelect', function() {
       // Wrapping HTML should not stretch as 251px is too big.
       expect($checkboxList.height()).toBeGreaterThan(100);
     });
-
   });
 
+  describe('filtering checkboxes', function(){
+    beforeEach(function(){
+      var filterMarkup =
+        '<div class="app-c-option-select__filter">'+
+          '<div class="govuk-form-group">'+
+            '<label for="input-b7f768b7" class="gem-c-label govuk-label">'+
+              'Filter Countries'+
+            '</label>'+
+            '<input name="filter" class="gem-c-input govuk-input" id="input-b7f768b7" type="text" aria-describedby="checkboxes-9b7ecc25-count" aria-controls="checkboxes-9b7ecc25">'+
+          '</div>'+
+          '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found"></span>'+
+        '</div>';
+
+      $('body').find('.gem-c-checkboxes').prepend($(filterMarkup));
+      optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
+
+      var timerCallback = jasmine.createSpy("timerCallback");
+      jasmine.clock().install();
+    });
+
+    afterEach(function() {
+      jasmine.clock().uninstall();
+    });
+
+    it('filters the checkboxes and updates the filter count correctly', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      expect($('.govuk-checkboxes__input:visible').length).toBe(12);
+
+      $optionSelectHTML.find('[name="filter"]').val('in').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(5);
+      expect($count.text()).toBe('5 options found');
+
+      $optionSelectHTML.find('[name="filter"]').val('ind').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(2);
+      expect($count.html()).toBe('2 options found');
+
+      $optionSelectHTML.find('[name="filter"]').val('shouldnotmatchanything').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(0);
+      expect($count.html()).toBe('0 options found');
+    });
+
+    it('shows checked checkboxes regardless of whether they match the filter', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $('#building-and-construction').prop('checked', true).change();
+      $('#chemicals').prop('checked', true).change();
+      jasmine.clock().tick(100);
+
+      $optionSelectHTML.find('[name="filter"]').val('electronics').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(3);
+      expect($count.html()).toBe('3 options found');
+
+      $optionSelectHTML.find('[name="filter"]').val('shouldnotmatchanything').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(2);
+      expect($count.html()).toBe('2 options found');
+    });
+
+    it('matches a filter regardless of text case', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('electroNICS industry').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+
+      $optionSelectHTML.find('[name="filter"]').val('Building and construction').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+    });
+
+    it('matches ampersands correctly', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('Distribution & Service Industries').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+
+      $optionSelectHTML.find('[name="filter"]').val('Distribution &amp; Service Industries').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(0);
+      expect($count.html()).toBe('0 options found');
+    });
+
+    it('ignores whitespace around the user input', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('   Clothing, footwear and fashion    ').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+    });
+
+    it('ignores duplicate whitespace in the user input', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('Clothing,     footwear      and      fashion').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+    });
+
+    it('ignores common punctuation characters', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+    });
+
+    it('normalises & and and', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('cows & llamas').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+
+      $optionSelectHTML.find('[name="filter"]').val('cows and llamas').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+    });
+
+    // there was a bug in cleanString() where numbers were being ignored
+    it('does not strip out numbers', function(){
+      var $count = $('#checkboxes-9b7ecc25-count');
+      $optionSelectHTML.find('[name="filter"]').val('1st and 2nd Military Courts').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(1);
+      expect($count.html()).toBe('1 option found');
+
+      $optionSelectHTML.find('[name="filter"]').val('footwear and f23907234973204723094ashion').keyup();
+      jasmine.clock().tick(400);
+      expect($('.govuk-checkboxes__input:visible').length).toBe(0);
+      expect($count.html()).toBe('0 options found');
+    });
+  });
 });


### PR DESCRIPTION
Improve the option select component by adding an option to provide a filter field, which shows/hides the checkboxes based on user input.

<img width="830" alt="screen shot 2019-02-27 at 10 11 08" src="https://user-images.githubusercontent.com/861310/53498655-a2acfb00-3a9e-11e9-90e6-bd8685909bee.png">

How it works:

- filtering is applied as a user types, with `setTimeout` used to provide a delay to avoid unnecessary processing
- filtering is done entirely in-page, no backend involvement, so reloading or returning to the page completely resets the filter
- string matching is case insensitive, ignores punctuation and ignores the difference between & and 'and'
- checked checkboxes are always shown regardless of what has been typed into the filter
- checkbox labels are processed and cached on page load to optimise filtering
- a hidden element is used to announce to screen readers the number of results that have been found with the filter, and also to provide context that something is happening when the filter is used

Test: https://finder-frontend-pr-907.herokuapp.com/component-guide/option-select/with_filter

Trello card: https://trello.com/c/ppFUeOhY/385-improve-option-select-functionality
