### PR TITLE
Remove bullets from advanced finder

### DIFF
--- a/app/views/advanced_search_finder/_results.mustache
+++ b/app/views/advanced_search_finder/_results.mustache
@@ -5,7 +5,7 @@
   </div>
 {{/atom_url}}
 
-<ul data-module="track-click">
+<ul data-module="track-click" class="finder-results">
   {{#documents}}
     {{! The following elements use BEM styles from the govuk_publishing_components/document-list component
     for visual consistency, this might prove to be a maintenance headache in which case it would be better

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -33,7 +33,7 @@
 
     <% if finder.related.any? %>
       <div class='related-links'>
-        <ul class="finder-results">
+        <ul>
           <% finder.related.each do |link| %>
             <li><%= link_to link['title'], link['web_url'] %></li>
           <% end %>


### PR DESCRIPTION
Bullets started appearing in the advanced search finder results list, I think as a result of [this change](https://github.com/alphagov/finder-frontend/pull/897/files#diff-32432de741de8d01ce8959f91547b1c5R36) adding the `finder-results` class to the wrong `ul` element.

## Before
<img width="669" alt="screen shot 2019-02-25 at 09 35 54" src="https://user-images.githubusercontent.com/29889908/53327890-b7dc2b00-38e0-11e9-86b6-827d0c891f5d.png">

## After
<img width="656" alt="screen shot 2019-02-25 at 09 36 00" src="https://user-images.githubusercontent.com/29889908/53327900-bc084880-38e0-11e9-8e68-07384008435c.png">

Links to test:

- https://finder-frontend-pr-908.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- https://finder-frontend-pr-908.herokuapp.com/news-and-communications
- https://finder-frontend-pr-908.herokuapp.com/aaib-reports
- https://finder-frontend-pr-908.herokuapp.com/find-eu-exit-guidance-business
