### PR TITLE
Only use people that are associated with documents

### DIFF
--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -2,39 +2,53 @@ module RegistrySpecHelper
   def stub_people_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {
-      count: 1500,
-      start: 0,
-      fields: %w(slug title),
-      filter_format: %(person),
-      order: 'title'
+      count: 0,
+      facet_people: '1500,examples:0,order:value.title'
     })
-    .to_return(body: { results: [
-      {
-        "title": "Albus Dumbledore",
-        "slug": "albus-dumbledore",
-        "_id": "a field that we're not using"
-      },
-      {
-        "title": "Cornelius Fudge",
-        "slug": "cornelius-fudge",
-        "_id": "a field that we're not using"
-      },
-      {
-        "title": "Harry Potter",
-        "slug": "harry-potter",
-        "_id": "a field that we're not using"
-      },
-      {
-        "title": "Ron Weasley",
-        "slug": "ron-weasley",
-        "_id": "a field that we're not using"
-      },
-      {
-        "title": "Rufus Scrimgeour",
-        "slug": "rufus-scrimgeour",
-        "_id": "/government/people/rufus-scrimgeour"
+    .to_return(body: {
+      results: [],
+      facets: {
+        people: {
+          options: [
+            {
+              value: {
+                title: "Albus Dumbledore",
+                slug: "albus-dumbledore",
+                _id: "a field that we're not using"
+              }
+            },
+            {
+              value: {
+                title: "Cornelius Fudge",
+                slug: "cornelius-fudge",
+                _id: "a field that we're not using"
+              }
+            },
+            {
+              value: {
+                title: "Harry Potter",
+                slug: "harry-potter",
+                _id: "a field that we're not using"
+              }
+            },
+            {
+              value: {
+                title: "Ron Weasley",
+                slug: "ron-weasley",
+                _id: "a field that we're not using"
+              }
+            },
+            {
+              value: {
+                title: "Rufus Scrimgeour",
+                slug: "rufus-scrimgeour",
+                _id: "/government/people/rufus-scrimgeour"
+              }
+            }
+          ]
+        }
       }
-    ] }.to_json)
+    }.to_json)
   end
 
   def stub_organisations_registry_request

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -2,27 +2,21 @@ require 'spec_helper'
 
 RSpec.describe Registries::PeopleRegistry do
   let(:slug) { 'cornelius-fudge' }
-  let(:default_rummager_params) {
+  let(:rummager_params) {
     {
-      "count" => 1500,
-      "fields" => %w(slug title),
-      "filter_format" => "person",
-      "order" => 'title'
+      count: 0,
+      facet_people: '1500,examples:0,order:value.title'
     }
   }
-  let(:rummager_params) { default_rummager_params.merge("start" => 0) }
-  let(:second_rummager_params) { default_rummager_params.merge("start" => 1) }
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
-  let(:second_rummager_url) { "#{Plek.current.find('search')}/search.json?#{second_rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do
       stub_request(:get, rummager_url).to_return(body: rummager_results)
-      stub_request(:get, second_rummager_url).to_return(body: { "results": [] }.to_json)
       clear_cache
     end
 
-    it "will fetch person breadcrumb information by slug" do
+    it "will fetch person information by slug" do
       person = described_class.new[slug]
       expect(person).to eq(
         'title' => 'Cornelius Fudge',
@@ -30,7 +24,7 @@ RSpec.describe Registries::PeopleRegistry do
       )
     end
 
-    it "will return all people ordered by title ascending" do
+    it "will return all people associated with documents ascending by name" do
       people = described_class.new.values
 
       expect(people.length).to eql(2)
@@ -61,21 +55,29 @@ RSpec.describe Registries::PeopleRegistry do
 
   def rummager_results
     %|{
-      "results": [
-        {
-          "title": "Cornelius Fudge",
-          "slug": "cornelius-fudge",
-          "_id": "a field that we're not using"
-        },
-        {
-          "title": "Rufus Scrimgeour",
-          "slug": "rufus-scrimgeour",
-          "_id": "/government/people/companies-house"
-        }
-      ],
-      "total": 2,
+      "results": [],
+      "total": 394075,
       "start": 0,
-      "aggregates": {},
+      "facets": {
+        "people": {
+          "options": [{
+            "value": {
+              "title": "Cornelius Fudge",
+              "slug": "cornelius-fudge",
+              "_id": "a field that we're not using"
+            },
+            "documents": 5
+          },
+          {
+            "value": {
+              "title": "Rufus Scrimgeour",
+              "slug": "rufus-scrimgeour",
+              "_id": "/government/people/companies-house"
+            },
+            "documents": 6
+          }]
+        }
+      },
       "suggested_queries": []
     }|
   end


### PR DESCRIPTION
Our person registry included more people than were associated with results which slowed down pages that used this large facet.  

This PR changes the query that populates the registry to just fetch people that are associated with documents in our search index.

This will mean reducing to 490 people rather than the 3368 we were rendering before.

Uses https://www.gov.uk/api/search.json?facet_people=1500,order:value.title&count=0
instead of: https://www.gov.uk/api/search.json?filter_format=person&fields=slug&fields=title&order=title

https://finder-frontend-pr-911.herokuapp.com/news-and-communications

https://trello.com/c/yp9p8lxj/438-scope-dynamic-facets-to-most-popular-options