### PR TITLE
Cache select facets with zero/one selected options

### DIFF
--- a/app/models/select_facet.rb
+++ b/app/models/select_facet.rb
@@ -44,11 +44,19 @@ class SelectFacet < FilterableFacet
   end
 
   def close_facet?
-    selected_values.empty? && allowed_values.count > 10
+    unselected? && allowed_values.count > 10
   end
 
   def unselected?
     selected_values.empty?
+  end
+
+  def cacheable?
+    unselected? || selected_values.one?
+  end
+
+  def cache_key
+    { selected: selected_values, allowed: allowed_values }
   end
 
 private

--- a/app/views/finders/_select_facet.html.erb
+++ b/app/views/finders/_select_facet.html.erb
@@ -1,10 +1,12 @@
-<% close_facet = select_facet.unselected? && ((select_facet_counter > 0) || select_facet.close_facet?) %>
-<%= render partial: 'components/option-select', locals: {
-  :key => select_facet.key,
-  :title => select_facet.name,
-  :aria_controls_id => "js-search-results-info",
-  :options_container_id => select_facet.key,
-  :options => select_facet.options("js-search-results-info", select_facet.key),
-  :closed_on_load => close_facet,
-}
-%>
+<% cache_if select_facet.cacheable?, select_facet.cache_key do %>
+  <% close_facet = select_facet.unselected? && ((select_facet_counter > 0) || select_facet.close_facet?) %>
+  <%= render partial: 'components/option-select', locals: {
+    :key => select_facet.key,
+    :title => select_facet.name,
+    :aria_controls_id => "js-search-results-info",
+    :options_container_id => select_facet.key,
+    :options => select_facet.options("js-search-results-info", select_facet.key),
+    :closed_on_load => close_facet,
+  }
+  %>
+<% end %>


### PR DESCRIPTION
The supergroup finders have select facets with lots of options (people, orgs, world locations).
Most of the journeys to these pages will have one or zero of these options selected by default
so an easy win is to cache the rendered facet under these circumstances.

We should consider caching popular selections of multiple options, but we want to be careful
not to evict other things from the cache store.  Memcached will expire the least recently accessed cache items first, so as long as we're not thrashing the cache, this should be OK.

This cache does not affect anything coming via the json endpoint, so won't improve
performance of mustache rendering.

For select facets with no selected options on dev, here are some indicative numbers:
Before:
```
  Rendered components/_option-select.html.erb (119.6ms)
Rendering Person partial (127.6ms)
  Rendered components/_option-select.html.erb (80.4ms)
Rendering Organisation partial (86.8ms)
  Rendered components/_option-select.html.erb (37.3ms)
Rendering World location partial (39.1ms)
```

After:
```
Cache read: views/finders/_select_facet:17bf5771ff2b6ef5ce745be3e230f1a8/Person/[{...
Rendering Person partial (5.3ms)
Cache read: views/finders/_select_facet:17bf5771ff2b6ef5ce745be3e230f1a8/Organisation/[{...
Rendering Organisation partial (6.6ms)
Cache read: views/finders/_select_facet:17bf5771ff2b6ef5ce745be3e230f1a8/World location/[{...
Rendering World location partial (1.8ms)
```

This does not affect the Organisations facet on site search.

URLs for testing: 
* https://finder-frontend-pr-913.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
* https://finder-frontend-pr-913.herokuapp.com/news-and-communications
* https://finder-frontend-pr-913.herokuapp.com/aaib-reports
* https://finder-frontend-pr-913.herokuapp.com/find-eu-exit-guidance-business


Useful reading: 
- https://api.rubyonrails.org/classes/ActionView/Helpers/CacheHelper.html#method-i-cache
- https://guides.rubyonrails.org/caching_with_rails.html#fragment-caching