### PR TITLE
Put closed orgs at the bottom of the facet

### DIFF
--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -25,6 +25,7 @@ module Registries
       GovukStatsd.time("registries.organisations.request_time") do
         fetch_organisations_from_rummager
           .reject { |result| result['slug'].empty? || result['title'].empty? }
+          .sort_by { |result| result['title'].sub("Closed organisation: ", "ZZ").upcase }
           .each_with_object({}) { |result, orgs|
             slug = result['slug']
             orgs[slug] = result.slice('title', 'slug', 'acronym')

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -463,10 +463,11 @@ Then(/^I should see all people in the people facet$/) do
 end
 
 And(/^I should see all organisations in the organisation facet$/) do
-  expect(page).to have_css('input[id^="organisations-"]', count: 3)
+  expect(page).to have_css('input[id^="organisations-"]', count: 4)
   find('label', text: 'Department of Mysteries')
   find('label', text: 'Gringots')
   find('label', text: 'Ministry of Magic')
+  find('label', text: 'Closed organisation: Death Eaters')
 end
 
 Then(/^I should see all world locations in the world location facet$/) do

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -61,6 +61,11 @@ module RegistrySpecHelper
     })
     .to_return(body: { results: [
       {
+        "title": "Closed organisation: Death Eaters",
+        "slug": "death-eaters",
+        "_id": "/government/organisations/death-eaters"
+      },
+      {
         "title": "Department of Mysteries",
         "slug": "department-of-mysteries",
         "_id": "/government/organisations/department-of-mysteries"

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Registries::OrganisationsRegistry do
       )
     end
 
-    it "will return all organisations by title ascending" do
+    it "will return organisations sorted by title with closed orgs at the end" do
       organisations = described_class.new.values
 
-      expect(organisations.length).to eql(3)
-      expect(organisations.keys).to eql(%w(department-of-mysteries gringots ministry-of-magic))
+      expect(organisations.length).to eql(4)
+      expect(organisations.keys).to eql(%w(department-of-mysteries gringots ministry-of-magic death-eaters))
     end
   end
 


### PR DESCRIPTION
We need to show closed organisations as they still have content tagged to them.  To help users navigate a long list, we're going to move them to the bottom.  At present they appear in a clump as the orgs list is sorted by title, and closed orgs start with "Closed organisation: ".

We also want to use a case insensitive sort because we have one org that starts with a lower case "j".
(Search for `jHub`)

https://finder-frontend-pr-914.herokuapp.com/news-and-communications

https://trello.com/c/leCxXdgK/367-closed-orgs-should-appear-at-the-bottom-of-the-org-autocomplete-facet