### PR TITLE
Use delegated event handlers for option selects

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -22,7 +22,7 @@
     if(allowCollapsible){
 
       // Attach listener to update checked count
-      this.$options.on('change', this.updateCheckedCount.bind(this));
+      this.$optionSelect.on('change', "input[type='checkbox']", this.updateCheckedCount.bind(this));
 
       // Replace div.container-head with a button
       this.replaceHeadWithButton();
@@ -38,7 +38,7 @@
       this.$optionSelect.on('blur', this.stopListeningForKeys.bind(this));
 
       // Add a listener to the checkboxes so if you navigate to them with the keyboard you can definitely see them
-      this.$options.on('focus', this.open.bind(this));
+      this.$optionSelect.on('focus', "input[type='checkbox']", this.open.bind(this));
 
       if (this.$optionSelect.data('closed-on-load') == true) {
         this.close();

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -29,7 +29,7 @@
     if(GOVUK.support.history()){
       this.saveState();
 
-      this.$form.find('input[type=checkbox], input[type=text], input[type=radio], select').on('change',
+      this.$form.on('change', 'input[type=checkbox], input[type=text], input[type=radio], select',
         function(e) {
           if (e.target.type == "text" && !e.suppressAnalytics) {
             LiveSearch.prototype.fireTextAnalyticsEvent(e);
@@ -38,7 +38,7 @@
         }.bind(this)
       );
 
-      this.$form.find('input[type=text]').on('keypress',
+      this.$form.on('keypress', 'input[type=text]',
         function(e){
           var ENTER_KEY = 13
 


### PR DESCRIPTION
Rather than setting up an event handler on every individual $option, set up delegated event handlers on the $optionSelect wrapper.

This will significantly reduce the number of event handlers being bound.