### PR TITLE
Removes site search from All Content finder

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -98,7 +98,7 @@ private
   end
 
   def remove_search_box
-    hide_site_serch = params['slug'] == 'all-content'
+    hide_site_serch = params['slug'] == 'search/all'
     set_slimmer_headers(remove_search: hide_site_serch)
   end
 end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   layout "finder_layout"
+  before_action :remove_search_box
 
   before_action do
     expires_in(5.minutes, public: true)
@@ -94,5 +95,10 @@ private
 
   def grouped_display?
     params["order"] == "topic" || finder.default_sort_option_key == "topic"
+  end
+
+  def remove_search_box
+    hide_site_serch = params['slug'] == 'all-content'
+    set_slimmer_headers(remove_search: hide_site_serch)
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -217,7 +217,7 @@ describe FindersController, type: :controller do
 
     describe "Show/Hiding site search form" do
       before do
-        content_store_has_item('/all-content', all_content_finder)
+        content_store_has_item('/search/all', all_content_finder)
         content_store_has_item('/lunch-finder', lunch_finder)
 
         rummager_response = %|{
@@ -237,7 +237,7 @@ describe FindersController, type: :controller do
       end
 
       it 'all content finder tells Slimmer to hide the form' do
-        get :show, params: { slug: 'all-content' }
+        get :show, params: { slug: 'search/all' }
         expect(response.headers["X-Slimmer-Remove-Search"]).to eq("true")
       end
 


### PR DESCRIPTION
The "All content" finder should have the following header:
![image](https://user-images.githubusercontent.com/3441519/54284971-ec1a4180-4598-11e9-9677-c807ee74cf56.png)

_____
All other finders should have the following header:
![image](https://user-images.githubusercontent.com/3441519/54285003-f9373080-4598-11e9-8754-39a586b3266d.png)



Ticket: https://trello.com/c/ccVdScVs/500-hide-search-field-from-header-on-all-content-finder
Demo:
**All Content**: https://finder-frontend-pr-918.herokuapp.com/search/all
**News & Comms**: https://finder-frontend-pr-918.herokuapp.com/search/news-and-communications
**Services**: https://finder-frontend-pr-918.herokuapp.com/search/services
**Guidance & regulation**: https://finder-frontend-pr-918.herokuapp.com/search/guidance-and-regulation
**Transparency & FOI**: https://finder-frontend-pr-918.herokuapp.com/search/transparency-and-freedom-of-information-releases