### PR TITLE
Remove call to GOVUK.SelectionButtons Javascript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,7 +42,4 @@ jQuery(function($) {
       templateDir: templateDir
     });
   }
-
-  var $buttons = $("label.block-label input[type='checkbox']");
-  new GOVUK.SelectionButtons($buttons);
 });


### PR DESCRIPTION
This code was causing the following JS error in the console:

```
Uncaught TypeError: GOVUK.SelectionButtons is not a constructor
    at HTMLDocument.<anonymous> (application.self-23554ec1afd1a09c9f17684021c71e9dcec03e07d10f08b007e4e5052a5fcb50.js?body=1:47)
```

Turns out that the `GOVUK.SelectionButtons` code was removed some time ago: https://github.com/alphagov/govuk_elements/blob/3a7f21838d7849d90434731488e1a0f0f209250d/packages/govuk-elements-sass/CHANGELOG.md#300 so this PR removes the call to something that doesn't exist.

UPDATE: selectionButtons was removed from elements but still exists in frontend toolkit, which is why the console error above appears in the finder-frontend component guide and not the main application (component guide doesn't pull in toolkit). We're pretty sure finder-frontend doesn't need SelectionButtons but it may still be in use in other applications, so I'm not going to try to change anything else at this time.

https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/selection-buttons.js
