### PR TITLE
Remove block-label class

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -233,38 +233,6 @@
       margin-left: -$gutter-half - 4;
       border-left: solid 4px $error-colour;
     }
-
-    .block-label {
-      display: block;
-      clear: left;
-      position: relative;
-      background: $panel-colour;
-      border: 1px solid $panel-colour;
-      padding: 18px $gutter $gutter-half 45px;
-      margin: 5px 0;
-      cursor: pointer;
-
-      @include media(tablet) {
-        float: left;
-      }
-
-      &:hover {
-        border-color: $black;
-      }
-
-      &.selected {
-        background: $white;
-        border-color: $black;
-      }
-
-      &.focused {
-        outline: 3px solid $yellow;
-
-        input[type=checkbox]:focus {
-          outline: none;
-        }
-      }
-    }
   }
 
   .button {


### PR DESCRIPTION
In eee8cfb we updated finder-frontend to use the checkboxes from govuk_publishing_components.

The previous checkboxes appear to be the only place where the `block-label` class was used, so these styles are no longer required.

Verified by searching the codebase for the string ‘block-label’ – the only other instance was for instantiating the SelectionButton object in application.js, which [is being removed in a separate PR](https://github.com/alphagov/finder-frontend/pull/920).