### PR TITLE
Adds new Policy Papers and Consultation finder

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 FinderFrontend::Application.load_tasks

--- a/app/lib/filters/text_filter.rb
+++ b/app/lib/filters/text_filter.rb
@@ -1,7 +1,27 @@
 module Filters
   class TextFilter < Filter
     def value
-      Array(params)
+      Array(parsed_value)
+    end
+
+  private
+
+    def parsed_value
+      return if params.blank?
+
+      if multi_value?
+        option_lookup.select { |key, _| params.include? key }.values.flatten
+      else
+        params
+      end
+    end
+
+    def multi_value?
+      facet.has_key?('option_lookup')
+    end
+
+    def option_lookup
+      @option_lookup ||= facet['option_lookup']
     end
   end
 end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -164,7 +164,8 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
-    "/statistics" => "statistics",
+    "/policy-papers-and-consultations" => 'policy_and_engagement',
+    "/statistics" => "statistics"
   }.freeze
 
   def development_env_finder_json

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application', __FILE__)
+APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -204,3 +204,9 @@ Feature: Filtering documents
     When I view the news and communications finder
     Then the page has a landmark to the search results
     And the page has a landmark to the search filters
+
+  @javascript
+  Scenario: Policy papers should have three options
+    When I view the policy papers and consultations finder
+    And I select some document types
+    Then I should see results for scoped by the selected document type

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -68,14 +68,19 @@
         "type":"text",
         "display_as_result_metadata": true,
         "filterable": true,
+        "option_lookup": {
+          "policy_papers": ["impact_assessment", "case_study", "policy_paper"],
+          "open_consultations": ["open_consultation"],
+          "closed_consultations": ["closed_consultation", "consultation_outcome"]
+        },
         "allowed_values": [
           {
             "label": "Policy papers",
-            "value": "[\"impact_assessment\",\"case_study\",\"policy_paper\"]"
+            "value": "policy_papers"
           },
           {
             "label": "Consultations (open)",
-            "value": "[\"open_consultation\"]"
+            "value": "open_consultations"
           },
           {
             "label": "Consultations (closed)",

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -27,6 +27,7 @@
   "details":{
     "document_noun":"result",
     "filter":{
+      "content_purpose_supergroup":"policy_and_engagement"
     },
     "format_name":"document",
     "show_summaries":true,
@@ -61,11 +62,33 @@
         "preposition": "about"
       },
       {
+        "key": "content_store_document_type",
+        "name": "Document type",
+        "preposition": "with document type",
+        "type":"text",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Policy papers",
+            "value": "[\"impact_assessment\",\"case_study\",\"policy_paper\"]"
+          },
+          {
+            "label": "Consultations (open)",
+            "value": "[\"open_consultation\"]"
+          },
+          {
+            "label": "Consultations (closed)",
+            "value": "closed_consultations"
+          }
+        ]
+      },
+      {
         "key": "organisations",
         "name": "Organisation",
         "short_name": "From",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },
@@ -73,32 +96,9 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
-      },
-      {
-        "key": "content_store_document_type",
-        "name": "Consultation status",
-        "preposition": "with consultation status",
-        "type":"dropdown_select",
-        "display_as_result_metadata": true,
-        "filterable": true,
-        "allowed_values": [
-          {
-            "text": "All consultations",
-            "value": "[\"open_consultation\",\"closed_consultation\",\"consultation_outcome\",\"impact_assessment\",\"case_study\",\"policy_paper\"]",
-            "default": true
-          },
-          {
-            "text": "Open consultation",
-            "value": "[\"open_consultation\"]"
-          },
-          {
-            "text": "Closed consultation",
-            "value": "[\"closed_consultation\",\"consultation_outcome\"]"
-          }
-        ]
       },
       {
         "key": "public_timestamp",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -98,6 +98,25 @@ When(/^I view the business readiness finder$/) do
   visit finder_path('find-eu-exit-guidance-business')
 end
 
+When(/^I view the policy papers and consultations finder$/) do
+  topic_taxonomy_has_taxons([
+    {
+      content_id: "Taxon_1",
+      title: "Taxon_1"
+    },
+    {
+      content_id: "Taxon_2",
+      title: "Taxon_2"
+    }
+  ])
+  content_store_has_policy_and_engagement_finder
+  stub_whitehall_api_world_location_request
+  stub_rummager_api_request_with_policy_papers_results
+  stub_rummager_api_request_with_filtered_policy_papers_results
+
+  visit finder_path('policy-papers-and-consultations')
+end
+
 When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons
   content_store_has_services_finder
@@ -449,6 +468,12 @@ And(/^I select a Person$/) do
   check('Rufus Scrimgeour')
 end
 
+And(/^I select some document types$/) do
+  click_on('Document type')
+  find('.govuk-label', text: 'Policy papers').click
+  find('.govuk-label', text: 'Consultations (closed)').click
+end
+
 And(/^I reload the page$/) do
   visit [current_path, page.driver.request.env['QUERY_STRING']].reject(&:blank?).join('?')
 end
@@ -543,6 +568,17 @@ Then("I should see results in the default group") do
   within("#js-results .filtered-results__group") do
     expect(page).to have_css("h2.filtered-results__facet-heading", text: "All businesses")
     expect(page.all("li.document").size).to eq(9) # 9 results in fixture
+  end
+end
+
+Then("I should see results for scoped by the selected document type") do
+  within("#js-results") do
+    expect(page.all("li.document").size).to eq(3) # 3 results in fixture
+    expect(page).to have_link('Restrictions on usage of spells within school grounds')
+    expect(page).to have_link('New platform at Hogwarts for the express train')
+    expect(page).to have_link('Installation of double glazing at Hogwarts')
+
+    expect(page).to have_no_link('Proposed changes to magic tournaments')
   end
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -77,6 +77,27 @@ module DocumentHelper
     ).to_return(body: filtered_business_readiness_results_json)
   end
 
+  def stub_rummager_api_request_with_policy_papers_results
+    stub_request(:get, rummager_policy_papers_url({}))
+      .to_return(body: policy_and_engagement_results_json)
+  end
+
+  def stub_rummager_api_request_with_filtered_policy_papers_results
+    stub_request(
+      :get,
+      rummager_policy_papers_url(
+        "filter_content_store_document_type[]" => %w(impact_assessment case_study policy_paper)
+      )
+    ).to_return(body: policy_and_engagement_results_for_policy_papers_json)
+
+    stub_request(
+      :get,
+      rummager_policy_papers_url(
+        "filter_content_store_document_type[]" => %w(impact_assessment case_study policy_paper closed_consultation consultation_outcome),
+      )
+    ).to_return(body: policy_and_engagement_results_for_policy_papers_and_closed_consultations_json)
+  end
+
   def stub_all_rummager_api_requests_with_all_documents_results
     stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
         .with(query: hash_including({}))
@@ -211,6 +232,12 @@ module DocumentHelper
       base_path,
       govuk_content_schema_example('policies_finder').to_json
     )
+  end
+
+  def content_store_has_policy_and_engagement_finder
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'policy_and_engagement.json'))
+
+    content_store_has_item('/policy-papers-and-consultations', finder_fixture)
   end
 
   def content_store_has_business_readiness_finder
@@ -523,6 +550,10 @@ module DocumentHelper
 
   def rummager_filtered_business_readiness_url(filter_params)
     rummager_url(business_readiness_params.merge(filter_params))
+  end
+
+  def rummager_policy_papers_url(filters)
+    rummager_url(policy_papers_params.merge(filters))
   end
 
   def organisation_link_results
@@ -1495,6 +1526,288 @@ module DocumentHelper
           }
         ]
       }
+    }|
+  end
+
+  def policy_and_engagement_results_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            },
+            {
+              "title": "Proposed changes to magic tournaments",
+              "link": "proposed-changes-to-magic-tournaments",
+              "description": "Proposed changes to magic tournaments",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/proposed-changes-to-magic-tournaments",
+              "elasticsearch_type": "open_consultation",
+              "document_type": "open_consultation"
+            },
+            {
+              "title": "New platform at Hogwarts for the express train",
+              "link": "new-platform-at-hogwarts-for-the-express-train",
+              "description": "New platform at Hogwarts for the express train",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/new-platform-at-hogwarts-for-the-express-train",
+              "elasticsearch_type": "closed_consultation",
+              "document_type": "closed_consultation"
+            },
+            {
+              "title": "Installation of double glazing at Hogwarts",
+              "link": "installation-of-double-glazing-at-hogwarts",
+              "description": "Installation of double glazing at Hogwarts",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/installation-of-double-glazing-at-hogwarts",
+              "elasticsearch_type": "consultation_outcome",
+              "document_type": "consultation_outcome"
+            }
+          ],
+          "total": 4,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def policy_and_engagement_results_for_policy_papers_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def policy_and_engagement_results_for_policy_papers_and_closed_consultations_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            },
+            {
+              "title": "New platform at Hogwarts for the express train",
+              "link": "new-platform-at-hogwarts-for-the-express-train",
+              "description": "New platform at Hogwarts for the express train",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/new-platform-at-hogwarts-for-the-express-train",
+              "elasticsearch_type": "closed_consultation",
+              "document_type": "closed_consultation"
+            },
+            {
+              "title": "Installation of double glazing at Hogwarts",
+              "link": "installation-of-double-glazing-at-hogwarts",
+              "description": "Installation of double glazing at Hogwarts",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/installation-of-double-glazing-at-hogwarts",
+              "elasticsearch_type": "consultation_outcome",
+              "document_type": "consultation_outcome"
+            }
+          ],
+          "total": 3,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
     }|
   end
 

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -63,6 +63,18 @@ module RummagerUrlHelper
       )
   end
 
+  def policy_papers_params
+    base_search_params.merge(
+      'fields' => policy_papers_search_fields.join(','),
+      'filter_content_purpose_supergroup' => 'policy_and_engagement',
+      'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
+      'facet_organisations' => '1500,order:value.title',
+      'facet_world_locations' => '1500,order:value.title',
+      'count' => 20,
+      'order' => '-public_timestamp',
+    )
+  end
+
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
@@ -76,6 +88,15 @@ module RummagerUrlHelper
     base_search_fields + %w(
       part_of_taxonomy_tree
       organisations
+    )
+  end
+
+  def policy_papers_search_fields
+    base_search_fields + %w(
+      part_of_taxonomy_tree
+      content_store_document_type
+      organisations
+      world_locations
     )
   end
 

--- a/spec/lib/filters/text_filter_spec.rb
+++ b/spec/lib/filters/text_filter_spec.rb
@@ -43,11 +43,39 @@ describe Filters::TextFilter do
   end
 
   describe "#value" do
-    context "when params is present" do
-      let(:params) { [:alpha] }
+    context "when params is present and option_lookup is absent" do
+      let(:params) { %w(alpha) }
+      let(:facet) { {} }
 
       it "should contain all values" do
-        expect(text_filter.value).to eq([:alpha])
+        expect(text_filter.value).to eq(%w(alpha))
+      end
+    end
+
+    context "when params is present and option_lookup is empty" do
+      let(:params) { %w(does_not_exist) }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+
+      it "should contain no values" do
+        expect(text_filter.value).to eq([])
+      end
+    end
+
+    context "when params is present and option_lookup is present" do
+      let(:params) { %w(policy_papers) }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+
+      it "should contain all values" do
+        expect(text_filter.value).to eq(%w(guidance))
+      end
+    end
+
+    context "when params has multiple values and option_lookup is present" do
+      let(:params) { %w(policy_papers does_not_exist consultations) }
+      let(:facet) { { "option_lookup" => { "consultations" => %w(open closed), "policy_papers" => %w(guidance) } } }
+
+      it "should contain all values" do
+        expect(text_filter.value).to eq(%w(open closed guidance))
       end
     end
   end


### PR DESCRIPTION
## Introduces new Policy papers and consultations finder

As a user, when I view this finder it should be scoped to just policy papers and consultations and I should have the option to filter by:
- Policy papers
- Consultations (open)
- Consultations (closed)

-----

**Ticket:** https://trello.com/c/40IA4pPe/241-introduce-documenttype-facet-behaviour-on-policy-papers-consultations-finder

**Demo:** https://finder-frontend-pr-922.herokuapp.com/policy-papers-and-consultations