### PR TITLE
Adds new Statistics and Research finder

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -16,9 +16,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var removeFilterName = $el.data('name');
       var removeFilterValue = $el.data('value');
-      if (removeFilterValue.length) {
-        removeFilterValue = removeFilterValue.replace(/'/g, '"');
-      }
       var removeFilterFacet = $el.data('facet');
       var isAutoComplete = !!$('#' + removeFilterFacet +'-select').length;
 

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -16,6 +16,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var removeFilterName = $el.data('name');
       var removeFilterValue = $el.data('value');
+      if (removeFilterValue.length) {
+        removeFilterValue = removeFilterValue.replace(/'/g, '"');
+      }
       var removeFilterFacet = $el.data('facet');
       var isAutoComplete = !!$('#' + removeFilterFacet +'-select').length;
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -194,18 +194,6 @@
     margin-bottom: $gutter;
   }
 
-  .radio-filter {
-    padding: 0 $gutter-one-third;
-
-    label {
-      margin-right:$gutter-one-third;
-      @include inline-block;
-    }
-  }
-  .radio-filter input {
-    width:14px;
-  }
-
   .form {
     @include core-19;
     @include media(tablet) {

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -282,17 +282,6 @@ main.search {
         font-weight:bold;
       }
     }
-    .radio-filter {
-      padding: $gutter-one-third;
-
-      label {
-        margin-right:$gutter-one-third;
-        @include inline-block;
-      }
-      input {
-        width:14px;
-      }
-    }
   }
 }
 

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -30,6 +30,7 @@ private
       'dropdown_select' => Filters::DropdownSelectFilter,
       'topical' => Filters::TopicalFilter,
       'taxon' => Filters::TaxonFilter,
+      'radio' => Filters::RadioFilter
     }.fetch(facet['type'])
 
     filter_class.new(facet, params(facet))

--- a/app/lib/filters/filter.rb
+++ b/app/lib/filters/filter.rb
@@ -20,5 +20,23 @@ module Filters
   private
 
     attr_reader :facet, :params
+
+    def parsed_value
+      return [] if params.blank?
+
+      if multi_value?
+        option_lookup.select { |key, _| params.include? key }.values.flatten
+      else
+        Array(params)
+      end
+    end
+
+    def multi_value?
+      facet.has_key?('option_lookup')
+    end
+
+    def option_lookup
+      @option_lookup ||= facet['option_lookup']
+    end
   end
 end

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -9,9 +9,19 @@ module Filters
     def parsed_value
       return if params.blank?
 
-      JSON.parse params
-    rescue JSON::ParserError
-      params
+      if multi_value?
+        option_lookup.select { |key, _| params.include? key }.values.flatten
+      else
+        params
+      end
+    end
+
+    def multi_value?
+      facet.has_key?('option_lookup')
+    end
+
+    def option_lookup
+      @option_lookup ||= facet['option_lookup']
     end
   end
 end

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -1,27 +1,7 @@
 module Filters
   class RadioFilter < Filter
     def value
-      Array(parsed_value)
-    end
-
-  private
-
-    def parsed_value
-      return if params.blank?
-
-      if multi_value?
-        option_lookup.select { |key, _| params.include? key }.values.flatten
-      else
-        params
-      end
-    end
-
-    def multi_value?
-      facet.has_key?('option_lookup')
-    end
-
-    def option_lookup
-      @option_lookup ||= facet['option_lookup']
+      parsed_value
     end
   end
 end

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -1,0 +1,17 @@
+module Filters
+  class RadioFilter < Filter
+    def value
+      Array(parsed_value)
+    end
+
+  private
+
+    def parsed_value
+      return if params.blank?
+
+      JSON.parse params
+    rescue JSON::ParserError
+      params
+    end
+  end
+end

--- a/app/lib/filters/text_filter.rb
+++ b/app/lib/filters/text_filter.rb
@@ -1,27 +1,7 @@
 module Filters
   class TextFilter < Filter
     def value
-      Array(parsed_value)
-    end
-
-  private
-
-    def parsed_value
-      return if params.blank?
-
-      if multi_value?
-        option_lookup.select { |key, _| params.include? key }.values.flatten
-      else
-        params
-      end
-    end
-
-    def multi_value?
-      facet.has_key?('option_lookup')
-    end
-
-    def option_lookup
-      @option_lookup ||= facet['option_lookup']
+      parsed_value
     end
   end
 end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -174,7 +174,7 @@ private
   FINDERS_IN_DEVELOPMENT = {
     "/search/policy-papers-and-consultations" => 'policy_and_engagement',
     "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
-    "/search/statistics" => "statistics"
+    "/search/statistics" =>  "statistics"
   }.freeze
 
   def development_env_finder_json

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -174,7 +174,7 @@ private
   FINDERS_IN_DEVELOPMENT = {
     "/search/policy-papers-and-consultations" => 'policy_and_engagement',
     "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
-    "/search/statistics" =>  "statistics"
+    "/search/statistics" => "statistics"
   }.freeze
 
   def development_env_finder_json

--- a/app/models/dropdown_select_facet.rb
+++ b/app/models/dropdown_select_facet.rb
@@ -37,6 +37,7 @@ private
     {
       'label' => selected_value['text'],
       'parameter_key' => key,
+      'value' => selected_value['value'].tr('"', "'")
     }
   end
 

--- a/app/models/dropdown_select_facet.rb
+++ b/app/models/dropdown_select_facet.rb
@@ -1,8 +1,4 @@
 class DropdownSelectFacet < FilterableFacet
-  def allowed_values
-    facet['allowed_values']
-  end
-
   def options
     allowed_values.map do |allowed_value|
       {

--- a/app/models/dropdown_select_facet.rb
+++ b/app/models/dropdown_select_facet.rb
@@ -33,7 +33,7 @@ private
     {
       'label' => selected_value['text'],
       'parameter_key' => key,
-      'value' => selected_value['value'].tr('"', "'")
+      'value' => selected_value['value']
     }
   end
 

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -27,7 +27,7 @@ class Facet
     facet['short_name']
   end
 
-  def hide_facet_tag
+  def hide_facet_tag?
     facet['hide_facet_tag']
   end
 

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -27,6 +27,10 @@ class Facet
     facet['short_name']
   end
 
+  def hide_facet_tag
+    facet['hide_facet_tag']
+  end
+
   def filterable?
     facet['filterable']
   end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -28,11 +28,11 @@ class Facet
   end
 
   def hide_facet_tag?
-    facet['hide_facet_tag']
+    facet['hide_facet_tag'] || false
   end
 
   def filterable?
-    facet['filterable']
+    facet['filterable'] || false
   end
 
   def has_filters?
@@ -40,7 +40,7 @@ class Facet
   end
 
   def metadata?
-    facet['display_as_result_metadata']
+    facet['display_as_result_metadata'] || false
   end
 
   def allowed_values

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -43,6 +43,10 @@ class Facet
     facet['display_as_result_metadata']
   end
 
+  def allowed_values
+    facet['allowed_values'] || []
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -28,6 +28,10 @@ class KeywordFacet
     [keywords]
   end
 
+  def hide_facet_tag
+    false
+  end
+
 private
 
   attr_reader :keywords

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -28,7 +28,7 @@ class KeywordFacet
     [keywords]
   end
 
-  def hide_facet_tag
+  def hide_facet_tag?
     false
   end
 

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -1,8 +1,4 @@
-class OptionSelectFacet < FilterableFacet
-  def allowed_values
-    facet['allowed_values'] || []
-  end
-
+class SelectFacet < FilterableFacet
   def options(controls, key)
     # NOTE: We use a symbol-based hash here unlike all our other hash
     # data-structures because we pass this to a govuk_component partial

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -1,4 +1,4 @@
-class SelectFacet < FilterableFacet
+class OptionSelectFacet < FilterableFacet
   def options(controls, key)
     # NOTE: We use a symbol-based hash here unlike all our other hash
     # data-structures because we pass this to a govuk_component partial

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -7,7 +7,7 @@ class RadioFacet < FilterableFacet
     allowed_values.map do |allowed_value|
       {
         value: allowed_value['value'],
-        text: allowed_value['text'],
+        text: allowed_value['label'],
         checked: selected_value == allowed_value,
       }
     end

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -1,5 +1,4 @@
 class RadioFacet < FilterableFacet
-
   def options
     allowed_values.map do |allowed_value|
       {

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -1,0 +1,33 @@
+class RadioFacet < FilterableFacet
+  def allowed_values
+    facet['allowed_values']
+  end
+
+  def options
+    allowed_values.map do |allowed_value|
+      {
+        value: allowed_value['value'],
+        text: allowed_value['text'],
+        checked: selected_value == allowed_value,
+      }
+    end
+  end
+
+  def name
+    facet['name']
+  end
+
+private
+
+  def selected_value
+    return default_value if @value.nil?
+
+    allowed_values.find { |option|
+      @value == option['value']
+    } || {}
+  end
+
+  def default_value
+    allowed_values.find { |option| option['default'] } || {}
+  end
+end

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -9,10 +9,6 @@ class RadioFacet < FilterableFacet
     end
   end
 
-  def name
-    facet['name']
-  end
-
 private
 
   def selected_value

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -1,7 +1,4 @@
 class RadioFacet < FilterableFacet
-  def allowed_values
-    facet['allowed_values']
-  end
 
   def options
     allowed_values.map do |allowed_value|

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -20,6 +20,8 @@ module FacetParser
         DropdownSelectFacet.new(facet)
       when 'autocomplete'
         AutocompleteFacet.new(facet)
+      when 'radio'
+        RadioFacet.new(facet)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet.type}")
       end

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -1,13 +1,16 @@
 class FacetTagPresenter
   include ERB::Util
 
-  def initialize(sentence_fragment, filter_params, base_url)
+  def initialize(sentence_fragment, filter_params, base_url, hide_facet_tag)
     @fragment = sentence_fragment
     @filter_params = filter_params
     @base_url = base_url
+    @hide_facet_tag = hide_facet_tag
   end
 
   def present
+    return {} if @hide_facet_tag
+
     if fragment.nil? || fragment['values'].nil?
       {}
     end

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -11,6 +11,7 @@ class FacetTagPresenter
   def present
     return {} if @hide_facet_tag
 
+    # what does this do???
     if fragment.nil? || fragment['values'].nil?
       {}
     end

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -11,7 +11,6 @@ class FacetTagPresenter
   def present
     return {} if @hide_facet_tag
 
-    # what does this do???
     if fragment.nil? || fragment['values'].nil?
       {}
     end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -45,7 +45,7 @@ class ResultSetPresenter
 
   def selected_filter_descriptions
     selected_filters.map { |filter|
-      FacetTagPresenter.new(filter.sentence_fragment, filter.value, finder.slug).present
+      FacetTagPresenter.new(filter.sentence_fragment, filter.value, finder.slug, filter.hide_facet_tag).present
     }.reject(&:empty?)
   end
 

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -115,6 +115,7 @@ private
     default_option = filter.allowed_values
                 &.detect { |option| option['default'] }
     return '' if default_option.nil?
+
     default_option.fetch('label', '')
   end
 

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -30,7 +30,7 @@ class ResultSetPresenter
       finder_name: finder.name,
       any_filters_applied: any_filters_applied?,
       next_and_prev_links: next_and_prev_links,
-      sort_options: hidden_text,
+      screen_reader_filter_description: ScreenReaderFilterDescriptionPresenter.new(filters, sort_option).present,
     }
   end
 
@@ -45,7 +45,7 @@ class ResultSetPresenter
 
   def selected_filter_descriptions
     selected_filters.map { |filter|
-      FacetTagPresenter.new(filter.sentence_fragment, filter.value, finder.slug, filter.hide_facet_tag).present
+      FacetTagPresenter.new(filter.sentence_fragment, filter.value, finder.slug, filter.hide_facet_tag?).present
     }.reject(&:empty?)
   end
 
@@ -66,11 +66,6 @@ class ResultSetPresenter
     @filter_params.fetch('keywords', '')
   end
 
-  def hidden_text
-    text = (facets_without_tags + sort_options).compact.join(", ")
-    "<span class='visually-hidden'>#{text}</span>"
-  end
-
   def has_email_signup_link?
     signup_links.any?
   end
@@ -82,46 +77,6 @@ class ResultSetPresenter
 private
 
   attr_reader :view_context
-
-  def facets_without_tags
-    return [] unless filters.any?
-
-    facet_description = []
-    filters.each do |filter|
-      if filter.hide_facet_tag
-        filter_label = facet_without_tag_selected_option(filter)
-
-        if filter_label.empty?
-          filter_label = facet_without_tag_default_option(filter)
-        end
-
-        facet_description << "#{filter.preposition} #{filter_label}" unless filter_label.empty?
-      end
-    end
-
-    facet_description.compact
-  end
-
-  def facet_without_tag_selected_option(filter)
-    filter.allowed_values.each do |allowed_value|
-      if filter.value == allowed_value['value']
-        return allowed_value['label']
-      end
-    end
-    ""
-  end
-
-  def facet_without_tag_default_option(filter)
-    default_option = filter.allowed_values
-                &.detect { |option| option['default'] }
-    return '' if default_option.nil?
-
-    default_option.fetch('label', '')
-  end
-
-  def sort_options
-    sort_option.present? ? ["sorted by #{sort_option['name']}"] : []
-  end
 
   def next_and_prev_links
     return unless finder.pagination

--- a/app/presenters/screen_reader_filter_description_presenter.rb
+++ b/app/presenters/screen_reader_filter_description_presenter.rb
@@ -5,7 +5,7 @@ class ScreenReaderFilterDescriptionPresenter
   end
 
   def present
-    text = (facets_without_tags + sort_options).compact.join(", ")
+    text = (facets_without_tags + sort_options).join(", ")
     "<span class='visually-hidden'>#{text}</span>"
   end
 
@@ -14,35 +14,21 @@ private
   attr_reader :filters, :sort_options
 
   def facets_without_tags
-    description = filters.each_with_object([]) do |filter, facets_description|
-      if filter.hide_facet_tag?
-        filter_label = facet_without_tag_selected_option(filter)
-
-        if filter_label.empty?
-          filter_label = facet_without_tag_default_option(filter)
-        end
-
-        facets_description << "#{filter.preposition} #{filter_label}" unless filter_label.empty?
-      end
+    description = filters.select(&:hide_facet_tag?).each_with_object([]) do |filter, facets_description|
+      label = filter_label(filter)
+      facets_description << "#{filter.preposition} #{label}" unless label.nil?
     end
 
     description.compact
   end
 
-  def facet_without_tag_selected_option(filter)
-    filter.allowed_values.each do |allowed_value|
-      if filter.value == allowed_value['value']
-        return allowed_value['label']
-      end
-    end
-    ""
-  end
+  def filter_label(filter)
+    selected_option = filter.allowed_values.find { |option| option['value'] == filter.value }
+    return selected_option['label'] unless selected_option.nil?
 
-  def facet_without_tag_default_option(filter)
-    default_option = filter.allowed_values
-                         &.detect { |option| option['default'] }
-    return '' if default_option.nil?
+    default_option = filter.allowed_values.find { |option| option['default'] }
+    return default_option['label'] unless default_option.nil?
 
-    default_option.fetch('label', '')
+    nil
   end
 end

--- a/app/presenters/screen_reader_filter_description_presenter.rb
+++ b/app/presenters/screen_reader_filter_description_presenter.rb
@@ -1,0 +1,48 @@
+class ScreenReaderFilterDescriptionPresenter
+  def initialize(filters, sort_option)
+    @filters = filters
+    @sort_options = sort_option.present? ? ["sorted by #{sort_option['name']}"] : []
+  end
+
+  def present
+    text = (facets_without_tags + sort_options).compact.join(", ")
+    "<span class='visually-hidden'>#{text}</span>"
+  end
+
+private
+
+  attr_reader :filters, :sort_options
+
+  def facets_without_tags
+    description = filters.each_with_object([]) do |filter, facets_description|
+      if filter.hide_facet_tag?
+        filter_label = facet_without_tag_selected_option(filter)
+
+        if filter_label.empty?
+          filter_label = facet_without_tag_default_option(filter)
+        end
+
+        facets_description << "#{filter.preposition} #{filter_label}" unless filter_label.empty?
+      end
+    end
+
+    description.compact
+  end
+
+  def facet_without_tag_selected_option(filter)
+    filter.allowed_values.each do |allowed_value|
+      if filter.value == allowed_value['value']
+        return allowed_value['label']
+      end
+    end
+    ""
+  end
+
+  def facet_without_tag_default_option(filter)
+    default_option = filter.allowed_values
+                         &.detect { |option| option['default'] }
+    return '' if default_option.nil?
+
+    default_option.fetch('label', '')
+  end
+end

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,12 +1,4 @@
-<div class='filter radio-filter' id="<%= radio_facet.key %>">
-  <span class="legend"><%= radio_facet.name %></span>
-  <fieldset>
-  <% radio_facet.allowed_values.each do | option | %>
-    <label for='<%= option['value']%>'>
-      <input type="radio" name='<%=radio_facet.key%>' value='<%= option['value']%>' id='<%= option['value']%>'<%= input_checked(radio_facet.key, option['value']) %> aria-controls="js-search-results-info">
-      <%= option['label']%>
-    </label>
-  <% end %>
-  </fieldset>
-</div>
-
+<%= render "govuk_publishing_components/components/radio", {
+  name: radio_facet.key,
+  items: radio_facet.options
+} %>

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -7,5 +7,5 @@
         {{> finders/_applied_filter}}
     {{/applied_filters}}
   </div>
-  {{{sort_options}}}
+  {{{screen_reader_filter_description}}}
 </div>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -292,3 +292,9 @@ Feature: Filtering documents
     When I view the policy papers and consultations finder
     And I select some document types
     Then I should see results for scoped by the selected document type
+
+  Scenario: Choosing between document types with a radio button facet with hidden facet tag
+    When I view the research and statistics finder
+    And I select upcoming statistics
+    Then I should see upcoming statistics
+    And I should not see an upcoming statistics facet tag

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -126,6 +126,7 @@
         "type":"dropdown_select",
         "display_as_result_metadata":false,
         "filterable":true,
+        "hide_facet_tag":true,
         "preposition": "that are",
         "allowed_values": [
           {

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -131,19 +131,24 @@
         "filterable":true,
         "hide_facet_tag":true,
         "preposition": "that are",
+        "option_lookup": {
+          "statistics_published": ["statistics", "national_statistics", "statistical_data_set", "official_statistics"],
+          "statistics_upcoming": ["statistics_announcement", "national_statistics_announcement", "official_statistics_announcement"],
+          "research": ["dfid_research_output", "independent_report", "research"]
+        },
         "allowed_values": [
           {
-            "text": "Statistics (Published)",
-            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]",
+            "label": "Statistics (published)",
+            "value": "statistics_published",
             "default": true
           },
           {
-            "text": "Statistics (Upcoming)",
-            "value": "[\"statistics_announcement\",\"national_statistics_announcement\",\"official_statistics_announcement\"]"
+            "label": "Statistics (upcoming)",
+            "value": "statistics_upcoming"
           },
           {
-            "text": "Research",
-            "value": "[\"dfid_research_output\",\"independent_report\",\"research\"]"
+            "label": "Research",
+            "value": "research"
           }
         ]
       },

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -25,6 +25,9 @@
   "details":{
     "document_noun":"statistic",
     "filter":{
+      "content_store_document_type": [
+        "statistics","national_statistics","statistical_data_set","official_statistics"
+      ]
     },
     "format_name":"statistic",
     "show_summaries":true,
@@ -123,7 +126,7 @@
       {
         "key":"content_store_document_type",
         "name":"Statistics",
-        "type":"dropdown_select",
+        "type":"radio",
         "display_as_result_metadata":false,
         "filterable":true,
         "hide_facet_tag":true,
@@ -131,7 +134,8 @@
         "allowed_values": [
           {
             "text": "Statistics (Published)",
-            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]"
+            "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]",
+            "default": true
           },
           {
             "text": "Statistics (Upcoming)",

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -140,6 +140,7 @@
         "short_name": "Organisation",
         "preposition": "from",
         "type": "text",
+        "show_option_select_filter": true,
         "display_as_result_metadata": true,
         "filterable": true
       },
@@ -148,6 +149,7 @@
         "name": "World location",
         "preposition": "in",
         "type": "text",
+        "show_option_select_filter": true,
         "display_as_result_metadata": true,
         "filterable": true
       },

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -105,24 +105,6 @@
         "filterable": true,
         "preposition": "about"
       },
-
-      {
-        "key": "organisations",
-        "name": "Organisation",
-        "short_name": "Organisation",
-        "preposition": "from",
-        "type": "text",
-        "display_as_result_metadata": true,
-        "filterable": true
-      },
-      {
-        "key": "world_locations",
-        "name": "World location",
-        "preposition": "in",
-        "type": "text",
-        "display_as_result_metadata": true,
-        "filterable": true
-      },
       {
         "key":"content_store_document_type",
         "name":"Statistics",
@@ -151,6 +133,23 @@
             "value": "research"
           }
         ]
+      },
+      {
+        "key": "organisations",
+        "name": "Organisation",
+        "short_name": "Organisation",
+        "preposition": "from",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
+      },
+      {
+        "key": "world_locations",
+        "name": "World location",
+        "preposition": "in",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true
       },
       {
         "key": "public_timestamp",

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -102,6 +102,7 @@
         "filterable": true,
         "preposition": "about"
       },
+
       {
         "key": "organisations",
         "name": "Organisation",

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -129,12 +129,16 @@
         "preposition": "that are",
         "allowed_values": [
           {
-            "text": "Published",
+            "text": "Statistics (Published)",
             "value": "[\"statistics\",\"national_statistics\",\"statistical_data_set\",\"official_statistics\"]"
           },
           {
-            "text": "Upcoming",
+            "text": "Statistics (Upcoming)",
             "value": "[\"statistics_announcement\",\"national_statistics_announcement\",\"official_statistics_announcement\"]"
+          },
+          {
+            "text": "Research",
+            "value": "[\"dfid_research_output\",\"independent_report\",\"research\"]"
           }
         ]
       },

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -132,7 +132,6 @@ When(/^I view the policy papers and consultations finder$/) do
   visit finder_path('search/policy-papers-and-consultations')
 end
 
-
 When(/^I view the research and statistics finder$/) do
   topic_taxonomy_has_taxons([
                                 {
@@ -151,8 +150,6 @@ When(/^I view the research and statistics finder$/) do
 
   visit finder_path('statistics')
 end
-
-
 
 When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -132,6 +132,28 @@ When(/^I view the policy papers and consultations finder$/) do
   visit finder_path('search/policy-papers-and-consultations')
 end
 
+
+When(/^I view the research and statistics finder$/) do
+  topic_taxonomy_has_taxons([
+                                {
+                                    content_id: "Taxon_1",
+                                    title: "Taxon_1"
+                                },
+                                {
+                                    content_id: "Taxon_2",
+                                    title: "Taxon_2"
+                                }
+                            ])
+  content_store_has_statistics_finder
+  stub_whitehall_api_world_location_request
+  stub_rummager_api_request_with_research_and_statistics_results
+  stub_rummager_api_request_with_filtered_research_and_statistics_results
+
+  visit finder_path('statistics')
+end
+
+
+
 When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons
   content_store_has_services_finder
@@ -520,6 +542,11 @@ And(/^I select some document types$/) do
   find('.govuk-label', text: 'Consultations (closed)').click
 end
 
+And(/^I select upcoming statistics$/) do
+  find('.govuk-label', text: 'Statistics (upcoming)').click
+  click_on "Filter results"
+end
+
 And(/^I reload the page$/) do
   visit [current_path, page.driver.request.env['QUERY_STRING']].reject(&:blank?).join('?')
 end
@@ -656,6 +683,17 @@ Then("I do not see results with pinned items") do
   end
 end
 
+Then("I should see upcoming statistics") do
+  within("#js-results") do
+    expect(page.all("li.document").size).to eq(1)
+    expect(page).to have_link('Restrictions on usage of spells within school grounds')
+    expect(page).to have_no_link('New platform at Hogwarts for the express train')
+    expect(page).to have_no_link('Installation of double glazing at Hogwarts')
+
+    expect(page).to have_no_link('Proposed changes to magic tournaments')
+  end
+end
+
 And(/^I press (tab) key to navigate$/) do |key|
   find_field('Search').send_keys key.to_sym
 end
@@ -675,4 +713,8 @@ end
 
 Then(/^the page has a landmark to the search filters$/) do
   expect(page).to have_css('.column-third[role="search"][aria-label]')
+end
+
+And(/^I should not see an upcoming statistics facet tag$/) do
+  expect(page).to_not have_css("p.facet-tag__text", text: "Upcoming statistics")
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -110,6 +110,20 @@ module DocumentHelper
     ).to_return(body: policy_and_engagement_results_for_policy_papers_and_closed_consultations_json)
   end
 
+  def stub_rummager_api_request_with_research_and_statistics_results
+    stub_request(:get, rummager_research_and_statistics_url({}))
+        .to_return(body: statistics_results_for_statistics_json)
+  end
+
+  def stub_rummager_api_request_with_filtered_research_and_statistics_results
+    stub_request(
+      :get,
+      rummager_research_and_statistics_url(
+        'filter_content_store_document_type' => %w(statistics_announcement national_statistics_announcement official_statistics_announcement)
+      )
+    ).to_return(body: upcoming_statistics_results_for_statistics_json)
+  end
+
   def stub_all_rummager_api_requests_with_all_documents_results
     stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
         .with(query: hash_including({}))
@@ -244,6 +258,12 @@ module DocumentHelper
       base_path,
       govuk_content_schema_example('policies_finder').to_json
     )
+  end
+
+  def content_store_has_statistics_finder
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'statistics.json'))
+
+    content_store_has_item('/statistics', finder_fixture)
   end
 
   def content_store_has_policy_and_engagement_finder
@@ -574,6 +594,10 @@ module DocumentHelper
 
   def rummager_policy_papers_url(filters)
     rummager_url(policy_papers_params.merge(filters))
+  end
+
+  def rummager_research_and_statistics_url(filters)
+    rummager_url(research_and_statistics_params.merge(filters))
   end
 
   def organisation_link_results
@@ -1824,6 +1848,154 @@ module DocumentHelper
             }
           ],
           "total": 3,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def statistics_results_for_statistics_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            },
+            {
+              "title": "New platform at Hogwarts for the express train",
+              "link": "new-platform-at-hogwarts-for-the-express-train",
+              "description": "New platform at Hogwarts for the express train",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/new-platform-at-hogwarts-for-the-express-train",
+              "elasticsearch_type": "closed_consultation",
+              "document_type": "closed_consultation"
+            },
+            {
+              "title": "Installation of double glazing at Hogwarts",
+              "link": "installation-of-double-glazing-at-hogwarts",
+              "description": "Installation of double glazing at Hogwarts",
+              "public_timestamp": "2018-11-16T11:11:42Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/installation-of-double-glazing-at-hogwarts",
+              "elasticsearch_type": "consultation_outcome",
+              "document_type": "consultation_outcome"
+            }
+          ],
+          "total": 3,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def upcoming_statistics_results_for_statistics_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            }
+          ],
+          "total": 1,
           "start": 0,
           "suggested_queries": []
         }

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -75,6 +75,18 @@ module RummagerUrlHelper
     )
   end
 
+  def research_and_statistics_params
+    base_search_params.merge(
+      'facet_organisations' => '1500,order:value.title',
+      'facet_world_locations' => '1500,order:value.title',
+      'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
+      'fields' => research_and_statistics_search_fields.join(','),
+      'filter_content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics),
+      'count' => 20,
+      'order' => '-public_timestamp',
+    )
+  end
+
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
@@ -93,6 +105,19 @@ module RummagerUrlHelper
 
   def policy_papers_search_fields
     base_search_fields + %w(
+      part_of_taxonomy_tree
+      content_store_document_type
+      organisations
+      world_locations
+    )
+  end
+
+  def research_and_statistics_search_fields
+    base_search_fields + %w(
+      release_timestamp
+      statistics_announcement_state
+      display_type
+      document_collections
       part_of_taxonomy_tree
       content_store_document_type
       organisations

--- a/spec/lib/filters/radio_filter_spec.rb
+++ b/spec/lib/filters/radio_filter_spec.rb
@@ -1,0 +1,82 @@
+require "spec_helper"
+
+describe Filters::RadioFilter do
+  subject(:radio_filter) {
+    Filters::RadioFilter.new(facet, params)
+  }
+
+  let(:facet) { double }
+  let(:params) { nil }
+
+  describe "#active?" do
+    context "when params is nil" do
+      it "should be false" do
+        expect(radio_filter).not_to be_active
+      end
+    end
+
+    context "when params is empty" do
+      let(:params) { [] }
+
+      it "should be false" do
+        expect(radio_filter).not_to be_active
+      end
+    end
+  end
+
+  describe "#key" do
+    context "when a filter_key is present" do
+      let(:facet) { { "filter_key" => "alpha", "key" => "beta" } }
+
+      it "returns filter_key" do
+        expect(radio_filter.key).to eq("alpha")
+      end
+    end
+
+    context "when a filter_key is not present" do
+      let(:facet) { { "key" => "beta" } }
+
+      it "returns key" do
+        expect(radio_filter.key).to eq("beta")
+      end
+    end
+  end
+
+  describe "#value" do
+    context "when params is present and option_lookup is absent" do
+      let(:params) { %w(alpha) }
+      let(:facet) { {} }
+
+      it "should contain all values" do
+        expect(radio_filter.value).to eq(%w(alpha))
+      end
+    end
+
+    context "when params is present and option_lookup is empty" do
+      let(:params) { %w(does_not_exist) }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+
+      it "should contain no values" do
+        expect(radio_filter.value).to eq([])
+      end
+    end
+
+    context "when params is present and option_lookup is present" do
+      let(:params) { %w(policy_papers) }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+
+      it "should contain all values" do
+        expect(radio_filter.value).to eq(%w(guidance))
+      end
+    end
+
+    context "when params has multiple values and option_lookup is present" do
+      let(:params) { %w(policy_papers does_not_exist consultations) }
+      let(:facet) { { "option_lookup" => { "consultations" => %w(open closed), "policy_papers" => %w(guidance) } } }
+
+      it "should contain all values" do
+        expect(radio_filter.value).to eq(%w(open closed guidance))
+      end
+    end
+  end
+end

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe AtomPresenter do
         'word_connectors' => { words_connector: 'and' }
       },
       has_filters?: true,
-      value: ['brexit', 'harry-potter']
+      value: ['brexit', 'harry-potter'],
+      hide_facet_tag: false
     )
   end
 
@@ -57,7 +58,8 @@ RSpec.describe AtomPresenter do
       'key' => 'closed_date',
       sentence_fragment: nil,
       has_filters?: false,
-      'word_connectors' => { words_connector: 'or' }
+      'word_connectors' => { words_connector: 'or' },
+      hide_facet_tag: false
     )
   end
 
@@ -79,7 +81,8 @@ RSpec.describe AtomPresenter do
       },
       has_filters?: true,
       value: %w[farming chemicals],
-      'word_connectors' => { words_connector: 'or' }
+      'word_connectors' => { words_connector: 'or' },
+      hide_facet_tag: false
     )
   end
 

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -32,15 +32,15 @@ RSpec.describe AtomPresenter do
       OptionSelectFacet,
       key: 'key_1',
       sentence_fragment: {
-        'key' => 'key_1',
-        'type' => 'text',
-        'preposition' => 'About',
-        'values' => first_facet_values,
-        'word_connectors' => { words_connector: 'and' }
+      'key' => 'key_1',
+      'type' => 'text',
+      'preposition' => 'About',
+      'values' => first_facet_values,
+      'word_connectors' => { words_connector: 'and' }
       },
-      has_filters?: true,
-      value: ['brexit', 'harry-potter'],
-      hide_facet_tag: false
+        has_filters?: true,
+        value: ['brexit', 'harry-potter'],
+        hide_facet_tag?: false
     )
   end
 
@@ -59,7 +59,7 @@ RSpec.describe AtomPresenter do
       sentence_fragment: nil,
       has_filters?: false,
       'word_connectors' => { words_connector: 'or' },
-      hide_facet_tag: false
+      hide_facet_tag?: false
     )
   end
 
@@ -73,16 +73,16 @@ RSpec.describe AtomPresenter do
       key: 'key_2',
       preposition: 'About',
       sentence_fragment: {
-        'key' => 'key_2',
-        'type' => 'text',
-        'preposition' => 'Related to',
-        'values' => second_facet_values,
-        'word_connectors' => { words_connector: 'or' }
+      'key' => 'key_2',
+      'type' => 'text',
+      'preposition' => 'Related to',
+      'values' => second_facet_values,
+      'word_connectors' => { words_connector: 'or' }
       },
-      has_filters?: true,
-      value: %w[farming chemicals],
-      'word_connectors' => { words_connector: 'or' },
-      hide_facet_tag: false
+        has_filters?: true,
+        value: %w[farming chemicals],
+        'word_connectors' => { words_connector: 'or' },
+        hide_facet_tag?: false
     )
   end
 

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe GroupedResultSetPresenter do
       values: {},
       pagination: pagination,
       sort: {},
+      filters: {}
     )
   end
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -16,7 +16,26 @@ RSpec.describe ResultSetPresenter do
       default_documents_per_page: 10,
       values: {},
       pagination: pagination,
-      sort: {},
+      sort: [
+        {
+          "name" => "Most viewed",
+          "key" => "-popularity"
+        },
+        {
+          "name" => "Relevance",
+          "key" => "-relevance"
+        },
+        {
+          "name" => "Updated (newest)",
+          "key" => "-public_timestamp",
+          "default" => true
+        }
+      ],
+      default_sort_option: {
+        "name" => "Updated (newest)",
+        "key" => "-public_timestamp",
+      },
+      filters: {}
     )
   end
 
@@ -152,6 +171,38 @@ RSpec.describe ResultSetPresenter do
       promoted: false,
       promoted_summary: nil,
       show_metadata: false,
+    )
+  end
+
+  let(:a_facet_without_facet_tags) do
+    double(
+      RadioFacet,
+      key: 'key_3',
+      preposition: 'that are',
+      allowed_values: [
+        {
+          'value' => 'statistics_published',
+          'label' => 'Statistics (published)',
+          'default' => true
+        },
+        {
+          'value' => 'statistics_upcoming',
+          'label' => 'Statistics (upcoming)'
+        },
+        {
+          'value' => 'research',
+          'label' => 'Research'
+        },
+      ],
+      has_filters?: true,
+      hide_facet_tag: true,
+      value: "something",
+      sort: [
+        {
+          'value' => 'most-viewed',
+          'name' => 'Most viewed'
+        }
+      ]
     )
   end
 
@@ -344,6 +395,16 @@ RSpec.describe ResultSetPresenter do
       it 'returns false' do
         expect(presenter.has_email_signup_link?).to eq(false)
       end
+    end
+  end
+
+  describe '#hidden_text' do
+    before(:each) do
+      allow(finder).to receive(:filters).and_return([a_facet, another_facet, a_date_facet, a_facet_without_facet_tags])
+    end
+
+    it 'creates appropriate hidden text for the facet without a facet tag' do
+      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>, that are Statistics (published) , sorted by Updated (newest)</span>")
     end
   end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -50,43 +50,43 @@ RSpec.describe ResultSetPresenter do
       OptionSelectFacet,
       key: 'key_1',
       selected_values: [
-        {
-          'value' => 'ca98-and-civil-cartels',
-          'label' => 'CA98 and civil cartels'
-        },
-        {
-          'value' => 'mergers',
-          'label' => 'Mergers'
-        },
-      ],
-      allowed_values: [
-        {
-          'value' => 'ca98-and-civil-cartels',
-          'label' => 'CA98 and civil cartels'
-        },
-        {
-          'value' => 'mergers',
-          'label' => 'Mergers'
-        },
-      ],
-      sentence_fragment: {
-        'key' => 'key_1',
-        'type' => 'text',
-        'preposition' => 'Of Type',
-        'values' => [
-          {
-            'label' => 'CA98 and civil cartels',
-          },
-          {
-            'label' => 'Mergers',
-          },
-        ],
-        'word_connectors' => { words_connector: 'or' }
+      {
+        'value' => 'ca98-and-civil-cartels',
+        'label' => 'CA98 and civil cartels'
       },
+      {
+        'value' => 'mergers',
+        'label' => 'Mergers'
+      },
+    ],
+      allowed_values: [
+      {
+        'value' => 'ca98-and-civil-cartels',
+        'label' => 'CA98 and civil cartels'
+      },
+      {
+        'value' => 'mergers',
+        'label' => 'Mergers'
+      },
+    ],
+      sentence_fragment: {
+      'key' => 'key_1',
+      'type' => 'text',
+      'preposition' => 'Of Type',
+      'values' => [
+        {
+          'label' => 'CA98 and civil cartels',
+        },
+        {
+          'label' => 'Mergers',
+        },
+      ],
+      'word_connectors' => { words_connector: 'or' }
+    },
       has_filters?: true,
       labels: %W(ca98-and-civil-cartels mergers),
       value: %W(ca98-and-civil-cartels mergers),
-      hide_facet_tag: false
+      hide_facet_tag?: false
     )
   end
 
@@ -103,33 +103,33 @@ RSpec.describe ResultSetPresenter do
       key: 'key_2',
       preposition: 'About',
       selected_values: [
+      {
+        'value' => 'farming',
+        'label' => 'Farming'
+      },
+      {
+        'value' => 'chemicals',
+        'label' => 'Chemicals'
+      },
+    ],
+      sentence_fragment: {
+      'key' => 'key_2',
+      'type' => 'text',
+      'preposition' => 'About',
+      'values' => [
         {
-          'value' => 'farming',
-          'label' => 'Farming'
+          'label' => 'Farming',
         },
         {
-          'value' => 'chemicals',
-          'label' => 'Chemicals'
+          'label' => 'Chemicals',
         },
       ],
-      sentence_fragment: {
-        'key' => 'key_2',
-        'type' => 'text',
-        'preposition' => 'About',
-        'values' => [
-          {
-            'label' => 'Farming',
-          },
-          {
-            'label' => 'Chemicals',
-          },
-        ],
-        'word_connectors' => { words_connector: 'or' }
-      },
+      'word_connectors' => { words_connector: 'or' }
+    },
       has_filters?: true,
       value: %w[farming chemicals],
       'word_connectors' => { words_connector: 'or' },
-      hide_facet_tag: false
+      hide_facet_tag?: false
     )
   end
 
@@ -140,7 +140,7 @@ RSpec.describe ResultSetPresenter do
       sentence_fragment: nil,
       has_filters?: false,
       'word_connectors' => { words_connector: 'or' },
-      hide_facet_tag: false
+      hide_facet_tag?: false
     )
   end
 
@@ -180,29 +180,29 @@ RSpec.describe ResultSetPresenter do
       key: 'key_3',
       preposition: 'that are',
       allowed_values: [
-        {
-          'value' => 'statistics_published',
-          'label' => 'Statistics (published)',
-          'default' => true
-        },
-        {
-          'value' => 'statistics_upcoming',
-          'label' => 'Statistics (upcoming)'
-        },
-        {
-          'value' => 'research',
-          'label' => 'Research'
-        },
-      ],
+      {
+        'value' => 'statistics_published',
+        'label' => 'Statistics (published)',
+        'default' => true
+      },
+      {
+        'value' => 'statistics_upcoming',
+        'label' => 'Statistics (upcoming)'
+      },
+      {
+        'value' => 'research',
+        'label' => 'Research'
+      },
+    ],
       has_filters?: true,
-      hide_facet_tag: true,
+      hide_facet_tag?: true,
       value: "something",
       sort: [
-        {
-          'value' => 'most-viewed',
-          'name' => 'Most viewed'
-        }
-      ]
+      {
+        'value' => 'most-viewed',
+        'name' => 'Most viewed'
+      }
+    ]
     )
   end
 
@@ -395,43 +395,6 @@ RSpec.describe ResultSetPresenter do
       it 'returns false' do
         expect(presenter.has_email_signup_link?).to eq(false)
       end
-    end
-  end
-
-  describe '#hidden_text' do
-    before(:each) do
-      allow(finder).to receive(:filters).and_return([a_facet, another_facet, a_date_facet, a_facet_without_facet_tags])
-    end
-
-    it 'creates appropriate hidden text for the facet without a facet tag for a default value' do
-      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>that are Statistics (published), sorted by Updated (newest)</span>")
-    end
-
-    it 'creates appropriate hidden text for the facet without a facet tag for a non default value' do
-      allow(a_facet_without_facet_tags).to receive(:value).and_return("research")
-      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>that are Research, sorted by Updated (newest)</span>")
-    end
-
-    it 'will not include a facet without a facet tag if there is no selected value or default value' do
-      allow(a_facet_without_facet_tags).to receive(:value).and_return("")
-      allow(a_facet_without_facet_tags).to receive(:allowed_values).and_return(
-        [
-          {
-              'value' => 'statistics_published',
-              'label' => 'Statistics (published)'
-          },
-          {
-              'value' => 'statistics_upcoming',
-              'label' => 'Statistics (upcoming)'
-          },
-          {
-              'value' => 'research',
-              'label' => 'Research'
-          },
-        ]
-      )
-
-      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>sorted by Updated (newest)</span>")
     end
   end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -403,8 +403,35 @@ RSpec.describe ResultSetPresenter do
       allow(finder).to receive(:filters).and_return([a_facet, another_facet, a_date_facet, a_facet_without_facet_tags])
     end
 
-    it 'creates appropriate hidden text for the facet without a facet tag' do
-      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>, that are Statistics (published) , sorted by Updated (newest)</span>")
+    it 'creates appropriate hidden text for the facet without a facet tag for a default value' do
+      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>that are Statistics (published), sorted by Updated (newest)</span>")
+    end
+
+    it 'creates appropriate hidden text for the facet without a facet tag for a non default value' do
+      allow(a_facet_without_facet_tags).to receive(:value).and_return("research")
+      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>that are Research, sorted by Updated (newest)</span>")
+    end
+
+    it 'will not include a facet without a facet tag if there is no selected value or default value' do
+      allow(a_facet_without_facet_tags).to receive(:value).and_return("")
+      allow(a_facet_without_facet_tags).to receive(:allowed_values).and_return(
+        [
+          {
+              'value' => 'statistics_published',
+              'label' => 'Statistics (published)'
+          },
+          {
+              'value' => 'statistics_upcoming',
+              'label' => 'Statistics (upcoming)'
+          },
+          {
+              'value' => 'research',
+              'label' => 'Research'
+          },
+        ]
+      )
+
+      expect(presenter.hidden_text).to eql("<span class='visually-hidden'>sorted by Updated (newest)</span>")
     end
   end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe ResultSetPresenter do
       },
       has_filters?: true,
       labels: %W(ca98-and-civil-cartels mergers),
-      value: %W(ca98-and-civil-cartels mergers)
+      value: %W(ca98-and-civil-cartels mergers),
+      hide_facet_tag: false
     )
   end
 
@@ -108,7 +109,8 @@ RSpec.describe ResultSetPresenter do
       },
       has_filters?: true,
       value: %w[farming chemicals],
-      'word_connectors' => { words_connector: 'or' }
+      'word_connectors' => { words_connector: 'or' },
+      hide_facet_tag: false
     )
   end
 
@@ -118,7 +120,8 @@ RSpec.describe ResultSetPresenter do
       'key' => 'closed_date',
       sentence_fragment: nil,
       has_filters?: false,
-      'word_connectors' => { words_connector: 'or' }
+      'word_connectors' => { words_connector: 'or' },
+      hide_facet_tag: false
     )
   end
 

--- a/spec/presenters/screen_reader_filter_description_presenter_spec.rb
+++ b/spec/presenters/screen_reader_filter_description_presenter_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe ScreenReaderFilterDescriptionPresenter do
+  subject(:presenter) { ScreenReaderFilterDescriptionPresenter.new([a_facet, a_facet_without_facet_tags], 'name' => 'Updated (newest)') }
+
+  let(:a_facet) do
+    double(
+      SelectFacet,
+      key: 'key_1',
+      selected_values: [
+          {
+              'value' => 'ca98-and-civil-cartels',
+              'label' => 'CA98 and civil cartels'
+          },
+          {
+              'value' => 'mergers',
+              'label' => 'Mergers'
+          },
+      ],
+      allowed_values: [
+          {
+              'value' => 'ca98-and-civil-cartels',
+              'label' => 'CA98 and civil cartels'
+          },
+          {
+              'value' => 'mergers',
+              'label' => 'Mergers'
+          },
+      ],
+      sentence_fragment: {
+          'key' => 'key_1',
+          'type' => 'text',
+          'preposition' => 'Of Type',
+          'values' => [
+              {
+                  'label' => 'CA98 and civil cartels',
+              },
+              {
+                  'label' => 'Mergers',
+              },
+          ],
+          'word_connectors' => { words_connector: 'or' }
+      },
+      has_filters?: true,
+      labels: %W(ca98-and-civil-cartels mergers),
+      value: %W(ca98-and-civil-cartels mergers),
+      hide_facet_tag?: false
+    )
+  end
+
+  let(:a_facet_without_facet_tags) do
+    double(
+      RadioFacet,
+      key: 'key_3',
+      preposition: 'that are',
+      allowed_values: [
+          {
+              'value' => 'statistics_published',
+              'label' => 'Statistics (published)',
+              'default' => true
+          },
+          {
+              'value' => 'statistics_upcoming',
+              'label' => 'Statistics (upcoming)'
+          },
+          {
+              'value' => 'research',
+              'label' => 'Research'
+          },
+      ],
+      has_filters?: true,
+      hide_facet_tag?: true,
+      value: "something",
+      sort: [
+          {
+              'value' => 'most-viewed',
+              'name' => 'Most viewed'
+          }
+      ]
+    )
+  end
+  describe '#hidden_text' do
+    it 'creates appropriate hidden text for the facet without a facet tag for a default value' do
+      expect(presenter.present).to eql("<span class='visually-hidden'>that are Statistics (published), sorted by Updated (newest)</span>")
+    end
+
+    it 'creates appropriate hidden text for the facet without a facet tag for a non default value' do
+      allow(a_facet_without_facet_tags).to receive(:value).and_return("research")
+      expect(presenter.present).to eql("<span class='visually-hidden'>that are Research, sorted by Updated (newest)</span>")
+    end
+
+    it 'will not include a facet without a facet tag if there is no selected value or default value' do
+      allow(a_facet_without_facet_tags).to receive(:value).and_return("")
+      allow(a_facet_without_facet_tags).to receive(:allowed_values).and_return(
+        [
+          {
+              'value' => 'statistics_published',
+              'label' => 'Statistics (published)'
+          },
+          {
+              'value' => 'statistics_upcoming',
+              'label' => 'Statistics (upcoming)'
+          },
+          {
+              'value' => 'research',
+              'label' => 'Research'
+          },
+        ]
+      )
+
+      expect(presenter.present).to eql("<span class='visually-hidden'>sorted by Updated (newest)</span>")
+    end
+  end
+end

--- a/spec/presenters/screen_reader_filter_description_presenter_spec.rb
+++ b/spec/presenters/screen_reader_filter_description_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ScreenReaderFilterDescriptionPresenter do
 
   let(:a_facet) do
     double(
-      SelectFacet,
+      OptionSelectFacet,
       key: 'key_1',
       selected_values: [
           {


### PR DESCRIPTION
Adds the statistics and research finder.

![screen shot 2019-03-08 at 14 08 54](https://user-images.githubusercontent.com/861310/54033271-beee1d80-41ab-11e9-99d2-b5b2b80f001b.png)

Since the three options in the new facet are mutually exclusive they are represented by a new radio button facet. This means that one option from this facet is always set and cannot be turned off, so having a facet tag for this facet makes no sense - if you removed it, it would immediately reappear as the default option.

This code change includes support for any facets that do not require a facet tag, not just this one. In order to be accessible any facets without a facet tag now have their details output into the `visually-hidden` element that also contains the 'sort by' information.

Ticket: https://trello.com/c/pNXeZLrW/403-introduce-documenttype-facet-behaviour-on-stats-finder

Demo: https://finder-frontend-pr-925.herokuapp.com/statistics