### PR TITLE
Redirect from the announcements Whitehall finder to news-and-comms

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -7,6 +7,9 @@ class RedirectionController < ApplicationController
                   organisations: params['departments'],
                   world_locations: params['world_locations'],
                   public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
-    redirect_to(finder_path('news-and-communications', params: parameters))
+    respond_to do |format|
+      format.html { redirect_to(finder_path('news-and-communications', params: parameters)) }
+      format.atom { redirect_to(finder_path('news-and-communications', params: parameters, format: :atom)) }
+    end
   end
 end

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -1,0 +1,12 @@
+class RedirectionController < ApplicationController
+  def announcements
+    parameters = { keywords: params['keywords'],
+                  level_one_taxon: params['taxons'].try(:first),
+                  level_two_taxon: params['subtaxons'].try(:first),
+                  people: params['people'],
+                  organisations: params['departments'],
+                  world_locations: params['world_locations'],
+                  public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
+    redirect_to(finder_path('news-and-communications', params: parameters))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,7 @@ FinderFrontend::Application.routes.draw do
 
   get '/search/advanced' => 'advanced_search_finder#show'
 
+  get '/redirect/announcements' => 'redirection#announcements'
+
   get '/*slug' => 'finders#show', as: :finder
 end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe RedirectionController, type: :controller do
+  it "redirects to the news-and-comms page" do
+    get :announcements
+    expect(response).to redirect_to finder_path('news-and-communications')
+  end
+  it 'passes on keywords params' do
+    get :announcements, params: { keywords: %w[one two] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { keywords: %w[one two] })
+  end
+  it 'converts taxons to level_one_taxon and converts array to string' do
+    get :announcements, params: { taxons: %w[one] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { level_one_taxon: 'one' })
+  end
+  it 'converts subtaxons to level_two_taxon and converts array to string' do
+    get :announcements, params: { subtaxons: %w[two] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { level_two_taxon: 'two' })
+  end
+  it 'passes on people params' do
+    get :announcements, params: { people: %w[one two] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { people: %w[one two] })
+  end
+  it 'converts departments into organisations' do
+    get :announcements, params: { departments: %w[one two] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { organisations: %w[one two] })
+  end
+  it 'passes on world_locations' do
+    get :announcements, params: { world_locations: %w[one two] }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { world_locations: %w[one two] })
+  end
+  it 'converts from_date to public_timestamp[from]' do
+    get :announcements, params: { from_date: '01/01/2014' }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { from: '01/01/2014' } })
+  end
+  it 'converts to_date to public_timestamp[to]' do
+    get :announcements, params: { to_date: '01/01/2014' }
+    expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { to: '01/01/2014' } })
+  end
+end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -37,4 +37,8 @@ describe RedirectionController, type: :controller do
     get :announcements, params: { to_date: '01/01/2014' }
     expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { to: '01/01/2014' } })
   end
+  it 'redirects to the atom feed' do
+    get :announcements, params: { keywords: %w[one two] }, format: :atom
+    expect(response).to redirect_to finder_path('news-and-communications', format: :atom, params: { keywords: %w[one two] })
+  end
 end


### PR DESCRIPTION
Adds a new endpoint redirect/announcements that converts search parameters
as used in the legacy announcements whitehall finder to equivalent ones
in the news-and comms finder and redirects the request

Handles HTML pages and Atom feeds

Trello: https://trello.com/c/K0wdqEpm/347-handle-redirects-in-finder-frontend-from-the-announcements-whitehall-finder-m