### PR TITLE
Automagically change order to relevancy when adding keywords

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -49,7 +49,6 @@
         }.bind(this)
       );
 
-      this.updateOrder();
       this.indexTrackingData();
 
       $(window).on('popstate', this.popState.bind(this));
@@ -184,21 +183,18 @@
     }
 
     var liveSearch = this;
-
     var keywords = this.getTextInputValue('keywords', this.state);
     var previousKeywords = this.getTextInputValue('keywords', this.previousState);
 
     var keywordsPresent = keywords !== "";
-    var keywordsBlank = !keywordsPresent;
-
     var previousKeywordsPresent = previousKeywords !== "";
-    var previousKeywordsBlank = !previousKeywordsPresent;
-
-    var keywordsChanged = keywordsPresent && (previousKeywordsBlank || (keywords !== previousKeywords));
-    var keywordsCleared = keywordsBlank && previousKeywordsPresent;
+    var keywordsCleared = !keywordsPresent && previousKeywordsPresent;
 
     if (keywordsPresent) {
       liveSearch.insertRelevanceOption();
+      if(!previousKeywordsPresent){
+        liveSearch.selectRelevanceSortOption();
+      }
     } else {
       liveSearch.removeRelevanceOption();
     }

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -106,12 +106,14 @@ Feature: Filtering documents
     When I view a list of news and communications
     Then I can sort by:
       | Most viewed      |
+      | Relevance        |
       | Updated (newest) |
       | Updated (oldest) |
     When I view a list of services
     Then I can sort by:
       | A-Z         |
       | Most viewed |
+      | Relevance   |
 
   Scenario: Sorting news and communications by most viewed
     When I view a list of news and communications
@@ -152,9 +154,23 @@ Feature: Filtering documents
   @javascript
   Scenario: Removing keyword filter
     When I view the news and communications finder
+    Then I see updated newest order selected
     And I fill in some keywords
+    Then I see most relevant order selected
     And I click the Keyword1 remove control
     Then The keyword textbox only contains Keyword2
+    And I see most relevant order selected
+    And I click the Keyword2 remove control
+    Then The keyword textbox is empty
+    And I see updated newest order selected
+
+  @javascript
+  Scenario: Adding keyword filter
+    When I view the news and communications finder
+    Then I see updated newest order selected
+    And I fill in some keywords
+    And I press tab key to navigate
+    Then I see most relevant order selected
 
   Scenario: Subscribing to email alerts
     Given a collection of documents exist that can be filtered by checkbox

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -432,6 +432,10 @@ Then(/^I see most relevant order selected$/) do
   expect(page).to have_select('order', selected: "Relevance")
 end
 
+Then(/^I see updated newest order selected$/) do
+  expect(page).to have_select('order', selected: "Updated (newest)")
+end
+
 And(/^I see the facet tag$/) do
   within '.facet-tags' do
     expect(page).to have_button("✕")


### PR DESCRIPTION
When someone enters a keyword search, we now helpfully change the order to be relevancy. If someone clears the keyword search, it reverts to default. It will not change the order if the user has entered some text, changed the order and then entered more text (as this would be annoying).

This behaviour is JS only, as documented in the card

Trello: https://trello.com/c/XQYQSODA/460-make-sort-change-to-relevance-when-keyword-entered-in-news-and-communications-finder