### PR TITLE
Adds email subscription to policy papers and consultations finder

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -165,7 +165,7 @@ private
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
     "/policy-papers-and-consultations" => 'policy_and_engagement',
-    "/statistics" => "statistics"
+    "/statistics" => "statistics",
   }.freeze
 
   def development_env_finder_json

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -22,7 +22,24 @@
 
   },
   "publishing_request_id":"",
-  "links":{},
+  "links":{
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/policy-papers-and-consultations/email-signup",
+        "base_path": "/policy-papers-and-consultations/email-signup",
+        "content_id": "5a4dc517-57cf-4dd6-873f-f1d29f6d540c",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2019-03-06T10:22:17Z",
+        "schema_name": "finder_email_signup",
+        "title": "Policy papers and consultations",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/policy-papers-and-consultations/email-signup",
+        "web_url": "/policy-papers-and-consultations/email-signup"
+      }
+    ]
+  },
   "description":"Find policy papers and consultations from government",
   "details":{
     "document_noun":"result",

--- a/features/fixtures/policy_and_engagement_signup_content_item.json
+++ b/features/fixtures/policy_and_engagement_signup_content_item.json
@@ -1,0 +1,43 @@
+{
+  "base_path": "/policy-papers-and-consultations/email-signup",
+  "content_id": "5a4dc517-57cf-4dd6-873f-f1d29f6d540c",
+  "document_type": "finder_email_signup",
+  "title": "Policy papers and consultations",
+  "description": "You'll get an email each time policy papers and consultations are published.",
+  "details": {
+    "filter": {
+      "content_purpose_supergroup": "policy-papers-and-consultations"
+    },
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Policy papers and consultations ",
+    "email_filter_facets": [
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "document_type",
+        "facet_name": "document types"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/features/fixtures/policy_and_engagement_signup_content_item.json
+++ b/features/fixtures/policy_and_engagement_signup_content_item.json
@@ -10,7 +10,7 @@
     },
     "email_filter_by": null,
     "email_filter_name": null,
-    "subscription_list_title_prefix": "Policy papers and consultations ",
+    "subscription_list_title_prefix": "Policy papers and consultations",
     "email_filter_facets": [
       {
         "facet_id": "people",


### PR DESCRIPTION
Adds email subscription to policy papers and consultations finder

Trello: https://trello.com/c/tIXZB4LG/482-make-post-review-changes-to-policy-papers-and-consultations-finder