### PR TITLE
Redirect from publications finder to all-content

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -12,4 +12,17 @@ class RedirectionController < ApplicationController
       format.atom { redirect_to(finder_path('news-and-communications', params: parameters, format: :atom)) }
     end
   end
+
+  def publications
+    parameters = { keywords: params['keywords'],
+                  level_one_taxon: params['taxons'].try(:first),
+                  level_two_taxon: params['subtaxons'].try(:first),
+                  organisations: params['departments'],
+                  world_locations: params['world_locations'],
+                  public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
+    respond_to do |format|
+      format.html { redirect_to(finder_path('all-content', params: parameters)) }
+      format.atom { redirect_to(finder_path('all-content', params: parameters, format: :atom)) }
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,7 @@ FinderFrontend::Application.routes.draw do
 
   get '/redirect/announcements' => 'redirection#announcements'
 
+  get '/redirect/publications' => 'redirection#publications'
+
   get '/*slug' => 'finders#show', as: :finder
 end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -1,44 +1,85 @@
 require 'spec_helper'
 
 describe RedirectionController, type: :controller do
-  it "redirects to the news-and-comms page" do
-    get :announcements
-    expect(response).to redirect_to finder_path('news-and-communications')
+  describe '#announcements' do
+    it "redirects to the news-and-comms page" do
+      get :announcements
+      expect(response).to redirect_to finder_path('news-and-communications')
+    end
+    it 'passes on keywords params' do
+      get :announcements, params: { keywords: %w[one two] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { keywords: %w[one two] })
+    end
+    it 'converts taxons to level_one_taxon and converts array to string' do
+      get :announcements, params: { taxons: %w[one] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { level_one_taxon: 'one' })
+    end
+    it 'converts subtaxons to level_two_taxon and converts array to string' do
+      get :announcements, params: { subtaxons: %w[two] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { level_two_taxon: 'two' })
+    end
+    it 'passes on people params' do
+      get :announcements, params: { people: %w[one two] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { people: %w[one two] })
+    end
+    it 'converts departments into organisations' do
+      get :announcements, params: { departments: %w[one two] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { organisations: %w[one two] })
+    end
+    it 'passes on world_locations' do
+      get :announcements, params: { world_locations: %w[one two] }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { world_locations: %w[one two] })
+    end
+    it 'converts from_date to public_timestamp[from]' do
+      get :announcements, params: { from_date: '01/01/2014' }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { from: '01/01/2014' } })
+    end
+    it 'converts to_date to public_timestamp[to]' do
+      get :announcements, params: { to_date: '01/01/2014' }
+      expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { to: '01/01/2014' } })
+    end
+    it 'redirects to the atom feed' do
+      get :announcements, params: { keywords: %w[one two] }, format: :atom
+      expect(response).to redirect_to finder_path('news-and-communications', format: :atom, params: { keywords: %w[one two] })
+    end
   end
-  it 'passes on keywords params' do
-    get :announcements, params: { keywords: %w[one two] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { keywords: %w[one two] })
-  end
-  it 'converts taxons to level_one_taxon and converts array to string' do
-    get :announcements, params: { taxons: %w[one] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { level_one_taxon: 'one' })
-  end
-  it 'converts subtaxons to level_two_taxon and converts array to string' do
-    get :announcements, params: { subtaxons: %w[two] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { level_two_taxon: 'two' })
-  end
-  it 'passes on people params' do
-    get :announcements, params: { people: %w[one two] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { people: %w[one two] })
-  end
-  it 'converts departments into organisations' do
-    get :announcements, params: { departments: %w[one two] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { organisations: %w[one two] })
-  end
-  it 'passes on world_locations' do
-    get :announcements, params: { world_locations: %w[one two] }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { world_locations: %w[one two] })
-  end
-  it 'converts from_date to public_timestamp[from]' do
-    get :announcements, params: { from_date: '01/01/2014' }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { from: '01/01/2014' } })
-  end
-  it 'converts to_date to public_timestamp[to]' do
-    get :announcements, params: { to_date: '01/01/2014' }
-    expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { to: '01/01/2014' } })
-  end
-  it 'redirects to the atom feed' do
-    get :announcements, params: { keywords: %w[one two] }, format: :atom
-    expect(response).to redirect_to finder_path('news-and-communications', format: :atom, params: { keywords: %w[one two] })
+
+  describe '#publications' do
+    it "redirects to the all-content page" do
+      get :publications
+      expect(response).to redirect_to finder_path('all-content')
+    end
+    it 'passes on keywords params' do
+      get :publications, params: { keywords: %w[one two] }
+      expect(response).to redirect_to finder_path('all-content', params: { keywords: %w[one two] })
+    end
+    it 'converts taxons to level_one_taxon and converts array to string' do
+      get :publications, params: { taxons: %w[one] }
+      expect(response).to redirect_to finder_path('all-content', params: { level_one_taxon: 'one' })
+    end
+    it 'converts subtaxons to level_two_taxon and converts array to string' do
+      get :publications, params: { subtaxons: %w[two] }
+      expect(response).to redirect_to finder_path('all-content', params: { level_two_taxon: 'two' })
+    end
+    it 'converts departments into organisations' do
+      get :publications, params: { departments: %w[one two] }
+      expect(response).to redirect_to finder_path('all-content', params: { organisations: %w[one two] })
+    end
+    it 'passes on world_locations' do
+      get :publications, params: { world_locations: %w[one two] }
+      expect(response).to redirect_to finder_path('all-content', params: { world_locations: %w[one two] })
+    end
+    it 'converts from_date to public_timestamp[from]' do
+      get :publications, params: { from_date: '01/01/2014' }
+      expect(response).to redirect_to finder_path('all-content', params: { public_timestamp: { from: '01/01/2014' } })
+    end
+    it 'converts to_date to public_timestamp[to]' do
+      get :publications, params: { to_date: '01/01/2014' }
+      expect(response).to redirect_to finder_path('all-content', params: { public_timestamp: { to: '01/01/2014' } })
+    end
+    it 'redirects to the atom feed' do
+      get :publications, params: { keywords: %w[one two] }, format: :atom
+      expect(response).to redirect_to finder_path('all-content', format: :atom, params: { keywords: %w[one two] })
+    end
   end
 end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -6,37 +6,26 @@ describe RedirectionController, type: :controller do
       get :announcements
       expect(response).to redirect_to finder_path('news-and-communications')
     end
-    it 'passes on keywords params' do
-      get :announcements, params: { keywords: %w[one two] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { keywords: %w[one two] })
-    end
-    it 'converts taxons to level_one_taxon and converts array to string' do
-      get :announcements, params: { taxons: %w[one] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { level_one_taxon: 'one' })
-    end
-    it 'converts subtaxons to level_two_taxon and converts array to string' do
-      get :announcements, params: { subtaxons: %w[two] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { level_two_taxon: 'two' })
-    end
-    it 'passes on people params' do
-      get :announcements, params: { people: %w[one two] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { people: %w[one two] })
-    end
-    it 'converts departments into organisations' do
-      get :announcements, params: { departments: %w[one two] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { organisations: %w[one two] })
-    end
-    it 'passes on world_locations' do
-      get :announcements, params: { world_locations: %w[one two] }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { world_locations: %w[one two] })
-    end
-    it 'converts from_date to public_timestamp[from]' do
-      get :announcements, params: { from_date: '01/01/2014' }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { from: '01/01/2014' } })
-    end
-    it 'converts to_date to public_timestamp[to]' do
-      get :announcements, params: { to_date: '01/01/2014' }
-      expect(response).to redirect_to finder_path('news-and-communications', params: { public_timestamp: { to: '01/01/2014' } })
+    it 'passes on a set of params' do
+      get :announcements, params: {
+        keywords: %w[one two],
+        taxons: %w[one],
+        subtaxons: %w[two],
+        people: %w[one two],
+        departments: %w[one two],
+        world_locations: %w[one two],
+        from_date: '01/01/2014',
+        to_date: '01/01/2014'
+      }
+      expect(response).to redirect_to finder_path('news-and-communications', params: {
+        keywords: %w[one two],
+        level_one_taxon: 'one',
+        level_two_taxon: 'two',
+        people: %w[one two],
+        organisations: %w[one two],
+        world_locations: %w[one two],
+        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+      })
     end
     it 'redirects to the atom feed' do
       get :announcements, params: { keywords: %w[one two] }, format: :atom
@@ -49,33 +38,24 @@ describe RedirectionController, type: :controller do
       get :publications
       expect(response).to redirect_to finder_path('all-content')
     end
-    it 'passes on keywords params' do
-      get :publications, params: { keywords: %w[one two] }
-      expect(response).to redirect_to finder_path('all-content', params: { keywords: %w[one two] })
-    end
-    it 'converts taxons to level_one_taxon and converts array to string' do
-      get :publications, params: { taxons: %w[one] }
-      expect(response).to redirect_to finder_path('all-content', params: { level_one_taxon: 'one' })
-    end
-    it 'converts subtaxons to level_two_taxon and converts array to string' do
-      get :publications, params: { subtaxons: %w[two] }
-      expect(response).to redirect_to finder_path('all-content', params: { level_two_taxon: 'two' })
-    end
-    it 'converts departments into organisations' do
-      get :publications, params: { departments: %w[one two] }
-      expect(response).to redirect_to finder_path('all-content', params: { organisations: %w[one two] })
-    end
-    it 'passes on world_locations' do
-      get :publications, params: { world_locations: %w[one two] }
-      expect(response).to redirect_to finder_path('all-content', params: { world_locations: %w[one two] })
-    end
-    it 'converts from_date to public_timestamp[from]' do
-      get :publications, params: { from_date: '01/01/2014' }
-      expect(response).to redirect_to finder_path('all-content', params: { public_timestamp: { from: '01/01/2014' } })
-    end
-    it 'converts to_date to public_timestamp[to]' do
-      get :publications, params: { to_date: '01/01/2014' }
-      expect(response).to redirect_to finder_path('all-content', params: { public_timestamp: { to: '01/01/2014' } })
+    it 'passes on a set of params' do
+      get :announcements, params: {
+        keywords: %w[one two],
+        taxons: %w[one],
+        subtaxons: %w[two],
+        departments: %w[one two],
+        world_locations: %w[one two],
+        from_date: '01/01/2014',
+        to_date: '01/01/2014'
+      }
+      expect(response).to redirect_to finder_path('news-and-communications', params: {
+        keywords: %w[one two],
+        level_one_taxon: 'one',
+        level_two_taxon: 'two',
+        organisations: %w[one two],
+        world_locations: %w[one two],
+        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+      })
     end
     it 'redirects to the atom feed' do
       get :publications, params: { keywords: %w[one two] }, format: :atom

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -39,7 +39,7 @@ describe RedirectionController, type: :controller do
       expect(response).to redirect_to finder_path('all-content')
     end
     it 'passes on a set of params' do
-      get :announcements, params: {
+      get :publications, params: {
         keywords: %w[one two],
         taxons: %w[one],
         subtaxons: %w[two],
@@ -48,7 +48,7 @@ describe RedirectionController, type: :controller do
         from_date: '01/01/2014',
         to_date: '01/01/2014'
       }
-      expect(response).to redirect_to finder_path('news-and-communications', params: {
+      expect(response).to redirect_to finder_path('all-content', params: {
         keywords: %w[one two],
         level_one_taxon: 'one',
         level_two_taxon: 'two',


### PR DESCRIPTION
Adds an endpoint redirect/publications which takes available parameters
from a request to publications, and converts them to suitable
all-content facet parameters.

https://trello.com/c/knEZK7G3/486-handle-redirects-from-the-publications-whitehall-finder-to-the-all-content-finder

It's sort of copied from this other one here! https://github.com/alphagov/finder-frontend/pull/926