### PR TITLE
Change the default sorting after a keyword search to 'by relevance' in the business readiness finder

### DIFF
--- a/features/finders.feature
+++ b/features/finders.feature
@@ -179,6 +179,37 @@ Feature: Filtering documents
     And I press tab key to navigate
     Then I see most relevant order selected
 
+  @javascript
+  Scenario: Removing keyword filter in business finder
+    When I view the business readiness finder
+    Then I see topic order selected
+    And I fill in some keywords
+    Then I see most relevant order selected
+    And I click the Keyword1 remove control
+    Then The keyword textbox only contains Keyword2
+    And I see most relevant order selected
+    And I click the Keyword2 remove control
+    Then The keyword textbox is empty
+    And I see topic order selected
+
+  @javascript
+  Scenario: Adding keyword filter in business finder
+    When I view the business readiness finder
+    Then I see topic order selected
+    And I fill in some keywords
+    And I press tab key to navigate
+    Then I see most relevant order selected
+
+  @javascript
+  Scenario: Adding keyword filter to facet search in business finder
+    When I view the business readiness finder
+    Then I see topic order selected
+    And I click button "Sector / Business Area" and select facet Aerospace
+    Then I see results grouped by primary facet value
+    And I fill in some keywords
+    And I press tab key to navigate
+    Then I see most relevant order selected
+
   Scenario: Subscribing to email alerts
     Given a collection of documents exist that can be filtered by checkbox
     When I use a checkbox filter

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -100,6 +100,13 @@ Feature: Filtering documents
       | A-Z         |
       | Most viewed |
       | Relevance   |
+    When I view the business readiness finder
+    Then I can sort by:
+      | Topic         |
+      | Most viewed   |
+      | Relevance     |
+      | Most recent   |
+      | A to Z        |
 
   @javascript
   Scenario: Live sorting options
@@ -186,6 +193,12 @@ Feature: Filtering documents
   Scenario: Filter documents by keywords and sort by most relevant
     When I view the news and communications finder
     And I fill in some keywords
+    And I sort by most relevant
+    Then I see most relevant order selected
+
+  Scenario: Filter documents by keywords and sort by most relevant for business finder
+    When I view the business readiness finder
+    And I search documents by keyword for business finder
     And I sort by most relevant
     Then I see most relevant order selected
 

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -206,9 +206,11 @@ Feature: Filtering documents
     Then I see topic order selected
     And I click button "Sector / Business Area" and select facet Aerospace
     Then I see results grouped by primary facet value
+    And I see results with pinned items
     And I fill in some keywords
     And I press tab key to navigate
     Then I see most relevant order selected
+    And I do not see results with pinned items
 
   Scenario: Subscribing to email alerts
     Given a collection of documents exist that can be filtered by checkbox

--- a/features/fixtures/business_readiness.json
+++ b/features/fixtures/business_readiness.json
@@ -85,6 +85,10 @@
         "key": "-popularity"
       },
       {
+        "name": "Relevance",
+        "key": "-relevance"
+      },
+      {
         "name": "Most recent",
         "key": "-public_timestamp"
       },

--- a/features/fixtures/business_readiness.json
+++ b/features/fixtures/business_readiness.json
@@ -33,6 +33,23 @@
         "web_url": "https://www.gov.uk/find-eu-exit-guidance-business/email-signup"
       }
     ],
+    "ordered_related_items": [
+      {
+        "api_path": "/api/content/guidance/regulations-and-standards-after-brexit",
+        "base_path": "/guidance/regulations-and-standards-after-brexit",
+        "content_id": "f026b0f9-ce9c-499a-a3cd-1ba9aad8f368",
+        "description": "When the UK leaves the EU there may be changes to the requirements for placing certain products on the UK and EU markets.",
+        "document_type": "detailed_guide",
+        "locale": "en",
+        "public_updated_at": "2019-02-01T17:46:00Z",
+        "schema_name": "detailed_guide",
+        "title": "Regulations and standards after Brexit",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/guidance/regulations-and-standards-after-brexit",
+        "web_url": "https://www.gov.uk/guidance/regulations-and-standards-after-brexit"
+      }
+    ],
     "available_translations": [
       {
         "title": "Find EU Exit guidance for your business",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -141,6 +141,21 @@ When(/^I search documents by keyword$/) do
   click_on "Filter results"
 end
 
+When(/^I search documents by keyword for business finder$/) do
+  content_store_has_business_readiness_finder
+  stub_keyword_business_readiness_search_api_request
+
+  visit finder_path('find-eu-exit-guidance-business')
+
+  @keyword_search = "keyword searchable"
+
+  within '.filter-form' do
+    fill_in("Search", with: @keyword_search)
+  end
+
+  click_on "Filter results"
+end
+
 Then(/^I see all documents which contain the keywords$/) do
   within ".filtered-results" do
     expect(page).to have_css("a", text: @keyword_search)

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -470,6 +470,10 @@ Then(/^I see updated newest order selected$/) do
   expect(page).to have_select('order', selected: "Updated (newest)")
 end
 
+Then(/^I see topic order selected$/) do
+  expect(page).to have_select('order', selected: "Topic")
+end
+
 And(/^I see the facet tag$/) do
   within '.facet-tags' do
     expect(page).to have_button("✕")
@@ -544,6 +548,8 @@ Then(/^The (.*) checkbox in deselected$/) do |checkbox|
 end
 
 And(/^I fill in some keywords$/) do
+  stub_all_rummager_api_requests_with_business_finder_results
+
   fill_in 'Search', with: "Keyword1 Keyword2\n"
 end
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -621,6 +621,18 @@ Then("I see results grouped by primary facet value") do
   end
 end
 
+Then("I see results with pinned items") do
+  within("#js-results") do
+    expect(page.all(".document-heading--pinned").length).to eq(1)
+  end
+end
+
+Then("I do not see results with pinned items") do
+  within("#js-results") do
+    expect(page.all(".document-heading--pinned").length).to eq(0)
+  end
+end
+
 And(/^I press (tab) key to navigate$/) do |key|
   find_field('Search').send_keys key.to_sym
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -29,6 +29,12 @@ module DocumentHelper
     )
   end
 
+  def stub_keyword_business_readiness_search_api_request
+    stub_request(:get, rummager_keyword_business_readiness_search_url).to_return(
+      body: keyword_search_results,
+    )
+  end
+
   def stub_rummager_api_request_with_government_results
     stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
       .with(query: hash_including({}))
@@ -436,6 +442,14 @@ module DocumentHelper
       mosw_search_params.merge(
         "q" => "keyword searchable",
         "order" => "-public_timestamp",
+      )
+    )
+  end
+
+  def rummager_keyword_business_readiness_search_url
+    rummager_url(
+      business_readiness_params.merge(
+        "q" => "keyword searchable"
       )
     )
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -83,6 +83,12 @@ module DocumentHelper
     ).to_return(body: filtered_business_readiness_results_json)
   end
 
+  def stub_all_rummager_api_requests_with_business_finder_results
+    stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
+      .with(query: hash_including({}))
+      .to_return(body: business_readiness_results_json)
+  end
+
   def stub_rummager_api_request_with_policy_papers_results
     stub_request(:get, rummager_policy_papers_url({}))
       .to_return(body: policy_and_engagement_results_json)


### PR DESCRIPTION
Trello: https://trello.com/c/xyDkF16R

# What's changed

* When a user searches by keywords, the option to sort by Relevance is added to the Sort by drop-down list.
* When a user searches by keywords, the default order of the content switches to Sort by: Relevance.
* Pinned content does not appear at the top of results sorted by relevance
* Pinned content does not have special styling when results are sorted by relevance

# Why

Allowing users to sort by relevance on a keyword search means that we can start tagging content as best bets for a term thereby increasing their relevancy score in elastic search.  

Paired with @MahmudH 