### PR TITLE
Allow option_select component to show/hide filter field

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -19,6 +19,10 @@ class Facet
     facet['type']
   end
 
+  def show_option_select_filter
+    facet['show_option_select_filter']
+  end
+
   def short_name
     facet['short_name']
   end

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -2,7 +2,7 @@
   title_id = "option-select-title-#{title.parameterize}"
   checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
   checkboxes_count_id = checkboxes_id + "-count"
-  show_filter = local_assigns.include?(:show_filter)
+  show_filter ||= false
 
   if show_filter
     filter_element = ActionController::Base.new.render_to_string(:partial => "govuk_publishing_components/components/input", :locals => {

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -6,7 +6,8 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => close_facet
+    :closed_on_load => close_facet,
+    :show_filter => option_select_facet.show_option_select_filter
   }
   %>
 <% end %>

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -28,7 +28,8 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       },
       {
         "display_as_result_metadata": false,
@@ -36,7 +37,8 @@
         "key": "people",
         "name": "Person",
         "preposition": "from",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       },
       {
         "display_as_result_metadata": true,
@@ -44,7 +46,8 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       },
       {
         "display_as_result_metadata": true,

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -28,7 +28,7 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "autocomplete"
+        "type": "text"
       },
       {
         "display_as_result_metadata": false,
@@ -36,7 +36,7 @@
         "key": "people",
         "name": "Person",
         "preposition": "from",
-        "type": "autocomplete"
+        "type": "text"
       },
       {
         "display_as_result_metadata": true,
@@ -44,7 +44,7 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete"
+        "type": "text"
       },
       {
         "display_as_result_metadata": true,

--- a/features/fixtures/guidance_and_regulation.json
+++ b/features/fixtures/guidance_and_regulation.json
@@ -66,7 +66,8 @@
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "world_locations",
@@ -74,7 +75,8 @@
         "preposition": "in",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "public_timestamp",

--- a/features/fixtures/guidance_and_regulation.json
+++ b/features/fixtures/guidance_and_regulation.json
@@ -64,7 +64,7 @@
         "name": "Organisation",
         "short_name": "From",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },
@@ -72,7 +72,7 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -94,7 +94,7 @@
         "name": "Organisation",
         "short_name": "From",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },
@@ -102,7 +102,7 @@
         "key": "people",
         "name": "Person",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": false,
         "filterable": true
       },
@@ -110,7 +110,7 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },

--- a/features/fixtures/news_and_communications_with_checkboxes.json
+++ b/features/fixtures/news_and_communications_with_checkboxes.json
@@ -96,7 +96,8 @@
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "people",
@@ -104,7 +105,8 @@
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": false,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "world_locations",
@@ -112,7 +114,8 @@
         "preposition": "in",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "public_timestamp",

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -112,7 +112,8 @@
         "preposition": "from",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "world_locations",
@@ -120,7 +121,8 @@
         "preposition": "in",
         "type": "text",
         "display_as_result_metadata": true,
-        "filterable": true
+        "filterable": true,
+        "show_option_select_filter": true
       },
       {
         "key": "public_timestamp",

--- a/features/fixtures/services.json
+++ b/features/fixtures/services.json
@@ -28,7 +28,8 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       }
     ],
     "filter": {

--- a/features/fixtures/services.json
+++ b/features/fixtures/services.json
@@ -28,7 +28,7 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "autocomplete"
+        "type": "text"
       }
     ],
     "filter": {

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -70,7 +70,7 @@
         "name": "State",
         "short_name": "State",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": false
       },
@@ -79,7 +79,7 @@
         "name": "content_store_document_type",
         "short_name": "Document type",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": false
       },
@@ -88,7 +88,7 @@
         "name": "document_collections",
         "short_name": "Part of a collection",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": false
       },
@@ -107,7 +107,7 @@
         "name": "Organisation",
         "short_name": "Organisation",
         "preposition": "from",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },
@@ -115,7 +115,7 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete",
+        "type": "text",
         "display_as_result_metadata": true,
         "filterable": true
       },

--- a/features/fixtures/transparency_and_freedom_of_information_releases.json
+++ b/features/fixtures/transparency_and_freedom_of_information_releases.json
@@ -28,7 +28,8 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       },
       {
         "display_as_result_metadata": true,
@@ -36,7 +37,8 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "text"
+        "type": "text",
+        "show_option_select_filter": true
       },
       {
         "display_as_result_metadata": true,

--- a/features/fixtures/transparency_and_freedom_of_information_releases.json
+++ b/features/fixtures/transparency_and_freedom_of_information_releases.json
@@ -28,7 +28,7 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "autocomplete"
+        "type": "text"
       },
       {
         "display_as_result_metadata": true,
@@ -36,7 +36,7 @@
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "autocomplete"
+        "type": "text"
       },
       {
         "display_as_result_metadata": true,

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -96,6 +96,15 @@ describe 'components/_option-select.html.erb', type: :view do
     expect(rendered).to have_selector('.app-c-option-select__count')
   end
 
+  it "does not show a filter control" do
+    arguments = option_select_arguments
+    arguments[:show_filter] = false
+    render_component(arguments)
+
+    expect(rendered).to have_no_selector('.app-c-option-select .gem-c-input[name="option-select-filter"]')
+    expect(rendered).to have_no_selector('.app-c-option-select__count')
+  end
+
   def expect_label_and_checked_checkbox(label, id, value)
     expect_label_and_checkbox(label, id, value, true)
   end


### PR DESCRIPTION
By default the option_select component will not display the filter field.
The reason for this is that we wanted to control which option_select facet
allowed users to filter the checkboxes. There maybe a scenario where the
facet only has a few checkboxes and therefore it wouldn't make sense to
filter the options out (For example Policy finders doc type filter which
only has 3 options)

Ticket: https://trello.com/c/sEGGP7dF/470-turn-on-option-select-filters-for-finders
Demo:
- [x] **All Content**: https://finder-frontend-pr-933.herokuapp.com/all-content
- [x] **News & Comms**: https://finder-frontend-pr-933.herokuapp.com/news-and-communications (https://github.com/alphagov/rummager/pull/1458 needs to be merged)
- [x] **Services**: https://finder-frontend-pr-933.herokuapp.com/services
- [x] **Guidance & regulation**: https://finder-frontend-pr-933.herokuapp.com/guidance-and-regulation
- [x] **Transparency & FOI**: https://finder-frontend-pr-933.herokuapp.com/transparency-and-freedom-of-information-releases