### PR TITLE
Also fire analytics when the enter key is pressed

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -17,6 +17,8 @@
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
     this.$emailLink = $('a[href*="email-signup"]');
+    this.previousSearchTerm = '';
+
     this.emailSignupHref = this.$emailLink.attr('href');
     this.$atomLink = $('a[href*=".atom"]');
     this.atomHref = this.$atomLink.attr('href');
@@ -29,7 +31,7 @@
     if(GOVUK.support.history()){
       this.saveState();
 
-      this.$form.on('change', 'input[type=checkbox], input[type=text], input[type=radio], select',
+      this.$form.on('change', 'input[type=checkbox], input[type=radio], select',
         function(e) {
           if (e.target.type == "text" && !e.suppressAnalytics) {
             LiveSearch.prototype.fireTextAnalyticsEvent(e);
@@ -38,12 +40,18 @@
         }.bind(this)
       );
 
-      this.$form.on('keypress', 'input[type=text]',
+      this.$form.on('change keypress', 'input[type=text]',
         function(e){
           var ENTER_KEY = 13
 
-          if(e.keyCode == ENTER_KEY) {
-            this.formChange(e);
+          if(e.keyCode == ENTER_KEY || e.type == "change") {
+            if (e.currentTarget.value != this.previousSearchTerm) {
+              if (e.target.type == "text" && !e.suppressAnalytics) {
+                LiveSearch.prototype.fireTextAnalyticsEvent(e);
+              }
+            }
+              this.formChange(e);
+              this.previousSearchTerm = $(e.currentTarget).val();
             e.preventDefault();
           }
         }.bind(this)

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -238,6 +238,33 @@ describe("liveSearch", function(){
       expect(GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent).toHaveBeenCalledTimes(1);
     });
 
+    it("should trigger filterClicked for both change and enter key events on text input", function() {
+      GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent = function (event) {}
+      spyOn(GOVUK.LiveSearch.prototype, 'fireTextAnalyticsEvent')
+
+      $form.find('input[name="published_at"]').val('searchChange').trigger('change');
+
+      expect(GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent).toHaveBeenCalledTimes(1);
+
+      var enterKeyPress = $.Event( "keypress", { keyCode: 13 } );
+      $form.find('input[name="published_at"]').val('searchEnter').trigger(enterKeyPress);
+
+      expect(GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not trigger multiple tracking events if the search term stays the same", function() {
+      GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent = function (event) {}
+      spyOn(GOVUK.LiveSearch.prototype, 'fireTextAnalyticsEvent')
+
+      $form.find('input[name="published_at"]').val('same term').trigger('change');
+      $form.find('input[name="published_at"]').val('same term').trigger('change');
+
+      var enterKeyPress = $.Event( "keypress", { keyCode: 13 } );
+      $form.find('input[name="published_at"]').val('same term').trigger(enterKeyPress);
+
+      expect(GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent).toHaveBeenCalledTimes(1);
+    });
+
     it("should not trigger filterClicked custom event when input type is text and analytics are suppressed", function() {
       GOVUK.LiveSearch.prototype.fireTextAnalyticsEvent = function (event) {}
       spyOn(GOVUK.LiveSearch.prototype, 'fireTextAnalyticsEvent')


### PR DESCRIPTION
It has been spotted that analytics is not firing when users are searching by keywords followed by a keypress to load their results. This PR adds the firing of analytics when enter key is pressed so that search terms are tracked.

Trello card: https://trello.com/c/1G26qKBs