### PR TITLE
fixes "disabled" Relevance sort option

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -217,7 +217,7 @@
 
   LiveSearch.prototype.insertRelevanceOption = function insertRelevanceOption() {
     var adjacentOption = this.$orderSelect.children("option").eq(this.$relevanceOrderOptionIndex);
-
+    this.$relevanceOrderOption.removeAttr('disabled');
     adjacentOption.before(this.$relevanceOrderOption);
   };
 

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -34,10 +34,12 @@ describe("liveSearch", function(){
   };
 
   beforeEach(function () {
+    sortList = '<select id="order" class="js-order-results" data-relevance-sort-option="relevance"><option>Test 1</option><option value="relevance" disabled>Relevance</option>';
     $form = $('<form action="/somewhere" class="js-live-search-form">' +
                 '<input type="checkbox" name="field" value="sheep" checked>' +
                 '<label for="published_at">Published at</label>' +
                 '<input type="text" name="published_at" value="2004" />' +
+                sortList +
                 '<input type="submit" value="Filter results" class="button js-live-search-fallback"/>' +
               '</form>');
     $results = $('<div class="js-live-search-results-block"></div>');
@@ -423,4 +425,14 @@ describe("liveSearch", function(){
     expect(liveSearch.$atomLink.attr('href')).toBe("http://an-atom-url.atom?published_at=2004");
     expect(liveSearch.$atomAutodiscoveryLink.attr('href')).toBe("http://an-atom-url.atom?published_at=2004");
   });
+
+  describe('insertRelevanceOption', function(){
+    it('adds "Relevance" to the Sort select list and should not be disabled', function(){
+      // Relevance option should initially be disabled when js is disabled
+      expect($('#order option:disabled').length).toBe(1);
+      //When we insert it again disabled attribute should be removed
+      liveSearch.insertRelevanceOption();
+      expect($('#order option:disabled').length).toBe(0);
+    })
+  })
 });


### PR DESCRIPTION
By default "Relevance" sort option is disabled when JS has been disabled.
When the livesearch initialises it remembers the state of "Relevance" sort
option and then inserts the option back into the sort list in its original
state. This means that the option is disabled and users cannot reselect it
should they want to.
______________________
## Before

![sort-bug-before](https://user-images.githubusercontent.com/3441519/54034170-1d1c0000-41ae-11e9-871e-1ebffd318bf3.gif)

## After
![sort-bug-after](https://user-images.githubusercontent.com/3441519/54034190-2c02b280-41ae-11e9-92e2-be699558a656.gif)

_____________
Ticket: https://trello.com/c/H4P3VKtH/492-bugfix-relevance-sort-option-is-disabled-incorrectly
Demo: https://finder-frontend-pr-935.herokuapp.com/news-and-communications