### PR TITLE
Have toggle option for facets on mobile only if facets are present

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -15,15 +15,18 @@
       href: '#js-results'}
     %>
   </div>
-  <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hidden">
-    <a href="#" class="facet-toggle" data-controls="facet-wrapper" data-expanded="false" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
-      + <%= t("finders.facet_disclosure.more", default: "Show more search options") %>
-    </a>
 
-    <div id="facet-wrapper" class="facet-toggle__content--hidden">
-      <%= render facet_collection.filters %>
+  <% if facet_collection.filters.any? %>
+    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hidden">
+      <a href="#" class="facet-toggle" data-controls="facet-wrapper" data-expanded="false" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
+        + <%= t("finders.facet_disclosure.more", default: "Show more search options") %>
+      </a>
+
+      <div id="facet-wrapper" class="facet-toggle__content--hidden">
+        <%= render facet_collection.filters %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="js-live-search-fallback button__wrapper">
     <%= render "govuk_publishing_components/components/button", {

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -47,6 +47,12 @@ Feature: Filtering documents
   Scenario: Visit a finder with dynamic filter
     Given a finder with a dynamic filter exists
     Then I can see filters based on the results
+    And filters are wrapped in a progressive disclosure element
+
+  Scenario: Visit a finder with no facets
+    Given no results
+    When I view the finder with no keywords and no facets
+    And filters are not wrapped in a progressive disclosure element
 
   Scenario: Visit a finder autocomplete
     Given a finder with autocomplete exists
@@ -280,7 +286,7 @@ Feature: Filtering documents
     Then I see email and feed sign up links
     And I click button "Person" and select facet Rufus Scrimgeour
     Then I see email and feed sign up links with filters applied with extra empty filters
-    
+
   @javascript
   Scenario: Policy papers should have three options
     When I view the policy papers and consultations finder

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -263,6 +263,14 @@ Then(/^I can see filters based on the results$/) do
   end
 end
 
+And(/^filters are wrapped in a progressive disclosure element$/) do
+  expect(page).to have_selector('#facet-wrapper')
+end
+
+And(/^filters are not wrapped in a progressive disclosure element$/) do
+  expect(page).not_to have_selector('#facet-wrapper')
+end
+
 Given(/^a finder with autocomplete exists$/) do
   content_store_has_mosw_reports_finder_with_autocomplete_facet
   stub_rummager_api_request


### PR DESCRIPTION
@sihugh noticed that on https://www.gov.uk/prepare-eu-exit/going-and-being-abroad the 'show more search options' link is visible on mobile, even though there are no more search options. This change fixes that.

![Screen Shot 2019-03-11 at 10 40 54](https://user-images.githubusercontent.com/861310/54118097-2d202380-43ea-11e9-82ef-08aaaa303def.png)

Example where there this link should be present: /news-and-communications

Example where it shouldn't be present: /prepare-eu-exit/going-and-being-abroad