### PR TITLE
Exclude option select filters from facet list

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -64,11 +64,18 @@
         that.checkboxLabels.push(that.cleanString($(this).text()));
       });
 
-      this.$filter.on('keyup', function(e) {
-        clearTimeout(that.filterTimeout);
-        that.filterTimeout = setTimeout(function(obj){
-          that.doFilter(obj);
-        }, 300, that);
+      this.$filter.on('change keypress', function(e) {
+        e.stopPropagation();
+        var ENTER_KEY = 13;
+
+        if(e.keyCode !== ENTER_KEY) {
+          clearTimeout(that.filterTimeout);
+          that.filterTimeout = setTimeout(function(obj){
+            that.doFilter(obj);
+          }, 300, that);
+        } else {
+          e.preventDefault(); // prevents finder forms from being submitted when user presses ENTER
+        }
       });
     }
   }

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -13,7 +13,7 @@
     this.$optionsContainer = this.$optionSelect.find('.options-container');
     this.$optionList = this.$optionsContainer.children('.js-auto-height-inner');
     this.$allCheckboxes = this.$optionsContainer.find('.govuk-checkboxes__item');
-    this.$filter = this.$optionsContainer.find('input[name="filter"]');
+    this.hasFilter = this.$optionSelect.data('filter-element') || "";
     this.checkedCheckboxes = [];
 
     this.attachCheckedCounter();
@@ -43,7 +43,15 @@
       }
     }
 
-    if (this.$filter.length) {
+    if (this.hasFilter.length) {
+      var filterEl = document.createElement('div');
+      filterEl.innerHTML = this.hasFilter;
+
+      $('<div class="app-c-option-select__filter"/>')
+        .html(filterEl.childNodes[0].nodeValue)
+        .prependTo(this.$optionList);
+
+      this.$filter = this.$optionsContainer.find('input[name="option-select-filter"]');
       this.$filterCount = $('#' + this.$filter.attr('aria-describedby'));
       this.filterTextSingle = ' ' + this.$filterCount.data('single');
       this.filterTextMultiple = ' ' + this.$filterCount.data('multiple');

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -40,7 +40,7 @@
         }.bind(this)
       );
 
-      this.$form.on('change keypress', 'input[type=text][name!="option-select-filter"]',
+      this.$form.on('change keypress', 'input[type=text]',
         function(e){
           var ENTER_KEY = 13;
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -33,25 +33,25 @@
 
       this.$form.on('change', 'input[type=checkbox], input[type=radio], select',
         function(e) {
-          if (e.target.type == "text" && !e.suppressAnalytics) {
+          if (!e.suppressAnalytics) {
             LiveSearch.prototype.fireTextAnalyticsEvent(e);
           }
-          this.formChange(e)
+          this.formChange(e);
         }.bind(this)
       );
 
-      this.$form.on('change keypress', 'input[type=text]',
+      this.$form.on('change keypress', 'input[type=text][name!="option-select-filter"]',
         function(e){
-          var ENTER_KEY = 13
+          var ENTER_KEY = 13;
 
           if(e.keyCode == ENTER_KEY || e.type == "change") {
             if (e.currentTarget.value != this.previousSearchTerm) {
-              if (e.target.type == "text" && !e.suppressAnalytics) {
+              if (!e.suppressAnalytics) {
                 LiveSearch.prototype.fireTextAnalyticsEvent(e);
               }
             }
-              this.formChange(e);
-              this.previousSearchTerm = $(e.currentTarget).val();
+            this.formChange(e);
+            this.previousSearchTerm = e.currentTarget.value;
             e.preventDefault();
           }
         }.bind(this)
@@ -63,16 +63,21 @@
     } else {
       this.$form.find('.js-live-search-fallback').show();
     }
-  };
+  }
 
   LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet() {
     this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: $('.app-taxonomy-select') });
     return this.taxonomy;
-  }
+  };
+
+  LiveSearch.prototype.getSerializeForm = function getSerializeForm(){
+    var uncleanState = this.$form.serializeArray();
+    return uncleanState.filter(function(field){ return field.name !== 'option-select-filter'; });
+  };
 
   LiveSearch.prototype.saveState = function saveState(state){
     if(typeof state === 'undefined'){
-      state = this.$form.serializeArray();
+      state = this.getSerializeForm();
     }
     this.previousState = this.state;
     this.state = state;
@@ -103,21 +108,21 @@
           this.trackingInit();
           this.trackPageView();
         }.bind(this)
-      )
+      );
     }
   };
 
   LiveSearch.prototype.trackingInit = function() {
     GOVUK.modules.start($('.js-live-search-results-block'));
     this.indexTrackingData();
-  }
+  };
 
   LiveSearch.prototype.trackPageView = function trackPageView() {
     if (this.canTrackPageview()) {
       var newPath = window.location.pathname + "?" + $.param(this.state);
       GOVUK.analytics.trackPageview(newPath);
     }
-  }
+  };
 
   /**
    * Results grouped by facet and facet value do not have an accurate document index
@@ -142,10 +147,10 @@
             trackingAction += 'p';
           }
           $documentLink.attr('data-track-action', trackingAction);
-        })
-      })
+        });
+      });
     }
-  }
+  };
 
   LiveSearch.prototype.fireTextAnalyticsEvent = function(event) {
     if (this.canTrackPageview()) {
@@ -162,11 +167,11 @@
         options
       );
     }
-  }
+  };
 
   LiveSearch.prototype.canTrackPageview = function() {
     return GOVUK.analytics && GOVUK.analytics.trackPageview;
-  }
+  };
 
   LiveSearch.prototype.cache = function cache(slug, data){
     if(typeof data === 'undefined'){
@@ -177,12 +182,12 @@
   };
 
   LiveSearch.prototype.isNewState = function isNewState(){
-    return $.param(this.state) !== this.$form.serialize();
+    return $.param(this.state) !== $.param(this.getSerializeForm());
   };
 
   LiveSearch.prototype.updateOrder = function updateOrder() {
     if (!this.$orderSelect.length) {
-      return
+      return;
     }
 
     var liveSearch = this;
@@ -211,7 +216,7 @@
     var defaultSortOption = this.$orderSelect.data('default-sort-option');
 
     this.$orderSelect.val(defaultSortOption);
-    this.state = this.$form.serializeArray();
+    this.state = this.getSerializeForm();
   };
 
   LiveSearch.prototype.selectRelevanceSortOption = function selectRelevanceSortOption() {
@@ -219,7 +224,7 @@
 
     if (relevanceSortOption) {
       this.$orderSelect.val(relevanceSortOption);
-      this.state = this.$form.serializeArray();
+      this.state = this.getSerializeForm();
     }
   };
 
@@ -252,7 +257,7 @@
       });
     } else {
       this.displayResults(cachedResultData, searchState);
-      var out = new $.Deferred()
+      var out = new $.Deferred();
       return out.resolve();
     }
   };
@@ -266,7 +271,7 @@
       this.$atomLink.attr('href', this.atomHref.split('?')[0] + searchState);
       this.$atomAutodiscoveryLink.attr('href', this.atomHref.split('?')[0] + searchState);
     }
-  }
+  };
 
   LiveSearch.prototype.showLoadingIndicator = function showLoadingIndicator(){
     this.$loadingBlock.text('Loading...').show();
@@ -318,7 +323,7 @@
     var i, _i;
     for(i=0,_i=state.length; i<_i; i++){
       if(state[i].name === name){
-        return state[i].value
+        return state[i].value;
       }
     }
     return '';

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -1,7 +1,27 @@
-<% title_id = "option-select-title-#{title.parameterize}" %>
+<%
+  title_id = "option-select-title-#{title.parameterize}"
+  checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
+  checkboxes_count_id = checkboxes_id + "-count"
+  show_filter = local_assigns.include?(:show_filter)
+
+  if show_filter
+    filter_element = ActionController::Base.new.render_to_string(:partial => "govuk_publishing_components/components/input", :locals => {
+      label: {
+        text: "Filter " + title
+      },
+      name: "option-select-filter",
+      controls: checkboxes_id,
+      describedby: checkboxes_count_id
+    })
+
+    filter_element = CGI::escapeHTML(filter_element)
+  end
+%>
+
 <div class="app-c-option-select"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
+  <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >
   <div class="container-head js-container-head">
     <div class="option-select-label" id="<%= title_id %>">
@@ -12,22 +32,8 @@
   </div>
   <div role="group" aria-labelledby="<%= title_id %>" class="options-container" id="<%= options_container_id %>">
     <div class="js-auto-height-inner">
-      <%
-        checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
-        checkboxes_count_id = checkboxes_id + "-count"
-      %>
-      <% if local_assigns.include?(:show_filter) %>
-        <div class="app-c-option-select__filter">
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Filter " + title
-            },
-            name: "filter",
-            controls: checkboxes_id,
-            describedby: checkboxes_count_id
-          } %>
-          <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
-        </div>
+      <% if show_filter %>
+        <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
       <% end %>
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "#{key}[]",

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -92,7 +92,7 @@ describe 'components/_option-select.html.erb', type: :view do
     arguments[:show_filter] = true
     render_component(arguments)
 
-    expect(rendered).to have_selector('.app-c-option-select .gem-c-input[name="filter"]')
+    expect(rendered).to have_selector('.app-c-option-select[data-filter-element]')
     expect(rendered).to have_selector('.app-c-option-select__count')
   end
 

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -348,17 +348,19 @@ describe('GOVUK.OptionSelect', function() {
   describe('filtering checkboxes', function(){
     beforeEach(function(){
       var filterMarkup =
-        '<div class="app-c-option-select__filter">'+
-          '<div class="govuk-form-group">'+
-            '<label for="input-b7f768b7" class="gem-c-label govuk-label">'+
+        '&lt;div class=&quot;app-c-option-select__filter&quot;&gt;'+
+          '&lt;div class=&quot;govuk-form-group&quot;&gt;'+
+            '&lt;label for=&quot;input-b7f768b7&quot; class=&quot;gem-c-label govuk-label&quot;&gt;'+
               'Filter Countries'+
-            '</label>'+
-            '<input name="filter" class="gem-c-input govuk-input" id="input-b7f768b7" type="text" aria-describedby="checkboxes-9b7ecc25-count" aria-controls="checkboxes-9b7ecc25">'+
-          '</div>'+
-          '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found"></span>'+
-        '</div>';
+            '&lt;/label&gt;'+
+            '&lt;input name=&quot;option-select-filter&quot; class=&quot;gem-c-input govuk-input&quot; id=&quot;input-b7f768b7&quot; type=&quot;text&quot; aria-describedby=&quot;checkboxes-9b7ecc25-count&quot; aria-controls=&quot;checkboxes-9b7ecc25&quot;&gt;'+
+          '&lt;/div&gt;'+
+        '&lt;/div&gt;';
 
-      $('body').find('.gem-c-checkboxes').prepend($(filterMarkup));
+      var filterSpan = '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found"></span>';
+
+      $('body').find('.app-c-option-select').attr('data-filter-element', filterMarkup);
+      $('body').find('.gem-c-checkboxes').prepend($(filterSpan));
       optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
 
       var timerCallback = jasmine.createSpy("timerCallback");
@@ -370,100 +372,108 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('filters the checkboxes and updates the filter count correctly', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
       expect($('.govuk-checkboxes__input:visible').length).toBe(12);
 
-      $optionSelectHTML.find('[name="filter"]').val('in').keyup();
+      $filterInput.val('in').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(5);
       expect($count.text()).toBe('5 options found');
 
-      $optionSelectHTML.find('[name="filter"]').val('ind').keyup();
+      $filterInput.val('ind').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
       expect($count.html()).toBe('2 options found');
 
-      $optionSelectHTML.find('[name="filter"]').val('shouldnotmatchanything').keyup();
+      $filterInput.val('shouldnotmatchanything').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');
     });
 
     it('shows checked checkboxes regardless of whether they match the filter', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
       $('#building-and-construction').prop('checked', true).change();
       $('#chemicals').prop('checked', true).change();
       jasmine.clock().tick(100);
 
-      $optionSelectHTML.find('[name="filter"]').val('electronics').keyup();
+      $filterInput.val('electronics').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(3);
       expect($count.html()).toBe('3 options found');
 
-      $optionSelectHTML.find('[name="filter"]').val('shouldnotmatchanything').keyup();
+      $filterInput.val('shouldnotmatchanything').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
       expect($count.html()).toBe('2 options found');
     });
 
     it('matches a filter regardless of text case', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('electroNICS industry').keyup();
+      $filterInput.val('electroNICS industry').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $optionSelectHTML.find('[name="filter"]').val('Building and construction').keyup();
+      $filterInput.val('Building and construction').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
     });
 
     it('matches ampersands correctly', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('Distribution & Service Industries').keyup();
+      $filterInput.val('Distribution & Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $optionSelectHTML.find('[name="filter"]').val('Distribution &amp; Service Industries').keyup();
+      $filterInput.val('Distribution &amp; Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');
     });
 
     it('ignores whitespace around the user input', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('   Clothing, footwear and fashion    ').keyup();
+      $filterInput.val('   Clothing, footwear and fashion    ').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
     });
 
     it('ignores duplicate whitespace in the user input', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('Clothing,     footwear      and      fashion').keyup();
+      $filterInput.val('Clothing,     footwear      and      fashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
     });
 
     it('ignores common punctuation characters', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
+      $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
     });
 
     it('normalises & and and', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('cows & llamas').keyup();
+      $filterInput.val('cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $optionSelectHTML.find('[name="filter"]').val('cows and llamas').keyup();
+      $filterInput.val('cows and llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -471,13 +481,14 @@ describe('GOVUK.OptionSelect', function() {
 
     // there was a bug in cleanString() where numbers were being ignored
     it('does not strip out numbers', function(){
+      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $optionSelectHTML.find('[name="filter"]').val('1st and 2nd Military Courts').keyup();
+      $filterInput.val('1st and 2nd Military Courts').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $optionSelectHTML.find('[name="filter"]').val('footwear and f23907234973204723094ashion').keyup();
+      $filterInput.val('footwear and f23907234973204723094ashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -376,17 +376,17 @@ describe('GOVUK.OptionSelect', function() {
       var $count = $('#checkboxes-9b7ecc25-count');
       expect($('.govuk-checkboxes__input:visible').length).toBe(12);
 
-      $filterInput.val('in').keyup();
+      $filterInput.val('in').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(5);
       expect($count.text()).toBe('5 options found');
 
-      $filterInput.val('ind').keyup();
+      $filterInput.val('ind').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
       expect($count.html()).toBe('2 options found');
 
-      $filterInput.val('shouldnotmatchanything').keyup();
+      $filterInput.val('shouldnotmatchanything').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');
@@ -399,12 +399,12 @@ describe('GOVUK.OptionSelect', function() {
       $('#chemicals').prop('checked', true).change();
       jasmine.clock().tick(100);
 
-      $filterInput.val('electronics').keyup();
+      $filterInput.val('electronics').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(3);
       expect($count.html()).toBe('3 options found');
 
-      $filterInput.val('shouldnotmatchanything').keyup();
+      $filterInput.val('shouldnotmatchanything').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
       expect($count.html()).toBe('2 options found');
@@ -413,12 +413,12 @@ describe('GOVUK.OptionSelect', function() {
     it('matches a filter regardless of text case', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('electroNICS industry').keyup();
+      $filterInput.val('electroNICS industry').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $filterInput.val('Building and construction').keyup();
+      $filterInput.val('Building and construction').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -427,12 +427,12 @@ describe('GOVUK.OptionSelect', function() {
     it('matches ampersands correctly', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('Distribution & Service Industries').keyup();
+      $filterInput.val('Distribution & Service Industries').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $filterInput.val('Distribution &amp; Service Industries').keyup();
+      $filterInput.val('Distribution &amp; Service Industries').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');
@@ -441,7 +441,7 @@ describe('GOVUK.OptionSelect', function() {
     it('ignores whitespace around the user input', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('   Clothing, footwear and fashion    ').keyup();
+      $filterInput.val('   Clothing, footwear and fashion    ').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -450,7 +450,7 @@ describe('GOVUK.OptionSelect', function() {
     it('ignores duplicate whitespace in the user input', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('Clothing,     footwear      and      fashion').keyup();
+      $filterInput.val('Clothing,     footwear      and      fashion').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -459,7 +459,7 @@ describe('GOVUK.OptionSelect', function() {
     it('ignores common punctuation characters', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
+      $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -468,12 +468,12 @@ describe('GOVUK.OptionSelect', function() {
     it('normalises & and and', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('cows & llamas').keyup();
+      $filterInput.val('cows & llamas').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $filterInput.val('cows and llamas').keyup();
+      $filterInput.val('cows and llamas').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
@@ -483,12 +483,12 @@ describe('GOVUK.OptionSelect', function() {
     it('does not strip out numbers', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       var $count = $('#checkboxes-9b7ecc25-count');
-      $filterInput.val('1st and 2nd Military Courts').keyup();
+      $filterInput.val('1st and 2nd Military Courts').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found');
 
-      $filterInput.val('footwear and f23907234973204723094ashion').keyup();
+      $filterInput.val('footwear and f23907234973204723094ashion').keypress();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
       expect($count.html()).toBe('0 options found');

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -39,6 +39,7 @@ describe("liveSearch", function(){
                 '<input type="checkbox" name="field" value="sheep" checked>' +
                 '<label for="published_at">Published at</label>' +
                 '<input type="text" name="published_at" value="2004" />' +
+                '<input type="text" name="option-select-filter" value="notincluded"/>' +
                 sortList +
                 '<input type="submit" value="Filter results" class="button js-live-search-fallback"/>' +
               '</form>');
@@ -64,6 +65,7 @@ describe("liveSearch", function(){
 
   it("should save initial state", function(){
     expect(liveSearch.state).toEqual([{name: 'field', value: 'sheep'}, {name: 'published_at', value: '2004'}]);
+    expect(liveSearch.state).not.toEqual([{name: 'field', value: 'sheep'}, {name: 'published_at', value: '2004'}, {name: 'option-select-filter', value: 'notincluded'}]);
   });
 
   it("should detect a new state", function(){


### PR DESCRIPTION
We recently added a new form field to the `option select` component...

<img width="830" alt="Screen Shot 2019-02-27 at 10 11 08" src="https://user-images.githubusercontent.com/861310/54195383-6de56e80-44b6-11e9-8e1a-7f1a096e59b6.png">

Unfortunately the way the finders JS works is by serialising the whole form, which unintentionally included these inputs, resulting in `&filter=&filter=&filter=` being added to the URL and causing further problems.

This PR firstly modifies the `option select` component to create the filter input using JS (to solve this problem when JS is disabled, previously it was only hiding the element), and secondly updates the `live_search.js` code to explicitly filter out the `option select` filter inputs.

Huge thanks to @aliuk2012 for pairing on this 👍 