### PR TITLE
Adds in routes for upcoming and published stats

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -1,28 +1,41 @@
 class RedirectionController < ApplicationController
   def announcements
-    parameters = { keywords: params['keywords'],
-                  level_one_taxon: params['taxons'].try(:first),
-                  level_two_taxon: params['subtaxons'].try(:first),
-                  people: params['people'],
-                  organisations: params['departments'],
-                  world_locations: params['world_locations'],
-                  public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/news-and-communications', params: parameters)) }
-      format.atom { redirect_to(finder_path('search/news-and-communications', params: parameters, format: :atom)) }
+      format.html { redirect_to(finder_path('search/news-and-communications', params: convert_common_parameters)) }
+      format.atom { redirect_to(finder_path('search/news-and-communications', params: convert_common_parameters, format: :atom)) }
     end
   end
 
   def publications
-    parameters = { keywords: params['keywords'],
-                  level_one_taxon: params['taxons'].try(:first),
-                  level_two_taxon: params['subtaxons'].try(:first),
-                  organisations: params['departments'],
-                  world_locations: params['world_locations'],
-                  public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/all', params: parameters)) }
-      format.atom { redirect_to(finder_path('search/all', params: parameters, format: :atom)) }
+      format.html { redirect_to(finder_path('search/all', params: convert_common_parameters)) }
+      format.atom { redirect_to(finder_path('search/all', params: convert_common_parameters, format: :atom)) }
     end
+  end
+
+  def published_statistics
+    respond_to do |format|
+      format.html { redirect_to(finder_path('search/statistics', params: convert_common_parameters)) }
+      format.atom { redirect_to(finder_path('search/statistics', params: convert_common_parameters, format: :atom)) }
+    end
+  end
+
+  def upcoming_statistics
+    respond_to do |format|
+      format.html { redirect_to(finder_path('search/statistics', params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming))) }
+      format.atom { redirect_to(finder_path('search/statistics', params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming), format: :atom)) }
+    end
+  end
+
+private
+
+  def convert_common_parameters
+    { keywords: params['keywords'],
+      level_one_taxon: params['taxons'].try(:first) || params['topics'].try(:first),
+      level_two_taxon: params['subtaxons'].try(:first),
+      organisations: params['departments'] || params['organisations'],
+      people: params['people'],
+      world_locations: params['world_locations'],
+      public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,9 @@ FinderFrontend::Application.routes.draw do
 
   get '/redirect/publications' => 'redirection#publications'
 
+  get '/redirect/statistics' => 'redirection#published_statistics'
+
+  get '/redirect/statistics/announcements' => 'redirection#upcoming_statistics'
+
   get '/*slug' => 'finders#show', as: :finder
 end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -62,4 +62,57 @@ describe RedirectionController, type: :controller do
       expect(response).to redirect_to finder_path('search/all', format: :atom, params: { keywords: %w[one two] })
     end
   end
+
+  describe '#published_statistics' do
+    it "redirects to the statistics page" do
+      get :published_statistics
+      expect(response).to redirect_to finder_path('search/statistics')
+    end
+    it 'passes on a set of params' do
+      get :published_statistics, params: {
+        keywords: %w[one two],
+        taxons: %w[one],
+        departments: %w[one two],
+        from_date: '01/01/2014',
+        to_date: '01/01/2014'
+      }
+      expect(response).to redirect_to finder_path('search/statistics', params: {
+        keywords: %w[one two],
+        level_one_taxon: 'one',
+        organisations: %w[one two],
+        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+      })
+    end
+    it 'redirects to the atom feed' do
+      get :published_statistics, params: { keywords: %w[one two] }, format: :atom
+      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two] })
+    end
+  end
+
+  describe '#upcoming_statistics' do
+    it "redirects to the statistics page" do
+      get :upcoming_statistics
+      expect(response).to redirect_to finder_path('search/statistics', params: { content_store_document_type: :statistics_upcoming })
+    end
+    it 'passes on a set of params' do
+      get :upcoming_statistics, params: {
+        keywords: %w[one two],
+        topics: %w[one],
+        organisations: %w[one two],
+        from_date: '01/01/2014',
+        to_date: '01/01/2014'
+      }
+      expect(response).to redirect_to finder_path('search/statistics', params: {
+        keywords: %w[one two],
+        level_one_taxon: 'one',
+        organisations: %w[one two],
+        content_store_document_type: :statistics_upcoming,
+        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+      })
+    end
+    it 'redirects to the atom feed' do
+      get :upcoming_statistics, params: { keywords: %w[one two] }, format: :atom
+      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two], content_store_document_type: :statistics_upcoming })
+    end
+  end
 end


### PR DESCRIPTION
Adds additional redirect routes from the old statistics finder, converting the upcoming and published pages into equivalent radio button selections. There are some tests that will currently fail though, so this should not be merged yet!

Relates to https://trello.com/c/XxjGvJ63/493-handle-redirects-from-the-stats-finder