### PR TITLE
Refactor step definitions to prevent breaking others.

### DIFF
--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -108,7 +108,19 @@ When(/^I view the business readiness finder$/) do
   content_store_has_business_readiness_finder
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_business_readiness_results
-  stub_rummager_api_request_with_filtered_business_readiness_results
+  stub_rummager_api_request_with_filtered_business_readiness_results(
+    "q" => 'Keyword2'
+  )
+  stub_rummager_api_request_with_filtered_business_readiness_results(
+    "q" => 'Keyword1 Keyword2'
+  )
+  stub_rummager_api_request_with_filtered_business_readiness_results(
+    "filter_sector_business_area[0]" => "aerospace"
+  )
+  stub_rummager_api_request_with_filtered_business_readiness_results(
+    "filter_sector_business_area[0]" => "aerospace",
+    "q" => 'Keyword1 Keyword2'
+  )
 
   visit finder_path('find-eu-exit-guidance-business')
 end
@@ -571,8 +583,6 @@ Then(/^The (.*) checkbox in deselected$/) do |checkbox|
 end
 
 And(/^I fill in some keywords$/) do
-  stub_all_rummager_api_requests_with_business_finder_results
-
   fill_in 'Search', with: "Keyword1 Keyword2\n"
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -74,11 +74,11 @@ module DocumentHelper
       .to_return(body: business_readiness_results_json)
   end
 
-  def stub_rummager_api_request_with_filtered_business_readiness_results
+  def stub_rummager_api_request_with_filtered_business_readiness_results(filter_params)
     stub_request(
       :get,
       rummager_filtered_business_readiness_url(
-        "filter_sector_business_area[0]" => "aerospace",
+        filter_params
       )
     ).to_return(body: filtered_business_readiness_results_json)
   end


### PR DESCRIPTION
At present the `I fill in some keywords` step stubs all
rummager requests with the business finder results.

This causes unrelated scenarios to break when I change
the format of the business finder response to something
incompatible with those finders.

This commit refactors the stubbing of results for
business finder scenarios into the
`I view the business readiness finder` step.

Trello: https://trello.com/c/Sd7omEFH/263-mapping-rummager-request-response-in-finder-frontend