### PR TITLE
[Do not merge] Option 1: Fiddle tags for business finder

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -63,6 +63,7 @@ private
       default_attributes: { filter: default_filters, reject: default_rejects },
       subscription_list_title_prefix: content['details']['subscription_list_title_prefix'],
       available_choices: signup_presenter.choices,
+      signup_content_id: signup_content_id,
     )
   end
 
@@ -88,5 +89,9 @@ private
 
   def default_rejects
     content['details'].fetch('reject', {})
+  end
+
+  def signup_content_id
+    content['content_id']
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -8,6 +8,7 @@ class EmailAlertSignupAPI
     @subscription_list_title_prefix = dependencies.fetch(:subscription_list_title_prefix)
     @available_choices = dependencies.fetch(:available_choices)
     @default_attributes = dependencies.fetch(:default_attributes, filter: {}, reject: {})
+    @signup_content_id = dependencies.fetch(:signup_content_id)
   end
 
   def signup_url
@@ -20,7 +21,7 @@ class EmailAlertSignupAPI
 
 private
 
-  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :default_attributes
+  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :default_attributes, :signup_content_id
 
   def subscriber_list
     response = email_alert_api.find_or_create_subscriber_list(subscriber_list_options)

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -2,6 +2,8 @@ require 'email_alert_title_builder'
 require 'validate_query'
 
 class EmailAlertSignupAPI
+  BUSINESS_READINESS_SIGNUP_CONTENT_ID = "2818d67a-029a-4899-a438-a543d5c6a20d".freeze
+
   def initialize(dependencies = {})
     @email_alert_api = dependencies.fetch(:email_alert_api)
     @attributes = dependencies.fetch(:attributes)
@@ -97,6 +99,6 @@ private
   end
 
   def business_readiness_signup?
-    signup_content_id == "2818d67a-029a-4899-a438-a543d5c6a20d"
+    signup_content_id == BUSINESS_READINESS_SIGNUP_CONTENT_ID
   end
 end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -56,6 +56,8 @@ private
   end
 
   def tags
+    return business_readiness_tags if business_readiness_signup?
+
     @tags ||= massaged_attributes.each_with_object({}) { |(key, value), hash|
       if is_all_field?(key)
         hash[key[4..-1]] = { all: value }
@@ -88,5 +90,13 @@ private
     options["reject_content_purpose_supergroup"] = reject_content_purpose_supergroup if reject_content_purpose_supergroup.present?
 
     @validater ||= ::ValidateQuery.new(options)
+  end
+
+  def business_readiness_tags
+    { "appear_in_find_eu_exit_guidance_business_finder" => { "any" => %W(yes) } }
+  end
+
+  def business_readiness_signup?
+    signup_content_id == "2818d67a-029a-4899-a438-a543d5c6a20d"
   end
 end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -12,12 +12,15 @@ describe EmailAlertSignupAPI do
       default_attributes: default_attributes,
       available_choices: available_choices,
       subscription_list_title_prefix: subscription_list_title_prefix,
+      signup_content_id: signup_content_id,
     )
   end
 
   let(:default_attributes) do
     { filter: {}, reject: {} }
   end
+
+  let(:signup_content_id) { SecureRandom.uuid }
 
   describe "default_attributes" do
     context "no default_attributes or attributes" do

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -424,4 +424,50 @@ describe EmailAlertSignupAPI do
       end
     end
   end
+
+  describe "business readiness tags" do
+    context "business readiness finder signup page" do
+      let(:subscription_list_title_prefix) { "Business readiness" }
+      let(:attributes) { {} }
+      let(:available_choices) { {} }
+      let(:subscription_url) { "http://gov.uk/email/business-readiness-subscription" }
+      let(:signup_content_id) { "2818d67a-029a-4899-a438-a543d5c6a20d" }
+
+      it "will send email_alert_api the business_readiness_tags" do
+        email_alert_api_has_subscriber_list(
+          "tags" => { "appear_in_find_eu_exit_guidance_business_finder" => { "any" => %W(yes) } },
+          "subscription_url" => subscription_url,
+        )
+
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+          "tags" => { "appear_in_find_eu_exit_guidance_business_finder" => { "any" => %W(yes) } },
+          "title" => "Business readiness",
+        ).and_call_original
+
+        expect(subject.signup_url).to eql subscription_url
+      end
+    end
+
+    context "other finder signup pages" do
+      let(:subscription_list_title_prefix) { "Other finder" }
+      let(:attributes) { {} }
+      let(:available_choices) { {} }
+      let(:subscription_url) { "http://gov.uk/email/business-readiness-subscription" }
+      let(:signup_content_id) { "not-the-business-readiness-signup-content-id" }
+
+      it "will not send email_alert_api the business_readiness_tags" do
+        email_alert_api_has_subscriber_list(
+          "tags" => {},
+          "subscription_url" => subscription_url,
+        )
+
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+          "tags" => {},
+          "title" => "Other finder",
+        ).and_call_original
+
+        expect(subject.signup_url).to eql subscription_url
+      end
+    end
+  end
 end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -431,7 +431,7 @@ describe EmailAlertSignupAPI do
       let(:attributes) { {} }
       let(:available_choices) { {} }
       let(:subscription_url) { "http://gov.uk/email/business-readiness-subscription" }
-      let(:signup_content_id) { "2818d67a-029a-4899-a438-a543d5c6a20d" }
+      let(:signup_content_id) { described_class::BUSINESS_READINESS_SIGNUP_CONTENT_ID }
 
       it "will send email_alert_api the business_readiness_tags" do
         email_alert_api_has_subscriber_list(


### PR DESCRIPTION
Trello: https://trello.com/c/0rDl6oiK

## Motivation

The way email signups work for the business readiness finder is
changing. This is because the finder works differently to other finders.
Rather than narrowing the results, the finder expands them, doing an
"or" query rather than an "and". That is not how email-alert-api works.
It creates an "and" query from the facets it's passed.

This means that most users subscribed to the business readiness finders
were not receiving updates.

## What's changed

The content-item is being updated in a related commit to remove `email_filter_facets`, so users won't be forced to select a facet to subscribe to.

We need to pass
```
{ "appear_in_find_eu_exit_guidance_business_finder" => { "any" => %W(yes) } }
```
in the tags for the business readiness finder to create the subscription.

Ideally we would add `appear_in_find_eu_exit_guidance_business_finder` to the email-signup content item, however we tried many combinations of adding the tag and nothing worked.

### What didn't work

``` 
email_filter_by: appear_in_find_eu_exit_guidance_business_finder
```
(both with and without the subscription_title_prefix whitespace)
This returned `all-government-publishing-updates` as the subscription
topic_id

```
filter: "appear_in_find_eu_exit_guidance_business_finder"
```
(both with and without the subscription_title_prefix whitespace)
We had to add it to the content schemas. This also returned
`all-government-publishing-updates` as the subscription topic_id

```
facet_id: appear_in_find_eu_exit_guidance_business_finder
filter_key: "appear_in_find_eu_exit_guidance_business_finder"
filter_value: "yes"
facet_name: appear_in_find_eu_exit_guidance_business_finder
```
(both with and without the subscription_title_prefix whitespace)
This also returned `all-government-publishing-updates` as the
subscription topic_id
