### PR TITLE
Converts q parameter into keywords to work with Google Chrome

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,6 +56,11 @@ private
                              :format
                            )
 
+      # Convert a query with 'q=search_term' into 'keywords=search_term'
+      if permitted_params.has_key?("q")
+        permitted_params["keywords"] = permitted_params.delete("q")
+      end
+
       ParamsCleaner
         .new(permitted_params)
         .cleaned

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -28,6 +28,12 @@ Feature: Filtering documents
     Then I see all documents which contain the keywords
     And there is not a zero results message
 
+  Scenario: Filter document by keyword with q parameter
+    Given a collection of documents exist
+    When I visit a finder by keyword with q parameter
+    Then I see all documents which contain the keywords
+    And there is not a zero results message
+
   Scenario: Hiding keyword search
     Given no results
     When I view the finder with no keywords and no facets

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -177,6 +177,12 @@ Then(/^I see all documents which contain the keywords$/) do
   end
 end
 
+When(/^I visit a finder by keyword with q parameter$/) do
+  stub_keyword_search_api_request
+
+  visit finder_path('mosw-reports', q: @keyword_search)
+end
+
 Given(/^a government finder exists$/) do
   content_store_has_government_finder
   stub_rummager_api_request_with_government_results


### PR DESCRIPTION
This means Google Chrome users will be able to
tab into a search of GOV.UK and our new finders
will be able to understand this.

Trello: https://trello.com/c/hWcX9Feo/502-setup-q-as-a-synonym-for-keywords-in-finders-m