### PR TITLE
Fix minor option select issues

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -10,7 +10,7 @@
 
     this.$optionSelect = options.$el;
     this.$options = this.$optionSelect.find("input[type='checkbox']");
-    this.$optionsContainer = this.$optionSelect.find('.options-container');
+    this.$optionsContainer = this.$optionSelect.find('.js-options-container');
     this.$optionList = this.$optionsContainer.children('.js-auto-height-inner');
     this.$allCheckboxes = this.$optionsContainer.find('.govuk-checkboxes__item');
     this.hasFilter = this.$optionSelect.data('filter-element') || "";
@@ -131,14 +131,14 @@
     //Add type button to override default type submit when this component is used within a form
     $button.attr('type', 'button');
     $button.attr('aria-expanded', true);
-    $button.attr('aria-controls', this.$optionSelect.find('.options-container').attr('id'));
+    $button.attr('aria-controls', this.$optionsContainer.attr('id'));
     $button.html(jsContainerHeadHTML);
     $containerHead.replaceWith($button);
 
   };
 
   OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter(){
-    this.$optionSelect.find('.js-container-head').append('<div class="js-selected-counter">'+this.checkedString()+'</div>');
+    this.$optionSelect.find('.js-container-head').append('<div class="govuk-!-font-size-14 js-selected-counter">'+this.checkedString()+'</div>');
   };
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -16,33 +16,6 @@
     this.hasFilter = this.$optionSelect.data('filter-element') || "";
     this.checkedCheckboxes = [];
 
-    this.attachCheckedCounter();
-
-    // Performance in ie 6/7 is not good enough to support animating the opening/closing
-    // so do not allow option-selects to be collapsible in this case
-    var allowCollapsible = (typeof ieVersion == "undefined" || ieVersion > 7) ? true : false;
-    if(allowCollapsible){
-
-      // Attach listener to update checked count
-      this.$optionSelect.on('change', "input[type='checkbox']", this.updateCheckedCount.bind(this));
-
-      // Replace div.container-head with a button
-      this.replaceHeadWithButton();
-
-      // Add js-collapsible class to parent for CSS
-      this.$optionSelect.addClass('js-collapsible');
-
-      // Add open/close listeners
-      this.$optionSelect.find('.js-container-head').on('click', this.toggleOptionSelect.bind(this));
-
-      if (this.$optionSelect.data('closed-on-load') === true) {
-        this.close();
-      }
-      else {
-        this.setupHeight();
-      }
-    }
-
     if (this.hasFilter.length) {
       var filterEl = document.createElement('div');
       filterEl.innerHTML = this.hasFilter;
@@ -77,6 +50,33 @@
           e.preventDefault(); // prevents finder forms from being submitted when user presses ENTER
         }
       });
+    }
+
+    this.attachCheckedCounter();
+
+    // Performance in ie 6/7 is not good enough to support animating the opening/closing
+    // so do not allow option-selects to be collapsible in this case
+    var allowCollapsible = (typeof ieVersion == "undefined" || ieVersion > 7) ? true : false;
+    if(allowCollapsible){
+
+      // Attach listener to update checked count
+      this.$optionSelect.on('change', "input[type='checkbox']", this.updateCheckedCount.bind(this));
+
+      // Replace div.container-head with a button
+      this.replaceHeadWithButton();
+
+      // Add js-collapsible class to parent for CSS
+      this.$optionSelect.addClass('js-collapsible');
+
+      // Add open/close listeners
+      this.$optionSelect.find('.js-container-head').on('click', this.toggleOptionSelect.bind(this));
+
+      if (this.$optionSelect.data('closed-on-load') === true) {
+        this.close();
+      }
+      else {
+        this.setupHeight();
+      }
     }
   }
 
@@ -200,34 +200,33 @@
   };
 
   OptionSelect.prototype.getVisibleCheckboxes = function getVisibleCheckboxes(){
-    return this.$options.filter(this.isCheckboxVisible.bind(this));
+    var visibleCheckboxes = this.$options.filter(this.isCheckboxVisible.bind(this));
+    // add an extra checkbox, if the label of the first is too long it collapses onto itself
+    visibleCheckboxes = visibleCheckboxes.add(this.$options[visibleCheckboxes.length]);
+    return visibleCheckboxes;
   };
 
   OptionSelect.prototype.setupHeight = function setupHeight(){
     var initialOptionContainerHeight = this.$optionsContainer.height();
-    var height = this.$optionList.height();
+    var height = this.$optionList.outerHeight(true);
 
-    // check whether this is hidden by progressive disclosure on mobile,
+    // check whether this is hidden by progressive disclosure,
     // because height calculations won't work
     if (this.$optionsContainer[0].offsetParent === null) {
       initialOptionContainerHeight = 200;
       height = 200;
     }
 
-
     // Resize if the list is only slightly bigger than its container
     if (height < initialOptionContainerHeight + 50) {
-      this.setContainerHeight(height);
+      this.setContainerHeight(height + 1);
       return;
     }
 
     // Resize to cut last item cleanly in half
-    var lastVisibleCheckbox, position, topPadding;
-    lastVisibleCheckbox = this.getVisibleCheckboxes().last();
-    position = lastVisibleCheckbox.parent().position().top; // parent element is relative
-    topPadding = parseInt(this.$optionList.css('padding-top'), 10);
-
-    this.setContainerHeight(position + topPadding + lastVisibleCheckbox.height() / 2);
+    var lastVisibleCheckbox = this.getVisibleCheckboxes().last();
+    var position = lastVisibleCheckbox.parent().position().top; // parent element is relative
+    this.setContainerHeight(position + (lastVisibleCheckbox.height() / 1.5));
   };
 
   GOVUK.OptionSelect = OptionSelect;

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -42,11 +42,14 @@
 
   .options-container {
     position: relative;
-    padding: $gutter-one-quarter;
+    height: 200px;
     background-color: $page-colour;
     overflow-y: auto;
     overflow-x: hidden;
-    max-height: 200px;
+  }
+
+  .options-container__inner {
+    padding: $gutter-one-quarter;
   }
 
   .app-c-option-select__filter {
@@ -156,6 +159,10 @@
     width: 12px;
     height: 5px;
     border-width: 0 0 3px 3px;
+  }
+
+  .gem-c-checkboxes {
+    margin: 0;
   }
 }
 

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -1,7 +1,3 @@
-@import "govuk-frontend/helpers/focusable";
-@import "govuk-frontend/settings/measurements";
-@import "govuk-frontend/settings/colours-applied";
-
 .app-c-option-select {
   background-color: $grey-3;
   padding: 5px;
@@ -80,10 +76,9 @@
 }
 
 .app-c-option-select__label {
-  @include core-19;
+  @include govuk-font(19, $weight: bold);
   position: relative;
   margin-right: 40px;
-  font-weight: bold;
   padding-top: 5px;
 }
 
@@ -106,14 +101,14 @@
 }
 
 .app-c-option-select__container-inner {
-  padding: $gutter-one-quarter;
+  padding-top: govuk-spacing(1);
 }
 
 .app-c-option-select__filter {
   display: none;
 
   .govuk-form-group {
-    margin-bottom: $gutter-one-third;
+    padding-top: govuk-spacing(2);
   }
 }
 
@@ -123,7 +118,7 @@
   }
 
   .app-c-option-select__container {
-    border: 5px solid $grey-3;
+    border: 5px solid govuk-colour("grey-2");
   }
 
   .app-c-option-select__filter {
@@ -147,14 +142,14 @@
     cursor: pointer;
     margin-bottom: -1px;
     padding: 5px 8px;
-    background-color: $grey-3;
+    background-color: govuk-colour("grey-3");
 
     &:hover {
-      background-color: $grey-2;
+      background-color: govuk-colour("grey-2");
     }
 
     &:hover + .app-c-option-select__container {
-      border-color: $grey-2;
+      border-color: govuk-colour("grey-2");
     }
 
     &[disabled] {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -28,97 +28,6 @@
     outline: 3px solid $yellow;
   }
 
-  .container-head {
-    padding: 0 5px;
-  }
-
-  .option-select-label {
-    @include core-19;
-    position: relative;
-    margin-right: 40px;
-    font-weight: bold;
-    padding-top: 5px;
-  }
-
-  .options-container {
-    position: relative;
-    height: 200px;
-    background-color: $page-colour;
-    overflow-y: auto;
-    overflow-x: hidden;
-  }
-
-  .options-container__inner {
-    padding: $gutter-one-quarter;
-  }
-
-  .app-c-option-select__filter {
-    display: none;
-
-    .govuk-form-group {
-      margin-bottom: $gutter-one-third;
-    }
-  }
-
-  .js-enabled & {
-    padding: 0 0 1px;
-
-    .js-selected-counter {
-      @include core-14;
-    }
-
-    .options-container {
-      border: 5px solid $grey-3;
-    }
-
-    // styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse
-    &.js-collapsible {
-      .app-c-option-select__button {
-        position: relative;
-        z-index: 100;
-        border: none;
-        display: block;
-        width: 100%;
-        text-align: left;
-        cursor: pointer;
-        margin-bottom: -1px;
-        padding: 5px 8px;
-        background-color: $grey-3;
-
-        &:hover {
-          background-color: $grey-2;
-        }
-
-        &:hover + .options-container {
-          border-color: $grey-2;
-        }
-
-        &[disabled] {
-          background-image: none;
-          color: inherit;
-        }
-
-        &:focus {
-          @include govuk-focusable;
-        }
-      }
-
-      &.js-closed {
-        button {
-          background-position: right -73px;
-        }
-
-        .options-container {
-          display: none;
-        }
-      }
-    }
-
-    .app-c-option-select__filter {
-      display: block;
-    }
-  }
-
   // This is a temporary overwrite for checkboxes
   // These styles should be removed in favour of small checkboxes from the Design System
   .govuk-checkboxes__item {
@@ -166,6 +75,18 @@
   }
 }
 
+.app-c-option-select__container-head {
+  padding: 0 5px;
+}
+
+.app-c-option-select__label {
+  @include core-19;
+  position: relative;
+  margin-right: 40px;
+  font-weight: bold;
+  padding-top: 5px;
+}
+
 .app-c-option-select__icon {
   display: none;
   position: absolute;
@@ -176,16 +97,87 @@
   fill: currentColor;
 }
 
-.js-enabled .app-c-option-select__icon--up {
-  display: block;
+.app-c-option-select__container {
+  position: relative;
+  height: 200px;
+  background-color: $page-colour;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-.js-closed {
-  .app-c-option-select__icon--up {
-    display: none;
+.app-c-option-select__container-inner {
+  padding: $gutter-one-quarter;
+}
+
+.app-c-option-select__filter {
+  display: none;
+
+  .govuk-form-group {
+    margin-bottom: $gutter-one-third;
+  }
+}
+
+.js-enabled {
+  .app-c-option-select {
+    padding: 0 0 1px;
   }
 
-  .app-c-option-select__icon--down {
+  .app-c-option-select__container {
+    border: 5px solid $grey-3;
+  }
+
+  .app-c-option-select__filter {
     display: block;
+  }
+
+  .app-c-option-select__icon--up {
+    display: block;
+  }
+}
+
+// styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse
+.js-collapsible {
+  .app-c-option-select__button {
+    position: relative;
+    z-index: 100;
+    border: none;
+    display: block;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    margin-bottom: -1px;
+    padding: 5px 8px;
+    background-color: $grey-3;
+
+    &:hover {
+      background-color: $grey-2;
+    }
+
+    &:hover + .app-c-option-select__container {
+      border-color: $grey-2;
+    }
+
+    &[disabled] {
+      background-image: none;
+      color: inherit;
+    }
+
+    &:focus {
+      @include govuk-focusable;
+    }
+  }
+
+  &.js-closed {
+    .app-c-option-select__container {
+      display: none;
+    }
+
+    .app-c-option-select__icon--up {
+      display: none;
+    }
+
+    .app-c-option-select__icon--down {
+      display: block;
+    }
   }
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -10,8 +10,8 @@
 
 @import "reset";
 @import "grid";
-@import "components/*";
 @import "govuk_publishing_components/all_components";
+@import "components/*";
 
 #wrapper {
   display: block;

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div role="group" aria-labelledby="<%= title_id %>" class="options-container" id="<%= options_container_id %>">
-    <div class="js-auto-height-inner">
+    <div class="options-container__inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
       <% end %>

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -23,15 +23,15 @@
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
   <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >
-  <div class="container-head js-container-head">
-    <div class="option-select-label" id="<%= title_id %>">
+  <div class="app-c-option-select__container-head js-container-head">
+    <div class="app-c-option-select__label" id="<%= title_id %>">
       <%= title %>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
     </div>
   </div>
-  <div role="group" aria-labelledby="<%= title_id %>" class="options-container" id="<%= options_container_id %>">
-    <div class="options-container__inner js-auto-height-inner">
+  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>">
+    <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
       <% end %>

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -71,12 +71,12 @@ describe 'components/_option-select.html.erb', type: :view do
 
   it "renders a heading for the option select box containing the title" do
     render_component(option_select_arguments)
-    expect(rendered).to have_selector(".option-select-label", text: 'Market sector')
+    expect(rendered).to have_selector(".app-c-option-select__label", text: 'Market sector')
   end
 
   it "renders a container with the id passed in" do
     render_component(option_select_arguments)
-    expect(rendered).to have_selector("\#list-of-sectors.options-container")
+    expect(rendered).to have_selector("\#list-of-sectors.app-c-option-select__container")
   end
 
   it "can begin with the options box closed on load" do

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -4,10 +4,10 @@ describe('GOVUK.OptionSelect', function() {
 
   beforeEach(function(){
     optionSelectFixture = '<div class="app-c-option-select">'+
-      '<div class="container-head js-container-head">'+
-        '<div class="option-select-label">Market sector</div>'+
+      '<div class="app-c-option-select__container-head js-container-head">'+
+        '<div class="app-c-option-select__label">Market sector</div>'+
       '</div>'+
-      '<div class="options-container">'+
+      '<div class="app-c-option-select__container js-options-container">'+
         '<div class="js-auto-height-inner">'+
           '<div id="checkboxes-9b7ecc25" class="gem-c-checkboxes govuk-form-group" data-module="checkboxes">'+
             '<fieldset class="govuk-fieldset">'+
@@ -78,8 +78,8 @@ describe('GOVUK.OptionSelect', function() {
 
   it('instantiates a closed option-select if data-closed-on-load is true', function(){
     closedOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=true>' +
-                            '<div class="container-head js-container-head"></div>' +
-                            '<div class="options-container"></div>'+
+                            '<div class="app-c-option-select__container-head js-container-head"></div>' +
+                            '<div class="app-c-option-select__container js-options-container"></div>'+
                           '</div>';
     $closedOnLoadFixture = $(closedOnLoadFixture);
 
@@ -91,8 +91,8 @@ describe('GOVUK.OptionSelect', function() {
 
   it('instantiates an open option-select if data-closed-on-load is false', function(){
     openOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=false>' +
-                            '<div class="container-head js-container-head"></div>' +
-                            '<div class="options-container"></div>'+
+                            '<div class="app-c-option-select__container-head js-container-head"></div>' +
+                            '<div class="app-c-option-select__container js-options-container"></div>'+
                           '</div>';
     $openOnLoadFixture = $(openOnLoadFixture);
 
@@ -104,8 +104,8 @@ describe('GOVUK.OptionSelect', function() {
 
   it('instantiates an open option-select if data-closed-on-load is not present', function(){
     openOnLoadFixture = '<div class="app-c-option-select">' +
-                          '<div class="container-head js-container-head"></div>' +
-                            '<div class="options-container"></div>'+
+                          '<div class="app-c-option-select__container-head js-container-head"></div>' +
+                            '<div class="app-c-option-select__container js-options-container"></div>'+
                         '</div>';
     $openOnLoadFixture = $(openOnLoadFixture);
 
@@ -116,22 +116,22 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it ('sets the height of the options container as part of initialisation', function(){
-    expect($optionSelectHTML.find('.options-container').attr('style')).toContain('height');
+    expect($optionSelectHTML.find('.js-options-container').attr('style')).toContain('height');
   });
 
   it ('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function(){
     closedOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=true>' +
-                            '<div class="options-container"></div>' +
+                            '<div class="app-c-option-select__container js-options-container"></div>' +
                           '</div>';
     $closedOnLoadFixture = $(closedOnLoadFixture);
 
     $('body').append($closedOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
-    expect($closedOnLoadFixture.find('.options-container').attr('style')).not.toContain('height');
+    expect($closedOnLoadFixture.find('.js-options-container').attr('style')).not.toContain('height');
   });
 
   describe('replaceHeadWithButton', function(){
-    it ("replaces the `div.container-head` with a button", function(){
+    it ("replaces the `div.app-c-option-select__container-head` with a button", function(){
       expect($optionSelectHTML.find('button')).toBeDefined();
     });
   });
@@ -169,7 +169,7 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it ('calls setupHeight() if a height has not been set', function(){
-      $optionSelectHTML.find('.options-container').attr('style', '');
+      $optionSelectHTML.find('.js-options-container').attr('style', '');
       spyOn(optionSelect, "setupHeight");
       optionSelect.open();
       expect(optionSelect.setupHeight.calls.count()).toBe(1);
@@ -269,7 +269,7 @@ describe('GOVUK.OptionSelect', function() {
 
     beforeEach(function(){
       // Set some visual properties which are done in the CSS IRL
-      $checkboxList = $optionSelectHTML.find('.options-container');
+      $checkboxList = $optionSelectHTML.find('.js-options-container');
       $checkboxList.css({
         'height': 200,
         'position': 'relative',
@@ -318,7 +318,7 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('sets the height of the container sensibly', function(){
-      var containerHeight = $('.options-container').height();
+      var containerHeight = $('.js-options-container').height();
       expect(containerHeight).toBe(201);
     });
   });
@@ -340,7 +340,7 @@ describe('GOVUK.OptionSelect', function() {
       $('.wrapper').show();
       $optionSelectHTML.find('button').click();
 
-      var containerHeight = $('.options-container').height();
+      var containerHeight = $('.js-options-container').height();
       expect(containerHeight).toBeGreaterThan(200);
       expect(containerHeight).toBeLessThan(500);
     });

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -289,7 +289,8 @@ describe('GOVUK.OptionSelect', function() {
       optionSelect.setupHeight();
 
       // Wrapping HTML should adjust to fit inner height
-      expect($checkboxList.height()).toBe($checkboxListInner.height());
+      // but we add 1px because some browsers still add a scrollbar
+      expect($checkboxList.height()).toBe($checkboxListInner.height() + 1);
     });
 
     it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
@@ -318,7 +319,7 @@ describe('GOVUK.OptionSelect', function() {
 
     it('sets the height of the container sensibly', function(){
       var containerHeight = $('.options-container').height();
-      expect(containerHeight).toBe(200);
+      expect(containerHeight).toBe(201);
     });
   });
 


### PR DESCRIPTION
Several fixes for the `option select` component.

**Adjust option select height calculation:**

- put filter box append code before height calculation code, so height calculation includes filter box
- simplify height calculation code slightly
- change styles for container and content so padding and margin are less of a problem when calculating, fixes scroll being added when only three items and scroll not necessary bug
- change getVisibleCheckboxes to include the first non-visible checkbox, not the last visible one, needed for when only one checkbox with a really long label bug
- add + 1 to the height calculation to remove scrollbar on some browsers

**Refactor the CSS:**

- use proper BEM conventions for classes
- reduce nesting and improve clarity of CSS

Trello card: https://trello.com/c/NIYEeEwu/485-fix-minor-option-select-issues
