### PR TITLE
Change Google Chrome config to search with new finder

### DIFF
--- a/app/views/search/opensearch.xml
+++ b/app/views/search/opensearch.xml
@@ -2,5 +2,5 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
     <ShortName>GOV.UK</ShortName>
     <Description>Search GOV.UK - The best place to find government services and information.</Description>
-    <Url type="text/html" template="https://www.gov.uk/search?q={searchTerms}"/>
+    <Url type="text/html" template="https://www.gov.uk/search/all?keywords={searchTerms}"/>
 </OpenSearchDescription>


### PR DESCRIPTION
This tells Google Chrome that if users tab when typing 'gov.uk' to
use the new finder and the correct parameter

Trello: https://trello.com/c/Rr6BrjXi/453-configure-chrome-address-bar-search-to-know-where-our-site-search-is-s

Relies on #947 - DO NOT MERGE until that is deployed