### PR TITLE
Remove reject_content_purpose_supergroup as email signup field

### DIFF
--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -34,7 +34,6 @@ private
     }
 
     options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
-    options["reject_content_purpose_supergroup"] = reject_content_purpose_supergroup if reject_content_purpose_supergroup.present?
     options
   end
 
@@ -48,10 +47,6 @@ private
 
   def content_purpose_supergroup
     massaged_attributes['content_purpose_supergroup'] || default_attributes[:filter]['content_purpose_supergroup']
-  end
-
-  def reject_content_purpose_supergroup
-    massaged_attributes['reject_content_purpose_supergroup'] || default_attributes[:reject]['content_purpose_supergroup']
   end
 
   def tags
@@ -84,7 +79,6 @@ private
   def validater
     options = massaged_attributes
     options["content_purpose_supergroup"] = content_purpose_supergroup if content_purpose_supergroup.present?
-    options["reject_content_purpose_supergroup"] = reject_content_purpose_supergroup if reject_content_purpose_supergroup.present?
 
     @validater ||= ::ValidateQuery.new(options)
   end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -82,13 +82,11 @@ describe EmailAlertSubscriptionsController, type: :controller do
           "tags" => {
             "format" => { any: %w(mosw_report) },
           },
-          "reject_content_purpose_supergroup" => 'other',
           "subscription_url" => 'http://www.example.com',
         )
 
         stub_validation_of_valid_query(
           'filter_format[]' => 'mosw_report',
-          'reject_content_purpose_supergroup' => 'other',
         )
 
         post :create, params: { slug: 'cma-cases' }

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -61,14 +61,12 @@ describe EmailAlertSignupAPI do
             "tags" => {},
             "subscription_url" => subscription_url,
             "content_purpose_supergroup" => "news_and_communications",
-            "reject_content_purpose_supergroup" => "other",
           )
 
           expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
             "tags" => {},
             "title" => "News and communications",
             "content_purpose_supergroup" => "news_and_communications",
-            "reject_content_purpose_supergroup" => "other",
           ).and_call_original
 
           expect(subject.signup_url).to eql subscription_url


### PR DESCRIPTION
This is no longer required.

https://trello.com/c/45eoS6mj/491-remove-rejectcontentpurposesupergroup-functionality-from-email-alert-api-m-%F0%9F%98%AD

Added in https://github.com/alphagov/finder-frontend/pull/862