### PR TITLE
Use Policy papers & consultations finder from Rummager

### DIFF
--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -172,8 +172,6 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
-    "/search/policy-papers-and-consultations" => 'policy_and_engagement',
-    "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
     "/search/statistics" => "statistics"
   }.freeze
 


### PR DESCRIPTION
Policy papers & consultations finder is now part of rummager so these two lines are no longer needed