### PR TITLE
Pass business readiness finder tag as hidden field

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -28,6 +28,20 @@ class SignupPresenter
     choices? && choices_formatted.any?
   end
 
+  def hidden_choices
+    hidden_choices = choices.map do |choice|
+      if ignore_facet?(choice["facet_id"])
+        choice['facet_choices'].map do |facet_choice|
+          {
+            name: "filter[#{choice['facet_id']}][]",
+            value: facet_choice["key"],
+          }
+        end
+      end
+    end
+    hidden_choices.flatten
+  end
+
   def choices?
     multiple_facet_choice_data.present? || single_facet_choice_data[0]["facet_choices"].present?
   end
@@ -96,5 +110,9 @@ private
     return nil unless email_filter_name
 
     (email_filter_name["plural"] || email_filter_name).capitalize
+  end
+
+  def ignore_facet?(facet_id)
+    %W(appear_in_find_eu_exit_guidance_business_finder).include?(facet_id)
   end
 end

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -10,8 +10,15 @@
 <div class="outer-block">
   <div class="signup-content">
     <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices form' do %>
-
-      <% if @signup_presenter.can_modify_choices? %>
+      <% if @signup_presenter.hidden_choices.any? %>
+        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+          title: @signup_presenter.name,
+          context: "Email alert subscription"
+        } %>
+        <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
+          <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
+        <% end %>
+      <% elsif @signup_presenter.can_modify_choices? %>
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: nil,
           heading: @signup_presenter.name,

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -234,10 +234,12 @@ Feature: Filtering documents
     When I use a checkbox filter and another disallowed filter
     Then I can sign up to email alerts for allowed filters
 
+  @javascript
   Scenario: Subscribing to email alerts for business readiness finder
     When I view the business readiness finder
     And I create an email subscription
-    Then I see the email subscription page  
+    Then I see the email subscription page
+    And I cannot select any filters
 
   @javascript
   Scenario: Filter documents by keywords and sort by most relevant

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -234,6 +234,11 @@ Feature: Filtering documents
     When I use a checkbox filter and another disallowed filter
     Then I can sign up to email alerts for allowed filters
 
+  Scenario: Subscribing to email alerts for business readiness finder
+    When I view the business readiness finder
+    And I create an email subscription
+    Then I see the email subscription page  
+
   @javascript
   Scenario: Filter documents by keywords and sort by most relevant
     When I view the news and communications finder

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -1,0 +1,19 @@
+{
+  "base_path": "/find-eu-exit-guidance-business/email-signup",
+  "content_id": "2818d67a-029a-4899-a438-a543d5c6a20d",
+  "document_type": "finder_email_signup",
+  "title": "Find EU Exit guidance for your business",
+  "description": "You'll get an email each time EU Exit guidance is published.",
+  "details": {
+    "email_filter_by": "appear_in_find_eu_exit_guidance_business_finder",
+    "email_filter_name": "appear_in_find_eu_exit_guidance_business_finder",
+    "email_signup_choice": [
+      {
+        "key": "yes",
+        "radio_button_name": "yes",
+        "prechecked": true
+      }
+    ],
+    "subscription_list_title_prefix": "Find EU Exit guidance for your business"
+  }
+}

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -662,6 +662,10 @@ Then("I see the email subscription page") do
   expect(page).to have_button("Create subscription")
 end
 
+Then("I cannot select any filters") do
+  find("input[name='filter[appear_in_find_eu_exit_guidance_business_finder][]']", visible: false)
+end
+
 Then("I should see results in the default group") do
   within("#js-results .filtered-results__group") do
     expect(page).to have_css("h2.filtered-results__facet-heading", text: "All businesses")

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -106,6 +106,7 @@ end
 
 When(/^I view the business readiness finder$/) do
   content_store_has_business_readiness_finder
+  content_store_has_business_readiness_email_signup
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_business_readiness_results
   stub_rummager_api_request_with_filtered_business_readiness_results(
@@ -650,6 +651,15 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
     expect(page.status_code).to eq(302)
     expect(page.response_headers['Location']).to eql('http://www.rathergood.com')
   end
+end
+
+When("I create an email subscription") do
+  click_link('Get email alerts')
+end
+
+Then("I see the email subscription page") do
+  visit finder_path('find-eu-exit-guidance-business/email-signup')
+  expect(page).to have_button("Create subscription")
 end
 
 Then("I should see results in the default group") do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -278,6 +278,12 @@ module DocumentHelper
     content_store_has_item('/find-eu-exit-guidance-business', finder_fixture)
   end
 
+  def content_store_has_business_readiness_email_signup
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'business_readiness_email_signup.json'))
+
+    content_store_has_item('/find-eu-exit-guidance-business/email-signup', finder_fixture)
+  end
+
   def search_params(params = {})
     default_search_params.merge(params).to_a.map { |tuple|
       tuple.join("=")

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -68,7 +68,12 @@ private
   end
 
   def selected_facets
-    facets.select { |facet| filter[facet["facet_id"]].present? || filter[facet["filter_key"]].present? }
+    facets.select do |facet|
+      (
+        filter[facet["facet_id"]].present? && !ignore_facet?(facet["facet_id"])
+      ) ||
+        filter[facet["filter_key"]].present?
+    end
   end
 
   def grouped_facets
@@ -131,5 +136,9 @@ private
 
   def is_brexit?(registry, content_id)
     registry.is_a?(Registries::TopicTaxonomyRegistry) && content_id == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+  end
+
+  def ignore_facet?(facet_id)
+    %W(appear_in_find_eu_exit_guidance_business_finder).include?(facet_id)
   end
 end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -419,4 +419,47 @@ describe EmailAlertSignupAPI do
       end
     end
   end
+
+  describe "business readiness tags" do
+    context "with the tags done right" do
+      let(:attributes) do
+        {
+          "filter" => {
+              "appear_in_find_eu_exit_guidance_business_finder" => %w(yes),
+          },
+        }
+      end
+      let(:subscription_list_title_prefix) { "Business readiness" }
+      let(:available_choices) do
+        [
+          {
+            "facet_id" => "appear_in_find_eu_exit_guidance_business_finder",
+            "facet_name" => "appear_in_find_eu_exit_guidance_business_finder",
+          }
+        ]
+      end
+      let(:subscription_url) { "http://gov.uk/email/business-readiness-subscription" }
+      let(:signup_content_id) { "not-the-business-readiness-signup-content-id" }
+
+      before do
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "appear_in_find_eu_exit_guidance_business_finder" => { any: %w(yes) },
+          },
+          "subscription_url" => subscription_url
+        )
+      end
+
+      it 'asks email-alert-api to find or create the subscriber list' do
+        expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+          "tags" => {
+            "appear_in_find_eu_exit_guidance_business_finder" => { any: %w(yes) },
+          },
+          "title" => "Business readiness",
+        ).and_call_original
+
+        expect(subject.signup_url).to eql subscription_url
+      end
+    end
+  end
 end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -30,4 +30,8 @@ module FixturesHelper
   def cma_cases_with_multi_facets_signup_content_item
     JSON.parse(File.read(fixtures_path + "/cma_cases_with_multi_facets_signup_content_item.json"))
   end
+
+  def business_readiness_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/business_readiness_email_signup.json"))
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/0rDl6oiK

Supersedes: PR #946

## Motivation

The way email signups work for the business readiness finder is
changing. This is because the finder works differently to other finders.
Rather than narrowing the results, the finder expands them, doing an
"or" query rather than an "and". That is not how email-alert-api works.
It creates an "and" query from the facets it's passed.

This means that most users subscribed to the business readiness finders
were not receiving updates.

## What's changed

The assumption is that "appear_in_find_eu_exit_guidance_business_finder" will be added to the email-signup content item:

```
    "email_filter_by": "appear_in_find_eu_exit_guidance_business_finder",
    "email_filter_name": "appear_in_find_eu_exit_guidance_business_finder",
    "email_signup_choice": [
      {
        "key": "yes",
        "radio_button_name": "yes",
        "prechecked": true
      }
    ],
```

As "email_signup_choice" has to be populated to get the value of "yes", the checkbox form will be rendered.  Additional code has been be added to hide the checkbox field, but still pass in the facet values to EmailAlertSignupAPI.