### PR TITLE
Hide organisation metadata in Services and All content finders

### DIFF
--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -22,7 +22,7 @@
         "type": "taxon"
       },
       {
-        "display_as_result_metadata": true,
+        "display_as_result_metadata": false,
         "filterable": true,
         "key": "organisations",
         "name": "Organisation",

--- a/features/fixtures/services.json
+++ b/features/fixtures/services.json
@@ -22,7 +22,7 @@
         "type": "taxon"
       },
       {
-        "display_as_result_metadata": true,
+        "display_as_result_metadata": false,
         "filterable": true,
         "key": "organisations",
         "name": "Organisation",


### PR DESCRIPTION
Hide organisation metadata in Services and All content finders

Trello: https://trello.com/c/GlohunbM/519-remove-org-metadata-from-mainstream-results-in-all-content-and-services-finders