### PR TITLE
Statistics finder email signup page

### DIFF
--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -1,7 +1,36 @@
 module Filters
   class RadioFilter < Filter
     def value
-      parsed_value
+      return default_value unless acceptable_param?
+
+      return option_lookup_values(params) if multi_value?
+
+      Array(params)
+    end
+
+  private
+
+    def default_value
+      return option_lookup_values(default_allowed_value) if multi_value?
+
+      Array(default_allowed_value)
+    end
+
+    def option_lookup_values(val)
+      option_lookup.select { |key, _| val.include? key }.values.flatten
+    end
+
+    def default_allowed_value
+      @default_allowed_value ||= facet['allowed_values'].find(Proc.new { {} }) { |option| option['default'] }
+      @default_allowed_value['value']
+    end
+
+    def acceptable_param?
+      params.present? && params.is_a?(String) && param_is_part_of_allowed_values
+    end
+
+    def param_is_part_of_allowed_values
+      facet['allowed_values'].find { |option| option['value'] == params }.present?
     end
   end
 end

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -11,6 +11,8 @@ module Filters
   private
 
     def default_value
+      return [] if default_allowed_value.blank?
+
       return option_lookup_values(default_allowed_value) if multi_value?
 
       Array(default_allowed_value)

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -30,7 +30,7 @@ module Filters
     end
 
     def param_is_part_of_allowed_values
-      facet['allowed_values'].find { |option| option['value'] == params }.present?
+      facet['allowed_values'].any? { |option| option['value'] == params }
     end
   end
 end

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -172,7 +172,10 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
-    "/search/statistics" => "statistics"
+    "/search/policy-papers-and-consultations" => 'policy_and_engagement',
+    "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
+    "/search/statistics" => "statistics",
+    "/search/statistics/email-signup" => "statistics_email_signup",
   }.freeze
 
   def development_env_finder_json

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -12,11 +12,7 @@ class RadioFacet < FilterableFacet
 private
 
   def selected_value
-    return default_value if @value.nil?
-
-    allowed_values.find { |option|
-      @value == option['value']
-    } || {}
+    allowed_values.find { |option| @value == option['value'] } || default_value
   end
 
   def default_value

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -1,4 +1,8 @@
 class RadioFacet < FilterableFacet
+  def value
+    @value || default_value['value']
+  end
+
   def options
     allowed_values.map do |allowed_value|
       {
@@ -9,6 +13,14 @@ class RadioFacet < FilterableFacet
     end
   end
 
+  def has_filters?
+    selected_value.present?
+  end
+
+  def sentence_fragment
+    return nil if hide_facet_tag?
+  end
+
 private
 
   def selected_value
@@ -16,6 +28,6 @@ private
   end
 
   def default_value
-    allowed_values.find { |option| option['default'] } || {}
+    @default_value ||= allowed_values.find { |option| option['default'] } || {}
   end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -71,7 +71,7 @@ class FinderPresenter
     signup_link = content_item['details']['signup_link']
     return signup_link if signup_link.present?
 
-    "#{email_alert_signup['web_url']}?#{email_alert_filter_query}" if email_alert_signup
+    "#{email_alert_signup['web_url']}#{alert_query_string}" if email_alert_signup
   end
 
   def facets
@@ -217,7 +217,7 @@ class FinderPresenter
   end
 
   def atom_url
-    ["#{slug}.atom", values.to_query].reject(&:blank?).join("?") if atom_feed_enabled?
+    "#{slug}.atom#{alert_query_string}" if atom_feed_enabled?
   end
 
   def description
@@ -271,7 +271,7 @@ private
     URI.parse(href).host != "www.gov.uk"
   end
 
-  def email_alert_filter_query
+  def alert_query_string
     facets_with_filters = facets.select(&:has_filters?)
 
     facets_with_values = facets_with_filters.reject { |facet|
@@ -284,7 +284,8 @@ private
       hash[facet.key] = facet.value
     }
 
-    filtered_values.to_query
+    query_string = filtered_values.to_query
+    query_string.blank? ? query_string : "?#{query_string}"
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -20,15 +20,28 @@
   "user_journey_document_supertype":"finding",
   "withdrawn_notice":{},
   "publishing_request_id":"",
-  "links":{},
+  "links":{
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/search/statistics/email-signup",
+        "base_path": "/search/statistics/email-signup",
+        "content_id": "119db584-0ae7-45e4-8f3a-fd79316c6921",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2019-03-14T10:22:17Z",
+        "schema_name": "finder_email_signup",
+        "title": "Statistics",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/policy-papers-and-consultations/email-signup",
+        "web_url": "/search/statistics/email-signup"
+      }
+    ]
+  },
   "description":"Find statistics from government",
   "details":{
     "document_noun":"statistic",
-    "filter":{
-      "content_store_document_type": [
-        "statistics","national_statistics","statistical_data_set","official_statistics"
-      ]
-    },
+    "filter":{},
     "format_name":"statistic",
     "show_summaries":true,
     "sort": [

--- a/features/fixtures/statistics_email_signup.json
+++ b/features/fixtures/statistics_email_signup.json
@@ -1,0 +1,42 @@
+{
+  "base_path": "/search/statistics/email-signup",
+  "content_id": "119db584-0ae7-45e4-8f3a-fd79316c6921",
+  "document_type": "finder_email_signup",
+  "title": "Statistics",
+  "description": "You'll get an email each time statistics are published.",
+  "details": {
+    "filter": {},
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Statistics",
+    "email_filter_facets": [
+      {
+        "facet_id": "content_store_document_type",
+        "facet_name": "document types",
+        "option_lookup": {
+          "statistics_published": ["statistics", "national_statistics", "statistical_data_set", "official_statistics"],
+          "statistics_upcoming": ["statistics_announcement", "national_statistics_announcement", "official_statistics_announcement"],
+          "research": ["dfid_research_output", "independent_report", "research"]
+        }
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -52,13 +52,13 @@ Then(/^I can get a list of all documents with matching metadata$/) do
 end
 
 And("I see email and feed sign up links") do
-  expect(page).to have_css('a[href="/search/news-and-communications/email-signup?"]')
+  expect(page).to have_css('a[href="/search/news-and-communications/email-signup"]')
   expect(page).to have_css('a[href="/search/news-and-communications.atom"]')
 end
 
 And("I see email and feed sign up links with filters applied") do
   expect(page).to have_css('a[href="/search/news-and-communications/email-signup?people%5B%5D=rufus-scrimgeour"]')
-  expect(page).to have_css('a[href="/search/news-and-communications.atom?order=updated-newest&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D="]')
+  expect(page).to have_css('a[href="/search/news-and-communications.atom?people%5B%5D=rufus-scrimgeour"]')
 end
 
 And("I see email and feed sign up links with filters applied with extra empty filters") do

--- a/spec/lib/filters/radio_filter_spec.rb
+++ b/spec/lib/filters/radio_filter_spec.rb
@@ -151,8 +151,19 @@ describe Filters::RadioFilter do
 
       context "when a disallowed value is provided" do
         let(:params) { "does_not_exist" }
-        it "should return the corresponding default values from the option_lookup" do
-          expect(radio_filter.value).to eq(%w(guidance))
+
+        context "when a default value is set" do
+          it "should return the corresponding default values from the option_lookup" do
+            expect(radio_filter.value).to eq(%w(guidance))
+          end
+        end
+
+        context "when a default value is not set" do
+          let(:allowed_values) { [] }
+
+          it "should return an empty array" do
+            expect(radio_filter.value).to eq([])
+          end
         end
       end
 

--- a/spec/lib/filters/radio_filter_spec.rb
+++ b/spec/lib/filters/radio_filter_spec.rb
@@ -5,28 +5,74 @@ describe Filters::RadioFilter do
     Filters::RadioFilter.new(facet, params)
   }
 
-  let(:facet) { double }
+  let(:facet) { { "allowed_values" => allowed_values } }
   let(:params) { nil }
+  let(:default_value) { %w(policy_papers) }
+  let(:option_lookup) {
+    { "open_consultations" => %w(open closed), "policy_papers" => %w(guidance) }
+  }
+  let(:allowed_values) {
+    [
+      {
+        "label" => "Policy papers",
+        "value" => "policy_papers",
+        "default" => true
+      },
+      {
+        "label" => "Consultations (open)",
+        "value" => "open_consultations"
+      },
+      {
+        "label" => "Consultations (closed)",
+        "value" => "closed_consultations"
+      }
+    ]
+  }
 
   describe "#active?" do
-    context "when params is nil" do
-      it "should be false" do
-        expect(radio_filter).not_to be_active
+    context "when no default allowed value is set" do
+      let(:allowed_values) { [] }
+
+      context "when params is nil" do
+        it "should be false" do
+          expect(radio_filter).not_to be_active
+        end
+      end
+
+      context "when params is empty" do
+        let(:params) { [] }
+
+        it "should be false" do
+          expect(radio_filter).not_to be_active
+        end
       end
     end
 
-    context "when params is empty" do
-      let(:params) { [] }
+    context "when a default allowed value is set" do
+      context "when params is nil" do
+        it "should be true" do
+          expect(radio_filter).to be_active
+        end
+      end
 
-      it "should be false" do
-        expect(radio_filter).not_to be_active
+      context "when params is an array" do
+        let(:params) { [] }
+
+        it "should be true" do
+          expect(radio_filter).to be_active
+        end
       end
     end
   end
 
   describe "#key" do
     context "when a filter_key is present" do
-      let(:facet) { { "filter_key" => "alpha", "key" => "beta" } }
+      let(:facet) {
+        {
+          "filter_key" => "alpha", "key" => "beta",
+          "allowed_values" => allowed_values
+        }
+      }
 
       it "returns filter_key" do
         expect(radio_filter.key).to eq("alpha")
@@ -34,7 +80,12 @@ describe Filters::RadioFilter do
     end
 
     context "when a filter_key is not present" do
-      let(:facet) { { "key" => "beta" } }
+      let(:facet) {
+        {
+          "key" => "beta",
+          "allowed_values" => allowed_values
+        }
+      }
 
       it "returns key" do
         expect(radio_filter.key).to eq("beta")
@@ -43,39 +94,73 @@ describe Filters::RadioFilter do
   end
 
   describe "#value" do
-    context "when params is present and option_lookup is absent" do
-      let(:params) { %w(alpha) }
-      let(:facet) { {} }
+    context "without option lookup" do
+      context "when an allowed option is provided" do
+        let(:params) { "open_consultations" }
 
-      it "should contain all values" do
-        expect(radio_filter.value).to eq(%w(alpha))
+        it "should return the option as an array" do
+          expect(radio_filter.value).to eq(%w(open_consultations))
+        end
+      end
+
+      context "when no option is provided and a default value is set" do
+        it "should return the default value" do
+          expect(radio_filter.value).to eq(default_value)
+        end
+      end
+
+      context "when the option is not a string and a default value is set" do
+        let(:params) { [] }
+
+        it "should return the default value" do
+          expect(radio_filter.value).to eq(default_value)
+        end
+      end
+
+      context "when a disallowed param is provided" do
+        let(:params) { "does_not_exist" }
+
+        context "a default option is set" do
+          it "should return the default value" do
+            expect(radio_filter.value).to eq(default_value)
+          end
+        end
+
+        context "a default option is NOT provided" do
+          let(:allowed_values) { [] }
+          it "should return an empty array" do
+            expect(radio_filter.value).to eq([])
+          end
+        end
       end
     end
 
-    context "when params is present and option_lookup is empty" do
-      let(:params) { %w(does_not_exist) }
-      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+    context "with option lookup" do
+      let(:facet) {
+        {
+          "option_lookup" => option_lookup,
+          "allowed_values" => allowed_values
+        }
+      }
 
-      it "should contain no values" do
-        expect(radio_filter.value).to eq([])
+      context "when no option is selected" do
+        it "should return the corresponding default values from the option_lookup" do
+          expect(radio_filter.value).to eq(%w(guidance))
+        end
       end
-    end
 
-    context "when params is present and option_lookup is present" do
-      let(:params) { %w(policy_papers) }
-      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
-
-      it "should contain all values" do
-        expect(radio_filter.value).to eq(%w(guidance))
+      context "when a disallowed value is provided" do
+        let(:params) { "does_not_exist" }
+        it "should return the corresponding default values from the option_lookup" do
+          expect(radio_filter.value).to eq(%w(guidance))
+        end
       end
-    end
 
-    context "when params has multiple values and option_lookup is present" do
-      let(:params) { %w(policy_papers does_not_exist consultations) }
-      let(:facet) { { "option_lookup" => { "consultations" => %w(open closed), "policy_papers" => %w(guidance) } } }
-
-      it "should contain all values" do
-        expect(radio_filter.value).to eq(%w(open closed guidance))
+      context "when an allowed option is selected" do
+        let(:params) { "open_consultations" }
+        it "should return the corresponding values from the option_lookup" do
+          expect(radio_filter.value).to eq(%w(open closed))
+        end
       end
     end
   end

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe FinderPresenter do
 
   describe "#email_alert_signup_url" do
     context "with no values" do
-      it "returns the finder URL appended with /email-signup?" do
-        expect(presenter.email_alert_signup_url).to eql("https://www.gov.uk/mosw-reports/email-signup?")
+      it "returns the finder URL appended with /email-signup" do
+        expect(presenter.email_alert_signup_url).to eql("https://www.gov.uk/mosw-reports/email-signup")
       end
     end
 
@@ -119,13 +119,15 @@ RSpec.describe FinderPresenter do
       let(:values) do
         {
           keyword: "legal",
-          format: "publication",
-          state: "open",
+          place_of_origin: "england",
+          walk_type: "open",
+          creator: "Harry Potter",
+          unpermitted_facet: "blah_blah",
         }
       end
 
-      it "returns the finder URL appended with .atom and query params" do
-        expect(presenter.atom_url).to eql("/mosw-reports.atom?format=publication&keyword=legal&state=open")
+      it "returns the finder URL appended with permitted query params" do
+        expect(presenter.atom_url).to eql("/mosw-reports.atom?place_of_origin%5B%5D=england")
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/mMPcqr2x/509-default-finder-radio-button-should-always-be-applied
https://trello.com/c/5oag3R25/288-publish-statistics-finder-from-rummager-s

This is the final step to enable us to publish the new stats finder.

Changes:
- Adds email signup page for testing
- Bugfix: the Radio facet & filter will now use a provided default value when unset
- Bugfix: the query strings for email alerts and atom feeds will be correct on first page load.

Reviewing by commit will be easier - see commit messages.