### PR TITLE
Use release_timestamp for atom feed entries

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,7 @@
 class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
-              :content_purpose_supergroup, :document_type, :organisations
+              :content_purpose_supergroup, :document_type, :organisations,
+              :release_timestamp
 
   def initialize(rummager_document, finder)
     rummager_document = rummager_document.with_indifferent_access
@@ -8,6 +9,7 @@ class Document
     @link = rummager_document.fetch(:link)
     @description = rummager_document.fetch(:description, nil)
     @public_timestamp = rummager_document.fetch(:public_timestamp, nil)
+    @release_timestamp = rummager_document.fetch(:release_timestamp, nil)
     @document_type = rummager_document.fetch(:content_store_document_type, nil)
     @organisations = rummager_document.fetch(:organisations, [])
     @content_purpose_supergroup = rummager_document.fetch(:content_purpose_supergroup, nil)

--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -18,7 +18,7 @@ class AtomPresenter
 
   def entries
     finder.results.documents
-    .reject { |d| d.public_timestamp.blank? }
+    .reject { |d| d.public_timestamp.blank? && d.release_timestamp.blank? }
     .map { |d| EntryPresenter.new(d) }
   end
 

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -15,7 +15,7 @@ class EntryPresenter
   end
 
   def updated_at
-    Time.zone.parse(entry.public_timestamp)
+    Time.zone.parse(entry.public_timestamp || entry.release_timestamp)
   end
 
   def self.feed_ended_id(schema, base_path)


### PR DESCRIPTION
If public_timestamp is not available we will try to use release_timestamp. This is only useful for upcoming stats which don't have a public timestamp, but do have a release timestamp.

https://trello.com/c/8D4Y1ye5/522-fix-upcoming-stats-atom-feed

View the change at: `/search/statistics?parent=&keywords=&level_one_taxon=&content_store_document_type=statistics_upcoming&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest`