### PR TITLE
Toggle all content facets

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -379,23 +379,34 @@
 
 .facet-toggle {
   display: none;
+  margin-bottom: $gutter;
 }
 
 .js-enabled {
   .facet-toggle {
     display: inline-block;
-    margin-bottom: $gutter;
+  }
 
-    @include media(tablet) {
+  .facet-toggle__content {
+    display: block;
+
+    &.facet-toggle__content--hide {
       display: none;
     }
   }
 
-  .facet-toggle__content--hidden {
-    display: none;
+  .facet-toggle--only-on-mobile {
+    .facet-toggle {
+      @include media(tablet) {
+        display: none;
+      }
+    }
 
-    @include media(tablet) {
-      display: block;
+    .facet-toggle__content.facet-toggle__content--hide {
+      @include media(tablet) {
+        display: block;
+      }
     }
   }
 }
+

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -176,6 +176,7 @@ private
     "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
     "/search/statistics" => "statistics",
     "/search/statistics/email-signup" => "statistics_email_signup",
+    "/search/all" => "all_content"
   }.freeze
 
   def development_env_finder_json

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -175,8 +175,7 @@ private
     "/search/policy-papers-and-consultations" => 'policy_and_engagement',
     "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
     "/search/statistics" => "statistics",
-    "/search/statistics/email-signup" => "statistics_email_signup",
-    "/search/all" => "all_content"
+    "/search/statistics/email-signup" => "statistics_email_signup"
   }.freeze
 
   def development_env_finder_json

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -37,6 +37,10 @@ class FinderPresenter
     content_item['details']['document_noun']
   end
 
+  def hide_facets_by_default
+    content_item['details']['hide_facets_by_default'] || false
+  end
+
   def human_readable_finder_format
     content_item['details']['human_readable_finder_format']
   end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -17,9 +17,7 @@
   </div>
 
   <% if facet_collection.filters.any? %>
-    <% facet_toggle_only_on_mobile = true %>
-
-    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hide" <%= "class=facet-toggle--only-on-mobile" if facet_toggle_only_on_mobile %>>
+    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hide" <%= "class=facet-toggle--only-on-mobile" unless finder.hide_facets_by_default %>>
       <a href="#" class="facet-toggle" data-controls="facet-wrapper" data-expanded="false" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
         + <%= t("finders.facet_disclosure.more", default: "Show more search options") %>
       </a>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -17,12 +17,14 @@
   </div>
 
   <% if facet_collection.filters.any? %>
-    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hidden">
+    <% facet_toggle_only_on_mobile = true %>
+
+    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hide" <%= "class=facet-toggle--only-on-mobile" if facet_toggle_only_on_mobile %>>
       <a href="#" class="facet-toggle" data-controls="facet-wrapper" data-expanded="false" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
         + <%= t("finders.facet_disclosure.more", default: "Show more search options") %>
       </a>
 
-      <div id="facet-wrapper" class="facet-toggle__content--hidden">
+      <div id="facet-wrapper" class="facet-toggle__content facet-toggle__content--hide">
         <%= render facet_collection.filters %>
       </div>
     </div>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -274,6 +274,13 @@ Feature: Filtering documents
     Then I should see a "Skip to results" link
     And the page has results region
 
+  @javascript
+  Scenario: Facets should be hidden by default on finders except all content
+    When I view the research and statistics finder
+    And I should not see a "Show more search options" link
+    Then I view the all content finder
+    And I should see a "Show more search options" link
+
   Scenario: Results should be a landmark to allow screenreaders to jump to it quickly
     When I view the news and communications finder
     Then the page has a landmark to the search results

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -7,6 +7,7 @@
   "details": {
     "default_documents_per_page": 20,
     "document_noun": "result",
+    "hide_facets_by_default": true,
     "facets": [
       {
         "display_as_result_metadata": false,

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -163,6 +163,16 @@ When(/^I view the research and statistics finder$/) do
   visit finder_path('statistics')
 end
 
+When(/^I view the all content finder$/) do
+  topic_taxonomy_has_taxons
+  content_store_has_all_content_finder
+  stub_whitehall_api_world_location_request
+  stub_people_registry_request
+  stub_rummager_api_request_with_all_content_results
+
+  visit finder_path('search/all-content')
+end
+
 When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons
   content_store_has_services_finder
@@ -714,6 +724,11 @@ end
 Then(/^I should (see|not see) a "Skip to results" link$/) do |can_be_seen|
   visibility = can_be_seen == 'see'
   expect(page).to have_css('[href="#js-results"]', visible: visibility)
+end
+
+Then(/^I should (see|not see) a "Show more search options" link$/) do |can_be_seen|
+  visibility = can_be_seen == 'see'
+  expect(page).to have_css('.facet-toggle', visible: visibility)
 end
 
 Then(/^the page has results region$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -94,6 +94,11 @@ module DocumentHelper
       .to_return(body: policy_and_engagement_results_json)
   end
 
+  def stub_rummager_api_request_with_all_content_results
+    stub_request(:get, all_content_url({}))
+      .to_return(body: all_content_results_json)
+  end
+
   def stub_rummager_api_request_with_filtered_policy_papers_results
     stub_request(
       :get,
@@ -264,6 +269,12 @@ module DocumentHelper
     finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'statistics.json'))
 
     content_store_has_item('/statistics', finder_fixture)
+  end
+
+  def content_store_has_all_content_finder
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'all_content.json'))
+
+    content_store_has_item('/search/all-content', finder_fixture)
   end
 
   def content_store_has_policy_and_engagement_finder
@@ -594,6 +605,10 @@ module DocumentHelper
 
   def rummager_policy_papers_url(filters)
     rummager_url(policy_papers_params.merge(filters))
+  end
+
+  def all_content_url(filters)
+    rummager_url(all_content_params.merge(filters))
   end
 
   def rummager_research_and_statistics_url(filters)
@@ -1960,6 +1975,50 @@ module DocumentHelper
   end
 
   def upcoming_statistics_results_for_statistics_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def all_content_results_json
     %|{
       "results": [
         {

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -87,6 +87,18 @@ module RummagerUrlHelper
     )
   end
 
+  def all_content_params
+    base_search_params.merge(
+      'facet_organisations' => '1500,order:value.title',
+      'facet_people' => '1500,order:value.title',
+      'facet_world_locations' => '1500,order:value.title',
+      'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
+      'fields' => all_content_search_fields.join(','),
+      'count' => 20,
+      'order' => '-public_timestamp',
+    )
+  end
+
   def news_and_communications_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
@@ -121,6 +133,15 @@ module RummagerUrlHelper
       part_of_taxonomy_tree
       content_store_document_type
       organisations
+      world_locations
+    )
+  end
+
+  def all_content_search_fields
+    base_search_fields + %w(
+      part_of_taxonomy_tree
+      organisations
+      people
       world_locations
     )
   end


### PR DESCRIPTION
Adds a toggle link to the all content finder so that all facets (apart from keyword search) are hidden by default. Other finders should not be affected.

![Screen Shot 2019-03-15 at 08 16 25](https://user-images.githubusercontent.com/861310/54417624-a70e2080-46fa-11e9-9b5b-115d5e3698c9.png)

This is a little confusing as the behaviour on mobile for all finders should be to hide the facets like this. Initial page load states should be as follows:

Finder | Element | Desktop state | Mobile state | JS disabled state
-------|---------|---------------|--------------|-----------------
All content | Facet toggle link | Show | Show | Hide
All content | Facets | Hide | Hide | Show
Others | Facet toggle link | Hide | Show | Hide
Others | Facets | Show | Hide | Show

Trello card: https://trello.com/c/Fy8KPoWV/501-all-content-show-hide-facets?menu=filter&filter=label:Finders