### PR TITLE
Remove document type from result metadata

### DIFF
--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -83,7 +83,7 @@
         "name": "Document type",
         "preposition": "with document type",
         "type":"text",
-        "display_as_result_metadata": true,
+        "display_as_result_metadata": false,
         "filterable": true,
         "option_lookup": {
           "policy_papers": ["impact_assessment", "case_study", "policy_paper"],


### PR DESCRIPTION
This PR removes document type on search result metadata.

Trello: https://trello.com/c/BaGKQ3FM/520-remove-doc-type-metadata-from-results-in-policy-papers-and-consultations-finder

Before:
<img width="580" alt="Screen Shot 2019-03-15 at 12 15 01" src="https://user-images.githubusercontent.com/5422487/54430582-f0bb3300-471b-11e9-99a7-f39533109ed4.png">


After:
<img width="549" alt="Screen Shot 2019-03-15 at 12 14 29" src="https://user-images.githubusercontent.com/5422487/54430595-f6187d80-471b-11e9-8d2e-c803237dabc9.png">


