### PR TITLE
Refactor FinderApi

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -23,6 +23,10 @@ private
     @content ||= fetch_content_item(request.path)
   end
 
+  def finder_content_item
+    @finder_content_item ||= fetch_content_item(finder_base_path)
+  end
+
   def signup_presenter
     @signup_presenter ||= SignupPresenter.new(content, params)
   end
@@ -66,14 +70,8 @@ private
     )
   end
 
-  def finder
-    @finder ||= FinderPresenter.new(fetch_content_item(finder_base_path))
-  end
-
   def finder_format
-    return nil unless finder.filter
-
-    finder.filter['document_type']
+    finder_content_item.dig('details', 'filter', 'document_type')
   end
 
   def email_signup_attributes

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -53,7 +53,7 @@ private
   end
 
   def fetch_content_item(content_item_path)
-    FinderApi.new(content_item_path, {}).content_item
+    ContentItem.new(content_item_path).as_hash
   end
 
   def email_alert_signup_api

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -53,6 +53,7 @@ private
   def finder
     @finder ||= finder_presenter_class.new(
       raw_finder,
+      finder_api.search_results,
       filter_params,
     )
   end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -12,20 +12,20 @@ class FindersController < ApplicationController
     respond_to do |format|
       format.html do
         @results = results
-        @content_item = raw_finder
+        @raw_content_item = content_item.as_hash
         @breadcrumbs = fetch_breadcrumbs
         @parent = parent
       end
       format.json do
-        if %w[finder search].include? finder_api.content_item['document_type']
+        if content_item.is_search? || content_item.is_finder?
           render json: results
         else
           render json: {}, status: :not_found
         end
       end
       format.atom do
-        if finder_api.content_item['document_type'] == 'redirect'
-          @redirect = finder_api.content_item.dig('redirects', 0, 'destination')
+        if content_item.is_redirect?
+          @redirect = content_item.as_hash.dig('redirects', 0, 'destination')
           @finder_slug = finder_slug
           render 'finders/show-redirect'
         elsif finder.atom_feed_enabled?
@@ -42,6 +42,10 @@ class FindersController < ApplicationController
 
 private
 
+  def content_item
+    @content_item ||= ContentItem.new(finder_base_path)
+  end
+
   def results
     @results ||= result_set_presenter_class.new(finder, filter_params, view_context)
   end
@@ -55,10 +59,7 @@ private
   helper_method :finder
 
   def finder_api
-    @finder_api ||= finder_api_class.new(
-      finder_base_path,
-      filter_params
-    )
+    @finder_api ||= finder_api_class.new(content_item.as_hash, filter_params)
   end
 
   def raw_finder
@@ -68,7 +69,7 @@ private
   def fetch_breadcrumbs
     parent_slug = params["parent"]
     org_info = org_registry[parent_slug] if parent_slug.present?
-    FinderBreadcrumbsPresenter.new(org_info, @content_item)
+    FinderBreadcrumbsPresenter.new(org_info, content_item.as_hash)
   end
 
   def finder_presenter_class

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -5,8 +5,9 @@ class AdvancedSearchFinderApi < FinderApi
     raise_on_missing_taxon_param
 
     filter_params[TAXON_SEARCH_FILTER] = taxon["content_id"] if taxon
-    content_item_with_results = augment_content_item_with_results
-    augment_content_item_links_with_taxon(content_item_with_results, taxon)
+    augment_content_item_with_results
+    augment_content_item_links_with_taxon(content_item, taxon)
+    content_item
   end
 
   def taxon
@@ -19,16 +20,20 @@ private
 
   def augment_content_item_links_with_taxon(content_item, taxon)
     content_item["links"]["taxons"] = [taxon]
-    content_item
   end
 
-  def augment_facets_with_dynamic_values(content_item, _search_response)
-    augment_facets_with_dynamic_subgroups(content_item) if supergroups.any?
+  def augment_content_item_with_results
+    content_item['details']['results'] = search_results.fetch("results")
+    augment_facets_with_dynamic_values(content_item)
   end
 
-  def augment_facets_with_dynamic_subgroups(content_item)
+  def augment_facets_with_dynamic_values(content_item_hash)
+    augment_facets_with_dynamic_subgroups(content_item_hash) if supergroups.any?
+  end
+
+  def augment_facets_with_dynamic_subgroups(content_item_hash)
     subgroups = supergroups.map(&:subgroups_as_hash).flatten
-    facet = find_facet(content_item, SUBGROUP_SEARCH_FILTER)
+    facet = find_facet(content_item_hash, SUBGROUP_SEARCH_FILTER)
     return unless facet
 
     facet["allowed_values"] = subgroups
@@ -39,8 +44,8 @@ private
     Supergroups.lookup(filter_params[GROUP_SEARCH_FILTER])
   end
 
-  def find_facet(content_item, key)
-    content_item["details"]["facets"].find { |f| f["key"] == key }
+  def find_facet(content_item_hash, key)
+    content_item_hash["details"]["facets"].find { |f| f["key"] == key }
   end
 
   def raise_on_missing_taxon_at_path

--- a/app/lib/advanced_search_finder_api.rb
+++ b/app/lib/advanced_search_finder_api.rb
@@ -5,12 +5,8 @@ class AdvancedSearchFinderApi < FinderApi
     raise_on_missing_taxon_param
 
     filter_params[TAXON_SEARCH_FILTER] = taxon["content_id"] if taxon
-    search_response = fetch_search_response(content_item)
-    content_item_with_taxon_links = augment_content_item_links_with_taxon(
-      content_item,
-      taxon
-    )
-    augment_content_item_with_results(content_item_with_taxon_links, search_response)
+    content_item_with_results = augment_content_item_with_results
+    augment_content_item_links_with_taxon(content_item_with_results, taxon)
   end
 
   def taxon

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -1,32 +1,21 @@
-# Facade that speaks to the content store and rummager. Returns a content
-# item for the finder combined with the actual search results from rummager.
+# Facade that speaks to rummager. Combines a content item with
+# search results from rummager.
 class FinderApi
-  def initialize(base_path, filter_params)
-    @base_path = base_path
+  attr_reader :content_item
+
+  def initialize(content_item, filter_params)
+    @content_item = content_item
     @filter_params = filter_params
     @order = filter_params['order']
   end
 
-  def content_item
-    @content_item ||= fetch_content_item
-  end
-
   def content_item_with_search_results
-    search_response = fetch_search_response(content_item)
-    augment_content_item_with_results(content_item, search_response)
+    augment_content_item_with_results
   end
 
 private
 
-  attr_reader :base_path, :filter_params
-
-  def fetch_content_item
-    if development_env_finder_json
-      JSON.parse(File.read(development_env_finder_json))
-    else
-      Services.cached_content_item(base_path)
-    end
-  end
+  attr_reader :filter_params
 
   def merge_and_deduplicate(search_response)
     results = search_response.fetch("results")
@@ -72,7 +61,7 @@ private
     results.all? { |result| result['es_score'].present? }
   end
 
-  def fetch_search_response(content_item)
+  def fetch_search_response
     queries = query_builder_class.new(
       finder_content_item: content_item,
       params: filter_params,
@@ -85,28 +74,32 @@ private
     end
   end
 
-  def augment_content_item_with_results(content_item, search_response)
-    content_item = augment_content_item_details_with_results(content_item, search_response)
-    augment_facets_with_dynamic_values(content_item, search_response)
-    content_item
+  def augment_content_item_with_results
+    item_hash = content_item
+    search_response = fetch_search_response
+
+    item_hash = augment_content_item_details_with_results(item_hash, search_response)
+    augment_facets_with_dynamic_values(item_hash, search_response)
+
+    item_hash
   end
 
-  def augment_content_item_details_with_results(content_item, search_response)
-    content_item['details']['results'] = search_response.fetch("results")
-    content_item['details']['total_result_count'] = search_response.fetch("total")
+  def augment_content_item_details_with_results(item_hash, search_response)
+    item_hash['details']['results'] = search_response.fetch("results")
+    item_hash['details']['total_result_count'] = search_response.fetch("total")
 
-    content_item['details']['pagination'] = build_pagination(
-      content_item['details']['default_documents_per_page'],
+    item_hash['details']['pagination'] = build_pagination(
+      item_hash['details']['default_documents_per_page'],
       search_response.fetch('start'),
       search_response.fetch('total')
     )
 
-    content_item
+    item_hash
   end
 
-  def augment_facets_with_dynamic_values(content_item, search_response)
+  def augment_facets_with_dynamic_values(item, search_response)
     search_response.fetch("facets", {}).each do |facet_key, facet_details|
-      facet = content_item['details']['facets'].find { |f| f['key'] == facet_key }
+      facet = item['details']['facets'].find { |f| f['key'] == facet_key }
 
       if registries.all.has_key?(facet_key) && facet
         facet['allowed_values'] = allowed_values_from_registry(facet_key)
@@ -166,30 +159,6 @@ private
 
   def query_builder_class
     SearchQueryBuilder
-  end
-
-  # Add a finder with the base path as a key and the finder name
-  # without filetype as the value; example:
-  # "/guidance-and-regulation" => "guidance_and_regulation"
-  FINDERS_IN_DEVELOPMENT = {
-    "/search/policy-papers-and-consultations" => 'policy_and_engagement',
-    "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
-    "/search/statistics" => "statistics",
-    "/search/statistics/email-signup" => "statistics_email_signup"
-  }.freeze
-
-  def development_env_finder_json
-    return development_json if is_development_json?
-
-    ENV["DEVELOPMENT_FINDER_JSON"]
-  end
-
-  def development_json
-    "features/fixtures/#{FINDERS_IN_DEVELOPMENT[base_path]}.json"
-  end
-
-  def is_development_json?
-    base_path.present? && FINDERS_IN_DEVELOPMENT[base_path].present?
   end
 
   def registries

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -40,7 +40,10 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
-    "/search/statistics" => "statistics"
+    "/search/policy-papers-and-consultations" => 'policy_and_engagement',
+    "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
+    "/search/statistics" => "statistics",
+    "/search/statistics/email-signup" => "statistics_email_signup",
   }.freeze
 
   def development_env_finder_json

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,0 +1,59 @@
+class ContentItem
+  def initialize(base_path)
+    @base_path = base_path
+    @content_item = fetch_content_item
+  end
+
+  def as_hash
+    @content_item
+  end
+
+  def is_search?
+    document_type == 'search'
+  end
+
+  def is_finder?
+    document_type == 'finder'
+  end
+
+  def is_redirect?
+    document_type == 'redirect'
+  end
+
+private
+
+  attr_reader :base_path
+
+  def document_type
+    @content_item['document_type']
+  end
+
+  def fetch_content_item
+    if development_env_finder_json
+      JSON.parse(File.read(development_env_finder_json))
+    else
+      Services.cached_content_item(base_path)
+    end
+  end
+
+  # Add a finder with the base path as a key and the finder name
+  # without filetype as the value; example:
+  # "/guidance-and-regulation" => "guidance_and_regulation"
+  FINDERS_IN_DEVELOPMENT = {
+    "/search/statistics" => "statistics"
+  }.freeze
+
+  def development_env_finder_json
+    return development_json if is_development_json?
+
+    ENV["DEVELOPMENT_FINDER_JSON"]
+  end
+
+  def development_json
+    "features/fixtures/#{FINDERS_IN_DEVELOPMENT[base_path]}.json"
+  end
+
+  def is_development_json?
+    base_path.present? && FINDERS_IN_DEVELOPMENT[base_path].present?
+  end
+end

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -1,8 +1,8 @@
 class AdvancedSearchFinderPresenter < FinderPresenter
   include AdvancedSearchParams
 
-  def initialize(content_item, values = {})
-    super(content_item, values)
+  def initialize(content_item, search_results, values = {})
+    super(content_item, search_results, values)
     # Restore the original topic param value as this is used in pagination links.
     @values[TAXON_SEARCH_FILTER] = taxon['base_path']
   end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,7 +14,7 @@
 <% if @breadcrumbs.breadcrumbs %>
   <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
 <% else %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item %>
 <% end %>
 
 <% if finder.government? %>

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -28,13 +28,10 @@ describe AdvancedSearchFinderApi do
     }
   }
 
-  subject(:instance) { described_class.new("/search/advanced", filter_params) }
+  subject(:instance) { described_class.new(finder_item, filter_params) }
 
   describe "content_item_with_search_results" do
     before do
-      allow(Services.content_store).to receive(:content_item)
-        .and_return(finder_item)
-
       allow(Services.content_store).to receive(:content_item)
         .with("/education")
         .and_return(taxon)

--- a/spec/lib/finder_api_spec.rb
+++ b/spec/lib/finder_api_spec.rb
@@ -22,30 +22,30 @@ describe FinderApi do
 
     shared_examples 'sorts by other fields' do
       context 'most-recent' do
-        subject { described_class.new(content_item, 'order' => 'most-recent').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-recent').search_results }
 
         it "de-duplicates and sorts by public_updated descending" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
           expect(results.second).to match(hash_including("_id" => "/hmrc"))
         end
       end
 
       context 'most-viewed' do
-        subject { described_class.new(content_item, 'order' => 'most-viewed').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-viewed').search_results }
 
         it "de-duplicates and sorts by popularity descending" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
           expect(results.second).to match(hash_including("_id" => "/hmrc"))
         end
       end
 
       context 'a-to-z' do
-        subject { described_class.new(content_item, 'order' => 'a-to-z').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'a-to-z').search_results }
 
         it "de-duplicates and sorts by title descending" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("title" => "HMRC"))
           expect(results.second).to match(hash_including("title" => "Register to Vote"))
         end
@@ -75,20 +75,20 @@ describe FinderApi do
       it_behaves_like 'sorts by other fields'
 
       context 'default' do
-        subject { described_class.new(content_item, {}).content_item_with_search_results }
+        subject { described_class.new(content_item, {}).search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
           expect(results.second).to match(hash_including("_id" => "/hmrc"))
         end
       end
 
       context 'most-relevant' do
-        subject { described_class.new(content_item, 'order' => 'most-relevant').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-relevant').search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("_id" => "/register-to-vote"))
           expect(results.second).to match(hash_including("_id" => "/hmrc"))
         end
@@ -118,20 +118,20 @@ describe FinderApi do
       it_behaves_like 'sorts by other fields'
 
       context 'default' do
-        subject { described_class.new(content_item, {}).content_item_with_search_results }
+        subject { described_class.new(content_item, {}).search_results }
 
         it "de-duplicates and sorts by es_score descending" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("title" => "HMRC"))
           expect(results.second).to match(hash_including("title" => "Register to Vote"))
         end
       end
 
       context 'most-relevant' do
-        subject { described_class.new(content_item, 'order' => 'most-relevant').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-relevant').search_results }
 
         it "de-duplicates and sorts by es_score descending" do
-          results = subject.fetch("details").fetch("results")
+          results = subject.fetch("results")
           expect(results.first).to match(hash_including("title" => "HMRC"))
           expect(results.second).to match(hash_including("title" => "Register to Vote"))
         end

--- a/spec/lib/finder_api_spec.rb
+++ b/spec/lib/finder_api_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe FinderApi do
+  let(:content_item) {
+    {
+      "details" => {
+        "facets" => []
+      },
+    }
+  }
+
   context "when merging, de-duplicating and sorting" do
     def result_item(id, title, score:, popularity:, updated:)
       {
@@ -12,19 +20,9 @@ describe FinderApi do
       }
     end
 
-    before do
-      allow(Services.content_store).to receive(:content_item)
-        .with("/finder")
-        .and_return(
-          "details" => {
-            "facets" => []
-          },
-        )
-    end
-
     shared_examples 'sorts by other fields' do
       context 'most-recent' do
-        subject { described_class.new("/finder", 'order' => 'most-recent').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-recent').content_item_with_search_results }
 
         it "de-duplicates and sorts by public_updated descending" do
           results = subject.fetch("details").fetch("results")
@@ -34,7 +32,7 @@ describe FinderApi do
       end
 
       context 'most-viewed' do
-        subject { described_class.new("/finder", 'order' => 'most-viewed').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-viewed').content_item_with_search_results }
 
         it "de-duplicates and sorts by popularity descending" do
           results = subject.fetch("details").fetch("results")
@@ -44,7 +42,7 @@ describe FinderApi do
       end
 
       context 'a-to-z' do
-        subject { described_class.new("/finder", 'order' => 'a-to-z').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'a-to-z').content_item_with_search_results }
 
         it "de-duplicates and sorts by title descending" do
           results = subject.fetch("details").fetch("results")
@@ -77,7 +75,7 @@ describe FinderApi do
       it_behaves_like 'sorts by other fields'
 
       context 'default' do
-        subject { described_class.new("/finder", {}).content_item_with_search_results }
+        subject { described_class.new(content_item, {}).content_item_with_search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
           results = subject.fetch("details").fetch("results")
@@ -87,7 +85,7 @@ describe FinderApi do
       end
 
       context 'most-relevant' do
-        subject { described_class.new("/finder", 'order' => 'most-relevant').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-relevant').content_item_with_search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
           results = subject.fetch("details").fetch("results")
@@ -120,7 +118,7 @@ describe FinderApi do
       it_behaves_like 'sorts by other fields'
 
       context 'default' do
-        subject { described_class.new("/finder", {}).content_item_with_search_results }
+        subject { described_class.new(content_item, {}).content_item_with_search_results }
 
         it "de-duplicates and sorts by es_score descending" do
           results = subject.fetch("details").fetch("results")
@@ -130,7 +128,7 @@ describe FinderApi do
       end
 
       context 'most-relevant' do
-        subject { described_class.new("/finder", 'order' => 'most-relevant').content_item_with_search_results }
+        subject { described_class.new(content_item, 'order' => 'most-relevant').content_item_with_search_results }
 
         it "de-duplicates and sorts by es_score descending" do
           results = subject.fetch("details").fetch("results")

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -26,7 +26,7 @@ describe ContentItem do
     end
 
     context "when document_type is search" do
-      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'search' }) }
+      let(:finder_content_item) { news_and_communications.merge("document_type" => 'search') }
       it "returns true when document_type is search" do
         expect(subject.is_search?).to be true
       end
@@ -39,7 +39,7 @@ describe ContentItem do
     end
 
     context "when document_type is not a finder" do
-      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'search' }) }
+      let(:finder_content_item) { news_and_communications.merge("document_type" => 'search') }
       it "returns false when document_type is finder" do
         expect(subject.is_finder?).to be false
       end
@@ -52,7 +52,7 @@ describe ContentItem do
     end
 
     context "when document_type is redirect" do
-      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'redirect' }) }
+      let(:finder_content_item) { news_and_communications.merge("document_type" => 'redirect') }
       it "returns true when document_type is redirect" do
         expect(subject.is_redirect?).to be true
       end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe ContentItem do
+  subject { described_class.new(base_path) }
+  let(:base_path) { "/search/news-and-communications" }
+  let(:finder_content_item) { news_and_communications }
+  let(:news_and_communications) {
+    JSON.parse(File.read(Rails.root.join("features", "fixtures", "news_and_communications.json")))
+  }
+
+  before do
+    allow(Services.content_store).to receive(:content_item)
+      .with(base_path)
+      .and_return(finder_content_item)
+  end
+
+  describe "as_hash" do
+    it "returns a content item as a hash" do
+      expect(subject.as_hash).to eql(finder_content_item)
+    end
+  end
+
+  describe "is_search?" do
+    it "returns false when document_type is not search" do
+      expect(subject.is_search?).to be false
+    end
+
+    context "when document_type is search" do
+      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'search' }) }
+      it "returns true when document_type is search" do
+        expect(subject.is_search?).to be true
+      end
+    end
+  end
+
+  describe "is_finder?" do
+    it "returns true when document_type is not finder" do
+      expect(subject.is_finder?).to be true
+    end
+
+    context "when document_type is not a finder" do
+      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'search' }) }
+      it "returns false when document_type is finder" do
+        expect(subject.is_finder?).to be false
+      end
+    end
+  end
+
+  describe "is_redirect?" do
+    it "returns false when document_type is not redirect" do
+      expect(subject.is_redirect?).to be false
+    end
+
+    context "when document_type is redirect" do
+      let(:finder_content_item) { news_and_communications.merge({ "document_type" => 'redirect' }) }
+      it "returns true when document_type is redirect" do
+        expect(subject.is_redirect?).to be true
+      end
+    end
+  end
+end

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -3,11 +3,12 @@ require "spec_helper"
 describe AdvancedSearchFinderPresenter do
   include ActionView::Helpers::UrlHelper
 
-  subject(:presenter) { described_class.new(content_item_response, values) }
+  subject(:presenter) { described_class.new(content_item_response, search_results, values) }
 
   let(:finder_item) {
     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
   }
+  let(:search_results) { {} }
   let(:taxon_content_id) { SecureRandom.uuid }
   let(:content_item) {
     finder_item.merge("links" => {

--- a/spec/presenters/advanced_search_result_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AdvancedSearchResultPresenter do
       }
     }
   }
-  let(:finder) { AdvancedSearchFinderPresenter.new(finder_content_item.merge(links)) }
+  let(:finder) { AdvancedSearchFinderPresenter.new(finder_content_item.merge(links), {}, {}) }
   let(:document_type) { "guidance" }
   let(:organisations) { [{ title: "Ministry of Defence" }] }
   let(:public_timestamp) { "2018-03-26" }

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe AdvancedSearchResultSetPresenter do
       filter_params
     ).content_item_with_search_results
   end
-  let(:finder) { AdvancedSearchFinderPresenter.new(finder_api, filter_params) }
+
   let(:group) { "news_and_communications" }
   let(:filter_params) { { "topic" => "/education", "group" => group } }
+  let(:finder) { AdvancedSearchFinderPresenter.new(finder_api, search_results, filter_params) }
   let(:view_context) { double(:view_context, render: nil) }
   let(:taxon_content_id) { SecureRandom.uuid }
   let(:taxon) {
@@ -35,10 +36,6 @@ RSpec.describe AdvancedSearchResultSetPresenter do
   subject(:instance) { described_class.new(finder, filter_params, view_context) }
 
   before do
-    # allow(Services.content_store).to receive(:content_item)
-    #   .and_return(
-    #     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
-    #   )
     allow(Services.content_store).to receive(:content_item)
       .with("/education")
       .and_return(taxon)

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -1,9 +1,12 @@
 require "spec_helper"
 
 RSpec.describe AdvancedSearchResultSetPresenter do
+  let(:content_item) {
+    JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
+  }
   let(:finder_api) do
     AdvancedSearchFinderApi.new(
-      "/search/advanced",
+      content_item,
       filter_params
     ).content_item_with_search_results
   end
@@ -32,10 +35,10 @@ RSpec.describe AdvancedSearchResultSetPresenter do
   subject(:instance) { described_class.new(finder, filter_params, view_context) }
 
   before do
-    allow(Services.content_store).to receive(:content_item)
-      .and_return(
-        JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
-      )
+    # allow(Services.content_store).to receive(:content_item)
+    #   .and_return(
+    #     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))
+    #   )
     allow(Services.content_store).to receive(:content_item)
       .with("/education")
       .and_return(taxon)

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
 
-  subject(:presenter) { described_class.new(content_item(sort_options: no_sort_options), values) }
-  subject(:presenter_with_sort) { described_class.new(content_item(sort_options: sort_options_without_relevance), values) }
-  subject(:presenter_with_email_signup) { described_class.new(content_item(email_alert_signup: email_alert_signup_options), values) }
+  subject(:presenter) { described_class.new(content_item(sort_options: no_sort_options), {}, values) }
+  subject(:presenter_with_sort) { described_class.new(content_item(sort_options: sort_options_without_relevance), {}, values) }
+  subject(:presenter_with_email_signup) { described_class.new(content_item(email_alert_signup: email_alert_signup_options), {}, values) }
 
   let(:no_sort_options) { nil }
 
@@ -196,7 +196,7 @@ RSpec.describe FinderPresenter do
         sort_option('Relevance', 'relevance', disabled: true)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), values)
+      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), {}, values)
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -208,7 +208,7 @@ RSpec.describe FinderPresenter do
         sort_option('Relevance', 'relevance', disabled: false)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), "keywords" => "something not blank")
+      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), {}, "keywords" => "something not blank")
 
       expect(presenter.sort_options).to eql(expected_options)
     end
@@ -242,7 +242,7 @@ RSpec.describe FinderPresenter do
         sort_option('Updated (newest)', 'updated-newest', selected: true)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options: sort_options_without_relevance), "order" => "updated-newest")
+      presenter = described_class.new(content_item(sort_options: sort_options_without_relevance), {}, "order" => "updated-newest")
 
       expect(presenter.sort_options).to eql(expected_options)
     end


### PR DESCRIPTION
This is a proposed refactor of `FinderApi`, a class that fetches and provides data for the finder presenters, views, controllers, etc. Reviewing by commit will be easier.

Changes:

- adds a ContentItem model, responsible for fetching and providing content items (logic moved from FinderApi)
- Refactor and moves augmentation code from `FinderApi` to the presenters. Manipulating a content item hash can be hard to debug, this should make things simpler.

It doesn't go the whole way and remove the `allowed_options` code and other content item manipulation from FinderApi and AdvancedSearchFinderApi. I hope it will make that easier, if we do want to do that.