### PR TITLE
Fix multiple Analytics events for checkbox facets

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -33,7 +33,8 @@
 
       this.$form.on('change', 'input[type=checkbox], input[type=radio], select',
         function(e) {
-          if (!e.suppressAnalytics) {
+          // Checkboxes fire their own GA tracking
+          if (!e.suppressAnalytics && $(e.target).attr("type") !== "checkbox") {
             LiveSearch.prototype.fireTextAnalyticsEvent(e);
           }
           this.formChange(e);

--- a/app/models/checkbox_facet.rb
+++ b/app/models/checkbox_facet.rb
@@ -41,8 +41,7 @@ class CheckboxFacet < FilterableFacet
         track_category: "filterClicked",
         uncheck_track_category: "filterRemoved",
         track_action: "checkboxFacet",
-        track_label: name,
-        module: "track-click"
+        track_label: name
     }
   end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -472,7 +472,7 @@ Then(/^The checkbox has the correct tracking data$/) do
   expect(page).to have_css("input[type='checkbox'][data-track-category='filterClicked']")
   expect(page).to have_css("input[type='checkbox'][data-track-action='checkboxFacet']")
   expect(page).to have_css("input[type='checkbox'][data-track-label='Show open cases']")
-  expect(page).to have_css("input[type='checkbox'][data-module='track-click']")
+  expect(page).to_not have_css("input[type='checkbox'][data-module='track-click']")
 end
 
 Then(/^I can sort by:$/) do |table|


### PR DESCRIPTION
They were firing three times per click, which would skew our analysis.
This prevents live-search and the built in checkbox component events
firing, thus allowing the TrackClick module in static to take over.
(This is defined in static/app/assets/javascripts/modules/track-click.js)

Trello: https://trello.com/c/7vQb8Yww/434-bug-fix-issue-where-use-of-brexit-checkbox-fires-multiple-ga-events