### PR TITLE
Remove organisation metadata for mainstream content

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -47,6 +47,20 @@ private
 
   attr_reader :link, :rummager_document, :finder, :description
 
+  def is_mainstream_content?
+    %w(completed_transaction
+       local_transaction
+       calculator
+       smart_answer
+       simple_smart_answer
+       place
+       licence
+       step_by_step
+       transaction
+       answer
+       guide).include?(@document_type)
+  end
+
   def truncated_description
     # This truncates the description at the end of the first sentence
     description.gsub(/\.\s[A-Z].*/, '.')
@@ -61,7 +75,10 @@ private
   end
 
   def tag_metadata_keys
-    finder.text_metadata_keys
+    keys = finder.text_metadata_keys
+    keys.reject do |key|
+      key == :organisations && is_mainstream_content?
+    end
   end
 
   def raw_metadata


### PR DESCRIPTION
Organisation metadata should not be shown for mainstream
content.

Trello: https://trello.com/c/GlohunbM/519-remove-org-metadata-from-mainstream-results-in-all-content-and-services-finders

![image](https://user-images.githubusercontent.com/6050162/54614364-2fbaf280-4a54-11e9-813c-d4295d27cd6f.png)
