### PR TITLE
Change document_noun for stats finder

### DIFF
--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -40,7 +40,7 @@
   },
   "description":"Find statistics from government",
   "details":{
-    "document_noun":"statistic",
+    "document_noun":"result",
     "filter":{},
     "format_name":"statistic",
     "show_summaries":true,


### PR DESCRIPTION
https://trello.com/c/Qja3OgT6/536-change-stats-finder-result-count-noun-to-results