### PR TITLE
All-Content: Update page heading to "Search"

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -40,7 +40,7 @@
         }.bind(this)
       );
 
-      this.$form.on('change keypress', 'input[type=text]',
+      this.$form.on('change keypress', 'input[type=text],input[type=search]',
         function(e){
           var ENTER_KEY = 13;
 
@@ -313,7 +313,7 @@
 
   LiveSearch.prototype.restoreTextInputs = function restoreTextInputs(){
     var that = this;
-    this.$form.find('input[type=text], select').each(function(i, el){
+    this.$form.find('input[type=text], input[type=search], select').each(function(i, el){
       var $el = $(el);
       $el.val(that.getTextInputValue($el.attr('name'), that.state));
     });

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -410,3 +410,12 @@
   }
 }
 
+.finder-frontend-content {
+  .app-c-search-page-heading {
+    @include govuk-font(48, $weight: bold);
+    @include govuk-responsive-margin(2, "top");
+    @include govuk-responsive-margin(4, "bottom");
+    color: govuk-colour("black");
+  }
+}
+

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -40,10 +40,9 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
-    "/search/policy-papers-and-consultations" => 'policy_and_engagement',
-    "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
     "/search/research-and-statistics" => "statistics",
     "/search/research-and-statistics/email-signup" => "statistics_email_signup",
+    "/review-search/all" => 'all_content'
   }.freeze
 
   def development_env_finder_json

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -274,6 +274,10 @@ class FinderPresenter
     content_item['details']['canonical_link']
   end
 
+  def all_content_finder?
+    self.content_item['content_id'] == 'dd395436-9b40-41f3-8157-740a453ac972'
+  end
+
 private
 
   attr_reader :search_results

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,13 +1,18 @@
-<div class="filter-form" id="keywords">
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "Search"
-    },
-    name: "keywords",
-    value: @results.user_supplied_keywords,
-    id: "finder-keyword-search",
-    controls: "js-search-results-info"
-  } if finder.show_keyword_search? %>
+<div class="filter-form">
+  <% if finder.show_keyword_search? and !finder.all_content_finder? %>
+    <div id="keywords">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Search"
+        },
+        name: "keywords",
+        value: @results.user_supplied_keywords,
+        id: "finder-keyword-search",
+        controls: "js-search-results-info"
+      }  %>
+    </div>
+  <% end %>
+
   <div class="govuk-form-group" data-module="track-click" data-track-category="filterClicked"
       data-track-action="skip-Link" data-track-label="">
     <%= render "govuk_publishing_components/components/skip_link", {

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -21,43 +21,62 @@
   <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>
 <% end %>
 
-<header>
-  <div class="title-and-metadata">
-    <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      context: finder.human_readable_finder_format,
-      title: finder.name
-    } %>
-    <% if finder.page_metadata.any? %>
-      <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
-    <% end %>
+<form method="get" action="<%= finder.slug %>" class="js-live-search-form">
+  <input type="hidden" name="parent" value="<%= @parent %>">
 
-    <% if finder.summary %>
-      <div class="summary">
-        <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
+  <header>
+    <div class="title-and-metadata">
+      <% if finder.all_content_finder? %>
+        <% label_text = capture do %>
+          <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
+        <% end %>
+        <div id="keywords">
+          <%= render "govuk_publishing_components/components/search", {
+              inline_label: false,
+              label_text: label_text,
+              name: "keywords",
+              hide_search_button: true,
+              value: @results.user_supplied_keywords,
+              id: "finder-keyword-search",
+              controls: "js-search-results-info"
+          } %>
+        </div>
+      <% else %>
+        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+            context: finder.human_readable_finder_format,
+            title: finder.name
+        } %>
+      <% end %>
+
+      <% if finder.page_metadata.any? %>
+        <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
+      <% end %>
+
+      <% if finder.summary %>
+        <div class="summary">
+          <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
+        </div>
+      <% end %>
+    </div>
+
+    <% if finder.logo_path %>
+      <div class="logo">
+        <%= image_tag finder.logo_path, id: "logo-image" %>
       </div>
     <% end %>
-  </div>
 
-  <% if finder.logo_path %>
-    <div class="logo">
-      <%= image_tag finder.logo_path, id: "logo-image" %>
-    </div>
-  <% end %>
+    <% if finder.related.any? %>
+      <div class="related-links">
+        <ul class="finder-results">
+          <% finder.related.each do |link| %>
+            <li><%= link_to link['title'], link['web_url'] %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </header>
 
-  <% if finder.related.any? %>
-    <div class='related-links'>
-      <ul class="finder-results">
-        <% finder.related.each do |link| %>
-          <li><%= link_to link['title'], link['web_url'] %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-</header>
-
-<div class="grid-row">
-  <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
-    <input type="hidden" name="parent" value="<%= @parent %>">
+  <div class="grid-row">
     <div class="column-third" role="search" aria-label="<%= finder.name %>">
       <%= render finder.facets %>
     </div>
@@ -91,5 +110,5 @@
         </div>
       </div>
     </div>
-  </form>
-</div>
+  </div>
+</form>

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -311,6 +311,17 @@ RSpec.describe FinderPresenter do
     end
   end
 
+  describe "#all_content_finder?" do
+    it 'returns true if finder is "All Content"' do
+      subject.content_item["content_id"] = 'dd395436-9b40-41f3-8157-740a453ac972'
+      expect(subject.all_content_finder?).to eq true
+    end
+
+    it 'returns false if finder is not "All Content"' do
+      expect(subject.all_content_finder?).to eq false
+    end
+  end
+
 private
 
   def content_item(sort_options: nil, email_alert_signup: nil, default_order: nil, facets: nil)


### PR DESCRIPTION
The All Content finder should have the keywords field at the top of the page instead of in the facets sidebar. All other finders should still have the keywords search field in their facets sidebar


Example:
![image](https://user-images.githubusercontent.com/3441519/54674948-63018e00-4af5-11e9-9f6f-eab04ef9683f.png)

____

Ticket: https://trello.com/c/LznDjL1r/505-all-content-update-page-heading-to-search
Demo:
All Content: https://finder-frontend-pr-976.herokuapp.com/review-search/all
News & Comms: https://finder-frontend-pr-976.herokuapp.com/search/news-and-communications