### PR TITLE
Add manuals filter to all content finder

### DIFF
--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -23,6 +23,16 @@
         "type": "taxon"
       },
       {
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "manual",
+        "name": "Manual",
+        "preposition": "in manual",
+        "short_name": "in",
+        "type": "text",
+        "show_option_select_filter": false
+      },
+      {
         "display_as_result_metadata": true,
         "filterable": true,
         "key": "organisations",

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -89,6 +89,7 @@ module RummagerUrlHelper
 
   def all_content_params
     base_search_params.merge(
+      'facet_manual' => '1500,order:value.title',
       'facet_organisations' => '1500,order:value.title',
       'facet_people' => '1500,order:value.title',
       'facet_world_locations' => '1500,order:value.title',
@@ -140,6 +141,7 @@ module RummagerUrlHelper
   def all_content_search_fields
     base_search_fields + %w(
       part_of_taxonomy_tree
+      manual
       organisations
       people
       world_locations


### PR DESCRIPTION
Adds hidden manuals filter to all-content filter.

Trello: https://trello.com/c/EXKGr1Uv/497-handle-scoped-manuals-filter-in-site-search