### PR TITLE
Fix facet tracking events being logged more than once

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -33,9 +33,6 @@
 
       this.$form.on('change', 'input[type=checkbox], input[type=radio], select',
         function(e) {
-          if (!e.suppressAnalytics) {
-            LiveSearch.prototype.fireTextAnalyticsEvent(e);
-          }
           this.formChange(e);
         }.bind(this)
       );
@@ -45,10 +42,8 @@
           var ENTER_KEY = 13;
 
           if(e.keyCode == ENTER_KEY || e.type == "change") {
-            if (e.currentTarget.value != this.previousSearchTerm) {
-              if (!e.suppressAnalytics) {
-                LiveSearch.prototype.fireTextAnalyticsEvent(e);
-              }
+            if (e.currentTarget.value != this.previousSearchTerm && !e.suppressAnalytics ) {
+              LiveSearch.prototype.fireTextAnalyticsEvent(e);
             }
             this.formChange(e);
             this.previousSearchTerm = e.currentTarget.value;

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -5,6 +5,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   'use strict';
 
   GOVUK.Modules.RemoveFilter = function () {
+    var onChangeSuppressAnalytics = {
+      type: "change",
+      suppressAnalytics: true
+    }
+
     this.start = function (element) {
       $(element).on('click', '[data-module="remove-filter-link"]', toggleFilter);
     };
@@ -19,8 +24,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var removeFilterFacet = $el.data('facet');
 
       var $input = getInput(removeFilterName, removeFilterValue, removeFilterFacet);
-      clearFacet($input, removeFilterValue, removeFilterFacet);
       fireRemoveTagTrackingEvent(removeFilterValue, removeFilterFacet);
+      clearFacet($input, removeFilterValue, removeFilterFacet);
     }
 
     function clearFacet($input, removeFilterValue, removeFilterFacet) {
@@ -30,7 +35,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (inputType == 'checkbox') {
         $input.prop("checked", false);
-        $input.trigger('change');
+        $input.trigger(onChangeSuppressAnalytics);
       }
       else if (inputType == 'text' || inputType == 'search') {
         var splitKeywords = currentVal.split(" ");
@@ -44,13 +49,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         var newVal = splitKeywords.join(" ").trim();
 
-        $input.val(newVal).trigger({
-          type: "change",
-          suppressAnalytics: true
-        });
+        $input.val(newVal).trigger(onChangeSuppressAnalytics);
       }
       else if (elementType == 'OPTION') {
-        $('#' + removeFilterFacet).val('').trigger('change');
+        $('#' + removeFilterFacet).val('').trigger(onChangeSuppressAnalytics);
       }
     }
 

--- a/app/models/checkbox_facet.rb
+++ b/app/models/checkbox_facet.rb
@@ -44,8 +44,7 @@ class CheckboxFacet < FilterableFacet
         track_category: "filterClicked",
         uncheck_track_category: "filterRemoved",
         track_action: "checkboxFacet",
-        track_label: name,
-        module: "track-click"
+        track_label: name
     }
   end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -452,7 +452,7 @@ Then(/^The checkbox has the correct tracking data$/) do
   expect(page).to have_css("input[type='checkbox'][data-track-category='filterClicked']")
   expect(page).to have_css("input[type='checkbox'][data-track-action='checkboxFacet']")
   expect(page).to have_css("input[type='checkbox'][data-track-label='Show open cases']")
-  expect(page).to have_css("input[type='checkbox'][data-module='track-click']")
+  expect(page).to_not have_css("input[type='checkbox'][data-module='track-click']")
 end
 
 Then(/^I can sort by:$/) do |table|


### PR DESCRIPTION
## This issue covered two different scenarios. 

1. All form elements were double logging tracking events.
2. Brexit checkbox facet was logging two events of its own.

## Solution 1:

There was condition on live search which always evaluated to true. The method then went on to call the tracking method in addition to the original tracking event. To solve this issue, I removed the condition and the function call.

## Solution 2:

**TL;DR - govuk_publishing_components and Static's Module.TrackClick were responsible for the double logging.**

Checkbox facets were adding `data-module="track-click"` html attribute. This is a hook for Static's Module.TrackClick.

govuk_publishing_component's checkbox component was also firing off its own event. So to resolve this issue I created this PR https://github.com/alphagov/govuk_publishing_components/pull/801 which uses the events `suppressAnalytics` flag to stop tracking event being called. 


Ticket: https://trello.com/c/7vQb8Yww/434-bug-fix-issue-where-use-of-brexit-checkbox-fires-multiple-ga-events

**Demo:** 
https://finder-frontend-pr-984.herokuapp.com/search/all
https://finder-frontend-pr-984.herokuapp.com/search/news-and-communications
https://finder-frontend-pr-984.herokuapp.com/search/research-and-statistics