### PR TITLE
Exclude brexit terms from keyword search

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -141,7 +141,7 @@ private
   def remove_stopwords
     keywords = params["keywords"].split(' ')
     keywords.delete_if do |keyword|
-      stopwords.include?(keyword.gsub(/\W/, ''))
+      stopwords.include?(keyword.downcase.gsub(/\W/, ''))
     end
     keywords.join(' ')
   end

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -129,7 +129,13 @@ private
   end
 
   def keywords
-    remove_stopwords if params["keywords"].present?
+    return remove_stopwords if remove_stopwords?
+
+    params["keywords"].presence
+  end
+
+  def remove_stopwords?
+    params["keywords"].present? && ["/find-eu-exit-guidance-business"].include?(finder_content_item["base_path"])
   end
 
   def remove_stopwords

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -141,7 +141,7 @@ private
   def remove_stopwords
     keywords = params["keywords"].split(' ')
     keywords.delete_if do |keyword|
-      stopwords.include?(keyword)
+      stopwords.include?(keyword.gsub(/\W/, ''))
     end
     keywords.join(' ')
   end

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -129,7 +129,15 @@ private
   end
 
   def keywords
-    params["keywords"].presence
+    remove_stopwords if params["keywords"].present?
+  end
+
+  def remove_stopwords
+    keywords = params["keywords"].split(' ')
+    keywords.delete_if do |keyword|
+      stopwords.include?(keyword)
+    end
+    keywords.join(' ')
   end
 
   def default_order
@@ -202,5 +210,27 @@ private
     @facet_params ||= FacetQueryBuilder.new(
       facets: finder_content_item['details']['facets'],
     ).call
+  end
+
+  def stopwords
+    %w(
+     a about above after again against all am an and any are arent as at
+     be because been before being below between both but by
+     cant cannot could couldnt
+     did didnt do does doesnt doing dont down during
+     each
+     few for from further
+     had hadnt has hasnt have havent having he hed hell hes her here heres hers herself him himself his how hows
+     i id ill im ive if in into is isnt it its itself
+     lets
+     me more most mustnt my myself
+     no nor not of off on once only or other ought our ours ourselves out over own
+     same shant she shed shell shes should shouldnt so some such
+     than that thats the their theirs them themselves then there theres these they theyd theyll theyre theyve this those through to too
+     under until up
+     very
+     was wasnt we wed well were werent weve what whats when whens where wheres which while who whos whom why whys with wont would wouldnt
+     you youd youll youre youve your yours yourself yourselves
+    )
   end
 end

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -213,7 +213,7 @@ private
   end
 
   def stopwords
-    %w(
+    generic_stopwords = %w(
      a about above after again against all am an and any are arent as at
      be because been before being below between both but by
      cant cannot could couldnt
@@ -232,5 +232,9 @@ private
      was wasnt we wed well were werent weve what whats when whens where wheres which while who whos whom why whys with wont would wouldnt
      you youd youll youre youve your yours yourself yourselves
     )
+
+    brexit_stopwords = %w(abroad brexit eu europe european exit leave union)
+
+    (generic_stopwords + brexit_stopwords).uniq
   end
 end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -228,6 +228,20 @@ describe SearchQueryBuilder do
         expect(query).not_to include("q" => "a, isn't a mango is it?")
       end
 
+      it "ignores case of keywords" do
+        params = {
+          "keywords" => "A mango"
+        }
+
+        query = SearchQueryBuilder.new(
+          finder_content_item: finder_content_item,
+          params: params
+        ).call.first
+
+        expect(query).to include("q" => "mango")
+        expect(query).not_to include("q" => "A mango")
+      end
+
       it "does not strip numbers from search" do
         params = {
           "keywords" => "50"

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -13,6 +13,7 @@ describe SearchQueryBuilder do
 
   let(:finder_content_item) {
     {
+      'base_path' => '/finder-path',
       'details' => {
         'facets' => facets,
         'filter' => filter,
@@ -173,14 +174,42 @@ describe SearchQueryBuilder do
       expect(query).not_to include("order")
     end
 
-    context "with stopwords" do
+    context "without stopwords" do
       let(:params) {
         {
           "keywords" => "a mango"
         }
       }
 
-      it "should not include stopwords" do
+      it "should include stopwords in search" do
+        expect(query).to include("q" => "a mango")
+      end
+    end
+
+    context "with stopwords" do
+      let(:finder_content_item) {
+        {
+          'base_path' => '/find-eu-exit-guidance-business',
+          'details' => {
+            'facets' => facets,
+            'filter' => filter,
+            'reject' => reject,
+            'default_order' => default_order,
+            'default_documents_per_page' => 10
+          }
+        }
+      }
+
+      it "should not include stopwords in search" do
+        params = {
+          "keywords" => "a mango"
+        }
+
+        query = SearchQueryBuilder.new(
+          finder_content_item: finder_content_item,
+          params: params
+        ).call.first
+
         expect(query).to include("q" => "mango")
         expect(query).not_to include("q" => "a mango")
       end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -172,6 +172,19 @@ describe SearchQueryBuilder do
     it "should not include an order query" do
       expect(query).not_to include("order")
     end
+
+    context "with stopwords" do
+      let(:params) {
+        {
+          "keywords" => "a mango"
+        }
+      }
+
+      it "should not include stopwords" do
+        expect(query).to include("q" => "mango")
+        expect(query).not_to include("q" => "a mango")
+      end
+    end
   end
 
   context "with a base filter" do

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -213,6 +213,33 @@ describe SearchQueryBuilder do
         expect(query).to include("q" => "mango")
         expect(query).not_to include("q" => "a mango")
       end
+
+      it "strips punctuation from stopword check" do
+        params = {
+          "keywords" => "a, isn't a mango is it?"
+        }
+
+        query = SearchQueryBuilder.new(
+          finder_content_item: finder_content_item,
+          params: params
+        ).call.first
+
+        expect(query).to include("q" => "mango")
+        expect(query).not_to include("q" => "a, isn't a mango is it?")
+      end
+
+      it "does not strip numbers from search" do
+        params = {
+          "keywords" => "50"
+        }
+
+        query = SearchQueryBuilder.new(
+          finder_content_item: finder_content_item,
+          params: params
+        ).call.first
+
+        expect(query).to include("q" => "50")
+      end
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/kklgC5ov

## What's changed
Remove stop words from the keyword search made to rummager. This will return fewer, more relevant results.

N.B. If your keyword search only contains stop words, the search behaves as if you haven't searched by any keywords and returns all results. 

### Before
<img width="1551" alt="Screen Shot 2019-03-21 at 16 02 09" src="https://user-images.githubusercontent.com/5793815/54766163-bd344900-4bf2-11e9-85c6-cdc9b1a9c5cc.png">

<img width="1551" alt="Screen Shot 2019-03-21 at 16 03 09" src="https://user-images.githubusercontent.com/5793815/54766250-dd640800-4bf2-11e9-8271-c7bc9672794c.png">


### After
![Screen Shot 2019-03-21 at 16 02 17](https://user-images.githubusercontent.com/5793815/54766179-c1f8fd00-4bf2-11e9-911f-a093274357f9.png)

![Screen Shot 2019-03-21 at 16 03 16](https://user-images.githubusercontent.com/5793815/54766274-e523ac80-4bf2-11e9-958e-1179b0d80ca4.png)
