### PR TITLE
[WIP] Demo of citizen readiness finder

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -40,6 +40,8 @@ private
   # without filetype as the value; example:
   # "/guidance-and-regulation" => "guidance_and_regulation"
   FINDERS_IN_DEVELOPMENT = {
+    "/prepare-eu-exit/all" => "citizen_readiness",
+    "/prepare-eu-exit/all/email-signup" => "citizen_readiness_signup",
     "/search/policy-papers-and-consultations" => 'policy_and_engagement',
     "/search/policy-papers-and-consultations/email-signup" => 'policy_and_engagement_email_signup',
     "/search/research-and-statistics" => "statistics",

--- a/features/fixtures/citizen_readiness.json
+++ b/features/fixtures/citizen_readiness.json
@@ -1,0 +1,136 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/prepare-eu-exit/all",
+  "content_id": "3a6d9383-5341-47a8-aaee-860dabd7c4d8",
+  "content_purpose_document_supertype": "navigation",
+  "description": "Detailed information about changes happening after Brexit.",
+  "details": {
+    "summary": "<p>Detailed information about changes happening after Brexit.</p>",
+    "default_documents_per_page": 20,
+    "document_noun": "result",
+    "hide_facets_by_default": false,
+    "filter":{
+      "all_part_of_taxonomy_tree": "d7bdaee2-8ea5-460e-b00d-6e9382eb6b61"
+    },
+    "facets": [
+      {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "any_part_of_taxonomy_tree",
+        "name": "Topic",
+        "preposition": "about",
+        "short_name": "About",
+        "type": "text",
+        "show_option_select_filter": false,
+        "allowed_values":[
+          {
+            "label": "Business and industry",
+            "value": "495afdb6-47be-4df1-8b38-91c8adb1eefc"
+          },
+          {
+            "label": "Crime, justice and law",
+            "value": "ba951b09-5146-43be-87af-44075eac3ae9"
+          },
+          {
+            "label": "Education, training and skills",
+            "value": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0"
+          },
+          {
+            "label": "Environment",
+            "value": "3cf97f69-84de-41ae-bc7b-7e2cc238fa58"
+          },
+          {
+            "label": "Going and being abroad",
+            "value": "9597c30a-605a-4e36-8bc1-47e5cdae41b3"
+          },
+          {
+            "label":"Health and social care",
+            "value":"8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8"
+          },
+          {
+            "label":"Parenting, childcare and children's services",
+            "value":"206b7f3a-49b5-476f-af0f-fd27e2a68473"
+          },
+          {
+            "label":"Transport",
+            "value":"a4038b29-b332-4f13-98b1-1c9709e216bc"
+          },
+          {
+            "label":"Work",
+            "value":"d0f1e5a3-c8f4-4780-8678-994f19104b21"
+          }
+        ]
+      }
+    ],
+    "show_summaries": true,
+    "sort": [
+      {
+        "key": "-popularity",
+        "name": "Most viewed"
+      },
+      {
+        "key": "-relevance",
+        "name": "Relevance"
+      },
+      {
+        "default": true,
+        "key": "-public_timestamp",
+        "name": "Updated (newest)"
+      },
+      {
+        "key": "public_timestamp",
+        "name": "Updated (oldest)"
+      }
+    ]
+  },
+  "document_type": "finder",
+  "email_document_supertype": "other",
+  "first_published_at": "2019-01-17T13:00:00.000+00:00",
+  "government_document_supertype": "other",
+  "links": {
+    "email_alert_signup": [
+      {
+      "api_path": "/api/content/prepare-eu-exit/all/email-signup",
+      "base_path": "/prepare-eu-exit/all/email-signup",
+      "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+      "description": "You'll get an email each time news or communications are published.",
+      "document_type": "finder_email_signup",
+      "locale": "en",
+      "public_updated_at": "2019-03-14T11:17:28Z",
+      "schema_name": "finder_email_signup",
+      "title": "News and communications",
+      "withdrawn": false,
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/prepare-eu-exit/all/email-signup",
+      "web_url": "https://www.gov.uk/prepare-eu-exit/all/email-signup"
+      }
+      ],
+    "parent": [
+      {
+      "api_path": "/api/content/prepare-eu-exit",
+      "base_path": "/prepare-eu-exit",
+      "content_id": "ecb55f9d-0823-43bd-a116-dbfab2b76ef9",
+      "description": "How Brexit affects you - visiting Europe, buying things, studying, family law.",
+      "document_type": "answer",
+      "locale": "en",
+      "public_updated_at": "2019-03-15T15:12:38Z",
+      "schema_name": "special_route",
+      "title": "Prepare for EU Exit if you live in the UK",
+      "withdrawn": false,
+      "links": {},
+      "api_url": "https://www.gov.uk/api/content/prepare-eu-exit",
+      "web_url": "https://www.gov.uk/prepare-eu-exit"
+      }
+    ]
+  },
+  "locale": "en",
+  "navigation_document_supertype": "other",
+  "public_updated_at": "2019-01-17T13:00:00.000+00:00",
+  "publishing_app": "finder-frontend",
+  "rendering_app": "finder-frontend",
+  "schema_name": "finder",
+  "search_user_need_document_supertype": "government",
+  "title": "Detailed EU Exit guidance",
+  "updated_at": "2019-01-17T13:00:00.000+00:00",
+  "user_journey_document_supertype": "finding"
+}

--- a/features/fixtures/citizen_readiness_signup.json
+++ b/features/fixtures/citizen_readiness_signup.json
@@ -1,0 +1,22 @@
+{
+  "base_path": "/prepare-eu-exit/all/email-signup",
+  "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+  "document_type": "finder_email_signup",
+  "title": "Detailed EU Exit guidance",
+  "description": "You'll get an email each time content is published.",
+  "details": {
+    "filter":{
+      "all_part_of_taxonomy_tree": "d7bdaee2-8ea5-460e-b00d-6e9382eb6b61"
+    },
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Detailed EU Exit guidance ",
+    "email_filter_facets": [
+      {
+        "facet_id": "topics",
+        "filter_key": "any_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This sets the citizen taxon as the default filter and allows selection of other topics to constrain/expand the selection.

http://finder-frontend-pr-989.herokuapp.com/prepare-eu-exit/all

https://trello.com/c/bapIIB9X/155-spin-up-a-finder-for-content-tagged-to-brexit-guidance-for-uk-citizens-taxon