### PR TITLE
Remove overriding development finders

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,10 +38,14 @@ private
 
   # Add a finder with the base path as a key and the finder name
   # without filetype as the value; example:
-  # "/guidance-and-regulation" => "guidance_and_regulation"
+  # "/review-search/guidance-and-regulation" => "guidance_and_regulation"
+  # This allows easy development of finders within finder-frontend
+  # *************************************
+  # *** THESE SHOULD NOT BE LIVE URLS ***
+  # *** AS THEY WILL TAKE PRECEDENCE  ***
+  # ***  OVER CONTENT STORE REQUESTS  ***
+  # *************************************
   FINDERS_IN_DEVELOPMENT = {
-    "/search/research-and-statistics" => "statistics",
-    "/search/research-and-statistics/email-signup" => "statistics_email_signup",
     "/review-search/all" => 'all_content'
   }.freeze
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ FinderFrontend::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']


### PR DESCRIPTION
We don't want the finders that we have been using for developing new features to override those that we've defined in content store.

It'll be really confusing to troubleshoot, and people may make unwitting changes to the development finders, not being aware that they might actually be in use on the production system.