### PR TITLE
Changes to facet tag sentence fragments

### DIFF
--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -63,6 +63,7 @@
       {
         "display_as_result_metadata": true,
         "filterable": true,
+        "preposition": "Updated",
         "key": "public_timestamp",
         "name": "Updated",
         "short_name": "Updated",

--- a/features/fixtures/guidance_and_regulation.json
+++ b/features/fixtures/guidance_and_regulation.json
@@ -82,6 +82,7 @@
         "key": "public_timestamp",
         "short_name": "Updated",
         "name": "Updated",
+        "preposition": "Updated",
         "type": "date",
         "display_as_result_metadata": true,
         "filterable": true

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -118,6 +118,7 @@
         "key": "public_timestamp",
         "short_name": "Updated",
         "name": "Updated",
+        "preposition": "Updated",
         "type": "date",
         "display_as_result_metadata": true,
         "filterable": true

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -128,6 +128,7 @@
         "key": "public_timestamp",
         "short_name": "Updated",
         "name": "Updated",
+        "preposition": "Updated",
         "type": "date",
         "display_as_result_metadata": true,
         "filterable": true

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -81,7 +81,7 @@
       {
         "key": "content_store_document_type",
         "name": "Document type",
-        "preposition": "with document type",
+        "preposition": "of type",
         "type":"text",
         "display_as_result_metadata": false,
         "filterable": true,

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -170,6 +170,7 @@
         "key": "public_timestamp",
         "short_name": "Updated",
         "name": "Updated",
+        "preposition": "Updated",
         "type": "date",
         "display_as_result_metadata": true,
         "filterable": true

--- a/features/fixtures/transparency_and_freedom_of_information_releases.json
+++ b/features/fixtures/transparency_and_freedom_of_information_releases.json
@@ -46,6 +46,7 @@
         "key": "public_timestamp",
         "name": "Updated",
         "short_name": "Updated",
+        "preposition": "Updated",
         "type": "date"
       }
     ],


### PR DESCRIPTION
Two changes here, both relating to facet tag preposition text. Please see individual commits for detail.

<img width="676" alt="Screen Shot 2019-03-25 at 10 43 20" src="https://user-images.githubusercontent.com/8124374/54915436-01736200-4eef-11e9-92cb-1f1ab938e8bd.png">

https://trello.com/c/kT5AMe3i/569