### PR TITLE
Remove some govuk_frontend_toolkit sass dependencies

### DIFF
--- a/app/assets/stylesheets/components/_date-filter.scss
+++ b/app/assets/stylesheets/components/_date-filter.scss
@@ -1,7 +1,7 @@
 .app-c-date-filter {
-  margin-bottom: $gutter-two-thirds;
+  margin-bottom: govuk-spacing(4);
 
   @include media(tablet) {
-    margin-bottom: $gutter;
+    margin-bottom: govuk-spacing(6);
   }
 }

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -1,7 +1,7 @@
 .app-c-option-select {
   background-color: govuk-colour("grey-3");
   padding: 5px;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 
   @include media(desktop) {
     // Redefine scrollbars on desktop where these lists are scrollable
@@ -101,7 +101,7 @@
 }
 
 .app-c-option-select__container-inner {
-  padding: $gutter-one-quarter;
+  padding: govuk-spacing(2);
   padding-top: govuk-spacing(1);
 }
 
@@ -110,7 +110,7 @@
 
   .govuk-form-group {
     padding-top: govuk-spacing(2);
-    margin-bottom: $gutter-one-third;
+    margin-bottom: govuk-spacing(2);
   }
 }
 

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -1,5 +1,5 @@
 .app-c-option-select {
-  background-color: $grey-3;
+  background-color: govuk-colour("grey-3");
   padding: 5px;
   margin-bottom: $gutter;
 
@@ -95,7 +95,7 @@
 .app-c-option-select__container {
   position: relative;
   height: 200px;
-  background-color: $page-colour;
+  background-color: govuk-colour("white");
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -2,7 +2,6 @@
 @import "typography";
 @import "measurements";
 @import "grid_layout";
-@import "colours";
 @import "shims";
 @import "css3";
 @import "design-patterns/buttons";
@@ -19,7 +18,7 @@
 }
 
 .document {
-  border-bottom: solid 1px $border-colour;
+  border-bottom: solid 1px $govuk-border-colour;
   padding: $gutter-half 0;
 
   &:first-child {
@@ -62,7 +61,7 @@
   p.historic {
     @include core-14;
     padding: 0 0 3px;
-    color: $secondary-text-colour;
+    color: $govuk-secondary-text-colour;
   }
 }
 
@@ -80,7 +79,7 @@
   }
 
   legend {
-    color:$text-colour;
+    color: $govuk-text-colour;
     margin-bottom: $gutter-half;
     @include media(tablet) {
       margin-bottom: $gutter-two-thirds;
@@ -92,7 +91,7 @@
   }
 
   a.button, input.button {
-    @include button($button-colour);
+    @include button(govuk-colour("green"));
     width: auto;
     @include bold-24;
   }
@@ -209,22 +208,22 @@
     }
 
     fieldset.invalid {
-      border-left: solid 4px $error-colour;
+      border-left: solid 4px $govuk-error-colour;
       padding-left: $gutter-half;
       margin-left: -$gutter-half - 4;
     }
 
     .validation-message {
-      color: $error-colour;
+      color: $govuk-error-colour;
       font-weight: bold;
       padding: $gutter-half;
       margin-left: -$gutter-half - 4;
-      border-left: solid 4px $error-colour;
+      border-left: solid 4px $govuk-error-colour;
     }
   }
 
   .button {
-    @include button($button-colour);
+    @include button(govuk-colour("green"));
     width: auto;
     @include bold-24;
   }
@@ -295,7 +294,7 @@
     padding: 5px;
 
     &:nth-child(odd) {
-      background-color: $grey-4;
+      background-color: govuk-colour("grey-4");
     }
   }
 
@@ -331,9 +330,9 @@
     display: block;
     position: relative;
     padding: 5px;
-    border: 1px solid $grey-1;
+    border: 1px solid govuk-colour("grey-1");
     border-radius: 5px;
-    background-color: $grey-4;
+    background-color: govuk-colour("grey-4");
 
     .js-enabled & {
       padding: 8px 7px 7px 23px;

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,5 +1,4 @@
 // govuk_frontend_toolkit helpers
-@import "measurements";
 @import "grid_layout";
 @import "shims";
 @import "css3";
@@ -18,7 +17,7 @@
 
 .document {
   border-bottom: solid 1px $govuk-border-colour;
-  padding: $gutter-half 0;
+  padding: govuk-spacing(3) 0;
 
   &:first-child {
     padding-top:0;
@@ -52,7 +51,7 @@
     }
 
     dd {
-      margin-right: $gutter-one-third;
+      margin-right: govuk-spacing(2);
       @include inline-block;
     }
   }
@@ -65,23 +64,23 @@
 }
 
 #finder-frontend {
-  margin-bottom: $gutter * 1.5;
+  margin-bottom: govuk-spacing(8);
 
   .signup-content p {
-    margin: $gutter-half 0;
+    margin: govuk-spacing(3) 0;
     @include govuk-font(19);
 
     @include media(tablet) {
-      margin: $gutter 0;
+      margin: govuk-spacing(6) 0;
       max-width: $two-thirds;
     }
   }
 
   legend {
     color: $govuk-text-colour;
-    margin-bottom: $gutter-half;
+    margin-bottom: govuk-spacing(3);
     @include media(tablet) {
-      margin-bottom: $gutter-two-thirds;
+      margin-bottom: govuk-spacing(4);
     }
   }
 
@@ -103,12 +102,12 @@
     }
 
     .summary {
-      margin-bottom: $gutter;
+      margin-bottom: govuk-spacing(6);
       @include govuk-font(19);
     }
 
     .email-link {
-      margin-bottom: $gutter;
+      margin-bottom: govuk-spacing(6);
 
       a {
         @include govuk-font(19, $weight: bold);
@@ -116,15 +115,15 @@
         background: image-url('mail-icon.png') 0 40% no-repeat;
         @include device-pixel-ratio(2.0) {
           background-image: image-url('mail-icon-retina.png');
-          background-size: $gutter-two-thirds 14px;
+          background-size: govuk-spacing(4) 14px;
         }
-        padding-left: $gutter;
+        padding-left: govuk-spacing(6);
       }
     }
 
     .logo {
       @include grid-column(1/3);
-      margin: $gutter 0;
+      margin: govuk-spacing(6) 0;
     }
 
     #logo-image{
@@ -134,8 +133,8 @@
     .related-links {
       @include grid-column(1/3);
       @include govuk-font(16, $weight: bold);
-      margin-top: $gutter * 1.5;
-      margin-bottom: $gutter * 1.5;
+      margin-top: govuk-spacing(8);
+      margin-bottom: govuk-spacing(8);
       list-style:none;
 
       li {
@@ -171,7 +170,7 @@
     p {
       max-width: $full-width;
       @include govuk-font(16);
-      margin-bottom: $gutter;
+      margin-bottom: govuk-spacing(6);
     }
 
     .govuk-select {
@@ -182,14 +181,14 @@
   .help-text {
     @include govuk-font(14);
     display:block;
-    padding: $gutter-one-third/2 0;
+    padding: govuk-spacing(2)/2 0;
     @include media(tablet) {
-      padding: $gutter-one-third 0;
+      padding: govuk-spacing(2) 0;
     }
   }
 
   .app-c-option-select {
-    margin-bottom: $gutter;
+    margin-bottom: govuk-spacing(6);
   }
 
   .form {
@@ -199,7 +198,7 @@
     }
 
     input.button[type=submit] {
-      margin-top: $gutter-one-third;
+      margin-top: govuk-spacing(2);
     }
 
     p {
@@ -208,15 +207,15 @@
 
     fieldset.invalid {
       border-left: solid 4px $govuk-error-colour;
-      padding-left: $gutter-half;
-      margin-left: -$gutter-half - 4;
+      padding-left: govuk-spacing(3);
+      margin-left: -govuk-spacing(3) - 4;
     }
 
     .validation-message {
       color: $govuk-error-colour;
       font-weight: bold;
-      padding: $gutter-half;
-      margin-left: -$gutter-half - 4;
+      padding: govuk-spacing(3);
+      margin-left: -govuk-spacing(3) - 4;
       border-left: solid 4px $govuk-error-colour;
     }
   }
@@ -241,12 +240,12 @@
     .result-info {
       @include govuk-font(16);
       vertical-align: baseline;
-      margin: 0 0 $gutter 0;
+      margin: 0 0 govuk-spacing(6) 0;
       border-bottom: solid 1px govuk-colour("black");
 
       .result-count {
         @include govuk-font(27, $weight: bold);
-        margin-right: $gutter-one-third / 2;
+        margin-right: govuk-spacing(2) / 2;
       }
     }
 
@@ -257,14 +256,14 @@
     .feed {
       @include govuk-font(14);
       display: block;
-      margin-bottom: $gutter;
+      margin-bottom: govuk-spacing(6);
       span {
-        padding-right: $gutter-one-third / 2;
+        padding-right: govuk-spacing(2) / 2;
       }
       a {
         background: image-url('feed-icon-black.png') 0 40% no-repeat;
         font-weight: bold;
-        padding: 0 $gutter-one-third 0 $gutter-half;
+        padding: 0 govuk-spacing(2) 0 govuk-spacing(3);
         text-decoration: none;
       }
     }
@@ -279,14 +278,14 @@
 
       .filtered-results__facet-heading {
         @include govuk-font($size: 24, $weight: bold);
-        margin-bottom: $gutter-half;
+        margin-bottom: govuk-spacing(3);
       }
     }
   }
 
   .facet-tags {
-    margin-top: $gutter-one-third;
-    margin-bottom: $gutter;
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(6);
   }
 
   .facet-tags__group {
@@ -377,7 +376,7 @@
 
 .facet-toggle {
   display: none;
-  margin-bottom: $gutter;
+  margin-bottom: govuk-spacing(6);
 }
 
 .js-enabled {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,5 +1,4 @@
 // govuk_frontend_toolkit helpers
-@import "typography";
 @import "measurements";
 @import "grid_layout";
 @import "shims";
@@ -27,7 +26,7 @@
   }
 
   .document__link {
-    @include bold-19;
+    @include govuk-font(19, $weight: bold);
     margin: 0;
     text-decoration: none;
 
@@ -40,7 +39,7 @@
     margin: 0;
 
     dt, dd {
-      @include core-14;
+      @include govuk-font(14);
       margin-left: 0;
     }
 
@@ -59,7 +58,7 @@
   }
 
   p.historic {
-    @include core-14;
+    @include govuk-font(14);
     padding: 0 0 3px;
     color: $govuk-secondary-text-colour;
   }
@@ -70,7 +69,7 @@
 
   .signup-content p {
     margin: $gutter-half 0;
-    @include core-19;
+    @include govuk-font(19);
 
     @include media(tablet) {
       margin: $gutter 0;
@@ -93,7 +92,7 @@
   a.button, input.button {
     @include button(govuk-colour("green"));
     width: auto;
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
   }
 
   header {
@@ -105,14 +104,14 @@
 
     .summary {
       margin-bottom: $gutter;
-      @include core-19;
+      @include govuk-font(19);
     }
 
     .email-link {
       margin-bottom: $gutter;
 
       a {
-        @include bold-19;
+        @include govuk-font(19, $weight: bold);
         text-decoration:none;
         background: image-url('mail-icon.png') 0 40% no-repeat;
         @include device-pixel-ratio(2.0) {
@@ -134,7 +133,7 @@
 
     .related-links {
       @include grid-column(1/3);
-      @include bold-16;
+      @include govuk-font(16, $weight: bold);
       margin-top: $gutter * 1.5;
       margin-bottom: $gutter * 1.5;
       list-style:none;
@@ -171,7 +170,7 @@
 
     p {
       max-width: $full-width;
-      @include core-16;
+      @include govuk-font(16);
       margin-bottom: $gutter;
     }
 
@@ -181,7 +180,7 @@
   }
 
   .help-text {
-    @include core-14;
+    @include govuk-font(14);
     display:block;
     padding: $gutter-one-third/2 0;
     @include media(tablet) {
@@ -194,7 +193,7 @@
   }
 
   .form {
-    @include core-19;
+    @include govuk-font(19);
     @include media(tablet) {
       max-width: $two-thirds;
     }
@@ -225,7 +224,7 @@
   .button {
     @include button(govuk-colour("green"));
     width: auto;
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
   }
 
   .search-results-title {
@@ -240,13 +239,13 @@
 
   .filtered-results {
     .result-info {
-      @include core-16;
+      @include govuk-font(16);
       vertical-align: baseline;
       margin: 0 0 $gutter 0;
       border-bottom: solid 1px govuk-colour("black");
 
       .result-count {
-        @include bold-27;
+        @include govuk-font(27, $weight: bold);
         margin-right: $gutter-one-third / 2;
       }
     }
@@ -256,7 +255,7 @@
     }
 
     .feed {
-      @include core-14;
+      @include govuk-font(14);
       display: block;
       margin-bottom: $gutter;
       span {
@@ -362,7 +361,7 @@
     padding: 8px;
     border-radius: 5px;
     font-weight: bold;
-    @include bold-16;
+    @include govuk-font(16, $weight: bold);
     text-align: left;
     cursor: pointer;
     color: #000;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,3 @@
-@import "colours";
 @import "shims";
 @import "govuk_publishing_components/all_components_print";
 
@@ -35,7 +34,7 @@ header {
   .document {
     margin: 10px 0;
     padding-bottom: 10px;
-    border-bottom: 1px solid $border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
     list-style: none;
   }
   a {

--- a/app/assets/stylesheets/views/_advanced-search.scss
+++ b/app/assets/stylesheets/views/_advanced-search.scss
@@ -11,7 +11,7 @@
   }
 
   .taxon-link {
-    @include bold-24;
+    @include govuk-font(24, $weight: bold);
   }
 
   .pub-c-title {
@@ -21,11 +21,11 @@
 
   .filtered-results {
     .metadata-date-value {
-      @include core-14;
+      @include govuk-font(14);
     }
 
     .result-info {
-      @include core-24;
+      @include govuk-font(24);
     }
   }
 

--- a/app/assets/stylesheets/views/_advanced-search.scss
+++ b/app/assets/stylesheets/views/_advanced-search.scss
@@ -2,7 +2,7 @@
 #finder-frontend.advanced-search {
   header {
     margin: 0;
-    margin-bottom: $gutter * 2;
+    margin-bottom: govuk-spacing(9);
   }
 
   .breadcrumb-wrapper,
@@ -15,8 +15,8 @@
   }
 
   .pub-c-title {
-    margin-bottom: $gutter-half;
-    margin-top: $gutter-half;
+    margin-bottom: govuk-spacing(3);
+    margin-top: govuk-spacing(3);
   }
 
   .filtered-results {

--- a/app/assets/stylesheets/views/_overrides.scss
+++ b/app/assets/stylesheets/views/_overrides.scss
@@ -1,8 +1,8 @@
 /* Overrides styling of legends in finder-frontend.scss */
 legend.gem-c-title--margin-bottom-5 {
-  margin-bottom: $gutter-half !important;
+  margin-bottom: govuk-spacing(3) !important;
 
   @include media(tablet) {
-    margin-bottom: $gutter * 1.5 !important;
+    margin-bottom: govuk-spacing(8) !important;
   }
 }

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -6,7 +6,7 @@ main.search {
   }
 
   h1 {
-    @include core-24;
+    @include govuk-font(24);
     font-weight: bold;
     padding-bottom: 10px;
   }
@@ -104,7 +104,7 @@ main.search {
               padding: 0 0 15px;
 
               p {
-                @include core-14;
+                @include govuk-font(14);
               }
 
             }
@@ -115,7 +115,7 @@ main.search {
           }
 
           h4 {
-            @include core-14;
+            @include govuk-font(14);
             margin: 0;
 
             a {
@@ -140,7 +140,7 @@ main.search {
           margin-bottom: $gutter;
 
           .descope-message {
-            @include core-16;
+            @include govuk-font(16);
           }
 
           ol {
@@ -149,7 +149,7 @@ main.search {
         }
 
         h3 {
-          @include core-24;
+          @include govuk-font(24);
           margin: 0;
           padding-bottom: 2px;
 
@@ -170,7 +170,7 @@ main.search {
         }
 
         .sections {
-          @include core-16;
+          @include govuk-font(16);
           margin: 0;
           padding: 0;
           overflow: hidden;
@@ -187,7 +187,7 @@ main.search {
         }
 
         .attributes {
-          @include core-14;
+          @include govuk-font(14);
           color: $govuk-secondary-text-colour;
           padding: 0 0 3px;
           margin: 0;
@@ -209,13 +209,13 @@ main.search {
         }
 
         p {
-          @include core-16;
+          @include govuk-font(16);
           margin: 0;
           padding: 0;
 
           &.historic,
           &.meta {
-            @include core-14;
+            @include govuk-font(14);
             padding: 0 0 3px;
             word-wrap: break-word;
             color: $govuk-secondary-text-colour;
@@ -225,11 +225,11 @@ main.search {
 
     }
     .zero-results {
-      @include core-19;
+      @include govuk-font(19);
 
       h2 {
         margin-top: $gutter;
-        @include bold-24;
+        @include govuk-font(24, $weight: bold);
       }
 
       ul,
@@ -262,7 +262,7 @@ main.search {
 
   .filter-form {
     p {
-      @include core-16;
+      @include govuk-font(16);
       margin-bottom: $gutter;
     }
 
@@ -276,7 +276,7 @@ main.search {
       }
 
       .legend {
-        @include core-19;
+        @include govuk-font(19);
         @include inline-block;
         margin-right:40px;
         font-weight:bold;
@@ -288,8 +288,7 @@ main.search {
 main.no-search-term {
   @include media(tablet) {
     h1 {
-      @include core-48;
-      font-weight: bold;
+      @include govuk-font(48, $weight: bold);
       padding-bottom: 15px;
     }
   }

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -18,11 +18,11 @@ main.search {
   .search-header {
     position: relative;
     margin: 0;
-    padding: $gutter 0 $gutter / 2;
+    padding: govuk-spacing(6) 0 govuk-spacing(3);
     overflow: visible;
 
     @include media(tablet) {
-      padding: ($gutter * 1.5) 0 $gutter;
+      padding: govuk-spacing(8) 0 govuk-spacing(6);
       width: 66.666%;
     }
 
@@ -136,15 +136,15 @@ main.search {
 
         li.descoped-results {
           border-left: 4px solid $govuk-blue;
-          padding: $gutter-half 0 0 $gutter-half;
-          margin-bottom: $gutter;
+          padding: govuk-spacing(3) 0 0 govuk-spacing(3);
+          margin-bottom: govuk-spacing(6);
 
           .descope-message {
             @include govuk-font(16);
           }
 
           ol {
-            padding: $gutter-half 0 0;
+            padding: govuk-spacing(3) 0 0;
           }
         }
 
@@ -228,20 +228,20 @@ main.search {
       @include govuk-font(19);
 
       h2 {
-        margin-top: $gutter;
+        margin-top: govuk-spacing(6);
         @include govuk-font(24, $weight: bold);
       }
 
       ul,
       p {
-        margin-top: $gutter-half;
-        margin-bottom: $gutter-half;
+        margin-top: govuk-spacing(3);
+        margin-bottom: govuk-spacing(3);
       }
 
       ul {
         list-style: disc;
         list-style-position: outside;
-        margin-left: $gutter-two-thirds;
+        margin-left: govuk-spacing(4);
       }
     }
   }
@@ -263,11 +263,11 @@ main.search {
   .filter-form {
     p {
       @include govuk-font(16);
-      margin-bottom: $gutter;
+      margin-bottom: govuk-spacing(6);
     }
 
     .filter {
-      margin-bottom: $gutter-one-third;
+      margin-bottom: govuk-spacing(2);
       background-color: govuk-colour("grey-3");
       padding:5px;
 

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -27,7 +27,7 @@ main.search {
     }
 
     h1 {
-      color: $black;
+      color: govuk-colour("black");
     }
   }
 
@@ -123,7 +123,7 @@ main.search {
               text-decoration: none;
 
               &:hover, &:focus {
-                color: $link-colour;
+                color: $govuk-link-colour;
                 text-decoration: underline;
               }
             }
@@ -158,12 +158,12 @@ main.search {
             text-decoration: none;
 
             &:visited mark {
-              color: $link-visited-colour;
+              color: $govuk-link-visited-colour;
             }
 
             &:hover, &:focus,
             &:hover mark, &:focus mark {
-              color: $link-colour;
+              color: $govuk-link-colour;
               text-decoration: underline;
             }
           }
@@ -188,7 +188,7 @@ main.search {
 
         .attributes {
           @include core-14;
-          color: $secondary-text-colour;
+          color: $govuk-secondary-text-colour;
           padding: 0 0 3px;
           margin: 0;
 
@@ -218,7 +218,7 @@ main.search {
             @include core-14;
             padding: 0 0 3px;
             word-wrap: break-word;
-            color: $secondary-text-colour;
+            color: $govuk-secondary-text-colour;
           }
         }
       }
@@ -268,7 +268,7 @@ main.search {
 
     .filter {
       margin-bottom: $gutter-one-third;
-      background-color:$grey-3;
+      background-color: govuk-colour("grey-3");
       padding:5px;
 
       &:focus {


### PR DESCRIPTION
Beginning to remove `govuk_frontend_toolkit` sass dependencies. 

**Colours**

Replacing [_palette.scss](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss) with [corresponding colours from GOVUK Frontend](https://design-system.service.gov.uk/styles/colour/). 

All colours have an exact corresponding variable in GOVUK Frontend, with the exception of `button-colour`, which has been replaced with the nearest GOVUK Frontend green value.

**Typography**

Replacing [_typography.scss](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss) with GOVUK Frontend typography mixins.

Interestingly once this change was complete the total CSS filesize according to Chrome developer tools jumped from `815KB` to `825KB`. This will be investigated separately.

**Measurements**

Replacing [_measurements.scss](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_measurements.scss) that includes all of the $gutter (30px) variables, with the GOVUK Frontend [spacing scale](https://design-system.service.gov.uk/styles/spacing/). No changes make use of the responsive spacing mixins, that was deemed too complex for this PR.

Includes some minor layout changes, specifically measurements like `$gutter * 1.5` (45px) which do not have a corresponding value in the spacing scale. Where this problem has been encountered, values have been replaced with the nearest, larger, value in the spacing scale e.g. 45px has been replaced with 50px.

Note that measurements.scss is still being pulled in as part of grid_layout, so this isn't a full removal yet. I'm going to look at grid_layout in a separate PR, as it's more likely to break things.