### PR TITLE
Adds in lib object for publications routes

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -1,4 +1,9 @@
+require 'publications_routes'
+
 class RedirectionController < ApplicationController
+  include PublicationsRoutes
+  DEFAULT_PUBLICATIONS_PATH = 'search/all'.freeze
+
   def announcements
     respond_to do |format|
       format.html { redirect_to(finder_path('search/news-and-communications', params: convert_common_parameters)) }
@@ -8,8 +13,8 @@ class RedirectionController < ApplicationController
 
   def publications
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/all', params: convert_common_parameters)) }
-      format.atom { redirect_to(finder_path('search/all', params: convert_common_parameters, format: :atom)) }
+      format.html { redirect_to(finder_path(publications_base_path, params: convert_common_parameters.merge(content_store_document_type: set_document_type).compact)) }
+      format.atom { redirect_to(finder_path(publications_base_path, params: convert_common_parameters.merge(content_store_document_type: set_document_type).compact, format: :atom)) }
     end
   end
 
@@ -28,6 +33,15 @@ class RedirectionController < ApplicationController
   end
 
 private
+
+  def publications_base_path
+    base_path = PUBLICATIONS_ROUTES.dig(params[:publication_filter_option], :base_path)
+    base_path || DEFAULT_PUBLICATIONS_PATH
+  end
+
+  def set_document_type
+    PUBLICATIONS_ROUTES.dig(params[:publication_filter_option], :special_params, :content_store_document_type)
+  end
 
   def convert_common_parameters
     { keywords: params['keywords'],

--- a/app/lib/publications_routes.rb
+++ b/app/lib/publications_routes.rb
@@ -1,0 +1,49 @@
+module PublicationsRoutes
+  PUBLICATIONS_ROUTES = {
+    'consultations' => {
+      base_path: 'search/policy-papers-and-consultations',
+      special_params: {
+        content_store_document_type: %w[open_consultations closed_consultations],
+      }
+    },
+    'closed-consultations' => {
+      base_path: 'search/policy-papers-and-consultations',
+      special_params: {
+        content_store_document_type: 'closed_consultations',
+      }
+    },
+    'open-consultations' => {
+      base_path: 'search/policy-papers-and-consultations',
+      special_params: {
+        content_store_document_type: 'open_consultations',
+      }
+    },
+    'foi-releases' => {
+      base_path: 'search/transparency-and-freedom-of-information-releases'
+    },
+    'transparency-data' => {
+      base_path: 'search/transparency-and-freedom-of-information-releases'
+    },
+    'guidance' => {
+      base_path: 'search/guidance-and-regulation'
+    },
+    'policy-papers' => {
+      base_path: 'search/policy-papers-and-consultations',
+      special_params: {
+        content_store_document_type: 'policy_papers'
+      }
+    },
+    'forms' => {
+      base_path: 'search/services'
+    },
+    'research-and-analysis' => {
+      base_path: 'search/research-and-statistics',
+      special_params: {
+        content_store_document_type: 'research'
+      }
+    },
+    'statistics' => {
+      base_path: 'search/research-and-statistics'
+    }
+  }.freeze
+end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -34,12 +34,8 @@ describe RedirectionController, type: :controller do
   end
 
   describe '#publications' do
-    it "redirects to the all page" do
-      get :publications
-      expect(response).to redirect_to finder_path('search/all')
-    end
-    it 'passes on a set of params' do
-      get :publications, params: {
+    let(:received_params) {
+      {
         keywords: %w[one two],
         taxons: %w[one],
         subtaxons: %w[two],
@@ -48,14 +44,96 @@ describe RedirectionController, type: :controller do
         from_date: '01/01/2014',
         to_date: '01/01/2014'
       }
-      expect(response).to redirect_to finder_path('search/all', params: {
+    }
+
+    let(:converted_params) {
+      {
         keywords: %w[one two],
         level_one_taxon: 'one',
         level_two_taxon: 'two',
         organisations: %w[one two],
         world_locations: %w[one two],
         public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
-      })
+      }
+    }
+
+    it "redirects to the all page by default" do
+      get :publications
+      expect(response).to redirect_to finder_path('search/all')
+    end
+    it 'passes on a set of params' do
+      get :publications, params: received_params
+      expect(response).to redirect_to finder_path('search/all', params: converted_params)
+    end
+    it 'redirects when consultations is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'consultations')
+      expect(response).to redirect_to finder_path(
+        'search/policy-papers-and-consultations',
+        params: converted_params.merge(content_store_document_type: %w[open_consultations closed_consultations])
+      )
+    end
+    it 'redirects when closed-consultations is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'closed-consultations')
+      expect(response).to redirect_to finder_path(
+        'search/policy-papers-and-consultations',
+        params: converted_params.merge(content_store_document_type: 'closed_consultations')
+      )
+    end
+    it 'redirects when open-consultations is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'open-consultations')
+      expect(response).to redirect_to finder_path(
+        'search/policy-papers-and-consultations',
+        params: converted_params.merge(content_store_document_type: 'open_consultations')
+      )
+    end
+    it 'redirects when foi-releases is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'foi-releases')
+      expect(response).to redirect_to finder_path(
+        'search/transparency-and-freedom-of-information-releases',
+        params: converted_params
+      )
+    end
+    it 'redirects when transparency-data is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'transparency-data')
+      expect(response).to redirect_to finder_path(
+        'search/transparency-and-freedom-of-information-releases',
+        params: converted_params
+      )
+    end
+    it 'redirects when guidance is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'guidance')
+      expect(response).to redirect_to finder_path(
+        'search/guidance-and-regulation',
+        params: converted_params
+      )
+    end
+    it 'redirects when policy-papers is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'policy-papers')
+      expect(response).to redirect_to finder_path(
+        'search/policy-papers-and-consultations',
+        params: converted_params.merge(content_store_document_type: 'policy_papers')
+      )
+    end
+    it 'redirects when forms is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'forms')
+      expect(response).to redirect_to finder_path(
+        'search/services',
+        params: converted_params
+      )
+    end
+    it 'redirects when research-and-analysis is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'research-and-analysis')
+      expect(response).to redirect_to finder_path(
+        'search/research-and-statistics',
+        params: converted_params.merge(content_store_document_type: 'research')
+      )
+    end
+    it 'redirects when statistics is selected' do
+      get :publications, params: received_params.merge(publication_filter_option: 'statistics')
+      expect(response).to redirect_to finder_path(
+        'search/research-and-statistics',
+        params: converted_params
+      )
     end
     it 'redirects to the atom feed' do
       get :publications, params: { keywords: %w[one two] }, format: :atom


### PR DESCRIPTION
Adds a big list of special behaviour for the publications redirections.
Depending on the publication_filter_option that's selected, there's a
variety of redirections, which this addresses.

Tests are also included for each of these special redirects, as well as
the default path to search/all when nothing special should happen.

https://trello.com/c/8iWtTLXi/514-redirect-publications-finder-to-finder-frontend-m