### PR TITLE
Add context to finders 'search' field

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,9 +1,12 @@
 <div class="filter-form">
   <% if finder.show_keyword_search? and !finder.all_content_finder? %>
     <div id="keywords">
+      <% label_text = capture do %>
+        Search <span class="govuk-visually-hidden"><%= finder.name %></span>
+      <% end %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: "Search"
+          text: label_text
         },
         name: "keywords",
         value: @results.user_supplied_keywords,

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -533,8 +533,8 @@ end
 
 And(/^I select some document types$/) do
   click_on('Document type')
-  find('.govuk-label', text: 'Policy papers').click
-  find('.govuk-label', text: 'Consultations (closed)').click
+  find('.govuk-checkboxes__item .govuk-label', text: 'Policy papers').click
+  find('.govuk-checkboxes__item .govuk-label', text: 'Consultations (closed)').click
 end
 
 And(/^I select upcoming statistics$/) do


### PR DESCRIPTION
Adds some visually hidden text to include the finder name, to improve the context of the search field for screen reader users.

Trello card: https://trello.com/c/SP6E75yt/435-add-some-context-to-search-field-for-screen-reader-users-m

This PR is a copy of https://github.com/alphagov/finder-frontend/pull/967, which is consistently failing its build for no clear reason.