### PR TITLE
Adds hidden clearable facet tag for manuals

### DIFF
--- a/app/lib/facet_query_builder.rb
+++ b/app/lib/facet_query_builder.rb
@@ -27,11 +27,11 @@ private
   attr_reader :facets
 
   def dynamic_facets
-    text_facets.select { |f| f['allowed_values'].blank? }
+    facets_that_could_be_dynamic.select { |f| f['allowed_values'].blank? }
   end
 
-  def text_facets
-    filterable_facets.select { |f| %w(text).include? f['type'] }
+  def facets_that_could_be_dynamic
+    filterable_facets.select { |f| %w(text hidden_clearable).include? f['type'] }
   end
 
   def filterable_facets

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -30,7 +30,8 @@ private
       'topical' => Filters::TopicalFilter,
       'taxon' => Filters::TaxonFilter,
       'radio' => Filters::RadioFilter,
-      'content_id' => Filters::ContentIdFilter
+      'content_id' => Filters::ContentIdFilter,
+      'hidden_clearable' => Filters::HiddenClearableFilter
     }.fetch(facet['type'])
 
     filter_class.new(facet, params(facet))

--- a/app/lib/filters/hidden_clearable_filter.rb
+++ b/app/lib/filters/hidden_clearable_filter.rb
@@ -1,0 +1,7 @@
+module Filters
+  class HiddenClearableFilter < Filter
+    def value
+      params
+    end
+  end
+end

--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -9,6 +9,7 @@ module Registries
         'part_of_taxonomy_tree' => topic_taxonomy,
         'people' => people,
         'organisations' => organisations,
+        'manual' => manuals,
       }
     end
 
@@ -28,6 +29,10 @@ module Registries
 
     def organisations
       @organisations ||= OrganisationsRegistry.new
+    end
+
+    def manuals
+      @manuals ||= ManualsRegistry.new
     end
   end
 end

--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -1,0 +1,43 @@
+module Registries
+  class ManualsRegistry
+    CACHE_KEY = 'registries/manuals'.freeze
+
+    def [](base_url)
+      manuals[base_url]
+    end
+
+    def values
+      manuals
+    end
+
+  private
+
+    def manuals
+      @manuals ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        manuals_as_hash
+      end
+    rescue GdsApi::HTTPServerError
+      GovukStatsd.increment('registries.manuals_api_errors')
+      {}
+    end
+
+    def manuals_as_hash
+      GovukStatsd.time('registries.manuals.request_time') do
+        fetch_manuals_from_rummager
+          .reject { |manual| manual['_id'].empty? || manual['title'].empty? }
+          .each_with_object({}) { |manual, manuals|
+            manuals[manual['_id']] = { 'title' => manual['title'], 'slug' => manual['_id'] }
+          }
+      end
+    end
+
+    def fetch_manuals_from_rummager
+      params = {
+          filter_document_type: 'manual',
+          fields: %w(title),
+          count: 1500,
+      }
+      Services.rummager.search(params)['results']
+    end
+  end
+end

--- a/app/models/hidden_clearable_facet.rb
+++ b/app/models/hidden_clearable_facet.rb
@@ -1,0 +1,42 @@
+class HiddenClearableFacet < FilterableFacet
+  def value=(new_value)
+    @value = Array(new_value)
+  end
+
+  def sentence_fragment
+    return nil unless selected_values.any?
+
+    {
+        'key' => key,
+        'preposition' => preposition,
+        'values' => value_fragments,
+        'word_connectors' => or_word_connectors
+    }
+  end
+
+  def has_filters?
+    selected_values.any?
+  end
+
+private
+
+  def value_fragments
+    @value_fragments ||= selected_values.map { |value|
+      {
+          'label' => value['label'],
+          'value' => value['value'],
+          'parameter_key' => key
+      }
+    }
+  end
+
+  def selected_values
+    @selected_values ||= begin
+      return [] if @value.nil?
+
+      allowed_values.select { |option|
+        @value.include?(option['value'])
+      }
+    end
+  end
+end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -20,6 +20,8 @@ module FacetParser
         DropdownSelectFacet.new(facet)
       when 'radio'
         RadioFacet.new(facet)
+      when 'hidden_clearable'
+        HiddenClearableFacet.new(facet)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet['type']}")
       end

--- a/app/views/finders/_hidden_clearable_facet.html.erb
+++ b/app/views/finders/_hidden_clearable_facet.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= hidden_clearable_facet.key %>" style="display: none">
+<%
+  key = hidden_clearable_facet.key
+  values = params[key]
+  key = "#{key}[]" if values.is_a?(Array)
+-%>
+<% [values].flatten.each_with_index do |value, index| -%>
+
+
+  <%= text_field_tag key, value, id: "#{hidden_clearable_facet.key}_#{index}" %>
+<% end -%>
+</div>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -343,3 +343,10 @@ Feature: Filtering documents
     And I select upcoming statistics
     Then I should see upcoming statistics
     And I should not see an upcoming statistics facet tag
+
+  @javascript
+  Scenario: Finder has a clearable hidden input
+    When I view the all content finder with a manual filter
+    Then I can see results filtered by that manual
+    And I click the Replacing bristles in your Nimbus 2000 remove control
+    Then I see all content results

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -29,8 +29,7 @@
         "name": "Manual",
         "preposition": "in manual",
         "short_name": "in",
-        "type": "text",
-        "show_option_select_filter": false
+        "type": "hidden_clearable"
       },
       {
         "display_as_result_metadata": true,

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -164,6 +164,24 @@ When(/^I view the research and statistics finder$/) do
   visit finder_path('research-and-statistics')
 end
 
+When(/^I view the all content finder with a manual filter$/) do
+  topic_taxonomy_has_taxons
+  content_store_has_all_content_finder
+  stub_whitehall_api_world_location_request
+  stub_people_registry_request
+  stub_manuals_registry_request
+  stub_request(:get,
+    all_content_url(
+      filter_manual: '/guidance/care-and-use-of-a-nimbus-2000',
+      q: 'Replacing bristles'
+    )).to_return(body: all_content_manuals_results_json)
+
+  stub_request(:get, all_content_url(q: 'Replacing bristles'))
+    .to_return(body: all_content_results_json)
+
+  visit finder_path('search/all', manual: '/guidance/care-and-use-of-a-nimbus-2000', q: 'Replacing bristles')
+end
+
 When(/^I view the all content finder$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
@@ -755,4 +773,22 @@ end
 
 And(/^The top result has the correct tracking data$/) do
   expect(page).to have_css("a[data-track-category='navFinderLinkClicked']")
+end
+
+Then(/^I can see results filtered by that manual$/) do
+  expect(page).to have_css('.filtered-results .document', count: 1)
+
+  within '.filtered-results .document:nth-child(1)' do
+    expect(page).to_not have_content('Restrictions on usage of spells within school grounds')
+    expect(page).to have_content('Replacing bristles in your Nimbus 2000')
+  end
+end
+
+Then(/^I see all content results$/) do
+  expect(page).to have_css('.filtered-results .document', count: 1)
+
+  within '.filtered-results .document:nth-child(1)' do
+    expect(page).to have_content('Restrictions on usage of spells within school grounds')
+    expect(page).to_not have_content('Replacing bristles in your Nimbus 2000')
+  end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -2043,6 +2043,66 @@ module DocumentHelper
     }|
   end
 
+  def all_content_manuals_results_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Replacing bristles in your Nimbus 2000",
+              "link": "/replacing-bristles-nimbus-2000",
+              "description": "Replacing bristles in your Nimbus 2000",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
+                {
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
+                }
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/replacing-bristles-nimbus-2000",
+              "elasticsearch_type": "manual",
+              "document_type": "manual"
+            }
+          ],
+        "facets": {
+            "manual": [
+                {
+                    "title": "Replacing bristles in your Nimbus 2000",
+                    "_id": "/guidance/care-and-use-of-a-nimbus-2000"
+                },
+                {
+                    "title": "Upgrading the baud rate on the Floo Network",
+                    "_id": "upgrading-baud-rate-on-the-floo-network"
+                }
+            ],
+            "documents_with_no_value": 0,
+            "total_options": 2,
+            "missing_options": 0,
+            "scope": "exclude_field_filter"
+          },
+          "total": 1,
+          "start": 0,
+          "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
   def business_readiness_results_json
     @business_readiness_results_json ||=
       File.read(Rails.root.join('features', 'fixtures', 'business_readiness_results.json'))

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -1,54 +1,54 @@
 module RegistrySpecHelper
   def stub_people_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
-    .with(query: {
-      count: 0,
-      facet_people: '1500,examples:0,order:value.title'
-    })
-    .to_return(body: {
-      results: [],
-      facets: {
-        people: {
-          options: [
-            {
-              value: {
-                title: "Albus Dumbledore",
-                slug: "albus-dumbledore",
-                _id: "a field that we're not using"
-              }
-            },
-            {
-              value: {
-                title: "Cornelius Fudge",
-                slug: "cornelius-fudge",
-                _id: "a field that we're not using"
-              }
-            },
-            {
-              value: {
-                title: "Harry Potter",
-                slug: "harry-potter",
-                _id: "a field that we're not using"
-              }
-            },
-            {
-              value: {
-                title: "Ron Weasley",
-                slug: "ron-weasley",
-                _id: "a field that we're not using"
-              }
-            },
-            {
-              value: {
-                title: "Rufus Scrimgeour",
-                slug: "rufus-scrimgeour",
-                _id: "/government/people/rufus-scrimgeour"
-              }
+        .with(query: {
+            count: 0,
+            facet_people: '1500,examples:0,order:value.title'
+        })
+        .to_return(body: {
+            results: [],
+            facets: {
+                people: {
+                    options: [
+                        {
+                            value: {
+                                title: "Albus Dumbledore",
+                                slug: "albus-dumbledore",
+                                _id: "a field that we're not using"
+                            }
+                        },
+                        {
+                            value: {
+                                title: "Cornelius Fudge",
+                                slug: "cornelius-fudge",
+                                _id: "a field that we're not using"
+                            }
+                        },
+                        {
+                            value: {
+                                title: "Harry Potter",
+                                slug: "harry-potter",
+                                _id: "a field that we're not using"
+                            }
+                        },
+                        {
+                            value: {
+                                title: "Ron Weasley",
+                                slug: "ron-weasley",
+                                _id: "a field that we're not using"
+                            }
+                        },
+                        {
+                            value: {
+                                title: "Rufus Scrimgeour",
+                                slug: "rufus-scrimgeour",
+                                _id: "/government/people/rufus-scrimgeour"
+                            }
+                        }
+                    ]
+                }
             }
-          ]
-        }
-      }
-    }.to_json)
+        }.to_json)
   end
 
   def stub_organisations_registry_request
@@ -83,5 +83,26 @@ module RegistrySpecHelper
         "_id": "a field that we're not using"
       }
     ] }.to_json)
+  end
+
+  def stub_manuals_registry_request
+    stub_request(:get, "http://search.dev.gov.uk/search.json")
+      .with(query: {
+          filter_document_type: 'manual',
+          fields: %w(title),
+          count: 1500,
+      })
+      .to_return(body: {
+        results: [
+          {
+              title: "Replacing bristles in your Nimbus 2000",
+              _id: "/guidance/care-and-use-of-a-nimbus-2000"
+          },
+          {
+              title: "Upgrading the baud rate on the Floo Network",
+              _id: "upgrading-baud-rate-on-the-floo-network"
+          }
+        ]
+      }.to_json)
   end
 end

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+RSpec.describe Registries::ManualsRegistry do
+  let(:slug) { '/guidance/care-and-use-of-a-nimbus-2000' }
+  let(:rummager_params) {
+    {
+      filter_document_type: 'manual',
+      fields: %w(title),
+      count: 1500
+    }
+  }
+  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+
+  describe "when rummager is available" do
+    before do
+      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      clear_cache
+    end
+
+    it "will fetch manual information by slug" do
+      manual = described_class.new
+      expect(manual[slug]).to eq(
+        'title' => 'Care and use of a Nimbus 2000',
+        'slug' => slug
+      )
+      expect(manual.values).to eq(
+        slug => {
+              'title' => 'Care and use of a Nimbus 2000',
+              'slug' => slug
+           }
+       )
+    end
+  end
+
+  describe 'there is no id or title' do
+    it 'will remove those results' do
+      stub_request(:get, rummager_url).to_return(
+        body: {
+          "results": [
+            {
+              'title' => '',
+              'index' => 'govuk',
+              'es_score' => nil,
+              '_id' => ''
+            }
+          ]
+        }
+        .to_json
+      )
+      clear_cache
+      expect(described_class.new.values).to be_empty
+    end
+  end
+
+  describe "when rummager is unavailable" do
+    before do
+      rummager_is_unavailable
+      clear_cache
+    end
+
+    it "will return an (uncached) empty hash" do
+      manual = described_class.new[slug]
+      expect(manual).to be_nil
+      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+    end
+  end
+
+  def rummager_is_unavailable
+    stub_request(:get, rummager_url).to_return(status: 500)
+  end
+
+  def clear_cache
+    Rails.cache.delete(described_class::CACHE_KEY)
+  end
+
+  def rummager_results
+    %|{
+      "results": [
+        {
+          "title": "Care and use of a Nimbus 2000",
+          "index": "govuk",
+          "es_score": "nil",
+          "_id": "/guidance/care-and-use-of-a-nimbus-2000",
+          "elasticsearch_type": "manual",
+          "document_type": "manual"
+        }
+      ]
+    }|
+  end
+end

--- a/spec/models/hidden_clearable_facet_spec.rb
+++ b/spec/models/hidden_clearable_facet_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe HiddenClearableFacet do
+  let(:allowed_values) {
+    [
+        {
+            'label' => "Allowed value 1",
+            'value' => "allowed-value-1"
+        },
+        {
+            'label' => "Allowed value 2",
+            'value' => "allowed-value-2"
+        },
+        {
+            'label' => "Allowed value 3",
+            'value' => "allowed-value-3"
+        }
+    ]
+  }
+
+  let(:facet_data) {
+    {
+      'key' => "test_facet",
+      'name' => "Test facet",
+      'preposition' => "of value",
+      'allowed_values' => allowed_values
+    }
+  }
+
+  let(:facet_class) { HiddenClearableFacet }
+  subject { facet_class.new(facet_data) }
+
+
+  describe "#sentence_fragment" do
+    before do
+      subject.value = value
+    end
+
+    context "single value" do
+      let(:value) { ["allowed-value-1"] }
+
+      specify {
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_facet")
+      }
+    end
+
+    context "multiple values" do
+      let(:value) { ["allowed-value-1", "allowed-value-2"] }
+
+      specify {
+        expect(subject.sentence_fragment['preposition']).to eql("of value")
+        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
+        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_facet")
+
+        expect(subject.sentence_fragment['values'].last['label']).to eql("Allowed value 2")
+        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("test_facet")
+      }
+    end
+
+    context "disallowed values" do
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
+      specify { expect(subject.sentence_fragment).to be_nil }
+    end
+  end
+
+  describe "#has_filters?" do
+    before do
+      subject.value = value
+    end
+
+    context "no value" do
+      let(:value) { nil }
+
+      specify {
+        expect(subject.has_filters?).to eql(false)
+      }
+    end
+
+    context "has a value" do
+      let(:value) { ["allowed-value-1"] }
+
+      specify {
+        expect(subject.has_filters?).to eql(true)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Creates new facet type called HiddenClearableFacet which is a facet that allows
users to clear but not amend or filter by that value - thus it only
shows a facet tag and not a component to amend it

This has the handy side effect of allowing users to search manuals

Trello: https://trello.com/c/CkBPvmeH/532-allow-hidden-facets-to-appear-in-facet-tags-if-used