### PR TITLE
Clean up finder api

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,10 +38,14 @@ private
 
   # Add a finder with the base path as a key and the finder name
   # without filetype as the value; example:
-  # "/guidance-and-regulation" => "guidance_and_regulation"
+  # "/review-search/guidance-and-regulation" => "guidance_and_regulation"
+  # This allows easy development of finders within finder-frontend
+  # *************************************
+  # *** THESE SHOULD NOT BE LIVE URLS ***
+  # *** AS THEY WILL TAKE PRECEDENCE  ***
+  # ***  OVER CONTENT STORE REQUESTS  ***
+  # *************************************
   FINDERS_IN_DEVELOPMENT = {
-    "/search/research-and-statistics" => "statistics",
-    "/search/research-and-statistics/email-signup" => "statistics_email_signup",
     "/review-search/all" => 'all_content'
   }.freeze
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ FinderFrontend::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -161,7 +161,7 @@ When(/^I view the research and statistics finder$/) do
   stub_rummager_api_request_with_research_and_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
 
-  visit finder_path('research-and-statistics')
+  visit finder_path('search/research-and-statistics')
 end
 
 When(/^I view the all content finder$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -239,7 +239,7 @@ module DocumentHelper
   def content_store_has_statistics_finder
     finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'statistics.json'))
 
-    content_store_has_item('/research-and-statistics', finder_fixture)
+    content_store_has_item('/search/research-and-statistics', finder_fixture)
   end
 
   def content_store_has_all_content_finder


### PR DESCRIPTION
We don't want the finders that we have been using for developing new features to override those that we've defined in content store.

It'll be really confusing to troubleshoot, and people may make unwitting changes to the development finders, not being aware that they might actually be in use on the production system.