### PR TITLE
Updating top section of results

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -11,7 +11,7 @@
 
     this.$form = options.$form;
     this.$resultsBlock = options.$results.find('#js-results');
-    this.$countBlock = options.$results.find('#js-search-results-info h2.govuk-body');
+    this.$countBlock = options.$results.find('.result-region-header__counter');
     this.$facetTagBlock = options.$results.find('.js-facet-tag-wrapper');
     this.$loadingBlock = options.$results.find('#js-loading-message');
     this.$resultsCount = options.$results.find('#js-result-count');

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -11,7 +11,8 @@
 
     this.$form = options.$form;
     this.$resultsBlock = options.$results.find('#js-results');
-    this.$countBlock = options.$results.find('#js-search-results-info');
+    this.$countBlock = options.$results.find('#js-search-results-info h2.govuk-body');
+    this.$facetTagBlock = options.$results.find('.js-facet-tag-wrapper');
     this.$loadingBlock = options.$results.find('#js-loading-message');
     this.$resultsCount = options.$results.find('#js-result-count');
     this.action = this.$form.attr('action') + '.json';
@@ -307,6 +308,7 @@
     if(action == $.param(this.state)) {
       this.$resultsBlock.mustache(this.templateDir + '_results', results);
       this.$countBlock.mustache(this.templateDir + '_result_count', results);
+      this.$facetTagBlock.mustache(this.templateDir + '_result_facet_tags', results);
       this.$resultsCount.text(results.total + " " + results.pluralised_document_noun);
       this.$atomAutodiscoveryLink.attr('href', results.atom_url);
       this.$loadingBlock.text('').hide();

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -246,6 +246,7 @@
   }
 
   .facet-tags {
+    padding-bottom: govuk-spacing(1);
   }
 
   .facet-tags__group {
@@ -380,22 +381,29 @@
   @include govuk-responsive-margin(4, "bottom");
 }
 
-.govuk-label--inline {
-  @include govuk-responsive-padding(1, "right");
-  display: inline-block;
-.result-count{
+.result-region-header__counter {
   white-space: nowrap;
+}
+
+.result-region-header__sort-label {
+  @include govuk-responsive-padding(1, "right");
+  @include govuk-font(16);
+  display: inline-block;
+  margin-bottom: govuk-spacing(3);
+}
+
+.result-region-header__sort-select {
+  @include govuk-font(16);
+  height: govuk-spacing(6);
 }
 
 .result-info {
   margin-bottom: govuk-spacing(2);
+
   .govuk-grid-column-two-thirds {
-    text-align: right;
-    white-space: nowrap;
-
-    @include govuk-media-query($from: mobile, $until: tablet) {
-      text-align: left;
+    text-align: left;
+    @include govuk-media-query($from: tablet) {
+      text-align: right;
     }
-
   }
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -206,15 +206,9 @@
 
   .filtered-results {
     .result-info {
-      @include govuk-font(16);
       vertical-align: baseline;
-      margin: 0 0 govuk-spacing(6) 0;
+      margin: 0 0 govuk-spacing(4) 0;
       border-bottom: solid 1px govuk-colour("black");
-
-      .result-count {
-        @include govuk-font(27, $weight: bold);
-        margin-right: govuk-spacing(2) / 2;
-      }
     }
 
     .govuk-checkboxes__conditional--hidden {
@@ -252,8 +246,6 @@
   }
 
   .facet-tags {
-    margin-top: govuk-spacing(2);
-    margin-bottom: govuk-spacing(6);
   }
 
   .facet-tags__group {
@@ -391,4 +383,19 @@
 .govuk-label--inline {
   @include govuk-responsive-padding(1, "right");
   display: inline-block;
+.result-count{
+  white-space: nowrap;
+}
+
+.result-info {
+  margin-bottom: govuk-spacing(2);
+  .govuk-grid-column-two-thirds {
+    text-align: right;
+    white-space: nowrap;
+
+    @include govuk-media-query($from: mobile, $until: tablet) {
+      text-align: left;
+    }
+
+  }
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -387,3 +387,8 @@
 .govspeak-wrapper {
   @include govuk-responsive-margin(4, "bottom");
 }
+
+.govuk-label--inline {
+  @include govuk-responsive-padding(1, "right");
+  display: inline-block;
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -382,19 +382,19 @@
 }
 
 .result-region-header__counter {
+  @include govuk-font(19);
   white-space: nowrap;
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(2);
+  }
 }
 
 .result-region-header__sort-label {
   @include govuk-responsive-padding(1, "right");
-  @include govuk-font(16);
   display: inline-block;
   margin-bottom: govuk-spacing(3);
-}
-
-.result-region-header__sort-select {
-  @include govuk-font(16);
-  height: govuk-spacing(6);
 }
 
 .result-info {
@@ -402,6 +402,7 @@
 
   .govuk-grid-column-two-thirds {
     text-align: left;
+
     @include govuk-media-query($from: tablet) {
       text-align: right;
     }

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -143,7 +143,6 @@ private
     links[:email_signup_link] = email_signup_link if email_signup_link.present?
     links[:feed_link] = feed_link if feed_link.present?
     if email_signup_link.present? || feed_link.present?
-      links[:margin_bottom] = 0
       links[:hide_heading] = true
       links[:small_form] = true
     end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -142,7 +142,11 @@ private
     links = {}
     links[:email_signup_link] = email_signup_link if email_signup_link.present?
     links[:feed_link] = feed_link if feed_link.present?
-    links[:margin_bottom] = 3 if email_signup_link.present? || feed_link.present?
+    if email_signup_link.present? || feed_link.present?
+      links[:margin_bottom] = 0
+      links[:hide_heading] = true
+      links[:small_form] = true
+    end
     links
   end
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -16,7 +16,7 @@
     </div>
   <% end %>
 
-  <div class="govuk-form-group" data-module="track-click" data-track-category="filterClicked"
+  <div data-module="track-click" data-track-category="filterClicked"
       data-track-action="skip-Link" data-track-label="">
     <%= render "govuk_publishing_components/components/skip_link", {
       text: 'Skip to results',

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,11 +1,5 @@
-<div class="result-info">
+<h2 class="govuk-body">
   <span class="result-count">
     {{total}} {{{pluralised_document_noun}}}
   </span>
-  <div class="facet-tags" data-module="track-click">
-    {{#applied_filters}}
-        {{> finders/_applied_filter}}
-    {{/applied_filters}}
-  </div>
-  {{{screen_reader_filter_description}}}
-</div>
+</h2>

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,5 +1,3 @@
-<h2 class="govuk-body">
-  <span class="result-count">
-    {{total}} {{{pluralised_document_noun}}}
-  </span>
+<h2>
+  {{total}} {{{pluralised_document_noun}}}
 </h2>

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,3 +1,3 @@
-<h2>
+<h2 class="result-region-header__counter">
   {{total}} {{{pluralised_document_noun}}}
 </h2>

--- a/app/views/finders/_result_facet_tags.mustache
+++ b/app/views/finders/_result_facet_tags.mustache
@@ -1,0 +1,8 @@
+<div class="js-facet-tag-wrapper">
+  <div class="facet-tags" data-module="track-click">
+    {{#applied_filters}}
+      {{> finders/_applied_filter}}
+    {{/applied_filters}}
+  </div>
+  {{{screen_reader_filter_description}}}
+</div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -89,14 +89,22 @@
 
     <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder.name %> search results">
       <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
-        <%= render_mustache('result_count', @results.to_hash) %>
+        <div class="result-info">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              <%= render_mustache('result_count', @results.to_hash) %>
+            </div>
+            <% if @results.has_email_signup_link? %>
+              <div class="govuk-grid-column-two-thirds">
+                <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
+              </div>
+            <% end %>
+          </div>
+          <%= render_mustache('result_facet_tags', @results.to_hash) %>
+        </div>
       </div>
 
       <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
-
-      <% if @results.has_email_signup_link? %>
-        <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
-      <% end %>
 
       <% if finder.sort %>
         <div class="govuk-form-group govuk-form-group--inline">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -87,36 +87,33 @@
       <%= render finder.facets %>
     </div>
 
-    <div class="govuk-grid-column-two-thirds" role="region" aria-label="<%= finder.name %> search results">
-      <div class='js-live-search-results-block'>
-        <div class="filtered-results">
-          <div aria-live='assertive' id='js-search-results-info' data-module="remove-filter">
-            <%= render_mustache('result_count', @results.to_hash) %>
-          </div>
-
-          <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
-
-          <% if @results.has_email_signup_link? %>
-            <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
-          <% end %>
-
-          <% if finder.sort %>
-            <div class="govuk-form-group govuk-form-group--inline">
-              <%= label_tag 'order', 'Sort by', class: 'govuk-label govuk-label--inline' %>
-              <%= select_tag 'order', finder.sort_options,
-                class: 'govuk-select js-order-results',
-                'aria-controls': 'js-search-results-info',
-                data: { 'default-sort-option' => finder.default_sort_option_value,
-                        'relevance-sort-option' => finder.relevance_sort_option_value,
-                        'module' => 'track-select-change'} %>
-            </div>
-          <% end %>
-
-          <div id='js-results'>
-            <%= render_mustache('results', @results.to_hash) %>
-          </div>
-        </div>
+    <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder.name %> search results">
+      <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
+        <%= render_mustache('result_count', @results.to_hash) %>
       </div>
+
+      <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
+
+      <% if @results.has_email_signup_link? %>
+        <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
+      <% end %>
+
+      <% if finder.sort %>
+        <div class="govuk-form-group govuk-form-group--inline">
+          <%= label_tag 'order', 'Sort by', class: 'govuk-label govuk-label--inline' %>
+          <%= select_tag 'order', finder.sort_options,
+            class: 'govuk-select js-order-results',
+            'aria-controls': 'js-search-results-info',
+            data: { 'default-sort-option' => finder.default_sort_option_value,
+                    'relevance-sort-option' => finder.relevance_sort_option_value,
+                    'module' => 'track-select-change'} %>
+        </div>
+      <% end %>
+
+      <div id="js-results">
+        <%= render_mustache('results', @results.to_hash) %>
+      </div>
+
     </div>
   </div>
 </form>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -91,7 +91,7 @@
       <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
         <div class="result-info">
           <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
+            <div class="govuk-grid-column-one-third result-region-header__counter">
               <%= render_mustache('result_count', @results.to_hash) %>
             </div>
             <% if @results.has_email_signup_link? %>
@@ -107,10 +107,10 @@
       <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
 
       <% if finder.sort %>
-        <div class="govuk-form-group govuk-form-group--inline">
-          <%= label_tag 'order', 'Sort by', class: 'govuk-label govuk-label--inline' %>
+        <div class="govuk-form-group">
+          <%= label_tag 'order', 'Sort by', class: 'result-region-header__sort-label' %>
           <%= select_tag 'order', finder.sort_options,
-            class: 'govuk-select js-order-results',
+            class: 'js-order-results result-region-header__sort-select',
             'aria-controls': 'js-search-results-info',
             data: { 'default-sort-option' => finder.default_sort_option_value,
                     'relevance-sort-option' => finder.relevance_sort_option_value,

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -91,7 +91,7 @@
       <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
         <div class="result-info">
           <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third result-region-header__counter">
+            <div class="govuk-grid-column-one-third">
               <%= render_mustache('result_count', @results.to_hash) %>
             </div>
             <% if @results.has_email_signup_link? %>
@@ -108,9 +108,9 @@
 
       <% if finder.sort %>
         <div class="govuk-form-group">
-          <%= label_tag 'order', 'Sort by', class: 'result-region-header__sort-label' %>
+          <%= label_tag 'order', 'Sort by', class: 'result-region-header__sort-label govuk-label' %>
           <%= select_tag 'order', finder.sort_options,
-            class: 'js-order-results result-region-header__sort-select',
+            class: 'js-order-results govuk-select',
             'aria-controls': 'js-search-results-info',
             data: { 'default-sort-option' => finder.default_sort_option_value,
                     'relevance-sort-option' => finder.relevance_sort_option_value,

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -95,12 +95,14 @@
           </div>
 
           <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
+
           <% if @results.has_email_signup_link? %>
             <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
           <% end %>
+
           <% if finder.sort %>
-            <div class="govuk-form-group">
-              <%= label_tag 'order', 'Sort by', class: 'govuk-label' %>
+            <div class="govuk-form-group govuk-form-group--inline">
+              <%= label_tag 'order', 'Sort by', class: 'govuk-label govuk-label--inline' %>
               <%= select_tag 'order', finder.sort_options,
                 class: 'govuk-select js-order-results',
                 'aria-controls': 'js-search-results-info',

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -775,7 +775,7 @@ Then(/^the page has results region$/) do
 end
 
 Then(/^the page has a landmark to the search results$/) do
-  expect(page).to have_css('[class="govuk-grid-column-two-thirds"][role="region"][aria-label$="search results"]')
+  expect(page).to have_css('[class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results"][role="region"][aria-label$="search results"]')
 end
 
 Then(/^the page has a landmark to the search filters$/) do

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -285,7 +285,7 @@ describe("liveSearch", function(){
       liveSearch.state = { the: "first" };
       liveSearch.displayResults(dummyResponse, $.param(liveSearch.state));
       expect($results.find('a').text()).toMatch('Test report');
-      expect($count.find('.result-count').text()).toMatch(/^\s*1\s*/);
+      expect($count.text()).toMatch(/^\s*1\s*/);
     });
 
     it("should update the Atom autodiscovery link", function(){

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -432,7 +432,11 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'returns both signup links' do
-        expect(presenter.signup_links).to eq(email_signup_link: "/email_signup", feed_link: "/finder.atom", margin_bottom: 3)
+        expect(presenter.signup_links).to eq(email_signup_link: "/email_signup",
+                                             feed_link: "/finder.atom",
+                                             hide_heading: true,
+                                             small_form: true,
+                                             margin_bottom: 0)
       end
     end
 
@@ -443,7 +447,9 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'returns just the atom link' do
-        expect(presenter.signup_links).to eq(feed_link: "/finder.atom", margin_bottom: 3)
+        expect(presenter.signup_links).to eq(feed_link: "/finder.atom", hide_heading: true,
+                                             small_form: true,
+                                             margin_bottom: 0)
       end
     end
   end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -435,8 +435,7 @@ RSpec.describe ResultSetPresenter do
         expect(presenter.signup_links).to eq(email_signup_link: "/email_signup",
                                              feed_link: "/finder.atom",
                                              hide_heading: true,
-                                             small_form: true,
-                                             margin_bottom: 0)
+                                             small_form: true)
       end
     end
 
@@ -448,8 +447,7 @@ RSpec.describe ResultSetPresenter do
 
       it 'returns just the atom link' do
         expect(presenter.signup_links).to eq(feed_link: "/finder.atom", hide_heading: true,
-                                             small_form: true,
-                                             margin_bottom: 0)
+                                             small_form: true)
       end
     end
   end


### PR DESCRIPTION
## Background and changes
This PR changes the way the section above the results is displayed in finder pages.
The point of the changes were to vertically compress the section above the results in an attempt to bring the results closer to the top of the page. 

- **Number of results**
  The current version seemed very loud, shouty and very prominent on the page.
  This was reduced to normal 19px font.

- **Subscription links**
  The current version seems very loud and shouty with the 19px and bold font. 
  https://github.com/alphagov/govuk_publishing_components/pull/803 was created to 
  reduce the font size to 16px, normal font weight and tidy up the spacing between
  the icon and text. This new smaller form seemed like it would be better placed to
  the the right of the results count

- **Facet tag labels**
  No major changes apart from breaking it out from `results_count.mustache` template
  into its own template to allow us the flexility to add the subscriptions link 
  next to the results counter.

- **Loading...**
  No changes here

- **Sort by**
  The current version seemed to be very prominent on the page and positioned exactly
  in the middle of the screen. To lower its importance we reduced the size to 16px 
  and and positioned the select list inline with the label

_____

## Before

### 👀 All content finder ([click here](https://www.gov.uk/search/all))

![image](https://user-images.githubusercontent.com/3441519/55189150-0b1df380-5195-11e9-8c2c-6ee244cd11e1.png)

_______

### 👀 News & Comms finder ([click here](https://www.gov.uk/search/news-and-communications))

![image](https://user-images.githubusercontent.com/3441519/55189351-97c8b180-5195-11e9-9805-fb8d4d9df2b2.png)

_______

### 👀 Example with applied filters ([click here](https://www.gov.uk/search/news-and-communications?parent=&keywords=&related_to_brexit=true&level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&level_two_taxon=&organisations%5B%5D=academy-for-social-justice&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest)

![image](https://user-images.githubusercontent.com/3441519/55189563-16255380-5196-11e9-9d38-46f890b347e4.png)

______

## After

### 👀 All content finder ([click here](https://finder-frontend-pr-1006.herokuapp.com/search/all))

![image](https://user-images.githubusercontent.com/3441519/55187017-df4c3f00-518f-11e9-9c32-1dc4c32199c2.png)

_______

### 👀 News & Comms finder ([click here](https://finder-frontend-pr-1006.herokuapp.com/search/news-and-communications))

![image](https://user-images.githubusercontent.com/3441519/55187065-f854f000-518f-11e9-8b59-d035e241891e.png)

_______

### 👀 Example with applied filters ([click here](https://finder-frontend-pr-1006.herokuapp.com/search/news-and-communications?parent=&keywords=&related_to_brexit=true&level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&level_two_taxon=&organisations%5B%5D=academy-for-social-justice&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest))

![image](https://user-images.githubusercontent.com/3441519/55187181-4538c680-5190-11e9-97df-107e80db0eec.png)

_______

## Ticket: https://trello.com/c/nMB9EUx0/581-update-top-section-of-results-layout
