### PR TITLE
Option select filter add search icon

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -107,10 +107,17 @@
 
 .app-c-option-select__filter {
   display: none;
+  padding-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
+}
 
-  .govuk-form-group {
-    padding-top: govuk-spacing(2);
-    margin-bottom: govuk-spacing(2);
+.app-c-option-select__filter-input {
+  padding-left: 33px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") govuk-colour("white") no-repeat -5px -3px;
+  @include govuk-font(19);
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-font(16);
   }
 }
 

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -3,20 +3,31 @@
   checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
   checkboxes_count_id = checkboxes_id + "-count"
   show_filter ||= false
-
-  if show_filter
-    filter_element = ActionController::Base.new.render_to_string(:partial => "govuk_publishing_components/components/input", :locals => {
-      label: {
-        text: "Filter " + title
-      },
-      name: "option-select-filter",
-      controls: checkboxes_id,
-      describedby: checkboxes_count_id
-    })
-
-    filter_element = CGI::escapeHTML(filter_element)
-  end
 %>
+
+<% if show_filter %>
+  <%
+    filter_id ||= "input-#{SecureRandom.hex(4)}"
+  %>
+  <% filter = capture do %>
+    <%= tag.label for: filter_id, class: "govuk-label govuk-visually-hidden" do %>
+      Filter <%= title %>
+    <% end %>
+
+    <%= tag.input name: "option-select-filter",
+      id: filter_id,
+      class: "app-c-option-select__filter-input govuk-input",
+      type: "text",
+      aria: {
+        describedby: checkboxes_count_id,
+        controls: checkboxes_id
+      }
+    %>
+  <% end %>
+  <%
+    filter_element = CGI::escapeHTML(filter)
+  %>
+<% end %>
 
 <div class="app-c-option-select"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>


### PR DESCRIPTION
Make some changes to the option select component filter option.

- visually hide the label on the checkbox filter and add a search icon
- screenreader users should have the exact same experience as before the label was hidden
- looks like this:

![Screen Shot 2019-03-27 at 12 43 48](https://user-images.githubusercontent.com/861310/55076748-1df9d080-508e-11e9-9054-4ff2f5cb877e.png)

https://trello.com/c/N16toILy/572-fix-minor-option-select-issues
