### PR TITLE
Update most relevant text

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -64,6 +64,11 @@
   margin-bottom: govuk-spacing(3);
 }
 
+.document__heading--top {
+  @include govuk-font(16, $weight: bold);
+  margin-bottom: govuk-spacing(3);
+}
+
 .document__link--top {
   @include govuk-font(24, $weight: bold);
   display: block;

--- a/app/views/finders/_document.mustache
+++ b/app/views/finders/_document.mustache
@@ -1,5 +1,5 @@
 <li class="document{{#document.top_result}} document--top{{/document.top_result}}">
-    {{#document.top_result}}<p>Most relevant result</p>{{/document.top_result}}
+    {{#document.top_result}}<p class="document__heading--top">Most relevant result</p>{{/document.top_result}}
   <a href='{{document.link}}'
       class="document__link{{#document.top_result}} document__link--top{{/document.top_result}}"
       data-track-category='navFinderLinkClicked'


### PR DESCRIPTION
# Update styling for`most relevant result` text 

**Changes made**:
- Adds `document__heading--top` class to `most relevant result` text
- Adds margin-bottom width of govuk-spacing(3)
- Adds bold styling to text

## Before
<img width="1086" alt="Screen Shot 2019-03-27 at 11 15 47" src="https://user-images.githubusercontent.com/4599889/55072052-07e61300-5082-11e9-9e5e-1da74944012c.png">

## After
<img width="1068" alt="Screen Shot 2019-03-27 at 11 16 22" src="https://user-images.githubusercontent.com/4599889/55072061-0d435d80-5082-11e9-8817-e35437904934.png">
