### PR TITLE
Add expected class to option-select component

### DIFF
--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -30,7 +30,7 @@
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
     </div>
   </div>
-  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>">
+  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container options-container js-options-container" id="<%= options_container_id %>">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>


### PR DESCRIPTION
`.options-container` is expected, and required by smokey:

See smokey/features/step_definitions/search_steps.rb

This will resolve critical alerts on production.