### PR TITLE
Add A/B test to show answer box in business finder

### DIFF
--- a/app/controllers/concerns/finder_top_result_ab_testable.rb
+++ b/app/controllers/concerns/finder_top_result_ab_testable.rb
@@ -1,0 +1,32 @@
+module FinderTopResultAbTestable
+  CUSTOM_DIMENSION = 69
+
+  def self.included(base)
+    base.helper_method(
+      :finder_top_result_variant,
+      :show_top_result?
+    )
+    base.after_action :set_test_response_header
+  end
+
+  def finder_top_result_test
+    @finder_top_result_test ||= GovukAbTesting::AbTest.new(
+      "FinderAnswerABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A"
+    )
+  end
+
+  def finder_top_result_variant
+    @finder_top_result_variant ||= finder_top_result_test.requested_variant(request.headers)
+  end
+
+  def set_test_response_header
+    finder_top_result_variant.configure_response(response)
+  end
+
+  def show_top_result?
+    finder_top_result_variant.variant?("B")
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,4 +1,6 @@
 class FindersController < ApplicationController
+  include FinderTopResultAbTestable
+
   layout "finder_layout"
   before_action :remove_search_box
 
@@ -47,7 +49,7 @@ private
   end
 
   def results
-    @results ||= result_set_presenter_class.new(finder, filter_params, view_context)
+    @results ||= result_set_presenter_class.new(finder, filter_params, view_context, show_top_result?)
   end
 
   def finder

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -10,12 +10,13 @@ class ResultSetPresenter
            :atom_url,
            to: :finder
 
-  def initialize(finder, filter_params, view_context)
+  def initialize(finder, filter_params, view_context, show_top_result = false)
     @finder = finder
     @results = finder.results.documents
     @total = finder.results.total
     @filter_params = filter_params
     @view_context = view_context
+    @show_top_result = show_top_result
   end
 
   def to_hash
@@ -84,7 +85,8 @@ private
   attr_reader :view_context
 
   def highlight_top_result?
-    finder.eu_exit_finder? &&
+    @show_top_result &&
+      finder.eu_exit_finder? &&
       results.length >= 2 &&
       sort_option &&
       sort_option["key"].eql?("-relevance") &&

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,6 +14,7 @@
     <meta name="govuk:relevant-result-shown" content="yes">
   <% end %>
 
+  <%= finder_top_result_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :meta_title, finder.name %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -235,9 +235,11 @@ Feature: Filtering documents
     And the correct facets have been pre-selected
 
   @javascript
-  Scenario: Adding top result in business finder
+  Scenario: Showing top result in business finder
+    Given I am in the variant B control group
     When I view the business readiness finder
     And I fill in some keywords
+    And I submit the form
     Then I see most relevant order selected
     And I see results with top result
     And The top result has the correct tracking data

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -120,6 +120,13 @@ When(/^I view the news and communications finder$/) do
   visit finder_path('search/news-and-communications')
 end
 
+Given(/^I am in the variant B control group$/) do
+  ab_test_variant = double(:variant, variant_name: "B", analytics_meta_tag: "")
+  allow(ab_test_variant).to receive(:variant?).with("B").and_return(true)
+  allow(ab_test_variant).to receive(:configure_response)
+  allow_any_instance_of(FindersController).to receive(:finder_top_result_variant).and_return(ab_test_variant)
+end
+
 When(/^I view the business readiness finder$/) do
   content_store_has_business_readiness_finder
   content_store_has_business_readiness_email_signup
@@ -627,6 +634,10 @@ end
 
 And(/^I fill in some keywords$/) do
   fill_in 'Search', with: "Keyword1 Keyword2\n"
+end
+
+And(/^I submit the form$/) do
+  page.execute_script("$('form.js-live-search-form').submit()")
 end
 
 Then(/^The keyword textbox is empty$/) do

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -339,6 +339,8 @@ RSpec.describe ResultSetPresenter do
     end
 
     context 'check top result' do
+      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, true) }
+
       before(:each) do
         allow(finder).to receive(:eu_exit_finder?).and_return(true)
         allow(presenter).to receive(:sort_option).and_return("key" => "-relevance")
@@ -400,6 +402,15 @@ RSpec.describe ResultSetPresenter do
             total
           )
         end
+
+        it 'has no top result' do
+          search_result_objects = presenter.documents
+          expect(search_result_objects[0][:document][:top_result]).to_not eql(true)
+        end
+      end
+
+      context 'top result not set if show top result is false' do
+        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, false) }
 
         it 'has no top result' do
           search_result_objects = presenter.documents


### PR DESCRIPTION
## What
We should set up an a/b test for answer boxes as documented [here](
https://docs.google.com/spreadsheets/d/1voQzdoGAFO9Tnvl7Xq4ahLEAyGtkeAtvTC26SxEP6rE/edit?ts=5c94d616#gid=985650788).

We should make sure we have the necessary tracking in place to measure the results.

## Why
https://trello.com/c/S1FUejEn/96-%F0%9F%A5%85-goal-3-enable-users-to-get-an-answer-quickly

PR: https://github.com/alphagov/govuk-cdn-config/pull/139

## Custom dimensions
I've now set up a 2nd custom dimension in Google Analytics.

The previous one is A/B Brexit finder (69), a session custom dimension (it will persist for the entire visit) and it will contain the values A, B or C. These will indicate which version of the test a user will see.

The new custom dimension is Relevant result shown (83). This should be set to 'Yes' if a  search in the finder search box results in a 'relevant result'. (The null label is 'No'.) This is set at a hit/pageview level, since a user may do several searches in their session.

Both custom dimensions only should be set on https://www.gov.uk/find-eu-exit-guidance-business.*

https://trello.com/c/lwQK2Pi7/336-set-up-a-b-test-for-answer-boxes
