### PR TITLE
Redirect site search to all content finder

### DIFF
--- a/features/site_search.feature
+++ b/features/site_search.feature
@@ -8,76 +8,22 @@ Feature: Site search
     When I search for an empty string
     Then I am able to set search terms
 
-  Scenario: When search terms are entered
+  Scenario: When search terms are entered and filtered by organisation
     Given search results exist
-    When I search for "search-term" from "hm-revenue-customs"
-    Then I am able to see the document in the search results
-    And I am able to see organisations with abbreviations
-    And I am able to see organisations without abbreviations
-    And I can see search suggestions
-    And I can see the search term
-    And Analytics values are sent
+    And the all content finder exists
+    When I search for "search-term" from "ministry-of-magic"
+    Then I am redirected to the html all content finder results page
+    And results are filtered with a facet tag of Ministry of Magic
 
-  Scenario: When search terms are entered
+  Scenario: When search terms are entered and filtered by manual
     Given search results exist
-    When I search for "<script>XSS</script>"
-    Then the search term is escaped
-
-  Scenario: When an invalid search is entered
-    Given no search results exist
-    When I search for "search-term"
-    Then I can see that no search results were found
-
-  Scenario: Search results for historical governments
-    Given search results for multiple governments exists
-    When I search for "search-term"
-    Then search results for previous known governments are tagged as such
-
-  Scenario: Search results for historical governments
-    Given search results for multiple governments exists
-    When I search for "search-term"
-    Then search results for previous known governments are tagged as such
-
-  Scenario: collapse state of the organisation filter
-    Given search results exist
-    When I search for "search-term" from "hm-revenue-customs"
-    Then Organisations filter should be expanded
-    When I search for "search-term"
-    Then Organisations filter should not be expanded
-    When I search for "search-term" with show organisation flag
-    Then Organisations filter should be expanded
-    When I search for "search-term" with manuals filter
-    Then Organisations filter should not be displayed
-
-  Scenario: Pagination
-    Given multiple pages of search results exists
-    When I search for "search-term"
-    Then I should see a link to the next page
-    When I navigate to the next page
-    Then I should see a link to the previous page
-
-  Scenario: External urls
-    Given external urls exist in the of search results
-    When I search for "search-term"
-    Then long urls should be truncated
-    And links should be schema-less
+    And the all content finder exists
+    When I search for "search-term" in manual "how-to-be-a-wizard"
+    Then I am redirected to the html all content finder results page
+    And results are filtered with a facet tag of How to be a Wizard
 
   Scenario: JSON endpoint
     Given search results exist
-    When I search for "search-term" on the json endpoint
-    Then I should get a valid JSON response
-
-  Scenario: JSON endpoint when no results
-    Given no search results exist
-    When I search for "search-term" on the json endpoint
-    Then I should get a valid JSON response
-
-  Scenario: Search API is down
-    Given the search API returns an error state
-    When I search for "search-term"
-    Then I should get an error page
-
-  Scenario: Search API refuses parameters
-    Given the search API returns an HTTP unprocessable entity error
-    When I search with bad parameters
-    Then I should get a bad request error
+    And the all content finder exists
+    When I search for "search-term" from "ministry-of-magic" on the json endpoint
+    Then I am redirected to the json all content finder results page

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -95,6 +95,26 @@ module DocumentHelper
       .to_return(body: all_content_results_json)
   end
 
+  def stub_rummager_api_request_with_organisation_filter_all_content_results
+    stub_request(
+      :get,
+      all_content_url(
+        "q" => "search-term",
+        "filter_organisations[]" => %w(ministry-of-magic)
+      )
+    ).to_return(body: filtered_by_organisation_all_content_results_json)
+  end
+
+  def stub_rummager_api_request_with_manual_filter_all_content_results
+    stub_request(
+      :get,
+      all_content_url(
+        "q" => "search-term",
+        "filter_manual[]" => %w(how-to-be-a-wizard)
+      )
+    ).to_return(body: filtered_by_manual_all_content_results_json)
+  end
+
   def stub_rummager_api_request_with_filtered_policy_papers_results
     stub_request(
       :get,
@@ -2081,24 +2101,103 @@ module DocumentHelper
             }
           ],
         "facets": {
-            "manual": [
+          "manual": [
+            {
+              "title": "Replacing bristles in your Nimbus 2000",
+              "_id": "/guidance/care-and-use-of-a-nimbus-2000"
+            },
+            {
+              "title": "Upgrading the baud rate on the Floo Network",
+              "_id": "upgrading-baud-rate-on-the-floo-network"
+            }
+          ],
+          "documents_with_no_value": 0,
+          "total_options": 2,
+          "missing_options": 0,
+          "scope": "exclude_field_filter"
+        },
+        "total": 1,
+        "start": 0,
+        "suggested_queries": []
+        }
+      ]
+    }|
+  end
+
+  def filtered_by_organisation_all_content_results_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Restrictions on usage of spells within school grounds",
+              "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "description": "Restrictions on usage of spells within school grounds",
+              "public_timestamp": "2017-12-30T10:00:00Z",
+              "part_of_taxonomy_tree": [
+                "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
+              ],
+              "organisations": [
                 {
-                    "title": "Replacing bristles in your Nimbus 2000",
-                    "_id": "/guidance/care-and-use-of-a-nimbus-2000"
-                },
-                {
-                    "title": "Upgrading the baud rate on the Floo Network",
-                    "_id": "upgrading-baud-rate-on-the-floo-network"
+                  "organisation_crest": "single-identity",
+                  "acronym": "MOM",
+                  "link": "/organisations/ministry-of-magic",
+                  "analytics_identifier": "MM1",
+                  "public_timestamp": "2017-12-15T11:11:02.000+00:00",
+                  "organisation_brand": "ministry-of-magic",
+                  "logo_formatted_title": "Ministry of Magic",
+                  "title": "Ministry of Magic",
+                  "content_id": "92881ac6-2804-4522-bf48-cf8c781c98bf",
+                  "slug": "ministry-of-magic",
+                  "organisation_type": "other",
+                  "organisation_state": "live"
                 }
-            ],
-            "documents_with_no_value": 0,
-            "total_options": 2,
-            "missing_options": 0,
-            "scope": "exclude_field_filter"
-          },
+              ],
+              "index": "govuk",
+              "es_score": null,
+              "_id": "/restrictions-on-usage-of-spells-within-school-grounds",
+              "elasticsearch_type": "policy_paper",
+              "document_type": "policy_paper"
+            }
+          ],
           "total": 1,
           "start": 0,
-          "suggested_queries": []
+          "suggested_queries": [],
+          "facets": {
+            "organisations": {
+              "options": [
+                {"value": {"title": "Ministry of Magic", "slug": "ministry-of-magic"}}
+              ]
+            }
+          }
+        }
+      ]
+    }|
+  end
+
+  def filtered_by_manual_all_content_results_json
+    %|{
+      "results": [
+        {
+          "results": [
+            {
+              "title": "Choosing your wand",
+              "link": "/choosing-your-wand",
+              "description": "Choosing your wand - a practical guide",
+              "_id": "/choosing-your-wand"
+            }
+          ],
+          "total": 1,
+          "start": 0,
+          "suggested_queries": [],
+          "facets": {
+            "manual": [
+              {
+                "title": "Choosing your wand",
+                "_id": "/choosing-your-wand"
+              }
+            ]
+          }
         }
       ]
     }|

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -101,6 +101,10 @@ module RegistrySpecHelper
           {
               title: "Upgrading the baud rate on the Floo Network",
               _id: "upgrading-baud-rate-on-the-floo-network"
+          },
+          {
+            title: "How to be a Wizard",
+            _id: "how-to-be-a-wizard"
           }
         ]
       }.to_json)


### PR DESCRIPTION
This PR redirects users going to site search to the all content finder. Specifically, it redirects all requests to the `.json` endpoint to the all content finder, and redirects regular user requests to the all content finder if the user searches for any keywords.