### PR TITLE
Remove toolkit button sass

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,7 +1,4 @@
-// govuk_frontend_toolkit helpers
-@import "design-patterns/buttons";
 @import "not-ie-conditional";
-
 @import "reset";
 @import "govuk_publishing_components/all_components";
 @import "components/*";
@@ -89,12 +86,6 @@
 
   strong {
     font-weight: 600;
-  }
-
-  a.button, input.button {
-    @include button(govuk-colour("green"));
-    width: auto;
-    @include govuk-font(24, $weight: bold);
   }
 
   header {
@@ -188,10 +179,6 @@
       max-width: $two-thirds;
     }
 
-    input.button[type=submit] {
-      margin-top: govuk-spacing(2);
-    }
-
     p {
       max-width: $full-width;
     }
@@ -209,12 +196,6 @@
       margin-left: -govuk-spacing(3) - 4;
       border-left: solid 4px $govuk-error-colour;
     }
-  }
-
-  .button {
-    @include button(govuk-colour("green"));
-    width: auto;
-    @include govuk-font(24, $weight: bold);
   }
 
   .search-results-title {
@@ -407,3 +388,6 @@
   }
 }
 
+.govspeak-wrapper {
+  @include govuk-responsive-margin(4, "bottom");
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -169,10 +169,6 @@
     }
   }
 
-  .app-c-option-select {
-    margin-bottom: govuk-spacing(6);
-  }
-
   .form {
     @include govuk-font(19);
     @include media(tablet) {

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -37,10 +37,15 @@
       <% end %>
 
       <% if @signup_presenter.body %>
-        <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+        <div class="govspeak-wrapper">
+          <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+        </div>
       <% end %>
 
-      <%= submit_tag 'Create subscription', class: "button" %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create subscription",
+        margin_bottom: true
+      } %>
     <% end %>
 
   </div>


### PR DESCRIPTION
Removes the last dependency on `govuk_frontend_toolkit`, for button styles. Most of the buttons in finder-frontend had already been converted to use the button component already. 

This change involves a visual change on the subscription page. This button is now using the button component:

**Before**

<img width="858" alt="Screen Shot 2019-03-28 at 14 12 41" src="https://user-images.githubusercontent.com/861310/55164565-c0d04e80-5163-11e9-88be-1392b3ac3029.png">

**After**

<img width="850" alt="Screen Shot 2019-03-28 at 14 12 51" src="https://user-images.githubusercontent.com/861310/55164589-cd54a700-5163-11e9-833e-6a82097f3383.png">

This change unfortunately required a custom wrapper on the text above in order to provide margin bottom. Hopefully this will be made obsolete at some point if the govspeak component is given margin bottom.

Note: in replacing this button I noticed that the `submit_tag` rails command adds a data attribute of `data-disable-with` to the outputted HTML. I don't know if this is important but to be safe I've configured the button component to include this attribute.

Example links:

- https://finder-frontend-pr-1016.herokuapp.com/search/news-and-communications/email-signup
- https://finder-frontend-pr-1016.herokuapp.com/search/news-and-communications/ (turn off JS)

I don't think there's any other buttons, but happy to be proved wrong.
