### PR TITLE
Update page title dynamically to reference search terms

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -16,7 +16,7 @@
     this.$resultsCount = options.$results.find('#js-result-count');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
-    this.title = document.title;
+    this.baseTitle = $("meta[name='govuk\:base_title']").attr("content");
     this.$emailLink = $('a[href*="email-signup"]');
     this.previousSearchTerm = '';
 
@@ -204,9 +204,9 @@
     var keywordsPresent = keywords !== "";
 
     if (keywordsPresent) {
-      document.title = keywords + " - " + this.title
+      document.title = keywords + " - " + this.baseTitle;
     }  else {
-      document.title = this.title
+      document.title = this.baseTitle;
     }
   };
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -16,6 +16,7 @@
     this.$resultsCount = options.$results.find('#js-result-count');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
+    this.title = document.title;
     this.$emailLink = $('a[href*="email-signup"]');
     this.previousSearchTerm = '';
 
@@ -100,6 +101,7 @@
       this.saveState();
       this.updateOrder();
       this.updateLinks();
+      this.updateTitle();
       pageUpdated = this.updateResults();
       pageUpdated.done(
         function(){
@@ -195,6 +197,17 @@
 
   LiveSearch.prototype.isNewState = function isNewState(){
     return $.param(this.state) !== $.param(this.getSerializeForm());
+  };
+
+  LiveSearch.prototype.updateTitle = function updateTitle() {
+    var keywords = this.getTextInputValue('keywords', this.state);
+    var keywordsPresent = keywords !== "";
+
+    if (keywordsPresent) {
+      document.title = keywords + " - " + this.title
+    }  else {
+      document.title = this.title
+    }
   };
 
   LiveSearch.prototype.updateOrder = function updateOrder() {

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,4 +1,8 @@
-<% content_for :title, finder.name %>
+<% if @results.user_supplied_keywords.length > 0 %>
+  <% content_for :title, "#{@results.user_supplied_keywords} - #{finder.name}" %>
+<% else %>
+  <% content_for :title, finder.name %>
+<% end %>
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.signup_links[:feed_link]) %>
   <%= render 'finder_meta', finder: finder %>
@@ -6,6 +10,8 @@
     <link rel="canonical" href="<%= "#{ENV['GOVUK_WEBSITE_ROOT']}#{finder.slug}" %>">
   <% end %>
 <% end %>
+
+<% content_for :meta_title, finder.name %>
 
 <% if finder.show_phase_banner? %>
   <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -14,6 +14,7 @@
     <% if params[:page] %>
       <meta name="robots" content="noindex">
     <% end %>
+    <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
   </head>
 
   <body>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -172,12 +172,15 @@ Feature: Filtering documents
     Then I see updated newest order selected
     And I fill in some keywords
     Then I see most relevant order selected
+    And the page title contains both keywords
     And I click the Keyword1 remove control
     Then The keyword textbox only contains Keyword2
     And I see most relevant order selected
+    And the page title contains only Keyword2
     And I click the Keyword2 remove control
     Then The keyword textbox is empty
     And I see updated newest order selected
+    And the page title contains no keywords
 
   @javascript
   Scenario: Adding keyword filter

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -27,6 +27,7 @@ Feature: Filtering documents
     When I search documents by keyword
     Then I see all documents which contain the keywords
     And there is not a zero results message
+    And the page title is updated
 
   Scenario: Filter document by keyword with q parameter
     Given a collection of documents exist

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -104,7 +104,7 @@
   "rendering_app": "finder-frontend",
   "schema_name": "finder",
   "search_user_need_document_supertype": "government",
-  "title": "All content",
+  "title": "Search",
   "updated_at": "2019-01-17T13:00:00.000+00:00",
   "user_journey_document_supertype": "finding"
 }

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -29,6 +29,18 @@ And(/there is not a zero results message$/) do
   expect(page).to_not have_content('no matching results')
 end
 
+And(/the page title contains both keywords$/) do
+  expect(page).to have_title "Keyword1 Keyword2 - News and communications - GOV.UK"
+end
+
+And(/the page title contains only Keyword2$/) do
+  expect(page).to have_title "Keyword2 - News and communications - GOV.UK"
+end
+
+And(/the page title contains no keywords$/) do
+  expect(page).to have_title "News and communications - GOV.UK"
+end
+
 Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -41,6 +41,10 @@ And(/the page title contains no keywords$/) do
   expect(page).to have_title "News and communications - GOV.UK"
 end
 
+And(/the page title is updated$/) do
+  expect(page).to have_title "keyword searchable - Ministry of Silly Walks reports - GOV.UK"
+end
+
 Then(/^I can get a list of all documents with matching metadata$/) do
   visit finder_path('mosw-reports')
 

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -44,12 +44,13 @@ describe("liveSearch", function(){
                 '<input type="submit" value="Filter results" class="button js-live-search-fallback"/>' +
               '</form>');
     $results = $('<div class="js-live-search-results-block"></div>');
+    $head = $('<meta name="govuk:base_title" content="All Content - GOV.UK">');
     $count = $('<div aria-live="assertive" id="js-search-results-info"><p class="result-info"></p></div>');
     $atomAutodiscoveryLink = $("<link href='http://an-atom-url.atom' rel='alternate' title='ATOM' type='application/atom+xml'>");
     $emailSubscriptionLinks = $("<a href='https://a-url/email-signup?query_param=something'>");
     $feedSubscriptionLinks = $("<a href='http://an-atom-url.atom?query_param=something'>");
     $('body').append($form).append($results).append($atomAutodiscoveryLink).append($feedSubscriptionLinks).append($emailSubscriptionLinks);
-
+    $('head').append('<meta name="govuk:base_title" content="All Content - GOV.UK">');
     _supportHistory = GOVUK.support.history;
     GOVUK.support.history = function(){ return true; };
     GOVUK.analytics = { trackPageview: function (){ }, trackEvent: function(){ } };


### PR DESCRIPTION
work to mirror existing functionality, so that the page title can be updated to reflect the search keywords