### PR TITLE
Fix for external links

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,7 +30,7 @@ class Document
   end
 
   def path
-    link.starts_with?("/") ? link : "/#{link}"
+    link
   end
 
   def summary

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -707,8 +707,8 @@ module DocumentHelper
               }],
               "creator": "Road Runner",
               "date_of_introduction": "2003-12-30",
-              "link": "mosw-reports/west-london-wobbley-walk",
-              "_id": "mosw-reports/west-london-wobbley-walk"
+              "link": "/mosw-reports/west-london-wobbley-walk",
+              "_id": "/mosw-reports/west-london-wobbley-walk"
             },
             {
               "title": "The Gerry Anderson",
@@ -725,8 +725,8 @@ module DocumentHelper
               }],
               "creator": "",
               "date_of_introduction": "1914-08-28",
-              "link": "mosw-reports/the-gerry-anderson",
-              "_id": "mosw-reports/the-gerry-anderson"
+              "link": "/mosw-reports/the-gerry-anderson",
+              "_id": "/mosw-reports/the-gerry-anderson"
             }
           ],
           "total": 2,

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -15,6 +15,19 @@ describe Document do
 
       expect(document.public_timestamp).to be_nil
     end
+
+    it 'does not break external links' do
+      rummager_document = {
+        title: 'A title',
+        link: 'https://link.com/mature-cheeses'
+      }
+      finder = double(
+        'finder', date_metadata_keys: [], text_metadata_keys: [], links: {}
+      )
+      document = described_class.new(rummager_document, finder)
+
+      expect(document.path).to eq("https://link.com/mature-cheeses")
+    end
   end
 
   describe "#promoted" do


### PR DESCRIPTION
Fixes results for external links like the first one in https://www.gov.uk/search/all?keywords=uttlesford&order=relevance

I've not found any evidence of internal links that don't start with a '/' so I'm not sure why we're doing this check.

It's used in `URI.join(Plek.current.website_root, path)` and was added in https://github.com/alphagov/finder-frontend/commit/a408d1436707b960c86c2f26d3ca5d78615eb9ea

It's used in `absolute_url_for` in application_helper.rb, but that code treats the path the same whether it has a leading slash or not:

```
irb(main):002:0> URI.join("https://www.gov.uk", "bernard")
=> #<URI::HTTPS https://www.gov.uk/bernard>
irb(main):003:0> URI.join("https://www.gov.uk", "/bernard")
=> #<URI::HTTPS https://www.gov.uk/bernard>
```

The test fixture seems to indicate that it might have been specialist content from back in the day that was missing the leading '/', but this looks to have been fixed.