### PR TITLE
Improve option select component accessibility

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -53,8 +53,6 @@
       });
     }
 
-    this.attachCheckedCounter();
-
     // Performance in ie 6/7 is not good enough to support animating the opening/closing
     // so do not allow option-selects to be collapsible in this case
     var allowCollapsible = (typeof ieVersion == "undefined" || ieVersion > 7) ? true : false;
@@ -79,6 +77,8 @@
         this.setupHeight();
       }
     }
+
+    this.attachCheckedCounter();
   }
 
   OptionSelect.prototype.cleanString = function cleanString(text) {
@@ -136,11 +136,11 @@
     $button.attr('aria-controls', this.$optionsContainer.attr('id'));
     $button.html(jsContainerHeadHTML);
     $containerHead.replaceWith($button);
-
   };
 
   OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter(){
-    this.$optionSelect.find('.js-container-head').append('<div class="govuk-!-font-size-14 js-selected-counter">'+this.checkedString()+'</div>');
+    this.$optionSelect.find('.js-container-head')
+      .after('<div class="govuk-!-font-size-14 app-c-option-select__selected-counter js-selected-counter">'+this.checkedString()+'</div>');
   };
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -37,7 +37,7 @@
         that.checkboxLabels.push(that.cleanString($(this).text()));
       });
 
-      this.$filter.on('change keyup', function(e) {
+      this.$filter.on('keyup', function(e) {
         e.stopPropagation();
         var ENTER_KEY = 13;
 

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -28,6 +28,7 @@
       this.$filterCount = $('#' + this.$filter.attr('aria-describedby'));
       this.filterTextSingle = ' ' + this.$filterCount.data('single');
       this.filterTextMultiple = ' ' + this.$filterCount.data('multiple');
+      this.filterTextSelected = ' ' + this.$filterCount.data('selected');
       this.checkboxLabels = [];
       this.filterTimeout = 0;
       var that = this;
@@ -113,7 +114,8 @@
     }
 
     var len = showCheckboxes.length || 0;
-    obj.$filterCount.html(len + (len == 1 ? obj.filterTextSingle : obj.filterTextMultiple));
+    var lenChecked = obj.$optionsContainer.find('.govuk-checkboxes__input:checked').length;
+    obj.$filterCount.html(len + (len == 1 ? obj.filterTextSingle : obj.filterTextMultiple) + ", " + lenChecked + obj.filterTextSelected);
   };
 
   OptionSelect.prototype.replaceHeadWithButton = function replaceHeadWithButton(){

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -79,7 +79,6 @@
   @include govuk-font(19, $weight: bold);
   position: relative;
   margin-right: 40px;
-  padding-top: 5px;
 }
 
 .app-c-option-select__icon {
@@ -149,8 +148,7 @@
     width: 100%;
     text-align: left;
     cursor: pointer;
-    margin-bottom: -1px;
-    padding: 5px 8px;
+    padding: 10px 8px 5px 8px;
     background-color: govuk-colour("grey-3");
 
     &:hover,

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -153,11 +153,12 @@
     padding: 5px 8px;
     background-color: govuk-colour("grey-3");
 
-    &:hover {
+    &:hover,
+    &:hover + .app-c-option-select__selected-counter {
       background-color: govuk-colour("grey-2");
     }
 
-    &:hover + .app-c-option-select__container {
+    &:hover + .app-c-option-select__selected-counter + .app-c-option-select__container {
       border-color: govuk-colour("grey-2");
     }
 
@@ -169,6 +170,10 @@
     &:focus {
       @include govuk-focusable;
     }
+  }
+
+  .app-c-option-select__selected-counter {
+    padding: 3px 8px 0px 8px;
   }
 
   &.js-closed {

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -49,7 +49,7 @@
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "#{key}[]",
         id: checkboxes_id,
-        heading: "Please select all that apply",
+        heading: title,
         visually_hide_heading: true,
         no_hint_text: true,
         items: options

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -44,7 +44,12 @@
   <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
-        <span id="<%= checkboxes_count_id %>" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="<%= t('components.option_select.found_single') %>" data-multiple="<%= t('components.option_select.found_multiple') %>"></span>
+        <span id="<%= checkboxes_count_id %>"
+          class="app-c-option-select__count govuk-visually-hidden"
+          aria-live="polite"
+          data-single="<%= t('components.option_select.found_single') %>"
+          data-multiple="<%= t('components.option_select.found_multiple') %>"
+          data-selected="<%= t('components.option_select.selected') %>"></span>
       <% end %>
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "#{key}[]",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     option_select:
       found_single: "option found"
       found_multiple: "options found"
+      selected: "selected"
   time:
     formats:
       as_date: "%d %B %Y"

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -358,7 +358,7 @@ describe('GOVUK.OptionSelect', function() {
           '&lt;/div&gt;'+
         '&lt;/div&gt;';
 
-      var filterSpan = '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found"></span>';
+      var filterSpan = '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found" data-selected="selected"></span>';
 
       $('body').find('.app-c-option-select').attr('data-filter-element', filterMarkup);
       $('body').find('.gem-c-checkboxes').prepend($(filterSpan));
@@ -380,17 +380,17 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('in').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(5);
-      expect($count.text()).toBe('5 options found');
+      expect($count.text()).toBe('5 options found, 0 selected');
 
       $filterInput.val('ind').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
-      expect($count.html()).toBe('2 options found');
+      expect($count.html()).toBe('2 options found, 0 selected');
 
       $filterInput.val('shouldnotmatchanything').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
-      expect($count.html()).toBe('0 options found');
+      expect($count.html()).toBe('0 options found, 0 selected');
     });
 
     it('does not propagate keypresses up', function(){
@@ -412,12 +412,12 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('electronics').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(3);
-      expect($count.html()).toBe('3 options found');
+      expect($count.html()).toBe('3 options found, 2 selected');
 
       $filterInput.val('shouldnotmatchanything').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(2);
-      expect($count.html()).toBe('2 options found');
+      expect($count.html()).toBe('2 options found, 2 selected');
     });
 
     it('matches a filter regardless of text case', function(){
@@ -426,12 +426,12 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('electroNICS industry').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
 
       $filterInput.val('Building and construction').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
     });
 
     it('matches ampersands correctly', function(){
@@ -440,12 +440,12 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('Distribution & Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
 
       $filterInput.val('Distribution &amp; Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
-      expect($count.html()).toBe('0 options found');
+      expect($count.html()).toBe('0 options found, 0 selected');
     });
 
     it('ignores whitespace around the user input', function(){
@@ -454,7 +454,7 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('   Clothing, footwear and fashion    ').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
     });
 
     it('ignores duplicate whitespace in the user input', function(){
@@ -463,7 +463,7 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('Clothing,     footwear      and      fashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
     });
 
     it('ignores common punctuation characters', function(){
@@ -472,7 +472,7 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
     });
 
     it('normalises & and and', function(){
@@ -481,12 +481,12 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
 
       $filterInput.val('cows and llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
     });
 
     // there was a bug in cleanString() where numbers were being ignored
@@ -496,12 +496,12 @@ describe('GOVUK.OptionSelect', function() {
       $filterInput.val('1st and 2nd Military Courts').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
-      expect($count.html()).toBe('1 option found');
+      expect($count.html()).toBe('1 option found, 0 selected');
 
       $filterInput.val('footwear and f23907234973204723094ashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(0);
-      expect($count.html()).toBe('0 options found');
+      expect($count.html()).toBe('0 options found, 0 selected');
     });
   });
 });


### PR DESCRIPTION
Following an accessibility review of the option select component, a number of fixes are required.

- change the legend given to the included checkboxes from `Please select all that apply` to the title of the option select, e.g. `Countries`
- change the eventlistener on the filter input from `change keyup` to `keyup`. An intermittent bug was occurring where deselecting a checkbox that didn't match a filter triggered that eventlistener, causing the checkbox to immediately disappear
- change the visually hidden text associated with the filter from `x options found` to `x options found, y selected`
- move the `x selected` visible count in the head of the component outside of the button element, as this was confusing some screen readers

Trello card: https://trello.com/c/8reo7ncp/592-fix-option-select-accessibility-issues
