### PR TITLE
Refactor of facets

### DIFF
--- a/app/models/checkbox_facet.rb
+++ b/app/models/checkbox_facet.rb
@@ -20,6 +20,10 @@ class CheckboxFacet < FilterableFacet
     is_checked?
   end
 
+  def has_value?
+    is_checked?
+  end
+
   def value
     facet['value'] || true
   end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -14,6 +14,10 @@ class DateFacet < FilterableFacet
     present_values.any?
   end
 
+  def has_value?
+    value.present? && value.values.any?(&:present?)
+  end
+
 private
 
   def value_fragments

--- a/app/models/dropdown_select_facet.rb
+++ b/app/models/dropdown_select_facet.rb
@@ -27,6 +27,10 @@ class DropdownSelectFacet < FilterableFacet
     selected_value.any?
   end
 
+  def has_value?
+    value.present?
+  end
+
 private
 
   def value_fragment
@@ -38,7 +42,7 @@ private
   end
 
   def selected_value
-    return default_value if @value.nil?
+    return default_value if value.nil?
 
     allowed_values.find { |option|
       @value == option['value']

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -47,6 +47,10 @@ class Facet
     facet['allowed_values'] || []
   end
 
+  def has_value?
+    raise NotImplementedError
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -18,6 +18,12 @@ class HiddenFacet < FilterableFacet
     value.present?
   end
 
+  def has_value?
+    value.present?
+  end
+
+private
+
   def value_fragments
     selected_values.map { |v|
       {

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -28,6 +28,10 @@ class KeywordFacet
     [keywords]
   end
 
+  def has_value?
+    keywords.present?
+  end
+
   def hide_facet_tag?
     false
   end

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -55,6 +55,10 @@ class OptionSelectFacet < FilterableFacet
     { selected: selected_values, allowed: allowed_values }
   end
 
+  def has_value?
+    value && value.any?
+  end
+
 private
 
   def value_fragments

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -21,6 +21,10 @@ class RadioFacet < FilterableFacet
     return nil if hide_facet_tag?
   end
 
+  def has_value?
+    @value.present?
+  end
+
 private
 
   def selected_value

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -27,6 +27,10 @@ class TaxonFacet < DropdownSelectFacet
     selected_level_one_value.present?
   end
 
+  def has_value?
+    @value_hash.present? && @value_hash.values.any?(&:present?)
+  end
+
 private
 
   def value_fragments

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -330,16 +330,10 @@ private
   end
 
   def alert_query_string
-    facets_with_filters = facets.select(&:has_filters?)
-
-    facets_with_values = facets_with_filters.reject { |facet|
-      facet.value.nil? ||
-        facet.value.is_a?(Hash) && facet.value.values.all?(&:blank?) ||
-        facet.value.is_a?(Array) && facet.value.empty?
-    }
-
-    filtered_values = facets_with_values.each_with_object({}) { |facet, hash|
-      hash[facet.key] = facet.value
+    filtered_values = facets.each_with_object({}) { |facet, hash|
+      if facet.has_filters? && facet.has_value?
+        hash[facet.key] = facet.value
+      end
     }
 
     query_string = filtered_values.to_query

--- a/spec/models/checkbox_facet_spec.rb
+++ b/spec/models/checkbox_facet_spec.rb
@@ -66,4 +66,21 @@ describe CheckboxFacet do
       }
     end
   end
+
+
+  describe "#has_value?" do
+    context "true if checkbox is selected" do
+      subject { CheckboxFacet.new(facet_data, "yes") }
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+
+    context "checkbox is not selected" do
+      subject { CheckboxFacet.new(facet_data, nil) }
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+  end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -58,4 +58,17 @@ describe ContentItem do
       end
     end
   end
+
+  describe "has_value?" do
+    it "returns false when document_type is not redirect" do
+      expect(subject.is_redirect?).to be false
+    end
+
+    context "when document_type is redirect" do
+      let(:finder_content_item) { news_and_communications.merge("document_type" => 'redirect') }
+      it "returns true when document_type is redirect" do
+        expect(subject.is_redirect?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -52,4 +52,41 @@ describe DateFacet do
       }
     end
   end
+
+  describe "#has_value?" do
+    context "value is nil" do
+      let(:value) { nil }
+      subject { DateFacet.new(facet_data, value) }
+
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+
+    context "value has a nil value" do
+      let(:value) {
+        {
+          "from" => nil
+        }
+      }
+      subject { DateFacet.new(facet_data, value) }
+
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+
+    context "value has a value" do
+      let(:value) {
+        {
+            "from" => "24/11/1990"
+        }
+      }
+      subject { DateFacet.new(facet_data, value) }
+
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+  end
 end

--- a/spec/models/dropdown_select_facet_spec.rb
+++ b/spec/models/dropdown_select_facet_spec.rb
@@ -50,4 +50,22 @@ describe DropdownSelectFacet do
       specify { expect(subject.sentence_fragment).to be_nil }
     end
   end
+
+  describe "#has_value?" do
+    context "value is nil" do
+      subject { DropdownSelectFacet.new(facet_data, nil) }
+
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+
+    context "value is present" do
+      subject { DropdownSelectFacet.new(facet_data, "allowed-value-1") }
+
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+  end
 end

--- a/spec/models/hidden_facet_spec.rb
+++ b/spec/models/hidden_facet_spec.rb
@@ -17,4 +17,15 @@ describe HiddenFacet do
       specify { expect(subject.to_partial_path).to eql("hidden_facet") }
     end
   end
+
+  describe "#has_value?" do
+    context "value is nil" do
+      specify { expect(subject.has_value?).to eql(false) }
+    end
+
+    context "value is present" do
+      subject { facet_class.new(facet_data, "some value") }
+      specify { expect(subject.has_value?).to eql(true) }
+    end
+  end
 end

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -50,4 +50,30 @@ describe KeywordFacet do
       }
     end
   end
+
+  describe "#has_value?" do
+    context "value is nil" do
+      subject { KeywordFacet.new(nil) }
+
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+
+    context "value is a single keyword" do
+      subject { KeywordFacet.new(query) }
+
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+
+    context "value has multiple quotes" do
+      subject { KeywordFacet.new(query_with_multiple_quotes) }
+
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+  end
 end

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -114,4 +114,30 @@ describe OptionSelectFacet do
       end
     end
   end
+
+  describe "#has_value?" do
+    context "value is empty" do
+      subject { OptionSelectFacet.new(facet_data, []) }
+
+      specify do
+        expect(subject.has_value?).to be false
+      end
+    end
+
+    context "value is nil" do
+      subject { OptionSelectFacet.new(facet_data, nil) }
+
+      specify do
+        expect(subject.has_value?).to be false
+      end
+    end
+
+    context "value has entries" do
+      subject { OptionSelectFacet.new(facet_data, %w(allowed-value-1 allowed-value-2)) }
+
+      specify do
+        expect(subject.has_value?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/radio_facet_spec.rb
+++ b/spec/models/radio_facet_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe RadioFacet do
+  let(:facet_data) {
+    {
+      'type' => "radio",
+      'key' => "document_type",
+      'name' => "Document type",
+      'short_name' => "Documents",
+      'preposition' => "of document type",
+    }
+  }
+
+
+
+  describe "#has_value?" do
+    context "value is nil" do
+      subject { CheckboxFacet.new(facet_data, nil) }
+
+      specify {
+        expect(subject.has_value?).to eql(false)
+      }
+    end
+
+    context "has a value" do
+      subject { CheckboxFacet.new(facet_data, "some_value") }
+
+      specify {
+        expect(subject.has_value?).to eql(true)
+      }
+    end
+  end
+end

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -110,4 +110,26 @@ describe TaxonFacet do
       specify { expect(subject.sentence_fragment).to be_nil }
     end
   end
+
+  describe "#has_value?" do
+    context "value is nil" do
+      subject { TaxonFacet.new(facet_data, nil) }
+      specify { expect(subject.has_value?).to be false }
+    end
+
+    context "value is empty hash" do
+      subject { TaxonFacet.new(facet_data, {}) }
+      specify { expect(subject.has_value?).to be false }
+    end
+
+    context "value is hash with key and nil values" do
+      subject { TaxonFacet.new(facet_data, "level_one_taxon" => nil, "level_two_taxon" => nil) }
+      specify { expect(subject.has_value?).to be false }
+    end
+
+    context "value is has been selected" do
+      subject { TaxonFacet.new(facet_data, allowed_values) }
+      specify { expect(subject.has_value?).to be true }
+    end
+  end
 end

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -53,4 +53,30 @@ describe TopicalFacet do
       specify { expect(subject.sentence_fragment).to be_nil }
     end
   end
+
+  describe "#has_value?" do
+    context "value is empty" do
+      subject { TopicalFacet.new(facet_data, []) }
+
+      specify do
+        expect(subject.has_value?).to be false
+      end
+    end
+
+    context "value is nil" do
+      subject { TopicalFacet.new(facet_data, nil) }
+
+      specify do
+        expect(subject.has_value?).to be false
+      end
+    end
+
+    context "value has entries" do
+      subject { TopicalFacet.new(facet_data, %w(allowed-value-1 allowed-value-2)) }
+
+      specify do
+        expect(subject.has_value?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION

*Set the value as part of the initializer in Facets instead of through setter
*Handle setting value of facets in subclasses of Facets because they mean different things in those subclasses.
*Set the values in FacetCollection as part of the initializer
*Remove unused code in FacetTagPresenter and simplify code

Almost entirely by @koetsier with minor fix from @oscarwyatt 


