### PR TITLE
Require govuk_publishing_components before app scripts

### DIFF
--- a/app/assets/javascripts/application-site-search.js
+++ b/app/assets/javascripts/application-site-search.js
@@ -9,6 +9,8 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
+//= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/all_components
 //
 //= require support
 //
@@ -19,4 +21,3 @@
 //= require search
 //= require_tree ./modules
 //= require_tree ./components
-//= require govuk_publishing_components/all_components

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/all_components
 //
 //= require support
 //
@@ -20,7 +21,6 @@
 //= require taxonomy-select
 //= require_tree ./modules
 //= require_tree ./components
-//= require govuk_publishing_components/all_components
 
 jQuery(function($) {
   var $form = $('.js-live-search-form'),


### PR DESCRIPTION
The previous order revealed a bug when an application script (search) was dependent on `GOVUK.Cookies` which lives in `govuk_publishing_components`.

### Before
<img width="704" alt="Screen Shot 2019-04-01 at 16 24 39" src="https://user-images.githubusercontent.com/788096/55339500-b4693000-549a-11e9-9c06-583720a2bf4c.png">

### After
_silence_