### PR TITLE
Add additional custom dimension for relevant result

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -103,11 +103,18 @@
           var newPath = window.location.pathname + "?" + $.param(this.state);
           history.pushState(this.state, '', newPath);
           this.trackingInit();
+          this.setRelevantResultCustomDimension();
           this.trackPageView();
         }.bind(this)
       );
     }
   };
+
+  LiveSearch.prototype.setRelevantResultCustomDimension = function() {
+    var $mostRelevantDocumentLink = $('.finder-results').find('.document__link--top');
+    var dimensionValue = $mostRelevantDocumentLink.length ? "yes" : "no";
+    GOVUK.analytics.setDimension(83, dimensionValue);
+  }
 
   LiveSearch.prototype.trackingInit = function() {
     GOVUK.modules.start($('.js-live-search-results-block'));

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -111,10 +111,12 @@
   };
 
   LiveSearch.prototype.setRelevantResultCustomDimension = function() {
-    var $mostRelevantDocumentLink = $('.finder-results').find('.document__link--top');
-    var dimensionValue = $mostRelevantDocumentLink.length ? "yes" : "no";
-    GOVUK.analytics.setDimension(83, dimensionValue);
-  }
+    if (this.canSetCustomDimension()) {
+      var $mostRelevantDocumentLink = $('.finder-results').find('.document__link--top');
+      var dimensionValue = $mostRelevantDocumentLink.length ? "yes" : "no";
+      GOVUK.analytics.setDimension(83, dimensionValue);
+    }
+  };
 
   LiveSearch.prototype.trackingInit = function() {
     GOVUK.modules.start($('.js-live-search-results-block'));
@@ -187,6 +189,10 @@
 
   LiveSearch.prototype.canTrackPageview = function() {
     return GOVUK.analytics && GOVUK.analytics.trackPageview;
+  };
+
+  LiveSearch.prototype.canSetCustomDimension = function() {
+    return GOVUK.analytics && GOVUK.analytics.setDimension;
   };
 
   LiveSearch.prototype.cache = function cache(slug, data){

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -9,6 +9,11 @@
   <% if finder.canonical_link? %>
     <link rel="canonical" href="<%= "#{ENV['GOVUK_WEBSITE_ROOT']}#{finder.slug}" %>">
   <% end %>
+
+  <% if @results.to_hash[:documents].present? && @results.to_hash[:documents].first[:document][:top_result] %>
+    <meta name="govuk:relevant-result-shown" content="yes">
+  <% end %>
+
 <% end %>
 
 <% content_for :meta_title, finder.name %>


### PR DESCRIPTION
The new custom dimension is Relevant result shown (83). This should be set to 'Yes' if a  search in the finder search box results in a 'relevant result'. This is set at a hit/pageview level, since a user may do several searches in their session.

Ticket:  https://trello.com/c/lwQK2Pi7/336-set-up-a-b-test-for-answer-boxes