### PR TITLE
Use new filter_research_and_statistics filter in Rummager

### DIFF
--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -119,27 +119,22 @@
         "preposition": "about"
       },
       {
-        "key":"content_store_document_type",
+        "key":"research_and_statistics",
         "name":"Statistics",
         "type":"radio",
         "display_as_result_metadata":false,
         "filterable":true,
         "hide_facet_tag":true,
         "preposition": "that are",
-        "option_lookup": {
-          "statistics_published": ["statistics", "national_statistics", "statistical_data_set", "official_statistics"],
-          "statistics_upcoming": ["statistics_announcement", "national_statistics_announcement", "official_statistics_announcement"],
-          "research": ["dfid_research_output", "independent_report", "research"]
-        },
         "allowed_values": [
           {
             "label": "Statistics (published)",
-            "value": "statistics_published",
+            "value": "published_statistics",
             "default": true
           },
           {
             "label": "Statistics (upcoming)",
-            "value": "statistics_upcoming"
+            "value": "upcoming_statistics"
           },
           {
             "label": "Research",

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -120,7 +120,7 @@ module DocumentHelper
     stub_request(
       :get,
       rummager_research_and_statistics_url(
-        'filter_content_store_document_type' => %w(statistics_announcement national_statistics_announcement official_statistics_announcement)
+        'filter_research_and_statistics[]' => %w(upcoming_statistics)
       )
     ).to_return(body: upcoming_statistics_results_for_statistics_json)
   end

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -81,7 +81,7 @@ module RummagerUrlHelper
       'facet_world_locations' => '1500,order:value.title',
       'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
       'fields' => research_and_statistics_search_fields.join(','),
-      'filter_content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics),
+      'filter_research_and_statistics[]' => %w(published_statistics),
       'count' => 20,
       'order' => '-public_timestamp',
     )
@@ -132,7 +132,7 @@ module RummagerUrlHelper
       display_type
       document_collections
       part_of_taxonomy_tree
-      content_store_document_type
+      research_and_statistics
       organisations
       world_locations
     )


### PR DESCRIPTION
Use new filter_research_and_statistics filter in Rummager

Fixes bug with showing the incorrect number of upcoming and published statistics on the research and statistics finder

Trello: https://trello.com/c/QpM8Vhwv/590-bug-stats-finder-is-only-displaying-a-few-upcoming-stats-docs
Trello: https://trello.com/c/mkf4eUXF/593-bug-stats-finder-displaying-wrong-number-of-published-stats-docs