### PR TITLE
Allow finders to be no-indexed

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -270,6 +270,10 @@ class FinderPresenter
     content_item['description']
   end
 
+  def no_index?
+    !!content_item["details"]["no_index"]
+  end
+
   def canonical_link?
     content_item['details']['canonical_link']
   end

--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -1,6 +1,9 @@
 <% if finder.description %>
   <meta name="description" content="<%= finder.description %>">
 <% end %>
+<% if finder.no_index? %>
+  <meta name="robots" content="noindex">
+<% end %>
 <link rel="alternate" type="application/json" href="/api/content<%= finder.slug %>">
 
 <%= render 'govuk_publishing_components/components/meta_tags', content_item: finder.content_item %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -73,6 +73,10 @@ Feature: Filtering documents
     Given a finder with description exists
     Then I can see that the description in the metadata is present
 
+  Scenario: Visit a finder with noindex
+    Given a finder with a no_index property exists
+    Then I can see that the noindex tag is is present in the metadata
+
   Scenario: Link tracking
     Given a government finder exists
     Then the links on the page have tracking attributes

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -402,12 +402,24 @@ Given(/^a finder with description exists$/) do
   stub_rummager_with_cma_cases
 end
 
+Given(/^a finder with a no_index property exists$/) do
+  stub_content_store_with_cma_cases_finder_with_no_index
+  stub_rummager_with_cma_cases
+end
+
 When(/^I can see that the description in the metadata is present$/) do
   visit "/cma-cases"
 
   desc_text = "Find reports and updates on current and historical CMA investigations"
   desc_tag = "meta[name='description'][content='#{desc_text}']"
   expect(page).to have_css(desc_tag, visible: false)
+end
+
+When(/^I can see that the noindex tag is is present in the metadata$/) do
+  visit "/cma-cases"
+
+  noindex_tag = "meta[name='robots'][content='noindex']"
+  expect(page).to have_css(noindex_tag, visible: false)
 end
 
 Given(/^an organisation finder exists$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -334,6 +334,16 @@ module DocumentHelper
     )
   end
 
+  def stub_content_store_with_cma_cases_finder_with_no_index
+    schema = govuk_content_schema_example("cma-cases", "finder")
+    schema["details"]["no_index"] = true
+
+    content_store_has_item(
+      schema.fetch("base_path"),
+      schema.to_json,
+    )
+  end
+
   def stub_content_store_with_cma_cases_finder_for_supergroup_checkbox_filter
     schema = govuk_content_schema_example("cma-cases", "finder")
     schema["details"]["facets"].map! do |facet|


### PR DESCRIPTION
We need to have the capability to set a noindex meta tag on some of our finders.

This should match [this content schemas PR](https://github.com/alphagov/govuk-content-schemas/pull/883)

Examples:
https://finder-frontend-pr-1029.herokuapp.com/prepare-eu-exit/all **should** have a `noindex` meta tag
https://finder-frontend-pr-1029.herokuapp.com/search/all should **not** have a `noindex` meta tag