### PR TITLE
Send default attributes to email alert api as tags

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -46,7 +46,8 @@ private
   # ***  OVER CONTENT STORE REQUESTS  ***
   # *************************************
   FINDERS_IN_DEVELOPMENT = {
-    "/review-search/all" => 'all_content'
+    "/review-search/all" => 'all_content',
+    "/review-search/news-and-communications" => 'news_and_communications',
   }.freeze
 
   def development_env_finder_json

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -44,7 +44,7 @@
   "details":{
     "document_noun":"result",
     "filter":{
-      "content_purpose_supergroup":"news_and_communications"
+      "content_purpose_subgroup": ["news", "speeches_and_statements"]
     },
     "format_name":"News or communiqué",
     "show_summaries":true,

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -6,7 +6,7 @@
   "description": "You'll get an email each time news or communications are published.",
   "details": {
     "filter": {
-      "content_purpose_supergroup": "news_and_communications"
+      "content_purpose_subgroup": ["news", "speeches_and_statements"]
     },
     "email_filter_by": null,
     "email_filter_name": null,

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -63,26 +63,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
       content_store_has_item('/cma-cases/email-signup', signup_finder)
     end
 
-    context "finder has default rejects" do
-      let(:signup_finder) {
-        cma_cases_signup_content_item.to_hash.merge("details" => {
-          "reject" => { "content_purpose_supergroup" => 'other' },
-        })
-      }
-
-      it "does not fail if no other attributes are provided" do
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "format" => { any: %w(mosw_report) },
-          },
-          "subscription_url" => 'http://www.example.com',
-        )
-
-        post :create, params: { slug: 'cma-cases' }
-        expect(subject).to redirect_to('http://www.example.com')
-      end
-    end
-
     context "finder has default filters" do
       let(:signup_finder) {
         cma_cases_signup_content_item.to_hash.merge("details" => {
@@ -94,8 +74,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
         email_alert_api_has_subscriber_list(
           "tags" => {
             "format" => { any: %w(mosw_report) },
+            "content_purpose_supergroup" => { any: %w(news-and-communications) },
           },
-          "content_purpose_supergroup" => 'news-and-communications',
           "subscription_url" => 'http://www.example.com',
         )
 


### PR DESCRIPTION
**Note:** Should be deployed after https://github.com/alphagov/email-alert-api/pull/833

Trello: https://trello.com/c/IUEMbTEA

We need to subscribe users to arbitrary groups of document types
rather than supergroups. In this case, for news and comms, we
want to subscribe users to groups of documents (news and speeches).

Rather than sending a content_purpose_supergroup or other separate
parameter, this change means we will start sending all default fields
as part of the tags. The change to email-alert-api means that these
new grouping tags will have an effect.

Changes in this commit:
- Removed all default reject filter logic. Its not used.
- Added default filter subgroups to news and comms finder and signup fixture
- Moved default filters into the tags we send to email-alert-api
- Moved EmailAlertTitleBuilder logic out of EmailAlertSignupApi
- Refactored EmailAlertSignupApi a bit to make building of tags easier to understand