### PR TITLE
Remove updated options from sort

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -198,15 +198,14 @@ class FinderPresenter
       ]
     end
 
-    disabled_option = keywords.blank? ? relevance_sort_option_value : ''
+    disabled_options = []
+    disabled_options << relevance_sort_option_value if keywords.blank?
+    disabled_options << 'updated-newest' if content_document_type == 'statistics_upcoming'
+    disabled_options << 'updated-oldest' if content_document_type == 'statistics_upcoming'
 
-    selected_option = if values['order'].present? && sort.any? { |option| option['name'].parameterize == values['order'] }
-                        values['order']
-                      else
-                        default_sort_option_value
-                      end
+    selected_option = selected_sort_option(disabled_options)
 
-    options_for_select(options, selected: selected_option, disabled: disabled_option)
+    options_for_select(options, selected: selected_option, disabled: disabled_options)
   end
 
   def show_keyword_search?
@@ -288,9 +287,27 @@ class FinderPresenter
     self.content_item['content_id'] == "42ce66de-04f3-4192-bf31-8394538e0734"
   end
 
+  def content_document_type
+    document_type = filters.find { |f| f.key == 'content_store_document_type' }
+    document_type.value if document_type.present?
+  end
+
 private
 
   attr_reader :search_results
+
+  def selected_sort_option(disabled_options)
+    unless values['order'].present? || sort.any? { |option| option['name'].parameterize == values['order'] }
+      return default_sort_option_value
+    end
+
+    if disabled_options.include?(values['order'])
+      sort_order = content_document_type == 'statistics_upcoming' ? 'release-date-latest' : default_sort_option
+      return sort_order
+    end
+
+    values['order']
+  end
 
   def part_of
     content_item['links']['part_of'] || []


### PR DESCRIPTION
This PR removes updated options from sort options when statistics upcoming is selected

This commit removes the options `Updated (newest)` and `Updated (oldest)` from the sort options when the user chooses to view `Statistics (upcoming)`. If the user later chooses to view `Statistics (published)` or `Research`, the options are added back.

In addition, the current default sort option is `Updated (newest)`; this presents us a problem after removing it for `Statistics (upcoming)` if we need to default back to showing it, either because:
- the user previously had a keyword search with a sort option of `Relevancy`, and then removed that keyword search, or
- the user previously sorted by `Upcoming (newest)` or `Upcoming (oldest)` and then chose to view `Statictics (upcoming)`

If for either of the above reasons, we need to default to an option, we will default to `Release date (latest)`.

This PR also fixes a bug which exists in finders when a user with no JS filters by keyword, chooses the Relevancy sort option and then removes the keyword. Previously, Relevancy would have stayed as the chosen sort option, even though it was disabled. This PR updates that behaviour to choose `Updated (newest)`.

Still to-do:
- Should be switching to sort option `Updated (newest)`, but instead is `Most viewed`.
- Add / update tests.
- Figure out how to codify the fallback sort options so that we don't have to hardcode them.

Trello: https://trello.com/c/IjADqrbb