### PR TITLE
Limit AB test header to the page in test

### DIFF
--- a/app/controllers/concerns/finder_top_result_ab_testable.rb
+++ b/app/controllers/concerns/finder_top_result_ab_testable.rb
@@ -23,7 +23,11 @@ module FinderTopResultAbTestable
   end
 
   def set_test_response_header
-    finder_top_result_variant.configure_response(response)
+    finder_top_result_variant.configure_response(response) if test_in_scope?
+  end
+
+  def test_in_scope?
+    content_item.is_finder? && finder.eu_exit_finder?
   end
 
   def show_top_result?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,7 +14,7 @@
     <meta name="govuk:relevant-result-shown" content="yes">
   <% end %>
 
-  <%= finder_top_result_variant.analytics_meta_tag.html_safe %>
+  <%= finder_top_result_variant.analytics_meta_tag.html_safe if finder.eu_exit_finder? %>
 <% end %>
 
 <% content_for :meta_title, finder.name %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -266,12 +266,24 @@ describe FindersController, type: :controller do
   end
 
   describe "Business finder top results AB tests" do
+    let(:breakfast_finder) do
+      finder = govuk_content_schema_example('finder').to_hash.merge(
+        'title' => 'Breakfast Finder',
+        'base_path' => '/breakfast-finder',
+        'content_id' => '42ce66de-04f3-4192-bf31-8394538e0734' #business finder id
+      )
+
+      finder["details"]["default_documents_per_page"] = 10
+      finder["details"]["sort"] = nil
+      finder
+    end
+
     let(:filter_params) { double(:filter_params, keywords: '') }
     let(:view_context) { double(:view_context) }
-    let(:finder_presenter) { FinderPresenter.new(lunch_finder, {}, filter_params) }
+    let(:finder_presenter) { FinderPresenter.new(breakfast_finder, {}, filter_params) }
 
     before do
-      content_store_has_item(lunch_finder['base_path'], lunch_finder)
+      content_store_has_item(breakfast_finder['base_path'], breakfast_finder)
       rummager_response = %|{
         "results": [],
         "total": 0,
@@ -284,14 +296,14 @@ describe FindersController, type: :controller do
 
     it "Finder variant A does not set show_top_result" do
       with_variant FinderAnswerABTest: "A" do
-        get :show, params: { slug: path_for(lunch_finder) }
+        get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.show_top_result?).to eq(false)
       end
     end
 
     it "Finder variant B does set show_top_result" do
       with_variant FinderAnswerABTest: "B" do
-        get :show, params: { slug: path_for(lunch_finder) }
+        get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.show_top_result?).to eq(true)
       end
     end


### PR DESCRIPTION
This header tells fastly that it needs to cache a version of the page for each value of the header.  We only need to do this for the business finder for this test (or so I believe).

This should reduce the number of requests that hit origin for other pages in finder-frontend.