### PR TITLE
Use has_filters? to query existence of a set value

### DIFF
--- a/app/presenters/advanced_search_result_set_presenter.rb
+++ b/app/presenters/advanced_search_result_set_presenter.rb
@@ -40,7 +40,7 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
     cleanup_whitespace(
       if selected_filter_descriptions.blank?
         subgroups_as_sentence
-      elsif subgroup_facet.value.blank?
+      elsif !subgroup_facet.has_filters?
         [subgroups_as_sentence, filters_to_sentence(selected_filter_descriptions)].to_sentence
       else
         [filters_to_sentence(selected_filter_descriptions)].to_sentence


### PR DESCRIPTION
Querying a value directly has been removed. Us has_filters? to
query if a facet has selected value.