### PR TITLE
Bugfix: Title of advanced finder can be undefined

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -17,7 +17,7 @@
     this.$resultsCount = options.$results.find('#js-result-count');
     this.action = this.$form.attr('action') + '.json';
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink;
-    this.baseTitle = $("meta[name='govuk\:base_title']").attr("content");
+    this.baseTitle = $("meta[name='govuk\:base_title']").attr("content") || document.title;
     this.$emailLink = $('a[href*="email-signup"]');
     this.previousSearchTerm = '';
 


### PR DESCRIPTION
Currently, if a user makes changes on an Advanced Search finder this will cause the title to become `undefined`.


Steps to reproduce:
1. Go to https://www.gov.uk/search/advanced?group=guidance_and_regulation&topic=%2Feducation
2. Enter a keyword or change a filter
3. See the `document.title` ends with `undefined`

This happens due to a JS error when setting document.title, introduced here https://github.com/alphagov/finder-frontend/commit/c4d322a5fc94dc01cd5915a4dea9f777e20adf79

This wasn't caught by the tests because we always assume that `<meta name=govuk:base_title>` [is always set](https://github.com/alphagov/finder-frontend/blob/master/spec/javascripts/live_search_spec.js#L47-L53). I haven't fixed the test in this commit; I will speak with a frontend developer to see if they have any thoughts.

Trello: https://trello.com/c/f1aY9BJZ/622