### PR TITLE
Truncate long queries, to match search-api

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -1,6 +1,16 @@
 # SearchQueryBuilder takes the content item for the finder and the query params
 # from the URL to generate a query for Rummager.
 class SearchQueryBuilder
+  # search-api rejects queries which are longer than this, but an
+  # error page isn't a good experience for users.  There are some
+  # legitimate queries over this length (people typing a length
+  # question into the search box), so rather than give them an error
+  # page just give them (probably unhelpful) results.  At some point
+  # we shall do UI work to direct people who enter a long query to the
+  # contact form, as even an untruncated long query isn't going to
+  # find anything useful, too much noise.
+  MAX_QUERY_LENGTH = 512
+
   def initialize(finder_content_item:, params: {})
     @finder_content_item = finder_content_item
     @params = params
@@ -129,7 +139,7 @@ private
   end
 
   def keyword_query
-    keywords ? { "q" => keywords } : {}
+    keywords ? { "q" => keywords[0, MAX_QUERY_LENGTH] } : {}
   end
 
   def keywords

--- a/spec/lib/advanced_search_query_builder_spec.rb
+++ b/spec/lib/advanced_search_query_builder_spec.rb
@@ -77,5 +77,17 @@ RSpec.describe AdvancedSearchQueryBuilder do
     it "should not include an order query" do
       expect(instance.call.first).not_to include("order")
     end
+
+    context "longer than the maximum query length" do
+      let(:params) {
+        {
+          "keywords" => "a" * 1024
+        }
+      }
+
+      it "should include a truncated" do
+        expect(instance.call.first).to include("q" => "a" * SearchQueryBuilder::MAX_QUERY_LENGTH)
+      end
+    end
   end
 end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -227,6 +227,18 @@ describe SearchQueryBuilder do
       expect(query).not_to include("order")
     end
 
+    context "longer than the maximum query length" do
+      let(:params) {
+        {
+          "keywords" => "a" * 1024
+        }
+      }
+
+      it "should include a truncated" do
+        expect(query).to include("q" => "a" * SearchQueryBuilder::MAX_QUERY_LENGTH)
+      end
+    end
+
     context "without stopwords" do
       let(:params) {
         {


### PR DESCRIPTION
search-api rejects queries which are longer than 512 characters, but
we do get some legitibale (ie, human-looking) queries over this
length.  These queries are generally long questions, asked as if you
were talking to a human (not performing a search).  Searching for such
a thing is very unlikely to find good results, there's too much noise
in the keywords, but giving an error page isn't a good experience.

So we're going to silently truncate the query to match the search-api
limits, and do a search (which will still return unhelpful results,
for the same reason as previously).  At somepoint we'll do some UI
work to direct people to the contact form if they enter a long query.

---

[Trello card](https://trello.com/c/taQuHzDe/124-return-a-422-through-the-public-search-api-for-any-queries-512-characters)