### PR TITLE
Truncate long non-finder queries, to match search-api

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -24,7 +24,10 @@ class SearchParameters
   end
 
   def search_term
-    params[:q]&.strip&.gsub(/\s{2,}/, ' ')
+    full_term = params[:q]&.strip&.gsub(/\s{2,}/, ' ')
+    unless full_term.nil?
+      full_term[0, SearchQueryBuilder::MAX_QUERY_LENGTH]
+    end
   end
 
   def show_organisations_filter?

--- a/spec/models/search_parameters_spec.rb
+++ b/spec/models/search_parameters_spec.rb
@@ -54,4 +54,13 @@ RSpec.describe SearchParameters do
       expect(params.rummager_parameters[:filter_organisations]).to eq(['ministry-of-silly-walks'])
     end
   end
+
+  context "#search_term" do
+    it "truncates a too-long search query" do
+      max_length = SearchQueryBuilder::MAX_QUERY_LENGTH
+      long_query = "a" * max_length
+      params = search_params("q" => "#{long_query}1234567890")
+      expect(params.rummager_parameters[:q]).to eq(long_query)
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/taQuHzDe/124-return-a-422-through-the-public-search-api-for-any-queries-512-characters)