### PR TITLE
Send facet label as label to GA when removing a facet

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -21,10 +21,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       var removeFilterName = $el.data('name');
       var removeFilterValue = $el.data('value');
+      var removeFilterLabel = $el.data('track-label');
       var removeFilterFacet = $el.data('facet');
 
       var $input = getInput(removeFilterName, removeFilterValue, removeFilterFacet);
-      fireRemoveTagTrackingEvent(removeFilterValue, removeFilterFacet);
+      fireRemoveTagTrackingEvent(removeFilterLabel, removeFilterFacet);
       clearFacet($input, removeFilterValue, removeFilterFacet);
     }
 

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -15,7 +15,8 @@ class FacetTagPresenter
         text: html_escape(value['label']),
         data_facet: value['parameter_key'],
         data_name: value['name'],
-        data_value: value['value']
+        data_value: value['value'],
+        data_track_label: value['label'],
       }
     end
   end

--- a/app/views/finders/_applied_filter.mustache
+++ b/app/views/finders/_applied_filter.mustache
@@ -8,6 +8,7 @@
         class="facet-tag__remove"
         aria-label="Remove filter {{{text}}}"
         data-module="remove-filter-link"
+        data-track-label="{{{data_track_label}}}"
         data-facet="{{{data_facet}}}"
         data-value="{{{data_value}}}"
         data-name="{{{data_name}}}">&#x2715;</button>

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -9,42 +9,42 @@ describe('remove-filter', function () {
   GOVUK.analytics = GOVUK.analytics || {};
   var $checkbox = $(
   '<div data-module="remove-filter">' +
-    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter Brexit" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-name="">✕</button>' +
+    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter Brexit" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-track-label="Brexit" data-name="">✕</button>' +
   '</div>');
 
   var $oneTextQuery = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-name="keywords">✕</button>' +
+      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-track-label="Education" data-name="keywords">✕</button>' +
     '</div>'
   );
 
   var $multipleTextQueries = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-name="keywords">✕</button>' +
+      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-track-label="the" data-name="keywords">✕</button>' +
     '</div>'
   );
 
   var $dropdown = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</button>' +
+      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>' +
     '</div>'
   );
 
   var $facetTagOne = $(
       '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="aa3a9702-da22-487f-86c1-8334a730e558" data-name="">✕</button>' +
+      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="aa3a9702-da22-487f-86c1-8334a730e558" data-track-label="A level one taxon" data-name="">✕</button>' +
       '</div>'
   );
 
   var $facetTagTwo = $(
    '<div data-module="remove-filter">' +
-     '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-name="">✕</button>' +
+     '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-track-label="Sub taxon" data-name="">✕</button>' +
    '</div>'
   );
 
   var $facetTagDate = $(
     '<div data-module="remove-filter">' +
-    '<a href="/search/news-and-communications?[][]=from&amp;[][]=2018&amp;[][]=to&amp;[][]=" class="remove-filter" role="button" aria-label="Remove filter  1 January 2018" data-module="remove-filter-link" data-facet="public_timestamp" data-value="2018" data-name="public_timestamp[from]">✕</a>' +
+    '<a href="/search/news-and-communications?[][]=from&amp;[][]=2018&amp;[][]=to&amp;[][]=" class="remove-filter" role="button" aria-label="Remove filter  1 January 2018" data-module="remove-filter-link" data-facet="public_timestamp" data-value="2018" data-track-label="1 January 2018" data-name="public_timestamp[from]">✕</a>' +
     '</div>'
   );
 
@@ -145,7 +145,7 @@ describe('remove-filter', function () {
       triggerRemoveFilterClick($facetTagOne);
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_one_taxon', {
-          label: 'aa3a9702-da22-487f-86c1-8334a730e558'
+          label: 'A level one taxon'
       });
     });
 
@@ -157,7 +157,7 @@ describe('remove-filter', function () {
       triggerRemoveFilterClick($facetTagTwo);
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_two_taxon', {
-          label: 'bb3a9702-da22-487f-86c1-8334a730e559'
+          label: 'Sub taxon'
       });
     });
   });


### PR DESCRIPTION
Currently we send the value of the facet, which can be an id. This
send the label of the facet value. E.g. Brexit rather than the brexit
content id.

Trello: https://trello.com/c/jGJHf4um/619.