### PR TITLE
Add alternative styling option to option select

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -11,9 +11,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
 
     var openOnLoad = this.$module.getAttribute('data-open-on-load') === 'true' ? true : false
 
-    if (!openOnLoad) {
-      this.collapseContent()
-    }
     this.replaceTitleWithButton(openOnLoad)
 
     this.$module.toggleContent = this.toggleContent.bind(this)
@@ -40,12 +37,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
   }
 
   Expander.prototype.toggleContent = function (e) {
-    if (this.$content.style.display === 'none') {
+    if (this.$toggleButton.getAttribute('aria-expanded') === 'false') {
       this.$toggleButton.setAttribute('aria-expanded', true)
-      this.$content.style.display = 'block'
+      this.$content.classList.add('app-c-expander__content--visible')
     } else {
       this.$toggleButton.setAttribute('aria-expanded', false)
-      this.$content.style.display = 'none'
+      this.$content.classList.remove('app-c-expander__content--visible')
     }
   }
 

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -133,10 +133,11 @@
 
     // Create button and replace the preexisting html with the button.
     var $button = $('<button>');
-    $button.addClass('js-container-head app-c-option-select__button');
+    $button.addClass('js-container-head app-c-option-select__title app-c-option-select__button');
     //Add type button to override default type submit when this component is used within a form
     $button.attr('type', 'button');
     $button.attr('aria-expanded', true);
+    $button.attr('id', $containerHead.attr('id'));
     $button.attr('aria-controls', this.$optionsContainer.attr('id'));
     $button.html(jsContainerHeadHTML);
     $containerHead.replaceWith($button);

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -79,7 +79,10 @@
       }
     }
 
-    this.attachCheckedCounter();
+    var checkedString = this.checkedString();
+    if (checkedString) {
+      this.attachCheckedCounter(checkedString);
+    }
   }
 
   OptionSelect.prototype.cleanString = function cleanString(text) {
@@ -139,21 +142,34 @@
     $containerHead.replaceWith($button);
   };
 
-  OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter(){
+  OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter(checkedString){
     this.$optionSelect.find('.js-container-head')
-      .after('<div class="govuk-!-font-size-14 app-c-option-select__selected-counter js-selected-counter">'+this.checkedString()+'</div>');
+      .after('<div class="govuk-!-font-size-14 app-c-option-select__selected-counter js-selected-counter">' + checkedString + '</div>');
   };
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){
-    this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
+    var checkedString = this.checkedString();
+    var checkedStringElement = this.$optionSelect.find('.js-selected-counter');
+
+    if (checkedString) {
+      if (checkedStringElement.length) {
+        checkedStringElement.text(checkedString);
+      } else {
+        this.attachCheckedCounter(checkedString);
+      }
+    } else {
+      checkedStringElement.remove();
+    }
+
+    //this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){
     this.getAllCheckedCheckboxes();
     var count = this.checkedCheckboxes.length;
-    var checkedString = "";
+    var checkedString = false;
     if (count > 0){
-      checkedString = count+" selected";
+      checkedString = count + " selected";
     }
 
     return checkedString;

--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -5,12 +5,22 @@
 .app-c-expander__title {
   @include govuk-font(19, $weight: bold);
   position: relative;
-  padding: govuk-spacing(2) 0 0 0;
+  padding: govuk-spacing(2) 0;
   cursor: pointer;
 }
 
 .app-c-expander__content {
   padding: govuk-spacing(2) 0;
+}
+
+.js-enabled {
+  .app-c-expander__content {
+    display: none;
+  }
+
+  .app-c-expander__content--visible {
+    display: block;
+  }
 }
 
 .app-c-expander__icon {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -1,4 +1,5 @@
 .app-c-option-select {
+  position: relative;
   padding: 0 0 1px;
   background-color: govuk-colour("grey-3");
   margin-bottom: govuk-spacing(6);
@@ -27,8 +28,8 @@
 
 .app-c-option-select__title {
   @include govuk-font(19, $weight: bold);
-  padding: 10px 8px 5px 15px;
-  position: relative;
+  padding: 10px 8px 5px 16px;
+  margin: 0;
 }
 
 .app-c-option-select__button {
@@ -46,7 +47,7 @@
   top: 0;
   right: govuk-spacing(2);
   width: 30px;
-  height: 100%;
+  height: 40px;
   fill: currentColor;
 }
 
@@ -55,8 +56,8 @@
   max-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
-  background-color: govuk-colour("white");
   border: govuk-spacing(1) solid govuk-colour("grey-3");
+  background-color: govuk-colour("white");
 }
 
 .app-c-option-select__container-inner {
@@ -99,16 +100,34 @@
 .js-collapsible {
   .app-c-option-select__button {
     z-index: 100;
-    @include govuk-focusable;
 
     &:hover,
     &:hover + .app-c-option-select__selected-counter {
       background-color: govuk-colour("grey-2");
     }
 
-    &:hover + .app-c-option-select__container,
-    &:hover + .app-c-option-select__selected-counter + .app-c-option-select__container {
+    &:hover ~ .app-c-option-select__container,
+    &:hover ~ .app-c-option-select__selected-counter,
+    &:hover ~ .app-c-option-select__filter {
       border-color: govuk-colour("grey-2");
+    }
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+
+    &:focus {
+      outline: none;
+
+      &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        outline: solid 3px govuk-colour('yellow');
+      }
     }
 
     &[disabled] {
@@ -118,7 +137,8 @@
   }
 
   .app-c-option-select__selected-counter {
-    padding: 3px 8px 0px 17px;
+    margin-top: -3px;
+    padding: 0 8px 3px 18px;
   }
 
   &.js-closed {
@@ -150,6 +170,7 @@
     border: 0;
     padding: 0 govuk-spacing(2);
     margin: 0 0 0 -10px;
+    background: none;
   }
 
   .app-c-option-select__container-inner {
@@ -161,6 +182,8 @@
   }
 
   .app-c-option-select__button {
+    position: relative;
+
     &:hover {
       background: none;
 
@@ -171,7 +194,9 @@
   }
 
   .app-c-option-select__selected-counter {
-    padding: govuk-spacing(1) 0 0 0;
+    padding-top: 3px;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .app-c-option-select__icon {
@@ -180,6 +205,7 @@
 
   .app-c-option-select__filter {
     padding: 0;
+    padding-top: 3px;
     padding-bottom: govuk-spacing(2);
     border: 0;
   }

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -1,6 +1,6 @@
 .app-c-option-select {
+  padding: 0 0 1px;
   background-color: govuk-colour("grey-3");
-  padding: 5px;
   margin-bottom: govuk-spacing(6);
 
   @include media(desktop) {
@@ -20,30 +20,31 @@
     }
   }
 
-  &:focus {
-    outline: 3px solid $yellow;
-  }
-
   .gem-c-checkboxes {
     margin: 0;
   }
 }
 
-.app-c-option-select__container-head {
-  padding: 0 5px;
+.app-c-option-select__title {
+  @include govuk-font(19, $weight: bold);
+  padding: 10px 8px 5px 15px;
+  position: relative;
 }
 
-.app-c-option-select__label {
-  @include govuk-font(19, $weight: bold);
-  position: relative;
-  margin-right: 40px;
+.app-c-option-select__button {
+  padding-right: 40px;
+  width: 100%;
+  background: none;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
 }
 
 .app-c-option-select__icon {
   display: none;
   position: absolute;
   top: 0;
-  right: -40px;
+  right: govuk-spacing(2);
   width: 30px;
   height: 100%;
   fill: currentColor;
@@ -51,10 +52,11 @@
 
 .app-c-option-select__container {
   position: relative;
-  height: 200px;
-  background-color: govuk-colour("white");
+  max-height: 200px;
   overflow-y: auto;
   overflow-x: hidden;
+  background-color: govuk-colour("white");
+  border: govuk-spacing(1) solid govuk-colour("grey-3");
 }
 
 .app-c-option-select__container-inner {
@@ -65,14 +67,13 @@
   background: govuk-colour('white');
   border-left: govuk-spacing(1) solid govuk-colour("grey-3");
   border-right: govuk-spacing(1) solid govuk-colour("grey-3");
-  display: none;
-  padding: govuk-spacing(2) 8px govuk-spacing(2) 8px;
+  padding: 13px 13px govuk-spacing(2) 13px;
 }
 
 .app-c-option-select__filter-input {
+  @include govuk-font(19);
   padding-left: 33px;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E") govuk-colour("white") no-repeat -5px -3px;
-  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     @include govuk-font(16);
@@ -80,36 +81,25 @@
 }
 
 .js-enabled {
-  .app-c-option-select {
-    padding: 0 0 1px;
-  }
-
   .app-c-option-select__container {
     border: govuk-spacing(1) solid govuk-colour("grey-3");
     border-top: 0;
   }
 
-  .app-c-option-select__filter {
+  .app-c-option-select__icon--up {
     display: block;
   }
 
-  .app-c-option-select__icon--up {
-    display: block;
+  .app-c-option-select__container {
+    height: 200px;
   }
 }
 
 // styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse
 .js-collapsible {
   .app-c-option-select__button {
-    position: relative;
     z-index: 100;
-    border: none;
-    display: block;
-    width: 100%;
-    text-align: left;
-    cursor: pointer;
-    padding: 10px 8px 5px 8px;
-    background-color: govuk-colour("grey-3");
+    @include govuk-focusable;
 
     &:hover,
     &:hover + .app-c-option-select__selected-counter {
@@ -125,18 +115,13 @@
       background-image: none;
       color: inherit;
     }
-
-    &:focus {
-      @include govuk-focusable;
-    }
   }
 
   .app-c-option-select__selected-counter {
-    padding: 3px 8px 0px 8px;
+    padding: 3px 8px 0px 17px;
   }
 
   &.js-closed {
-
     .app-c-option-select__filter {
       display: none;
     }
@@ -161,13 +146,6 @@
   background: none;
   border-bottom: solid 1px govuk-colour("black");
 
-  .app-c-option-select__container-inner {
-  }
-
-  .app-c-option-select__container-head {
-    padding: 0;
-  }
-
   .app-c-option-select__container {
     border: 0;
     padding: 0 govuk-spacing(2);
@@ -178,12 +156,11 @@
     padding: govuk-spacing(1) 0;
   }
 
-  .app-c-option-select__button {
-    @include govuk-font(19, $weight: bold);
-    position: relative;
+  .app-c-option-select__title {
     padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
-    background: none;
+  }
 
+  .app-c-option-select__button {
     &:hover {
       background: none;
 
@@ -197,21 +174,13 @@
     padding: govuk-spacing(1) 0 0 0;
   }
 
-  .app-c-option-select__label {
-    position: static;
-    padding: 0;
-    margin: 0;
-  }
-
   .app-c-option-select__icon {
-    position: absolute;
-    top: 0;
     right: 0;
-    width: 30px;
-    height: 100%;
   }
 
   .app-c-option-select__filter {
-    padding-top: 0;
+    padding: 0;
+    padding-bottom: govuk-spacing(2);
+    border: 0;
   }
 }

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -116,6 +116,7 @@
       background-color: govuk-colour("grey-2");
     }
 
+    &:hover + .app-c-option-select__container,
     &:hover + .app-c-option-select__selected-counter + .app-c-option-select__container {
       border-color: govuk-colour("grey-2");
     }

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -153,3 +153,64 @@
     }
   }
 }
+
+.app-c-option-select--expander {
+  padding: 0;
+  margin: 0;
+  background: none;
+  border-bottom: solid 1px govuk-colour("black");
+
+  .app-c-option-select__container-inner {
+  }
+
+  .app-c-option-select__container-head {
+    padding: 0;
+  }
+
+  .app-c-option-select__container {
+    border: 0;
+    padding: 0 govuk-spacing(2);
+    margin: 0 0 0 -10px;
+  }
+
+  .app-c-option-select__container-inner {
+    padding: govuk-spacing(1) 0;
+  }
+
+  .app-c-option-select__button {
+    @include govuk-font(19, $weight: bold);
+    position: relative;
+    padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
+    background: none;
+
+    &:hover {
+      background: none;
+
+      & + .app-c-option-select__selected-counter {
+        background: none;
+      }
+    }
+  }
+
+  .app-c-option-select__selected-counter {
+    padding: govuk-spacing(1) 0 0 0;
+  }
+
+  .app-c-option-select__label {
+    position: static;
+    padding: 0;
+    margin: 0;
+  }
+
+  .app-c-option-select__icon {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 30px;
+    height: 100%;
+  }
+
+  .app-c-option-select__filter {
+    padding-top: 0;
+  }
+}

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -17,7 +17,7 @@
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
     </div>
 
-    <div class="app-c-expander__content js-content" id="<%= content_id %>">
+    <div class="app-c-expander__content js-content <%= 'app-c-expander__content--visible' if open_on_load %>" id="<%= content_id %>">
       <%= yield %>
     </div>
   <% end %>

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -3,6 +3,7 @@
   checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
   checkboxes_count_id = checkboxes_id + "-count"
   show_filter ||= false
+  expander_style ||= false
 %>
 
 <% if show_filter %>
@@ -27,7 +28,7 @@
   <% filter_element = CGI::escapeHTML(filter) %>
 <% end %>
 
-<div class="app-c-option-select"
+<div class="app-c-option-select <% if expander_style %>app-c-option-select--expander<% end %>"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
   <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -38,7 +38,7 @@
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </div>
-  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>">
+  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>" tabindex="-1">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>"

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -33,12 +33,10 @@
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
   <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >
-  <div class="app-c-option-select__container-head js-container-head">
-    <div class="app-c-option-select__label" id="<%= title_id %>">
-      <%= title %>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
-    </div>
+  <div class="app-c-option-select__title js-container-head" id="<%= title_id %>">
+    <%= title %>
+    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+    <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </div>
   <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>">
     <div class="app-c-option-select__container-inner js-auto-height-inner">

--- a/app/views/components/docs/option-select.yml
+++ b/app/views/components/docs/option-select.yml
@@ -251,3 +251,30 @@ examples:
       - value: trinidad
         label: Trinidad & Tobago
         id: trinidad
+  expander_style:
+    description: Changes the appearance of the component.
+    data:
+      key: filter_demo
+      title: Cartoon characters
+      expander_style: true
+      options_container_id: list_of_cartoon_characters_to_filter
+      show_filter: true
+      options:
+      - value: bartsimpson
+        label: Bart Simpson
+        id: bartsimpson
+      - value: brucesato
+        label: Bruce Sato
+        id: brucesato
+      - value: donaldduck
+        label: Donald Duck
+        id: donaldduck
+      - value: panthro
+        label: Panthro
+        id: panthro
+      - value: quickkick
+        label: Quick Kick
+        id: quickkick
+      - value: wheeljack
+        label: Wheeljack
+        id: wheeljack

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -105,6 +105,14 @@ describe 'components/_option-select.html.erb', type: :view do
     expect(rendered).to have_no_selector('.app-c-option-select__count')
   end
 
+  it "adds alternative styling" do
+    arguments = option_select_arguments
+    arguments[:expander_style] = true
+    render_component(arguments)
+
+    expect(rendered).to have_selector('.app-c-option-select.app-c-option-select--expander')
+  end
+
   def expect_label_and_checked_checkbox(label, id, value)
     expect_label_and_checkbox(label, id, value, true)
   end

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -71,7 +71,7 @@ describe 'components/_option-select.html.erb', type: :view do
 
   it "renders a heading for the option select box containing the title" do
     render_component(option_select_arguments)
-    expect(rendered).to have_selector(".app-c-option-select__label", text: 'Market sector')
+    expect(rendered).to have_selector(".app-c-option-select__title", text: 'Market sector')
   end
 
   it "renders a container with the id passed in" do

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -15,7 +15,7 @@ describe('An expander module', function () {
       </div>\
     </div>';
 
-  describe("a normal expander", function () {
+  describe("in default mode", function () {
     beforeEach(function () {
       expander = new GOVUK.Modules.Expander();
       $element = $(html);
@@ -27,7 +27,7 @@ describe('An expander module', function () {
     });
 
     it("collapses the content on page load", function () {
-      expect($element.find('.app-c-expander__content').css('display')).toBe('none');
+      expect($element.find('.app-c-expander__content').is(':visible')).toBe(false);
     });
 
     it("replaces the title with a button and sets correct aria attributes", function () {
@@ -43,11 +43,11 @@ describe('An expander module', function () {
       var $button = $element.find('.app-c-expander__button');
 
       $button.click();
-      expect($element.find('.app-c-expander__content').css('display')).toBe('block');
+      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true);
       expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true');
 
       $button.click();
-      expect($element.find('.app-c-expander__content').css('display')).toBe('none');
+      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false);
       expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('false');
     });
   });
@@ -57,6 +57,7 @@ describe('An expander module', function () {
       expander = new GOVUK.Modules.Expander();
       $element = $(html);
       $element.attr('data-open-on-load', true)
+      $element.find('.js-content').addClass('app-c-expander__content--visible');
       expander.start($element);
     });
 
@@ -65,7 +66,9 @@ describe('An expander module', function () {
     });
 
     it("does not collapse the content on page load", function () {
-      expect($element.find('.app-c-expander__content').css('display')).not.toBe('none');
+      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true);
+      $element.find('.app-c-expander__button').click();
+      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false);
     });
 
     it("sets correct aria attributes on the button", function () {

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -4,11 +4,11 @@ describe('GOVUK.OptionSelect', function() {
 
   beforeEach(function(){
     optionSelectFixture = '<div class="app-c-option-select">'+
-      '<div class="app-c-option-select__container-head js-container-head">'+
-        '<div class="app-c-option-select__label">Market sector</div>'+
+      '<div class="app-c-option-select__title js-container-head">'+
+        'Market sector'+
       '</div>'+
       '<div class="app-c-option-select__container js-options-container">'+
-        '<div class="js-auto-height-inner">'+
+        '<div class="app-c-option-select__container-inner js-auto-height-inner">'+
           '<div id="checkboxes-9b7ecc25" class="gem-c-checkboxes govuk-form-group" data-module="checkboxes">'+
             '<fieldset class="govuk-fieldset">'+
               '<legend class="govuk-fieldset__legend govuk-fieldset__legend--m gem-c-checkboxes__legend--hidden">Please select all that apply</legend>'+


### PR DESCRIPTION
This PR contains the following:

- add an option to the option select component to make it look like the new expander component, which it will sit alongside in the facets down the left of a finder
- modify the JS of the option select so that the element that houses the 'x selected' text is only present if that text is present (solves a long standing layout bug)
- change the expander component so there's no 'jump' on page load when the JS kicks in and hides the content, instead, use classes and `js-enabled` to show/hide the content
- clean up the option select CSS and markup, makes it a bit cleaner and and solves a similar 'jump' problem on page load
- changes the focus state of the component to surround it rather than just put the outline on the title (button)

These changes are preparatory work ahead of implementing an accordion style wrapper for the facets in the 6 new supergroup finders and the all content finder.

Demo URL: https://finder-frontend-pr-1052.herokuapp.com/component-guide

Trello cards: 

- https://trello.com/c/NS594ugt/644-make-option-select-facet-look-like-accordion
- https://trello.com/c/RwdoOufs/669-implement-facet-redesign
- https://trello.com/c/bDJmf7Sq/609-build-the-new-facet-accordion