### PR TITLE
Research and statistics filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,6 @@ group :test do
   gem 'launchy', '~> 2.4.2'
   gem 'rails-controller-testing'
   gem 'simplecov', '~> 0.16.1'
+  gem "timecop"
   gem 'webmock', '~> 3.5.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -419,6 +420,7 @@ DEPENDENCIES
   shared_mustache (~> 1.0.1)
   simplecov (~> 0.16.1)
   slimmer (~> 13.1.0)
+  timecop
   uglifier (~> 4.1)
   webmock (~> 3.5.1)
 

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -12,8 +12,6 @@ class FilterQueryBuilder
     end
   end
 
-
-
 private
 
   attr_reader :facets, :user_params
@@ -33,18 +31,11 @@ private
       'taxon' => Filters::TaxonFilter,
       'radio' => Filters::RadioFilter,
       'content_id' => Filters::ContentIdFilter,
-      'hidden_clearable' => Filters::HiddenClearableFilter
+      'hidden_clearable' => Filters::HiddenClearableFilter,
+      'research_and_statistics' => Filters::ResearchAndStatisticsFilter
     }.fetch(facet['type'])
 
     filter_class.new(facet, params(facet))
-  end
-
-  def filter_value(query, filter)
-    # If the same filter key is provided multiple times, provide an array
-    # of all values for that filter key
-    return Array(query[filter.key]) + Array(filter.value) if query[filter.key]
-
-    filter.value
   end
 
   def params(facet)

--- a/app/lib/filter_query_builder.rb
+++ b/app/lib/filter_query_builder.rb
@@ -7,17 +7,19 @@ class FilterQueryBuilder
   end
 
   def call
-    filters.select(&:active?).reduce({}) { |query, filter|
-      query.merge(filter.key => filter_value(query, filter))
-    }
+    filters.select(&:active?).map(&:query_hash).inject({}) do |query, filter_hash|
+      query.merge(filter_hash) { |_, v1, v2| Array(v1) + Array(v2) }
+    end
   end
+
+
 
 private
 
   attr_reader :facets, :user_params
 
   def filters
-    @filters ||= facets.select { |f| f['filterable'] }.map { |f| build_filter(f) }
+    facets.select { |f| f['filterable'] }.map { |f| build_filter(f) }
   end
 
   def build_filter(facet)

--- a/app/lib/filters/checkbox_filter.rb
+++ b/app/lib/filters/checkbox_filter.rb
@@ -1,12 +1,12 @@
 module Filters
   class CheckboxFilter < Filter
+  private
+
     def value
       # 'params' for a checkbox should be true or false. the value
       # we send to rummager can be params or a static value provided in
       # the finder content item
-      if params
-        facet['filter_value'] || params
-      end
+      @value ||= params.nil? ? nil : facet['filter_value'] || params
     end
   end
 end

--- a/app/lib/filters/content_id_filter.rb
+++ b/app/lib/filters/content_id_filter.rb
@@ -1,10 +1,10 @@
 module Filters
   class ContentIdFilter < Filter
-    def value
-      Array(params).map(&method(:content_id_for))
-    end
-
   private
+
+    def value
+      @value ||= Array(params).map(&method(:content_id_for))
+    end
 
     def content_id_for(value)
       content_id_map[value]

--- a/app/lib/filters/date_filter.rb
+++ b/app/lib/filters/date_filter.rb
@@ -1,10 +1,10 @@
 module Filters
   class DateFilter < Filter
-    def value
-      serialized_values.join(",")
-    end
-
   private
+
+    def value
+      @value ||= serialized_values.join(",")
+    end
 
     def serialized_values
       present_values.map { |key, date|

--- a/app/lib/filters/dropdown_select_filter.rb
+++ b/app/lib/filters/dropdown_select_filter.rb
@@ -1,10 +1,10 @@
 module Filters
   class DropdownSelectFilter < Filter
-    def value
-      Array(parsed_value)
-    end
-
   private
+
+    def value
+      @value ||= Array(parsed_value)
+    end
 
     def parsed_value
       return if params.blank?

--- a/app/lib/filters/filter.rb
+++ b/app/lib/filters/filter.rb
@@ -13,13 +13,17 @@ module Filters
       value.present?
     end
 
-    def value
-      raise NotImplementedError
+    def query_hash
+      { key => value }
     end
 
   private
 
     attr_reader :facet, :params
+
+    def value
+      raise NotImplementedError
+    end
 
     def parsed_value
       return [] if params.blank?

--- a/app/lib/filters/hidden_clearable_filter.rb
+++ b/app/lib/filters/hidden_clearable_filter.rb
@@ -1,5 +1,7 @@
 module Filters
   class HiddenClearableFilter < Filter
+  private
+
     def value
       params
     end

--- a/app/lib/filters/hidden_filter.rb
+++ b/app/lib/filters/hidden_filter.rb
@@ -1,5 +1,7 @@
 module Filters
   class HiddenFilter < Filter
+  private
+
     def value
       params
     end

--- a/app/lib/filters/radio_filter.rb
+++ b/app/lib/filters/radio_filter.rb
@@ -1,14 +1,16 @@
 module Filters
   class RadioFilter < Filter
-    def value
-      return default_value unless acceptable_param?
-
-      return option_lookup_values(params) if multi_value?
-
-      Array(params)
-    end
-
   private
+
+    def value
+      @value ||= if !acceptable_param?
+                   default_value
+                 elsif multi_value?
+                   option_lookup_values(params)
+                 else
+                   Array(params)
+                 end
+    end
 
     def default_value
       return [] if default_allowed_value.blank?

--- a/app/lib/filters/research_and_statistics_filter.rb
+++ b/app/lib/filters/research_and_statistics_filter.rb
@@ -1,0 +1,25 @@
+module Filters
+  class ResearchAndStatisticsFilter < Filter
+    def query_hash
+      find_filter(value)['filter']
+    end
+
+  private
+
+    def value
+      validated_value(params)
+    end
+
+    def default_value
+      Filters.research_and_statistics_filters.find { |filter| filter['default'] }.fetch('key')
+    end
+
+    def validated_value(value)
+      Filters.research_and_statistics_filters.map { |filter| filter['key'] }.include?(value) ? value : default_value
+    end
+
+    def find_filter(key)
+      Filters.research_and_statistics_filters.find { |filter| filter['key'] == key }
+    end
+  end
+end

--- a/app/lib/filters/taxon_filter.rb
+++ b/app/lib/filters/taxon_filter.rb
@@ -1,11 +1,15 @@
 module Filters
   class TaxonFilter < Filter
-    def value
-      topic = params['level_one_taxon']
-      subtopic = params['level_two_taxon']
+  private
 
-      # we send a conjunctive query to rummager for part_of_taxonomy_tree
-      [topic, subtopic]
+    def value
+      @value ||= begin
+        topic = params['level_one_taxon']
+        subtopic = params['level_two_taxon']
+
+        # we send a conjunctive query to rummager for part_of_taxonomy_tree
+        [topic, subtopic]
+      end
     end
   end
 end

--- a/app/lib/filters/text_filter.rb
+++ b/app/lib/filters/text_filter.rb
@@ -1,5 +1,7 @@
 module Filters
   class TextFilter < Filter
+  private
+
     def value
       parsed_value
     end

--- a/app/lib/filters/topical_filter.rb
+++ b/app/lib/filters/topical_filter.rb
@@ -1,6 +1,12 @@
 module Filters
   class TopicalFilter < Filter
+  private
+
     def value
+      @value ||= fetch_value
+    end
+
+    def fetch_value
       return nil if params.blank?
 
       user_has_selected_open = params.include?(facet['open_value']['value'])
@@ -13,8 +19,6 @@ module Filters
         closed_value
       end
     end
-
-  private
 
     # A thing is open when it ends on a future day
     def open_value

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -1,0 +1,29 @@
+module Filters
+  def self.research_and_statistics_filters
+    [
+      {
+        'key' => 'upcoming_statistics',
+        'label' => 'Statistics (upcoming)',
+        'filter' => {
+          'release_timestamp' => "from:#{Date.today.iso8601}",
+          'format' => %w(statistics_announcement)
+        }
+      },
+      {
+        'key' => 'published_statistics',
+        'label' => 'Statistics (published)',
+        'filter' => {
+          'content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics)
+        },
+        'default' => true
+      },
+      {
+        'key' => 'research',
+        'label' => 'Research',
+        'filter' => {
+          'content_store_document_type' => %w(dfid_research_output independent_report research)
+        }
+      }
+    ]
+  end
+end

--- a/app/models/research_and_statistics_facet.rb
+++ b/app/models/research_and_statistics_facet.rb
@@ -1,0 +1,43 @@
+class ResearchAndStatisticsFacet < FilterableFacet
+  def initialize(facet, value)
+    @filter_hashes = ::Filters.research_and_statistics_filters
+    @value = validated_value(value, @filter_hashes)
+    super(facet)
+  end
+
+  def options
+    @filter_hashes.map do |filter_hash|
+      {
+        value: filter_hash['key'],
+        text: filter_hash['label'],
+        checked: @value == filter_hash['key'],
+      }
+    end
+  end
+
+  def has_filters?
+    true
+  end
+
+  def sentence_fragment
+    nil
+  end
+
+  def query_params
+    { key => @value }
+  end
+
+  def to_partial_path
+    "radio_facet"
+  end
+
+private
+
+  def validated_value(value, filter_hashes)
+    filter_hashes.map { |f| f['key'] }.include?(value) ? value : default_value
+  end
+
+  def default_value
+    @filter_hashes.find { |hash_hash| hash_hash['default'] }.fetch('key')
+  end
+end

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -18,6 +18,8 @@ module FacetParser
         RadioFacet.new(facet, value_hash[facet['key']])
       when 'hidden_clearable'
         HiddenClearableFacet.new(facet, value_hash[facet['key']])
+      when 'research_and_statistics'
+        ResearchAndStatisticsFacet.new(facet, value_hash[facet['key']])
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet['type']}")
       end

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -348,7 +348,15 @@ Feature: Filtering documents
     And I select some document types
     Then I should see results for scoped by the selected document type
 
-  Scenario: Choosing between document types with a radio button facet with hidden facet tag
+  Scenario: Choosing between document types with a research and statistics facet - no facet tag
+    When I view the research and statistics finder
+    And I select upcoming statistics
+    And I click filter results
+    Then I should see upcoming statistics
+    And I should not see an upcoming statistics facet tag
+
+  @javascript
+  Scenario: Choosing between document types research and statistics - no facet tag; javascript version
     When I view the research and statistics finder
     And I select upcoming statistics
     Then I should see upcoming statistics

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -119,28 +119,13 @@
         "preposition": "about"
       },
       {
-        "key":"research_and_statistics",
+        "key":"content_store_document_type",
         "name":"Statistics",
-        "type":"radio",
+        "type":"research_and_statistics",
         "display_as_result_metadata":false,
         "filterable":true,
         "hide_facet_tag":true,
-        "preposition": "that are",
-        "allowed_values": [
-          {
-            "label": "Statistics (published)",
-            "value": "published_statistics",
-            "default": true
-          },
-          {
-            "label": "Statistics (upcoming)",
-            "value": "upcoming_statistics"
-          },
-          {
-            "label": "Research",
-            "value": "research"
-          }
-        ]
+        "preposition": "that are"
       },
       {
         "key": "organisations",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -183,7 +183,6 @@ When(/^I view the research and statistics finder$/) do
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_research_and_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
-
   visit finder_path('search/research-and-statistics')
 end
 
@@ -591,6 +590,9 @@ end
 
 And(/^I select upcoming statistics$/) do
   find('.govuk-label', text: 'Statistics (upcoming)').click
+end
+
+And(/^I click filter results$/) do
   click_on "Filter results"
 end
 
@@ -709,6 +711,7 @@ Then("I should see results in the default group") do
 end
 
 Then("I should see results for scoped by the selected document type") do
+  expect(page).to have_text('3 results')
   within("#js-results") do
     expect(page.all("li.document").size).to eq(3) # 3 results in fixture
     expect(page).to have_link('Restrictions on usage of spells within school grounds')
@@ -752,12 +755,12 @@ Then("I do not see results with pinned items") do
 end
 
 Then("I should see upcoming statistics") do
+  expect(page).to have_text('1 result')
   within("#js-results") do
     expect(page.all("li.document").size).to eq(1)
     expect(page).to have_link('Restrictions on usage of spells within school grounds')
     expect(page).to have_no_link('New platform at Hogwarts for the express train')
     expect(page).to have_no_link('Installation of double glazing at Hogwarts')
-
     expect(page).to have_no_link('Proposed changes to magic tournaments')
   end
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -112,17 +112,24 @@ module DocumentHelper
   end
 
   def stub_rummager_api_request_with_research_and_statistics_results
-    stub_request(:get, rummager_research_and_statistics_url({}))
+    stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
+        .with(query: batch_search_includes("filter_content_store_document_type" => hash_including("0" => 'statistics',
+                                                                                                "1" => "national_statistics",
+                                                                                                "2" => "statistical_data_set",
+                                                                                                "3" => "official_statistics")))
         .to_return(body: statistics_results_for_statistics_json)
   end
 
   def stub_rummager_api_request_with_filtered_research_and_statistics_results
-    stub_request(
-      :get,
-      rummager_research_and_statistics_url(
-        'filter_research_and_statistics[]' => %w(upcoming_statistics)
-      )
-    ).to_return(body: upcoming_statistics_results_for_statistics_json)
+    Timecop.freeze(Time.local("2019-01-01"))
+    stub_request(:get, "#{Plek.current.find('search')}/batch_search.json")
+      .with(query: batch_search_includes("filter_format" => hash_including("0" => "statistics_announcement"),
+                                         "filter_release_timestamp" => "from:2019-01-01"))
+      .to_return(body: upcoming_statistics_results_for_statistics_json)
+  end
+
+  def batch_search_includes(query_hash)
+    hash_including('search' => include("0" => hash_including(query_hash)))
   end
 
   def stub_all_rummager_api_requests_with_all_documents_results
@@ -591,10 +598,6 @@ module DocumentHelper
 
   def all_content_url(filters)
     rummager_url(all_content_params.merge(filters))
-  end
-
-  def rummager_research_and_statistics_url(filters)
-    rummager_url(research_and_statistics_params.merge(filters))
   end
 
   def organisation_link_results

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -75,18 +75,6 @@ module RummagerUrlHelper
     )
   end
 
-  def research_and_statistics_params
-    base_search_params.merge(
-      'facet_organisations' => '1500,order:value.title',
-      'facet_world_locations' => '1500,order:value.title',
-      'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
-      'fields' => research_and_statistics_search_fields.join(','),
-      'filter_research_and_statistics[]' => %w(published_statistics),
-      'count' => 20,
-      'order' => '-public_timestamp',
-    )
-  end
-
   def all_content_params
     base_search_params.merge(
       'facet_manual' => '1500,order:value.title',

--- a/spec/lib/filters/date_filter_spec.rb
+++ b/spec/lib/filters/date_filter_spec.rb
@@ -5,7 +5,7 @@ describe Filters::DateFilter do
     Filters::DateFilter.new(facet, params)
   }
 
-  let(:facet) { double }
+  let(:facet) { { "key" => "date_key" } }
   let(:params) { nil }
 
   describe "#active?" do
@@ -29,7 +29,7 @@ describe Filters::DateFilter do
     end
   end
 
-  describe "#value" do
+  describe "#query_hash" do
     context "when to date is provided" do
       let(:params) {
         {
@@ -38,7 +38,7 @@ describe Filters::DateFilter do
       }
 
       it "include the to date" do
-        expect(date_filter.value).to eq("to:2015-06-27")
+        expect(date_filter.query_hash).to eq("date_key" => "to:2015-06-27")
       end
     end
 
@@ -50,7 +50,7 @@ describe Filters::DateFilter do
       }
 
       it "include the from date" do
-        expect(date_filter.value).to eq("from:2015-05-11")
+        expect(date_filter.query_hash).to eq("date_key" => "from:2015-05-11")
       end
     end
 
@@ -63,7 +63,7 @@ describe Filters::DateFilter do
       }
 
       it "include both to and from dates" do
-        expect(date_filter.value).to eq("to:2015-06-27,from:2015-05-11")
+        expect(date_filter.query_hash).to eq("date_key" => "to:2015-06-27,from:2015-05-11")
       end
     end
   end

--- a/spec/lib/filters/radio_filter_spec.rb
+++ b/spec/lib/filters/radio_filter_spec.rb
@@ -5,7 +5,7 @@ describe Filters::RadioFilter do
     Filters::RadioFilter.new(facet, params)
   }
 
-  let(:facet) { { "allowed_values" => allowed_values } }
+  let(:facet) { { "allowed_values" => allowed_values, 'key' => 'radio_key' } }
   let(:params) { nil }
   let(:default_value) { %w(policy_papers) }
   let(:option_lookup) {
@@ -99,13 +99,13 @@ describe Filters::RadioFilter do
         let(:params) { "open_consultations" }
 
         it "should return the option as an array" do
-          expect(radio_filter.value).to eq(%w(open_consultations))
+          expect(radio_filter.query_hash).to eq('radio_key' => %w(open_consultations))
         end
       end
 
       context "when no option is provided and a default value is set" do
         it "should return the default value" do
-          expect(radio_filter.value).to eq(default_value)
+          expect(radio_filter.query_hash).to eq('radio_key' => default_value)
         end
       end
 
@@ -113,7 +113,7 @@ describe Filters::RadioFilter do
         let(:params) { [] }
 
         it "should return the default value" do
-          expect(radio_filter.value).to eq(default_value)
+          expect(radio_filter.query_hash).to eq('radio_key' => default_value)
         end
       end
 
@@ -122,14 +122,14 @@ describe Filters::RadioFilter do
 
         context "a default option is set" do
           it "should return the default value" do
-            expect(radio_filter.value).to eq(default_value)
+            expect(radio_filter.query_hash).to eq('radio_key' => default_value)
           end
         end
 
         context "a default option is NOT provided" do
           let(:allowed_values) { [] }
           it "should return an empty array" do
-            expect(radio_filter.value).to eq([])
+            expect(radio_filter.query_hash).to eq('radio_key' => [])
           end
         end
       end
@@ -139,13 +139,14 @@ describe Filters::RadioFilter do
       let(:facet) {
         {
           "option_lookup" => option_lookup,
-          "allowed_values" => allowed_values
+          "allowed_values" => allowed_values,
+          "key" => "radio_key"
         }
       }
 
       context "when no option is selected" do
         it "should return the corresponding default values from the option_lookup" do
-          expect(radio_filter.value).to eq(%w(guidance))
+          expect(radio_filter.query_hash).to eq('radio_key' => %w(guidance))
         end
       end
 
@@ -154,7 +155,7 @@ describe Filters::RadioFilter do
 
         context "when a default value is set" do
           it "should return the corresponding default values from the option_lookup" do
-            expect(radio_filter.value).to eq(%w(guidance))
+            expect(radio_filter.query_hash).to eq('radio_key' => %w(guidance))
           end
         end
 
@@ -162,7 +163,7 @@ describe Filters::RadioFilter do
           let(:allowed_values) { [] }
 
           it "should return an empty array" do
-            expect(radio_filter.value).to eq([])
+            expect(radio_filter.query_hash).to eq('radio_key' => [])
           end
         end
       end
@@ -170,7 +171,7 @@ describe Filters::RadioFilter do
       context "when an allowed option is selected" do
         let(:params) { "open_consultations" }
         it "should return the corresponding values from the option_lookup" do
-          expect(radio_filter.value).to eq(%w(open closed))
+          expect(radio_filter.query_hash).to eq('radio_key' => %w(open closed))
         end
       end
     end

--- a/spec/lib/filters/research_and_statistics_filter_spec.rb
+++ b/spec/lib/filters/research_and_statistics_filter_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe Filters::ResearchAndStatisticsFilter do
+  subject(:filter) {
+    Filters::ResearchAndStatisticsFilter.new(facet, params)
+  }
+
+  let(:facet) { { 'key' => 'content_store_document_type' } }
+
+  describe '#query_hash' do
+    context 'empty parameter' do
+      let(:params) { nil }
+      it 'returns the default query hash' do
+        expect(filter.query_hash).to eq('content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics))
+      end
+    end
+    context 'invalid parameter' do
+      let(:params) { "I'm not valid" }
+      it 'returns the default query hash' do
+        expect(filter.query_hash).to eq('content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics))
+      end
+    end
+    context 'valid parameter' do
+      let(:params) { "upcoming_statistics" }
+      it 'returns the default query hash' do
+        Timecop.freeze(Time.local("2019-01-01"))
+        expect(filter.query_hash).to eq('release_timestamp' => "from:2019-01-01",
+                                         'format' => %w(statistics_announcement))
+      end
+    end
+  end
+end

--- a/spec/lib/filters/text_filter_spec.rb
+++ b/spec/lib/filters/text_filter_spec.rb
@@ -42,40 +42,40 @@ describe Filters::TextFilter do
     end
   end
 
-  describe "#value" do
+  describe "#query_hash" do
     context "when params is present and option_lookup is absent" do
       let(:params) { %w(alpha) }
-      let(:facet) { {} }
+      let(:facet) { { "key" => "text_key" } }
 
       it "should contain all values" do
-        expect(text_filter.value).to eq(%w(alpha))
+        expect(text_filter.query_hash).to eq("text_key" => %w(alpha))
       end
     end
 
     context "when params is present and option_lookup is empty" do
       let(:params) { %w(does_not_exist) }
-      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) }, "key" => "text_key" } }
 
       it "should contain no values" do
-        expect(text_filter.value).to eq([])
+        expect(text_filter.query_hash).to eq("text_key" => [])
       end
     end
 
     context "when params is present and option_lookup is present" do
       let(:params) { %w(policy_papers) }
-      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) } } }
+      let(:facet) { { "option_lookup" => { "policy_papers" => %w(guidance) }, "key" => "text_key" } }
 
       it "should contain all values" do
-        expect(text_filter.value).to eq(%w(guidance))
+        expect(text_filter.query_hash).to eq("text_key" => %w(guidance))
       end
     end
 
     context "when params has multiple values and option_lookup is present" do
       let(:params) { %w(policy_papers does_not_exist consultations) }
-      let(:facet) { { "option_lookup" => { "consultations" => %w(open closed), "policy_papers" => %w(guidance) } } }
+      let(:facet) { { "option_lookup" => { "consultations" => %w(open closed), "policy_papers" => %w(guidance) }, "key" => "text_key" } }
 
       it "should contain all values" do
-        expect(text_filter.value).to eq(%w(open closed guidance))
+        expect(text_filter.query_hash).to eq("text_key" => %w(open closed guidance))
       end
     end
   end

--- a/spec/models/research_and_statistics_facet_spec.rb
+++ b/spec/models/research_and_statistics_facet_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+describe ResearchAndStatisticsFacet do
+  let(:facet_data) {
+    {
+      'type' => "research_and_statistics",
+      'key' => "facet_key",
+      'filterable' => true
+    }
+  }
+  describe "#query_params" do
+    context "value selected" do
+      subject { ResearchAndStatisticsFacet.new(facet_data, "research") }
+      specify {
+        expect(subject.query_params).to eq("facet_key" => "research")
+      }
+    end
+  end
+
+  describe "#options" do
+    context 'valid value' do
+      subject { ResearchAndStatisticsFacet.new(facet_data, "research") }
+      it 'sets the options, selecting the correct value' do
+        expect(subject.options).to eq([
+                                        {
+                                          value: 'upcoming_statistics',
+                                          text: 'Statistics (upcoming)',
+                                          checked: false,
+                                        },
+                                        {
+                                          value: 'published_statistics',
+                                          text: 'Statistics (published)',
+                                          checked: false,
+                                        },
+                                        {
+                                          value: 'research',
+                                          text: 'Research',
+                                          checked: true
+                                        }
+                                      ])
+      end
+    end
+    context 'invalid value' do
+      subject { ResearchAndStatisticsFacet.new(facet_data, "something") }
+      it 'sets the options, selecting the default value' do
+        expect(subject.options).to include(
+          value: 'published_statistics',
+          text: 'Statistics (published)',
+          checked: true,
+                                   )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The research and statistics finder has a radio button with the following options:

'Statistics (upcoming)'
'Statistics (published)'
'Research'

Upcoming statistics are filtered using the format and release_timestamp field. This is difficult to do using the existing RadioButton facet/filter and so we introduce a new ResearchAndStatistics facet/filter that can filter using the correct Search-api queries.


Trello: https://trello.com/c/mkf4eUXF/593-bug-stats-finder-displaying-wrong-number-of-published-stats-docs
https://trello.com/c/QpM8Vhwv/590-bug-stats-finder-is-only-displaying-a-few-upcoming-stats-docs