### PR TITLE
Fix how filtering by business activity groups results

### DIFF
--- a/app/presenters/grouped_result_set_presenter.rb
+++ b/app/presenters/grouped_result_set_presenter.rb
@@ -17,7 +17,6 @@ class GroupedResultSetPresenter < ResultSetPresenter
     # TODO: These could live in a finder definition to make this finder-agnostic grouping.
     default_group_name = "all_businesses"
     primary_facet = :sector_business_area
-    primary_facet_group = %W(sector_business_area business_activity)
     default_group = empty_facet_group(default_group_name, "All businesses")
 
     primary_group = {}
@@ -41,12 +40,9 @@ class GroupedResultSetPresenter < ResultSetPresenter
             key = metadata[:id]
             next unless key && facet_filters.has_key?(key.to_sym)
 
-            # FIXME: There's an inconsistency here, an item which isn't tagged to the primary facet
-            # but tagged to the activity facet will not appear. In terms of the current metadata this
-            # doesn't happen, but as the results are metadata driven it _can_ happen.
-            if primary_facet_group.include?(key)
+            if primary_facet.to_s == key
               # Group by value for the primary facet
-              (metadata[:labels] & facet_filters.fetch(primary_facet, [])).each do |value|
+              (metadata[:labels] & facet_filters[primary_facet]).each do |value|
                 populate_group(primary_group, value, facet_label_for(value), item)
               end
             else


### PR DESCRIPTION
https://trello.com/c/t7Uwj2fS/56-group-content-under-all-businesses-when-user-only-filters-by-business-activity-and-not-sector

There's a mismatch between how sectors and activities are notionally grouped
and how we use the filters to determine what displays in the 'All businesses'
grouping. Make sure we use these facets consistently to provide the right
results when the user only filters by activity.

[Heroku preview app](http://finder-frontend-pr-1057.herokuapp.com/find-eu-exit-guidance-business?parent=&keywords=&business_activity%5B%5D=products-or-goods&business_activity%5B%5D=buying&order=topic)

![Screenshot from 2019-05-01 11-10-34](https://user-images.githubusercontent.com/93511/57013123-dec91d00-6c01-11e9-8bed-64a6562e20db.png)


`...`
![Screenshot from 2019-04-18 13-49-28](https://user-images.githubusercontent.com/93511/56362057-d5db5300-61e0-11e9-85d3-1202b46a696d.png)

