### PR TITLE
Use relevance as default search/all sort order

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -41,7 +41,8 @@ protected
       keywords: search_params.search_term,
       organisations: params['filter_organisations'],
       manual: params['filter_manual'],
-      format: params['format']
+      format: params['format'],
+      order: 'relevance'
     }.compact
 
     redirect_to(finder_path('search/all', params: all_content_params), status: 301)

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -195,10 +195,11 @@ When(/^I view the all content finder with a manual filter$/) do
   stub_request(:get,
     all_content_url(
       filter_manual: '/guidance/care-and-use-of-a-nimbus-2000',
-      q: 'Replacing bristles'
+      q: 'Replacing bristles',
+      order: '-public_timestamp',
     )).to_return(body: all_content_manuals_results_json)
 
-  stub_request(:get, all_content_url(q: 'Replacing bristles'))
+  stub_request(:get, all_content_url(q: 'Replacing bristles', order: '-public_timestamp'))
     .to_return(body: all_content_results_json)
 
   visit finder_path('search/all', manual: '/guidance/care-and-use-of-a-nimbus-2000', q: 'Replacing bristles')

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -91,7 +91,7 @@ module DocumentHelper
   end
 
   def stub_rummager_api_request_with_all_content_results
-    stub_request(:get, all_content_url({}))
+    stub_request(:get, all_content_url(order: '-public_timestamp'))
       .to_return(body: all_content_results_json)
   end
 

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -84,7 +84,6 @@ module RummagerUrlHelper
       'filter_all_part_of_taxonomy_tree[]' => [nil, nil],
       'fields' => all_content_search_fields.join(','),
       'count' => 20,
-      'order' => '-public_timestamp',
     )
   end
 


### PR DESCRIPTION
This will ensure that most relevant results are displayed first when coming from site-wide search.

Try it out:

1. Go to https://finder-frontend-pr-1058.herokuapp.com/search/
2. Search for something
3. The search results page should be sorted by 'relevance'.