### PR TITLE
Escape all search input

### DIFF
--- a/app/views/advanced_search_finder/_result_count.mustache
+++ b/app/views/advanced_search_finder/_result_count.mustache
@@ -1,5 +1,5 @@
 {{#any_filters_applied}}
 <p class="result-info">
-  <strong>{{total}} {{{pluralised_document_noun}}} {{{applied_filters}}}</strong>
+  <strong>{{total}} {{pluralised_document_noun}} {{applied_filters}}</strong>
 </p>
 {{/any_filters_applied}}

--- a/app/views/finders/_applied_filter.mustache
+++ b/app/views/finders/_applied_filter.mustache
@@ -1,17 +1,17 @@
 <div class="facet-tags__group">
   {{#.}}
   <div class="facet-tags__wrapper">
-    <p class="facet-tags__preposition">{{{preposition}}}</p>
+    <p class="facet-tags__preposition">{{preposition}}</p>
     <div class="facet-tag">
       <p class="facet-tag__text">{{{text}}}</p>
       <button type="button"
         class="facet-tag__remove"
-        aria-label="Remove filter {{{text}}}"
+        aria-label="Remove filter {{text}}"
         data-module="remove-filter-link"
-        data-track-label="{{{data_track_label}}}"
-        data-facet="{{{data_facet}}}"
-        data-value="{{{data_value}}}"
-        data-name="{{{data_name}}}">&#x2715;</button>
+        data-track-label="{{data_track_label}}"
+        data-facet="{{data_facet}}"
+        data-value="{{data_value}}"
+        data-name="{{data_name}}">&#x2715;</button>
     </div>
   </div>
   {{/.}}

--- a/app/views/finders/_result_count.mustache
+++ b/app/views/finders/_result_count.mustache
@@ -1,3 +1,3 @@
 <h2 class="result-region-header__counter">
-  {{total}} {{{pluralised_document_noun}}}
+  {{total}} {{pluralised_document_noun}}
 </h2>

--- a/app/views/search/_result.mustache
+++ b/app/views/search/_result.mustache
@@ -2,7 +2,7 @@
   <h3><a href="{{link}}" {{#external}}rel="external"{{/external}}
        data-ecommerce-row
        data-ecommerce-path="{{link}}"
-       data-ecommerce-content-id="{{content_id}}">{{{title_with_highlighting}}}</a></h3>
+       data-ecommerce-content-id="{{content_id}}">{{title_with_highlighting}}</a></h3>
 
   {{#debug_score}}
     <p class="debug-link">


### PR DESCRIPTION
The facet-tag__text is unescaped, but this is fine as it's escaped by
the backend.