### PR TITLE
Update business email links

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -113,6 +113,6 @@ private
   end
 
   def ignore_facet?(facet_id)
-    %W(appear_in_find_eu_exit_guidance_business_finder).include?(facet_id)
+    %W(facet_groups).include?(facet_id)
   end
 end

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -5,12 +5,12 @@
   "title": "Find EU Exit guidance for your business",
   "description": "You'll get an email each time EU Exit guidance is published.",
   "details": {
-    "email_filter_by": "appear_in_find_eu_exit_guidance_business_finder",
-    "email_filter_name": "appear_in_find_eu_exit_guidance_business_finder",
+    "email_filter_by": "facet_groups",
+    "email_filter_name": "facet_groups",
     "email_signup_choice": [
       {
-        "key": "yes",
-        "radio_button_name": "yes",
+        "key": "52435175-82ed-4a04-adef-74c0199d0f46",
+        "radio_button_name": "52435175-82ed-4a04-adef-74c0199d0f46",
         "prechecked": true
       }
     ],

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -698,7 +698,7 @@ Then("I see the email subscription page") do
 end
 
 Then("I cannot select any filters") do
-  find("input[name='filter[appear_in_find_eu_exit_guidance_business_finder][]']", visible: false)
+  find("input[name='filter[facet_groups][]']", visible: false)
 end
 
 Then("I should see results in the default group") do

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -20,10 +20,29 @@ private
   end
 
   def subscriber_list_options
-    {
-      "tags" => tags,
-      "title" => subscriber_list_title,
-    }
+    options = if facet_groups?
+                {
+                  "links" => facet_groups,
+                }
+              else
+                {
+                  "tags" => tags,
+                }
+              end
+
+    options.merge("title" => subscriber_list_title)
+  end
+
+  def facet_groups?
+    facets.any? { |facet| facet["facet_id"] == "facet_groups" }
+  end
+
+  def facet_groups
+    facet_groups = facets.map do |facet|
+      facet["facet_choices"]["key"]
+    end
+
+    { "facet_groups" => { any: facet_groups } }
   end
 
   def tags

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -139,6 +139,6 @@ private
   end
 
   def ignore_facet?(facet_id)
-    %W(appear_in_find_eu_exit_guidance_business_finder).include?(facet_id)
+    %W(facet_groups).include?(facet_id)
   end
 end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -389,14 +389,19 @@ describe EmailAlertSignupAPI do
     context "with the tags done right" do
       let(:applied_filters) do
         {
-          "appear_in_find_eu_exit_guidance_business_finder" => %w(yes),
+          "facet_groups" => %w(52435175-82ed-4a04-adef-74c0199d0f46),
         }
       end
       let(:facets) do
         [
           {
-            "facet_id" => "appear_in_find_eu_exit_guidance_business_finder",
-            "facet_name" => "appear_in_find_eu_exit_guidance_business_finder",
+            "facet_id" => "facet_groups",
+            "facet_name" => "facet_groups",
+            "facet_choices" => {
+               "key" => "52435175-82ed-4a04-adef-74c0199d0f46",
+               "radio_button_name" => "52435175-82ed-4a04-adef-74c0199d0f46",
+               "prechecked" => true
+            },
           }
         ]
       end
@@ -405,8 +410,8 @@ describe EmailAlertSignupAPI do
 
       before do
         email_alert_api_has_subscriber_list(
-          "tags" => {
-            appear_in_find_eu_exit_guidance_business_finder: { any: %w(yes) },
+          "links" => {
+            "facet_groups" => { any: %w(52435175-82ed-4a04-adef-74c0199d0f46) },
           },
           "subscription_url" => subscription_url
         )
@@ -414,8 +419,8 @@ describe EmailAlertSignupAPI do
 
       it 'asks email-alert-api to find or create the subscriber list' do
         expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-          "tags" => {
-            appear_in_find_eu_exit_guidance_business_finder: { any: %w(yes) },
+          "links" => {
+            "facet_groups" => { any: %w(52435175-82ed-4a04-adef-74c0199d0f46) },
           },
           "title" => subscriber_list_title,
         ).and_call_original


### PR DESCRIPTION
Trello: https://trello.com/c/hKKTZdoj

## What
Changes the `topic_id` passed in create subscription page from `find-eu-exit-guidance-for-your-business-appear-in-find-eu-exit-guidance-business-finder` to the content_id of the [facet_group](https://github.com/alphagov/content-tagger/blob/master/lib/data/find-eu-exit-guidance-business.yml).

## Why
The new facet_group is replacing `appear-in-find-eu-exit-guidance-business-finder` as the filter for determining whether a piece of content appears on the business finder. Users need to be able to create an email subscription based on the same criteria, or they won't receive any emails.

There is another [PR](https://github.com/alphagov/email-alert-api/pull/838) that covers migrating the existing email subscriptions.