### PR TITLE
Open first facet box by default

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -51,6 +51,10 @@ class Facet
     {}
   end
 
+  def open_on_load?
+    true
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/facet_collection.rb
+++ b/app/models/facet_collection.rb
@@ -21,10 +21,7 @@ class FacetCollection
   end
 
   def ensure_minimum_one_open_facet(facets_to_ensure)
-    at_least_one_facet_selected = (facets_to_ensure.map { |f|
-      # TODO figure out where to move this method so that it only applies to `OptionSelectFacet`. Then can remove the `defined?` check.
-      (defined? f.close_facet?) ? !f.close_facet? : false
-    }).any?
+    at_least_one_facet_selected = facets_to_ensure.any?(&:open_on_load?)
     unless at_least_one_facet_selected
       facets_to_ensure.first.open_facet!
     end

--- a/app/models/facet_collection.rb
+++ b/app/models/facet_collection.rb
@@ -23,7 +23,9 @@ class FacetCollection
   def ensure_minimum_one_open_facet(facets_to_ensure)
     at_least_one_facet_selected = facets_to_ensure.any?(&:open_on_load?)
     unless at_least_one_facet_selected
-      facets_to_ensure.first.open_facet!
+      if defined? facets_to_ensure.first.open_facet!
+        facets_to_ensure.first.open_facet!
+      end
     end
     facets_to_ensure
   end

--- a/app/models/facet_collection.rb
+++ b/app/models/facet_collection.rb
@@ -7,9 +7,9 @@ class FacetCollection
 
   def initialize(facet_hashes, values)
     stringified_values_hash = values.stringify_keys
-    @facets = facet_hashes.map { |facet_hash|
+    @facets = ensure_minimum_one_open_facet(facet_hashes.map { |facet_hash|
       FacetParser.parse(facet_hash, stringified_values_hash)
-    }
+    })
   end
 
   def to_partial_path
@@ -18,6 +18,17 @@ class FacetCollection
 
   def filters
     facets.select(&:filterable?)
+  end
+
+  def ensure_minimum_one_open_facet(facets_to_ensure)
+    at_least_one_facet_selected = (facets_to_ensure.map { |f|
+      # TODO figure out where to move this method so that it only applies to `OptionSelectFacet`. Then can remove the `defined?` check.
+      (defined? f.close_facet?) ? !f.close_facet? : false
+    }).any?
+    unless at_least_one_facet_selected
+      facets_to_ensure.first.open_facet!
+    end
+    facets_to_ensure
   end
 
   def metadata

--- a/app/models/facet_collection.rb
+++ b/app/models/facet_collection.rb
@@ -21,13 +21,16 @@ class FacetCollection
   end
 
   def ensure_minimum_one_open_facet(facets_to_ensure)
-    at_least_one_facet_selected = facets_to_ensure.any?(&:open_on_load?)
-    unless at_least_one_facet_selected
+    unless at_least_one_facet_selected? facets_to_ensure
       if defined? facets_to_ensure.first.open_facet!
         facets_to_ensure.first.open_facet!
       end
     end
     facets_to_ensure
+  end
+
+  def at_least_one_facet_selected?(facets_to_ensure)
+    facets_to_ensure.any?(&:open_on_load?)
   end
 
   def metadata

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -47,14 +47,8 @@ class OptionSelectFacet < FilterableFacet
     @facet_forced_open = true
   end
 
-  def close_facet?
-    if @facet_forced_open
-      false
-    elsif unselected? || allowed_values.count > 10
-      true
-    else
-      false
-    end
+  def open_on_load?
+    @facet_forced_open || !unselected?
   end
 
   def unselected?

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -48,7 +48,15 @@ class OptionSelectFacet < FilterableFacet
   end
 
   def open_on_load?
-    @facet_forced_open || !unselected?
+    @facet_forced_open || selected?
+  end
+
+  def closed_on_load?
+    !open_on_load?
+  end
+
+  def selected?
+    !unselected?
   end
 
   def unselected?

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -3,6 +3,7 @@ class OptionSelectFacet < FilterableFacet
 
   def initialize(facet, values)
     @value = Array(values)
+    @facet_forced_open = false
     super(facet)
   end
 
@@ -42,8 +43,18 @@ class OptionSelectFacet < FilterableFacet
     selected_values.any?
   end
 
+  def open_facet!
+    @facet_forced_open = true
+  end
+
   def close_facet?
-    unselected? && allowed_values.count > 10
+    if @facet_forced_open
+      false
+    elsif unselected? || allowed_values.count > 10
+      true
+    else
+      false
+    end
   end
 
   def unselected?

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -1,12 +1,11 @@
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
-  <% close_facet = option_select_facet.unselected? && ((option_select_facet_counter > 0) || option_select_facet.close_facet?) %>
   <%= render partial: 'components/option-select', locals: {
     :key => option_select_facet.key,
     :title => option_select_facet.name,
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => close_facet,
+    :closed_on_load => option_select_facet.close_facet?,
     :show_filter => option_select_facet.show_option_select_filter
   }
   %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -5,7 +5,7 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => !option_select_facet.open_on_load?,
+    :closed_on_load => option_select_facet.closed_on_load?,
     :show_filter => option_select_facet.show_option_select_filter
   }
   %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -5,7 +5,7 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => option_select_facet.close_facet?,
+    :closed_on_load => !option_select_facet.open_on_load?,
     :show_filter => option_select_facet.show_option_select_filter
   }
   %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -297,6 +297,18 @@ Feature: Filtering documents
     And I should see all world locations in the world location facet
 
   @javascript
+  Scenario: Business readiness finder with no facets selected
+    When I view the business readiness finder with no preselected facets
+    Then only the first facet should be expanded
+    And all other facets should be closed by default
+
+  @javascript
+  Scenario: Business readiness finder with one facet selected
+    When I view the business readiness finder with a preselected facet
+    Then only the selected facet should be expanded
+    And all other facets should be closed by default
+
+  @javascript
   Scenario: Skip to results after inputing some keywords
     When I view the news and communications finder
     And I should not see a "Skip to results" link

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -220,7 +220,7 @@ Feature: Filtering documents
   Scenario: Adding keyword filter to facet search in business finder
     When I view the business readiness finder
     Then I see topic order selected
-    And I click button "Sector / Business Area" and select facet Aerospace
+    And I select facet Aerospace in the already expanded "Sector / Business Area" section
     Then I see results grouped by primary facet value
     And I see results with pinned items
     And I fill in some keywords
@@ -285,7 +285,7 @@ Feature: Filtering documents
   @javascript
   Scenario: Filter documents and group by facets
     When I view the business readiness finder
-    And I click button "Sector / Business Area" and select facet Aerospace
+    And I select facet Aerospace in the already expanded "Sector / Business Area" section
     Then I see results grouped by primary facet value
 
   Scenario: Dynamic facets continue to show all options on page reload

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -634,6 +634,10 @@ And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
   find('label', text: facet).click
 end
 
+And(/^I select facet (.*) in the already expanded \"([^\"]*)\" section$/) do |facet, _button|
+  find('label', text: facet).click
+end
+
 When(/^I click the (.*) remove control$/) do |filter|
   expect(page).to have_css(".js-enabled")
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -283,10 +283,10 @@ module DocumentHelper
     content_store_has_item(mock_bus_finder_qa_config['base_path'], mock_bus_finder_qa_config)
   end
 
-  def content_store_has_business_readiness_finder
+  def content_store_has_business_readiness_finder(params = '')
     finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'business_readiness.json'))
 
-    content_store_has_item('/find-eu-exit-guidance-business', finder_fixture)
+    content_store_has_item("/find-eu-exit-guidance-business#{params}", finder_fixture)
   end
 
   def content_store_has_business_readiness_email_signup

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -60,41 +60,23 @@ describe OptionSelectFacet do
   end
 
   describe "#open_on_load?" do
-    describe "with a small number of options" do
-      subject { OptionSelectFacet.new(facet_data, []) }
-
-      context "should not be closed" do
-        specify { expect(subject.open_on_load?).to be true }
-      end
+    context "when a facet is selected" do
+      subject { OptionSelectFacet.new(facet_data, "allowed-value-1") }
+      specify { expect(subject.open_on_load?).to be true }
     end
 
-    describe "with a large number of options" do
-      let(:allowed_values) {
-        11.times.map { |i| { 'label' => "Label #{i}", 'value' => "allowed-value-#{i}" } }
+    context "when NO facet is selected" do
+      subject { OptionSelectFacet.new(facet_data, []) }
+      specify { expect(subject.open_on_load?).to be false }
+    end
+
+    context "when NO facet is selected but we have called `open_facet!`" do
+      subject {
+        facet = OptionSelectFacet.new(facet_data, [])
+        facet.open_facet!
+        facet
       }
-
-      let(:large_facet_data) {
-        {
-          'type' => "multi-select",
-          'name' => "Test values",
-          'key' => "test_values",
-          'preposition' => "of value",
-          'allowed_values' => allowed_values,
-        }
-      }
-
-      subject { OptionSelectFacet.new(large_facet_data, {}) }
-
-      context "should be closed" do
-        specify { expect(subject.open_on_load?).to be false }
-      end
-
-      context "can force open with #open_facet!" do
-        specify {
-          subject.open_facet!
-          expect(subject.open_on_load?).to be true
-        }
-      end
+      specify { expect(subject.open_on_load?).to be true }
     end
   end
 

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -65,12 +65,12 @@ describe OptionSelectFacet do
       specify { expect(subject.open_on_load?).to be true }
     end
 
-    context "when NO facet is selected" do
+    context "when no facet is selected" do
       subject { OptionSelectFacet.new(facet_data, []) }
       specify { expect(subject.open_on_load?).to be false }
     end
 
-    context "when NO facet is selected but we have called `open_facet!`" do
+    context "when no facet is selected but we have called `open_facet!`" do
       subject {
         facet = OptionSelectFacet.new(facet_data, [])
         facet.open_facet!

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -60,13 +60,15 @@ describe OptionSelectFacet do
   end
 
   describe "#close_facet?" do
-    subject { OptionSelectFacet.new(facet_data, []) }
+    describe "with a small number of options" do
+      subject { OptionSelectFacet.new(facet_data, []) }
 
-    context "small number of options" do
-      specify { expect(subject.close_facet?).to be false }
+      context "should not be closed" do
+        specify { expect(subject.close_facet?).to be false }
+      end
     end
 
-    context "large number of options" do
+    describe "with a large number of options" do
       let(:allowed_values) {
         11.times.map { |i| { 'label' => "Label #{i}", 'value' => "allowed-value-#{i}" } }
       }
@@ -83,7 +85,16 @@ describe OptionSelectFacet do
 
       subject { OptionSelectFacet.new(large_facet_data, {}) }
 
-      specify { expect(subject.close_facet?).to be true }
+      context "should be closed" do
+        specify { expect(subject.close_facet?).to be true }
+      end
+
+      context "can force open with #open_facet!" do
+        specify {
+          subject.open_facet!
+          expect(subject.close_facet?).to be false
+        }
+      end
     end
   end
 

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -59,12 +59,12 @@ describe OptionSelectFacet do
     end
   end
 
-  describe "#close_facet?" do
+  describe "#open_on_load?" do
     describe "with a small number of options" do
       subject { OptionSelectFacet.new(facet_data, []) }
 
       context "should not be closed" do
-        specify { expect(subject.close_facet?).to be false }
+        specify { expect(subject.open_on_load?).to be true }
       end
     end
 
@@ -86,13 +86,13 @@ describe OptionSelectFacet do
       subject { OptionSelectFacet.new(large_facet_data, {}) }
 
       context "should be closed" do
-        specify { expect(subject.close_facet?).to be true }
+        specify { expect(subject.open_on_load?).to be false }
       end
 
       context "can force open with #open_facet!" do
         specify {
           subject.open_facet!
-          expect(subject.close_facet?).to be false
+          expect(subject.open_on_load?).to be true
         }
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/5ZwqcRWh 
Test: https://finder-frontend-pr-1063.herokuapp.com/find-eu-exit-guidance-business

## What
- opens first facet box by default - but only if another facet isn't already selected.
- implemented this logic by adding a `ensure_minimum_one_open_facet` method, which wraps around the `FacetCollection` and ensures that there is at least one open facet.
- updates integration tests that relied on the old behaviour
- adds new integration tests that capture the new behaviour explicitly
- removes unused facet logic ('facets with more than 10 options collapsed by default') and removes the corresponding tests.
- renames `close_facet?` to `open_on_load?` & updates application to use this new API (i.e. flip from `true` to `false` and vice versa)
- removes some logic from 'views/finders/_option_select_facter.html.erb' and delegates responsibility to the model.

## Why
- we can't look at a facet in isolation and determine whether or not it should be expanded. We need to look at the other facets, and _only if none of them are selected_ do we open the first facet box.
- therefore I've had to add a method higher up the chain than simply the `OptionSelectFacet` class.
- The rename of `close_facet?` to `open_on_load?` is for readability (much easier not having to deal with double negatives!).
- The logic added to `FacetCollection` runs irrespective of the facet type. If `open_on_load?` is missing, the application errors - so I've had to stub this `open_on_load?` method in the top-level `Facet` class. It defaults to `true`.
- Removes unused facet logic ('facets with more than 10 options collapsed by default') as currently ALL facets are collapsed by default (i.e. this code doesn't appear to be doing anything!) 
- I took the opportunity to remove business logic from the view as this isn't best practice.

## Screenshots

|Current behaviour | New behaviour introduced by this PR | Behaviour when something selected (unchanged by this PR - have manually verified & added an integration test to explicitly test this) |
|-------------------|--------------------------------------|----|
|![current](https://user-images.githubusercontent.com/5111927/56670543-ed1bb400-66aa-11e9-89d3-10c2e13dea7c.png)|![new default](https://user-images.githubusercontent.com/5111927/56670550-f3119500-66aa-11e9-8a0a-291129b7d735.png)|![with one selected (current   new)](https://user-images.githubusercontent.com/5111927/56670589-06bcfb80-66ab-11e9-8d63-602ca4bc3055.png)|


