### PR TITLE
Use 'q' instead of 'keywords' parameter in text search [DO NOT MERGE]

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -209,7 +209,7 @@
   };
 
   LiveSearch.prototype.updateTitle = function updateTitle() {
-    var keywords = this.getTextInputValue('keywords', this.state);
+    var keywords = this.getTextInputValue('q', this.state);
     var keywordsPresent = keywords !== "";
 
     if (keywordsPresent) {
@@ -225,8 +225,8 @@
     }
 
     var liveSearch = this;
-    var keywords = this.getTextInputValue('keywords', this.state);
-    var previousKeywords = this.getTextInputValue('keywords', this.previousState);
+    var keywords = this.getTextInputValue('q', this.state);
+    var previousKeywords = this.getTextInputValue('q', this.previousState);
 
     var keywordsPresent = keywords !== "";
     var previousKeywordsPresent = previousKeywords !== "";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,9 +56,9 @@ private
                              :format
                            )
 
-      # Convert a query with 'q=search_term' into 'keywords=search_term'
-      if permitted_params.has_key?("q")
-        permitted_params["keywords"] = permitted_params.delete("q")
+      # Convert a query with 'keywords=search_term' into 'q=search_term'
+      if permitted_params.has_key?("keywords")
+        permitted_params["q"] = permitted_params.delete("keywords")
       end
 
       ParamsCleaner

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -44,7 +44,7 @@ private
   end
 
   def convert_common_parameters
-    { keywords: params['keywords'],
+    { q: params['keywords'],
       level_one_taxon: params['taxons'].try(:first) || params['topics'].try(:first),
       level_two_taxon: params['subtaxons'].try(:first),
       organisations: params['departments'] || params['organisations'],

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -38,7 +38,7 @@ protected
 
   def redirect_to_all_content_finder(search_params)
     all_content_params = {
-      keywords: search_params.search_term,
+      q: search_params.search_term,
       organisations: params['filter_organisations'],
       manual: params['filter_manual'],
       format: params['format'],

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -145,15 +145,15 @@ private
   def keywords
     return remove_stopwords if remove_stopwords?
 
-    params["keywords"].presence
+    params["q"].presence
   end
 
   def remove_stopwords?
-    params["keywords"].present? && ["/find-eu-exit-guidance-business"].include?(finder_content_item["base_path"])
+    params["q"].present? && ["/find-eu-exit-guidance-business"].include?(finder_content_item["base_path"])
   end
 
   def remove_stopwords
-    keywords = params["keywords"].split(' ')
+    keywords = params["q"].split(' ')
     keywords.delete_if do |keyword|
       stopwords.include?(keyword.downcase.gsub(/\W/, ''))
     end

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -21,7 +21,7 @@ class KeywordFacet
   end
 
   def key
-    'keywords'
+    'q'
   end
 
   def value
@@ -51,7 +51,7 @@ private
         keyword_fragments << {
           'label' => keyword,
           'parameter_key' => key,
-          'name' => 'keywords',
+          'name' => 'q',
           'value' => keyword.gsub('"', "&quot;")
         }
       end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -16,7 +16,7 @@ class FinderPresenter
     @values = values
     @facet_hashes = facet_hashes(@content_item)
     @facets = facet_collection(@facet_hashes, @values)
-    @keywords = values["keywords"].presence
+    @keywords = values["q"].presence
   end
 
   def phase_message

--- a/app/presenters/grouped_result_set_presenter.rb
+++ b/app/presenters/grouped_result_set_presenter.rb
@@ -119,6 +119,6 @@ private
   end
 
   def facet_filters
-    @filter_params.symbolize_keys.without(:order, :keywords)
+    @filter_params.symbolize_keys.without(:order, :q)
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -69,7 +69,7 @@ class ResultSetPresenter
   end
 
   def user_supplied_keywords
-    @filter_params.fetch('keywords', '')
+    @filter_params.fetch('q', '')
   end
 
   def has_email_signup_link?

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,6 +1,6 @@
 <div class="filter-form">
   <% if finder.show_keyword_search? and !finder.all_content_finder? %>
-    <div id="keywords">
+    <div id="q">
       <% label_text = capture do %>
         Search <span class="govuk-visually-hidden"><%= finder.name %></span>
       <% end %>
@@ -8,7 +8,7 @@
         label: {
           text: label_text
         },
-        name: "keywords",
+        name: "q",
         value: @results.user_supplied_keywords,
         id: "finder-keyword-search",
         controls: "js-search-results-info"

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -42,11 +42,11 @@
         <% label_text = capture do %>
           <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
         <% end %>
-        <div id="keywords">
+        <div id="q">
           <%= render "govuk_publishing_components/components/search", {
               inline_label: false,
               label_text: label_text,
-              name: "keywords",
+              name: "q",
               hide_search_button: true,
               value: @results.user_supplied_keywords,
               id: "finder-keyword-search",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -78,8 +78,8 @@ And("I see email and feed sign up links with filters applied") do
 end
 
 And("I see email and feed sign up links with filters applied with extra empty filters") do
-  expect(page).to have_css('a[href="/search/news-and-communications/email-signup?parent=&keywords=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
-  expect(page).to have_css('a[href="/search/news-and-communications.atom?parent=&keywords=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
+  expect(page).to have_css('a[href="/search/news-and-communications/email-signup?parent=&q=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
+  expect(page).to have_css('a[href="/search/news-and-communications.atom?parent=&q=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
 end
 
 When(/^I view a list of news and communications$/) do

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -278,7 +278,7 @@ describe FindersController, type: :controller do
       finder
     end
 
-    let(:filter_params) { double(:filter_params, keywords: '') }
+    let(:filter_params) { double(:filter_params, q: '') }
     let(:view_context) { double(:view_context) }
     let(:finder_presenter) { FinderPresenter.new(breakfast_finder, {}, filter_params) }
 

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -18,7 +18,7 @@ describe RedirectionController, type: :controller do
         to_date: '01/01/2014'
       }
       expect(response).to redirect_to finder_path('search/news-and-communications', params: {
-        keywords: %w[one two],
+        q: %w[one two],
         level_one_taxon: 'one',
         level_two_taxon: 'two',
         people: %w[one two],
@@ -29,7 +29,7 @@ describe RedirectionController, type: :controller do
     end
     it 'redirects to the atom feed' do
       get :announcements, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/news-and-communications', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path('search/news-and-communications', format: :atom, params: { q: %w[one two] })
     end
   end
 
@@ -48,7 +48,7 @@ describe RedirectionController, type: :controller do
 
     let(:converted_params) {
       {
-        keywords: %w[one two],
+        q: %w[one two],
         level_one_taxon: 'one',
         level_two_taxon: 'two',
         organisations: %w[one two],
@@ -137,7 +137,7 @@ describe RedirectionController, type: :controller do
     end
     it 'redirects to the atom feed' do
       get :publications, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/all', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path('search/all', format: :atom, params: { q: %w[one two] })
     end
   end
 
@@ -155,7 +155,7 @@ describe RedirectionController, type: :controller do
         to_date: '01/01/2014'
       }
       expect(response).to redirect_to finder_path('search/statistics', params: {
-        keywords: %w[one two],
+        q: %w[one two],
         level_one_taxon: 'one',
         organisations: %w[one two],
         public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
@@ -163,7 +163,7 @@ describe RedirectionController, type: :controller do
     end
     it 'redirects to the atom feed' do
       get :published_statistics, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { q: %w[one two] })
     end
   end
 
@@ -181,7 +181,7 @@ describe RedirectionController, type: :controller do
         to_date: '01/01/2014'
       }
       expect(response).to redirect_to finder_path('search/statistics', params: {
-        keywords: %w[one two],
+        q: %w[one two],
         level_one_taxon: 'one',
         organisations: %w[one two],
         content_store_document_type: :statistics_upcoming,
@@ -190,7 +190,7 @@ describe RedirectionController, type: :controller do
     end
     it 'redirects to the atom feed' do
       get :upcoming_statistics, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two], content_store_document_type: :statistics_upcoming })
+      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { q: %w[one two], content_store_document_type: :statistics_upcoming })
     end
   end
 end

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -3,7 +3,7 @@ describe("liveSearch", function(){
   var dummyResponse = {
     "total":1,
     "pluralised_document_noun":"reports",
-    "applied_filters":" \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026keywords='\u003E×\u003C/a\u003E\u003C/strong\u003E",
+    "applied_filters":" \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026q='\u003E×\u003C/a\u003E\u003C/strong\u003E",
     "any_filters_applied":true,
     "atom_url": "http://an-atom-url.atom?some-query-param",
     "documents":[
@@ -148,14 +148,14 @@ describe("liveSearch", function(){
   describe("should not display out of date results", function(){
 
     it('should not update the results if the state associated with these results is not the current state of the page', function(){
-      liveSearch.state = 'cma-cases.json?keywords=123';
+      liveSearch.state = 'cma-cases.json?q=123';
       spyOn(liveSearch.$resultsBlock, 'mustache');
       liveSearch.displayResults(dummyResponse, 'made up state');
       expect(liveSearch.$resultsBlock.mustache).not.toHaveBeenCalled();
     });
 
     it('should have an order state selected when keywords are present', function(){
-      liveSearch.state = 'find-eu-exit-guidance-business.json?keywords=123';
+      liveSearch.state = 'find-eu-exit-guidance-business.json?q=123';
       expect(liveSearch.$orderSelect.val()).not.toBe(null);
     });
 
@@ -363,7 +363,7 @@ describe("liveSearch", function(){
       "total":4,
       "finder_name":"foo",
       "pluralised_document_noun":"things",
-      "applied_filters":" \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026keywords='\u003E×\u003C/a\u003E\u003C/strong\u003E",
+      "applied_filters":" \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026q='\u003E×\u003C/a\u003E\u003C/strong\u003E",
       "any_filters_applied":true,
       "atom_url": "http://an-atom-url.atom?some-query-param",
       "display_grouped_results": true,

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -14,13 +14,13 @@ describe('remove-filter', function () {
 
   var $oneTextQuery = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-track-label="Education" data-name="keywords">✕</button>' +
+      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="q" data-value="education" data-track-label="Education" data-name="q">✕</button>' +
     '</div>'
   );
 
   var $multipleTextQueries = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-track-label="the" data-name="keywords">✕</button>' +
+      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="q" data-value="the" data-track-label="the" data-name="q">✕</button>' +
     '</div>'
   );
 
@@ -53,8 +53,8 @@ describe('remove-filter', function () {
       '<option value="">All topics</option>' +
       '<option value="ba3a9702-da22-487f-86c1-8334a730e559">Entering and staying in the UK</option>' +
     '</select>' +
-    '<div id="keywords">'+
-      '<input name="keywords" value="" id="finder-keyword-search" type="text">' +
+    '<div id="q">'+
+      '<input name="q" value="" id="finder-keyword-search" type="text">' +
     '</div>' +
     '<div>'+
       '<input name="public_timestamp[from]" value="" id="public_timestamp[from]" type="text">' +
@@ -90,7 +90,7 @@ describe('remove-filter', function () {
   });
 
   it('clears the text search field if removing all text queries', function (done) {
-    var searchField = $('input[name=keywords]')[0];
+    var searchField = $('input[name=q]')[0];
     searchField.value = "education";
     removeFilter.start($oneTextQuery);
 
@@ -106,7 +106,7 @@ describe('remove-filter', function () {
 
 
   it('removes one text query from the text search field if there are multiple', function (done) {
-    var searchField = $('input[name=keywords]')[0];
+    var searchField = $('input[name=q]')[0];
     searchField.value = "therefore the search term";
     removeFilter.start($multipleTextQueries);
 

--- a/spec/lib/advanced_search_query_builder_spec.rb
+++ b/spec/lib/advanced_search_query_builder_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe AdvancedSearchQueryBuilder do
   context "with keywords" do
     let(:params) {
       {
-        "keywords" => "mangoes",
+        "q" => "mangoes",
       }
     }
 
@@ -81,7 +81,7 @@ RSpec.describe AdvancedSearchQueryBuilder do
     context "longer than the maximum query length" do
       let(:params) {
         {
-          "keywords" => "a" * 1024
+          "q" => "a" * 1024
         }
       }
 

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -215,7 +215,7 @@ describe SearchQueryBuilder do
   context "with keywords" do
     let(:params) {
       {
-        "keywords" => "mangoes",
+        "q" => "mangoes",
       }
     }
 
@@ -230,7 +230,7 @@ describe SearchQueryBuilder do
     context "longer than the maximum query length" do
       let(:params) {
         {
-          "keywords" => "a" * 1024
+          "q" => "a" * 1024
         }
       }
 
@@ -242,7 +242,7 @@ describe SearchQueryBuilder do
     context "without stopwords" do
       let(:params) {
         {
-          "keywords" => "a mango"
+          "q" => "a mango"
         }
       }
 
@@ -267,7 +267,7 @@ describe SearchQueryBuilder do
 
       it "should not include stopwords in search" do
         params = {
-          "keywords" => "a mango"
+          "q" => "a mango"
         }
 
         query = SearchQueryBuilder.new(
@@ -281,7 +281,7 @@ describe SearchQueryBuilder do
 
       it "strips punctuation from stopword check" do
         params = {
-          "keywords" => "a, isn't a mango is it?"
+          "q" => "a, isn't a mango is it?"
         }
 
         query = SearchQueryBuilder.new(
@@ -295,7 +295,7 @@ describe SearchQueryBuilder do
 
       it "ignores case of keywords" do
         params = {
-          "keywords" => "A mango"
+          "q" => "A mango"
         }
 
         query = SearchQueryBuilder.new(
@@ -309,7 +309,7 @@ describe SearchQueryBuilder do
 
       it "does not strip numbers from search" do
         params = {
-          "keywords" => "50"
+          "q" => "50"
         }
 
         query = SearchQueryBuilder.new(

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -14,7 +14,7 @@ describe KeywordFacet do
 
       specify {
         expect(subject.sentence_fragment['preposition']).to eql("containing")
-        expect(first_word['parameter_key']).to eql("keywords")
+        expect(first_word['parameter_key']).to eql("q")
         expect(first_word['label']).to eql("Happy")
         expect(second_word['label']).to eql("Christmas")
 
@@ -54,7 +54,7 @@ describe KeywordFacet do
     context "value selected" do
       subject { KeywordFacet.new("keyword") }
       specify {
-        expect(subject.query_params).to eql("keywords" => %w[keyword])
+        expect(subject.query_params).to eql("q" => %w[keyword])
       }
     end
   end

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AtomPresenter do
     )
   end
 
-  let(:filter_params) { double(:filter_params, keywords: '') }
+  let(:filter_params) { double(:filter_params, q: '') }
   let(:view_context) { double(:view_context) }
 
   let(:a_facet) do

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe FinderPresenter do
     context "with some values" do
       let(:values) do
         {
-          keyword: "legal",
+          q: "legal",
           place_of_origin: "england",
           walk_type: "open",
           creator: "Harry Potter",
@@ -120,7 +120,7 @@ RSpec.describe FinderPresenter do
     context "with some values" do
       let(:values) do
         {
-          keyword: "legal",
+          q: "legal",
           place_of_origin: "england",
           walk_type: "open",
           creator: "Harry Potter",
@@ -203,7 +203,7 @@ RSpec.describe FinderPresenter do
                                           "checkbox" => true,
                                           "content_store_document_type" => "type",
                                           "public_timestamp" => { "from" => "21/11/2014", "to" => "21/11/2019" },
-                                          "keywords" => "keyword",
+                                          "q" => "keyword",
                                           "people" => %w[me you],
                                           "topic" => "hiding",
                                           "manual" => "my_manual")
@@ -295,7 +295,7 @@ RSpec.describe FinderPresenter do
         sort_option('Relevance', 'relevance', disabled: false)
       ].join("\n")
 
-      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), {}, "keywords" => "something not blank")
+      presenter = described_class.new(content_item(sort_options: sort_options_with_relevance), {}, "q" => "something not blank")
 
       expect(presenter.sort_options).to eql(expected_options)
     end

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GroupedResultSetPresenter do
 
   let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
 
-  let(:filter_params) { { keywords: 'test' } }
+  let(:filter_params) { { q: 'test' } }
 
   let(:view_context) { double(:view_context) }
 
@@ -18,7 +18,7 @@ RSpec.describe GroupedResultSetPresenter do
       document_noun: document_noun,
       total: 20,
       facets: a_facet_collection,
-      keywords: keywords,
+      q: keywords,
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ResultSetPresenter do
 
   let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
 
-  let(:filter_params) { { keywords: 'test' } }
+  let(:filter_params) { { q: 'test' } }
 
   let(:view_context) { double(:view_context) }
 


### PR DESCRIPTION
Because our Google Analytics uses the 'q' parameter to process
events, we have to change the 'keywords' parameter to use 'q'
instead.

The legacy 'keywords' to 'q' translation has been reversed so that
legacy URLs using 'keywords' are now translated to 'q'

Trello: https://trello.com/c/bJQyIrmp/675-change-faceted-search-query-param-from-keywords-to-q?menu=filter&filter=label:Finders