### PR TITLE
Option select with sticky search

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -44,9 +44,10 @@
 
         if(e.keyCode !== ENTER_KEY) {
           clearTimeout(that.filterTimeout);
-          that.filterTimeout = setTimeout(function(obj){
-            that.doFilter(obj);
-          }, 300, that);
+          that.filterTimeout = setTimeout(
+            function(){ this.doFilter(this) }.bind(that),
+            300
+          );
         } else {
           e.preventDefault(); // prevents finder forms from being submitted when user presses ENTER
         }

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -22,9 +22,9 @@
 
       $('<div class="app-c-option-select__filter"/>')
         .html(filterEl.childNodes[0].nodeValue)
-        .prependTo(this.$optionList);
+        .insertBefore(this.$optionsContainer)
 
-      this.$filter = this.$optionsContainer.find('input[name="option-select-filter"]');
+      this.$filter = this.$optionSelect.find('input[name="option-select-filter"]');
       this.$filterCount = $('#' + this.$filter.attr('aria-describedby'));
       this.filterTextSingle = ' ' + this.$filterCount.data('single');
       this.filterTextMultiple = ' ' + this.$filterCount.data('multiple');
@@ -145,6 +145,8 @@
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){
     this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
+
+    this.doFilter(this);
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -146,8 +146,6 @@
 
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){
     this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
-
-    this.doFilter(this);
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -105,9 +105,11 @@
 }
 
 .app-c-option-select__filter {
+  background: govuk-colour('white');
+  border-left: govuk-spacing(1) solid govuk-colour("grey-3");
+  border-right: govuk-spacing(1) solid govuk-colour("grey-3");
   display: none;
-  padding-top: govuk-spacing(2);
-  margin-bottom: govuk-spacing(2);
+  padding: govuk-spacing(2) 8px govuk-spacing(2) 8px;
 }
 
 .app-c-option-select__filter-input {
@@ -126,7 +128,8 @@
   }
 
   .app-c-option-select__container {
-    border: 5px solid govuk-colour("grey-3");
+    border: govuk-spacing(1) solid govuk-colour("grey-3");
+    border-top: 0;
   }
 
   .app-c-option-select__filter {
@@ -175,6 +178,11 @@
   }
 
   &.js-closed {
+
+    .app-c-option-select__filter {
+      display: none;
+    }
+
     .app-c-option-select__container {
       display: none;
     }

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -24,9 +24,7 @@
       }
     %>
   <% end %>
-  <% # NOTE - could this be achieved with a <template> instead of putting it into a data attribute? Or by putting the filter_id into a data attribute to us?
-    filter_element = CGI::escapeHTML(filter)
-  %>
+  <% filter_element = CGI::escapeHTML(filter) %>
 <% end %>
 
 <div class="app-c-option-select"

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -24,7 +24,7 @@
       }
     %>
   <% end %>
-  <%
+  <% # NOTE - could this be achieved with a <template> instead of putting it into a data attribute? Or by putting the filter_id into a data attribute to us?
     filter_element = CGI::escapeHTML(filter)
   %>
 <% end %>

--- a/app/views/components/docs/option-select.yml
+++ b/app/views/components/docs/option-select.yml
@@ -1,6 +1,9 @@
 name: Option select
 description: A scrollable list of checkboxes to be displayed on a form where one might
   otherwise use a multi-select
+body: |
+  There is a bug where the option select will be scrolled to the bottom when the component is tested using Axe in Internet Explorer 10 and 11. This bug is not present when Axe and the test is not run, so is not seen when in production. This is caused by the `TODO:` SVG patch on line 32 of `accessibility-test.js` setting `restoreScroll` to `false`.
+
 accessibility_criteria: |
   The option select must:
 

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -349,14 +349,10 @@ describe('GOVUK.OptionSelect', function() {
   describe('filtering checkboxes', function(){
     beforeEach(function(){
       var filterMarkup =
-        '&lt;div class=&quot;app-c-option-select__filter&quot;&gt;'+
-          '&lt;div class=&quot;govuk-form-group&quot;&gt;'+
             '&lt;label for=&quot;input-b7f768b7&quot; class=&quot;gem-c-label govuk-label&quot;&gt;'+
               'Filter Countries'+
             '&lt;/label&gt;'+
-            '&lt;input name=&quot;option-select-filter&quot; class=&quot;gem-c-input govuk-input&quot; id=&quot;input-b7f768b7&quot; type=&quot;text&quot; aria-describedby=&quot;checkboxes-9b7ecc25-count&quot; aria-controls=&quot;checkboxes-9b7ecc25&quot;&gt;'+
-          '&lt;/div&gt;'+
-        '&lt;/div&gt;';
+            '&lt;input name=&quot;option-select-filter&quot; class=&quot;gem-c-input app-c-option-select__filter-input govuk-input&quot; id=&quot;input-b7f768b7&quot; type=&quot;text&quot; aria-describedby=&quot;checkboxes-9b7ecc25-count&quot; aria-controls=&quot;checkboxes-9b7ecc25&quot;&gt;'
 
       var filterSpan = '<span id="checkboxes-9b7ecc25-count" class="app-c-option-select__count govuk-visually-hidden" aria-live="polite" data-single="option found" data-multiple="options found" data-selected="selected"></span>';
 


### PR DESCRIPTION
As per the [card](https://trello.com/c/wlc28Ccl/632-option-select-make-filter-stay-at-top-when-checkbox-list-is-scrolled), this makes the option-select search input remain visible whilst the checkboxes are scrolled.

Video:

![option-select-sticky-input](https://user-images.githubusercontent.com/1732331/56797550-d68d6e00-680c-11e9-9453-173364ada8a4.gif)
