### PR TITLE
Fix removing keyword filters which have a "

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -39,10 +39,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $input.trigger(onChangeSuppressAnalytics);
       }
       else if (inputType == 'text' || inputType == 'search') {
+        var needle = decodeEntities(removeFilterValue.toString());
         var splitKeywords = currentVal.split(" ");
 
         for (var i = 0; i < splitKeywords.length; i++) {
-          if (splitKeywords[i].toString() === removeFilterValue.toString()) {
+          if (splitKeywords[i].toString() === needle) {
             splitKeywords.splice(i, 1);
             break;
           }
@@ -73,6 +74,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         action,
         { label: label }
       );
+    }
+
+    function decodeEntities(string) {
+      return string
+        .replace(/&quot;/g, '"');
     }
   };
 })(window, window.GOVUK);

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -41,7 +41,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       else if (inputType == 'text' || inputType == 'search') {
         var splitKeywords = currentVal.split(" ");
 
-        for (var i = 0; splitKeywords.length; i++) {
+        for (var i = 0; i < splitKeywords.length; i++) {
           if (splitKeywords[i].toString() === removeFilterValue.toString()) {
             splitKeywords.splice(i, 1);
             break;

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -24,6 +24,12 @@ describe('remove-filter', function () {
     '</div>'
   );
 
+  var $quotedTextQuery = $(
+    '<div data-module="remove-filter">' +
+      '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fi&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fi&quot;" data-facet="keywords" data-value="&amp;quot;fi&amp;quot;" data-name="keywords">✕</button>' +
+    '</div>'
+  );
+
   var $dropdown = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>' +
@@ -116,6 +122,21 @@ describe('remove-filter', function () {
 
     setTimeout(function() {
       expect(searchField.value).toEqual("therefore search term");
+      done();
+    }, timeout);
+  });
+
+  it('removes text queries with quotes from the text search field', function (done) {
+    var searchField = $('input[name=keywords]')[0];
+    searchField.value = 'fee "fi" fo fum';
+    removeFilter.start($quotedTextQuery);
+
+    expect(searchField.value).toContain('"fi"');
+
+    triggerRemoveFilterClick($quotedTextQuery);
+
+    setTimeout(function() {
+      expect(searchField.value).toEqual("fee fo fum");
       done();
     }, timeout);
   });


### PR DESCRIPTION
The issue is that the input field value had `"` but the filter tag had `&quot;`.  I've solved *this specific case*, but I can't find a nice way to handle HTML entities in general (without rendering a div to a page and mucking about with its innerHTML... but that then opens the possibility of XSS attacks).

If there's a better way to do this, it would be good to know.

Tested on staging as I couldn't get the javascript tests to run locally even with a clean checkout of master:

```
=> finder-frontend component guide available at: /component-guide
Running `"phantomjs"  "/usr/lib/rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/jasmine-rails-0.14.8/lib/jasmine_rails/../assets/javascripts/jasmine-runner.js" "file:///var/govuk/finder-frontend/tmp/jasmine/runner.html?root=/var/govuk/finder-frontend&spec="`
Running: file:///var/govuk/finder-frontend/tmp/jasmine/runner.html?root=/var/govuk/finder-frontend&spec=
Starting...
GOVUK.OptionSelect initialising when the parent is hidden and data-closed-on-load is true sets the height of the container sensibly when the option select is opened
  Expected 512 to be less than 500.
    Error: Expected 512 to be less than 500.
(a big stack trace goes here)
```

---

[Trello card](https://trello.com/c/lUl9kTAQ/676-bug-search-input-text-with-surrounding-quotes-cannot-be-removed-using-a-facet-tag)