### PR TITLE
Remove unnecessary focus state from checkbox wrapper

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -69,6 +69,7 @@
 }
 
 .app-c-option-select__filter {
+  position: relative;
   background: govuk-colour('white');
   border-left: govuk-spacing(1) solid govuk-colour("grey-3");
   border-right: govuk-spacing(1) solid govuk-colour("grey-3");

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -58,6 +58,10 @@
   overflow-x: hidden;
   border: govuk-spacing(1) solid govuk-colour("grey-3");
   background-color: govuk-colour("white");
+
+  &:focus {
+    outline: 0;
+  }
 }
 
 .app-c-option-select__container-inner {


### PR DESCRIPTION
Fixes this minor focus state problem on the option select:

![Screen Shot 2019-04-29 at 12 16 45](https://user-images.githubusercontent.com/861310/56892833-b6fa7d80-6a78-11e9-89f7-7cf540ea4580.png)

Also fixes a bug where clicking to expand the option select, then clicking on the filter element would cause it to collapse again (good spot @injms!).

Demo URLs:

- https://finder-frontend-pr-1072.herokuapp.com/search/all?parent=&keywords=&level_one_taxon=&manual=&organisations%5B%5D=academy-for-social-justice&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=most-viewed
- https://finder-frontend-pr-1072.herokuapp.com/component-guide/option-select