### PR TITLE
Open first facet box by default - Business Finder

### DIFF
--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -42,10 +42,6 @@ class OptionSelectFacet < FilterableFacet
     selected_values.any?
   end
 
-  def close_facet?
-    unselected? && allowed_values.count > 10
-  end
-
   def unselected?
     selected_values.empty?
   end

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -1,12 +1,11 @@
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
-  <% close_facet = option_select_facet.unselected? && ((option_select_facet_counter > 0) || option_select_facet.close_facet?) %>
   <%= render partial: 'components/option-select', locals: {
     :key => option_select_facet.key,
     :title => option_select_facet.name,
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => close_facet,
+    :closed_on_load => option_select_facet_counter > 0 && option_select_facet.unselected?,
     :show_filter => option_select_facet.show_option_select_filter
   }
   %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -220,7 +220,7 @@ Feature: Filtering documents
   Scenario: Adding keyword filter to facet search in business finder
     When I view the business readiness finder
     Then I see topic order selected
-    And I click button "Sector / Business Area" and select facet Aerospace
+    And I select facet Aerospace in the already expanded "Sector / Business Area" section
     Then I see results grouped by primary facet value
     And I see results with pinned items
     And I fill in some keywords
@@ -285,7 +285,7 @@ Feature: Filtering documents
   @javascript
   Scenario: Filter documents and group by facets
     When I view the business readiness finder
-    And I click button "Sector / Business Area" and select facet Aerospace
+    And I select facet Aerospace in the already expanded "Sector / Business Area" section
     Then I see results grouped by primary facet value
 
   Scenario: Dynamic facets continue to show all options on page reload

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -634,6 +634,10 @@ And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
   find('label', text: facet).click
 end
 
+And(/^I select facet (.*) in the already expanded \"([^\"]*)\" section$/) do |facet, _button|
+  find('label', text: facet).click
+end
+
 When(/^I click the (.*) remove control$/) do |filter|
   expect(page).to have_css(".js-enabled")
 

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -59,34 +59,6 @@ describe OptionSelectFacet do
     end
   end
 
-  describe "#close_facet?" do
-    subject { OptionSelectFacet.new(facet_data, []) }
-
-    context "small number of options" do
-      specify { expect(subject.close_facet?).to be false }
-    end
-
-    context "large number of options" do
-      let(:allowed_values) {
-        11.times.map { |i| { 'label' => "Label #{i}", 'value' => "allowed-value-#{i}" } }
-      }
-
-      let(:large_facet_data) {
-        {
-          'type' => "multi-select",
-          'name' => "Test values",
-          'key' => "test_values",
-          'preposition' => "of value",
-          'allowed_values' => allowed_values,
-        }
-      }
-
-      subject { OptionSelectFacet.new(large_facet_data, {}) }
-
-      specify { expect(subject.close_facet?).to be true }
-    end
-  end
-
   describe "#query_params" do
     context "value selected" do
       subject { OptionSelectFacet.new(facet_data, "allowed-value-1") }


### PR DESCRIPTION
Trello: https://trello.com/c/5ZwqcRWh 
Heroku URL: https://finder-frontend-pr-1073.herokuapp.com/find-eu-exit-guidance-business

## What
- the first facet box on the business finder now opens by default, regardless of what is selected
- removes old "force facet closed if > 10 options" logic
- removes redundant `close_facet?` method

## Why
- the "10 option limit" was added in fa89296d41554268cc412e1df7611d7a79c9625c to fix a usability issue on mobile. The designs have since changed to toggle _all_ facets on mobile, so this should no longer be an issue.
- `close_facet?` cannot contain all of the information required to decide whether or not a facet should be closed, as the OptionSelectFacet model doesn't know whether it is the first facet in the page or not. It's _more_ confusing trying to delegate this decision to the model when in fact it also depends on external factors. This is a front-end problem and is best handled with a tiny bit of front-end logic.

## Screenshots

Here's the screenshots demonstrating the issue that the "10 option limit" resolved:

| Landing view | Scrolling below the fold |
|--------------|-------------------------|
|![Image-1](https://user-images.githubusercontent.com/5111927/57011946-fd2c1a00-6bfb-11e9-8fab-382625e1c39e.png)|![Image-2](https://user-images.githubusercontent.com/5111927/57011950-01f0ce00-6bfc-11e9-9521-8c0fe49feb8c.png)|

And here is the most recent design, demonstrating that the 10 option limit is no longer required (expanded facet has a max height, making it easy to scroll past):

| Landing view (options behind toggle) | Options expanded |
|--------------|-------------------------|
|![Screen Shot 2019-05-01 at 10 30 45](https://user-images.githubusercontent.com/5111927/57012066-86435100-6bfc-11e9-9958-3eaf6cdc0b80.png)|![Screen Shot 2019-05-01 at 10 30 55](https://user-images.githubusercontent.com/5111927/57012020-4c724a80-6bfc-11e9-8ff3-eaa42f4df52f.png)|
