### PR TITLE
Fix short name lookup for content id facets

### DIFF
--- a/app/lib/facets_from_facet_group_extractor.rb
+++ b/app/lib/facets_from_facet_group_extractor.rb
@@ -15,6 +15,7 @@ private
     facet_details = facet['details']
     {
       'name' => facet_details['name'],
+      'short_name' => facet_details['short_name'],
       'key' => facet_details['key'],
       'display_as_result_metadata' => facet_details['display_as_result_metadata'],
       'filterable' => facet_details['filterable'],

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -93,7 +93,7 @@ class FinderPresenter
   def facet_details_lookup
     @facet_details_lookup ||= begin
       result_hashes = @facet_hashes.map do |facet|
-        facet_name = facet['name']
+        facet_name = facet.fetch('short_name', facet['name'])
         facet_key = facet['key']
         facet.fetch('allowed_values', []).to_h do |value|
           [value['content_id'], {

--- a/spec/lib/facet_extractor_spec.rb
+++ b/spec/lib/facet_extractor_spec.rb
@@ -86,6 +86,7 @@ describe FacetExtractor do
                 {
                   details: {
                     name: 'Who you employ',
+                    short_name: 'Employing EU citizens',
                     key: 'employ_eu_citizens',
                     filter_key: 'any_facet_values',
                     filterable: true,
@@ -129,6 +130,7 @@ describe FacetExtractor do
         },
         {
           name: 'Who you employ',
+          short_name: 'Employing EU citizens',
           key: 'employ_eu_citizens',
           filterable: true,
           filter_key: 'any_facet_values',

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -382,6 +382,27 @@ RSpec.describe FinderPresenter do
         presenter = described_class.new(content_item(facets: facets), [])
         expect(presenter.facet_details_lookup).to eq(expected)
       end
+
+      context 'when a facet contains a short_name attribute' do
+        let(:more_facets) do
+          facets <<
+            {
+              'key' => 'employ_eu_citizens',
+              'name' => 'Who you employ',
+              'short_name' => 'Employing EU citizens',
+              'allowed_values' => [
+                { 'label' => 'EU citizens', 'value' => 'yes', 'content_id' => '5476f0c7-d029-459b-8a17-196374ae3366' }
+              ]
+            }
+        end
+
+        it 'overrides the facet name in the details lookup' do
+          presenter = described_class.new(content_item(facets: more_facets), [])
+          expect(presenter.facet_details_lookup["5476f0c7-d029-459b-8a17-196374ae3366"]).to eq(
+            id: "employ_eu_citizens", key: "employ_eu_citizens", name: "Employing EU citizens", type: "content_id"
+          )
+        end
+      end
     end
 
     describe '#facet_value_lookup' do


### PR DESCRIPTION
https://trello.com/c/krOLVujz/68-update-title-for-employing-eu-citizens-when-ordered-by-topic

Facet display names can be overridden by the optional `short_name` attribute value.
eg. The EU Exit business readiness finder facet _Who you employ_ should display the short name _Employing EU citizens_ when displaying grouped results.

![Screenshot from 2019-04-29 15-58-07](https://user-images.githubusercontent.com/93511/56905172-a9082500-6a97-11e9-9233-ff315679f325.png)


[Heroku preview](https://finder-frontend-pr-1074.herokuapp.com/find-eu-exit-guidance-business?parent=&keywords=&employ_eu_citizens%5B%5D=yes&order=topic)

See https://github.com/alphagov/content-tagger/pull/906

This should be supported when the facet type is 'content_id', this
commit adds similar support as the `label_for_metadata_key` method but with reduced complexity.