### PR TITLE
Remove keywords by find/replace, not by exploding into words.

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -39,17 +39,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $input.trigger(onChangeSuppressAnalytics);
       }
       else if (inputType == 'text' || inputType == 'search') {
-        var needle = decodeEntities(removeFilterValue.toString());
-        var splitKeywords = currentVal.split(" ");
-
-        for (var i = 0; i < splitKeywords.length; i++) {
-          if (splitKeywords[i].toString() === needle) {
-            splitKeywords.splice(i, 1);
-            break;
-          }
-        }
-
-        var newVal = splitKeywords.join(" ").trim();
+        var haystack = ' ' + currentVal.trim() + ' ';
+        var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' ';
+        var newVal = haystack.replace(needle, ' ').replace(/  /g, ' ').trim();
 
         $input.val(newVal).trigger(onChangeSuppressAnalytics);
       }

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -39,6 +39,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $input.trigger(onChangeSuppressAnalytics);
       }
       else if (inputType == 'text' || inputType == 'search') {
+        /* By padding the haystack with spaces, we can remove the
+         * first instance of " $needle ", and this will catch it in
+         * the middle of the haystack, at the ends, and when the
+         * needle is the haystack; without needing to consider these
+         * boundary conditions explicitly.
+         *
+         * The only caveat is that the matched needle needs replacing
+         * with " ", to avoid merging adjacent keywords when it was in
+         * the middle of the string, eg:
+         *
+         * needle = "beta"
+         * haystack = "alpha beta gamma"
+         *
+         * Just removing " beta " from the haystack would result in
+         * "alphagamma", which is wrong.
+         */
         var haystack = ' ' + currentVal.trim() + ' ';
         var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' ';
         var newVal = haystack.replace(needle, ' ').replace(/  /g, ' ').trim();

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -30,6 +30,12 @@ describe('remove-filter', function () {
     '</div>'
   );
 
+  var $quotedTextQuerySpaces = $(
+    '<div data-module="remove-filter">' +
+      '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fee fi fo&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fee fi fo&quot;" data-facet="keywords" data-value="&amp;quot;fee fi fo&amp;quot;" data-name="keywords">✕</button>' +
+    '</div>'
+  );
+
   var $dropdown = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>' +
@@ -141,6 +147,20 @@ describe('remove-filter', function () {
     }, timeout);
   });
 
+  it('removes text queries with multiple words inside quotes from the text search field', function (done) {
+    var searchField = $('input[name=keywords]')[0];
+    searchField.value = '"fee fi fo" fum';
+    removeFilter.start($quotedTextQuerySpaces);
+
+    expect(searchField.value).toContain('"fee fi fo"');
+
+    triggerRemoveFilterClick($quotedTextQuerySpaces);
+
+    setTimeout(function() {
+      expect(searchField.value).toEqual("fum");
+      done();
+    }, timeout);
+  });
 
   it('sets default state for dropdown', function (done) {
     var dropdown = $('select[name=level_one_taxon]')[0];


### PR DESCRIPTION
Splitting the query on spaces falls down if we're trying to remove a quoted search phrase which contains spaces.  Rather than make the splitting logic quote-aware, I removed it.

`string.replace(old, new)` only replaces the first occurrence, which is what the previous loop did.

Padding everything with spaces is to avoid needing to check for the boundaries of the string.

---

[Trello card](https://trello.com/c/lUl9kTAQ/676-bug-search-input-text-with-surrounding-quotes-cannot-be-removed-using-a-facet-tag)