### PR TITLE
Refactor option-select-spec.js

### DIFF
--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -10,7 +10,7 @@ describe('GOVUK.OptionSelect', function() {
   }
 
   beforeEach(function(){
-    optionSelectFixture = '<div class="app-c-option-select">'+
+    $optionSelectHTML = $('<div class="app-c-option-select">'+
       '<div class="app-c-option-select__title js-container-head">'+
         'Market sector'+
       '</div>'+
@@ -72,9 +72,8 @@ describe('GOVUK.OptionSelect', function() {
             '</fieldset>'+
           '</div>'+
         '</div>'+
-      '</div>';
-
-    $optionSelectHTML = $(optionSelectFixture);
+      '</div>'
+    );
     $('body').append($optionSelectHTML);
     optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
   });
@@ -84,8 +83,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates a closed option-select if data-closed-on-load is true', function(){
-    closedOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=true');
-    $closedOnLoadFixture = $(closedOnLoadFixture);
+    $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
@@ -94,8 +92,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is false', function(){
-    openOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=false');
-    $openOnLoadFixture = $(openOnLoadFixture);
+    $openOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=false'));
 
     $('body').append($openOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
@@ -104,8 +101,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is not present', function(){
-    openOnLoadFixture = optionSelectWithAttrs('');
-    $openOnLoadFixture = $(openOnLoadFixture);
+    $openOnLoadFixture = $(optionSelectWithAttrs(''));
 
     $('body').append($openOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
@@ -118,8 +114,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it ('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function(){
-    closedOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=true');
-    $closedOnLoadFixture = $(closedOnLoadFixture);
+    $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -351,7 +351,6 @@ describe('GOVUK.OptionSelect', function() {
       $('body').find('.gem-c-checkboxes').prepend($(filterSpan));
       optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
 
-      jasmine.createSpy("timerCallback");
       jasmine.clock().install();
       $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $count = $('#checkboxes-9b7ecc25-count');

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -336,6 +336,8 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   describe('filtering checkboxes', function(){
+    var $count;
+
     beforeEach(function(){
       var filterMarkup =
             '&lt;label for=&quot;input-b7f768b7&quot; class=&quot;gem-c-label govuk-label&quot;&gt;'+
@@ -351,6 +353,7 @@ describe('GOVUK.OptionSelect', function() {
 
       jasmine.createSpy("timerCallback");
       jasmine.clock().install();
+      $count = $('#checkboxes-9b7ecc25-count');
     });
 
     afterEach(function() {
@@ -359,7 +362,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('filters the checkboxes and updates the filter count correctly', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       expect($('.govuk-checkboxes__input:visible').length).toBe(12);
 
       $filterInput.val('in').keyup();
@@ -389,7 +391,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('shows checked checkboxes regardless of whether they match the filter', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $('#building-and-construction').prop('checked', true).change();
       $('#chemicals').prop('checked', true).change();
       jasmine.clock().tick(100);
@@ -407,7 +408,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('matches a filter regardless of text case', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('electroNICS industry').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -421,7 +421,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('matches ampersands correctly', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('Distribution & Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -435,7 +434,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('ignores whitespace around the user input', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('   Clothing, footwear and fashion    ').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -444,7 +442,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('ignores duplicate whitespace in the user input', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('Clothing,     footwear      and      fashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -453,7 +450,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('ignores common punctuation characters', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -462,7 +458,6 @@ describe('GOVUK.OptionSelect', function() {
 
     it('normalises & and and', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -477,7 +472,6 @@ describe('GOVUK.OptionSelect', function() {
     // there was a bug in cleanString() where numbers were being ignored
     it('does not strip out numbers', function(){
       var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-      var $count = $('#checkboxes-9b7ecc25-count');
       $filterInput.val('1st and 2nd Military Courts').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -1,4 +1,4 @@
-describe('GOVUK.OptionSelect', function() {
+describe('GOVUK.OptionSelect', function () {
 
   var $optionSelectHTML, optionSelect;
 
@@ -9,7 +9,7 @@ describe('GOVUK.OptionSelect', function() {
     '</div>';
   }
 
-  beforeEach(function(){
+  beforeEach(function () {
     $optionSelectHTML = $('<div class="app-c-option-select">'+
       '<div class="app-c-option-select__title js-container-head">'+
         'Market sector'+
@@ -75,190 +75,188 @@ describe('GOVUK.OptionSelect', function() {
       '</div>'
     );
     $('body').append($optionSelectHTML);
-    optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
+    optionSelect = new GOVUK.OptionSelect({ $el: $optionSelectHTML });
   });
 
-  afterEach(function(){
+  afterEach(function () {
     $optionSelectHTML.remove();
   });
 
-  it('instantiates a closed option-select if data-closed-on-load is true', function(){
+  it('instantiates a closed option-select if data-closed-on-load is true', function () {
     var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
-    optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
+    optionSelect = new GOVUK.OptionSelect({ $el: $closedOnLoadFixture });
     expect(optionSelect.isClosed()).toBe(true);
     expect($closedOnLoadFixture.find('button').attr('aria-expanded')).toBe('false');
   });
 
-  it('instantiates an open option-select if data-closed-on-load is false', function(){
+  it('instantiates an open option-select if data-closed-on-load is false', function () {
     var $openOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=false'));
 
     $('body').append($openOnLoadFixture);
-    optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
+    optionSelect = new GOVUK.OptionSelect({ $el: $openOnLoadFixture });
     expect(optionSelect.isClosed()).toBe(false);
     expect($openOnLoadFixture.find('button').attr('aria-expanded')).toBe('true');
   });
 
-  it('instantiates an open option-select if data-closed-on-load is not present', function(){
+  it('instantiates an open option-select if data-closed-on-load is not present', function () {
     var $openOnLoadFixture = $(optionSelectWithAttrs(''));
 
     $('body').append($openOnLoadFixture);
-    optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
+    optionSelect = new GOVUK.OptionSelect({ $el: $openOnLoadFixture });
     expect(optionSelect.isClosed()).toBe(false);
     expect($openOnLoadFixture.find('button').attr('aria-expanded')).toBe('true');
   });
 
-  it ('sets the height of the options container as part of initialisation', function(){
+  it('sets the height of the options container as part of initialisation', function () {
     expect($optionSelectHTML.find('.js-options-container').attr('style')).toContain('height');
   });
 
-  it ('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function(){
+  it('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function () {
     var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
-    optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
+    optionSelect = new GOVUK.OptionSelect({ $el: $closedOnLoadFixture });
     expect($closedOnLoadFixture.find('.js-options-container').attr('style')).not.toContain('height');
   });
 
-  describe('replaceHeadWithButton', function(){
-    it ("replaces the `div.app-c-option-select__container-head` with a button", function(){
+  describe('replaceHeadWithButton', function () {
+    it('replaces the `div.app-c-option-select__container-head` with a button', function () {
       expect($optionSelectHTML.find('button')).toBeDefined();
     });
   });
 
-  describe('toggleOptionSelect', function(){
-    it("calls optionSelect.close() if the optionSelect is currently open", function(){
+  describe('toggleOptionSelect', function () {
+    it('calls optionSelect.close() if the optionSelect is currently open', function () {
       $optionSelectHTML.removeClass('js-closed');
-      spyOn(optionSelect, "close");
-      optionSelect.toggleOptionSelect(jQuery.Event("click"));
+      spyOn(optionSelect, 'close');
+      optionSelect.toggleOptionSelect(jQuery.Event('click'));
       expect(optionSelect.close.calls.count()).toBe(1);
     });
 
-    it("calls optionSelect.open() if the optionSelect is currently closed", function(){
+    it('calls optionSelect.open() if the optionSelect is currently closed', function () {
       $optionSelectHTML.addClass('js-closed');
-      spyOn(optionSelect, "open");
-      optionSelect.toggleOptionSelect(jQuery.Event("click"));
+      spyOn(optionSelect, 'open');
+      optionSelect.toggleOptionSelect(jQuery.Event('click'));
       expect(optionSelect.open.calls.count()).toBe(1);
     });
   });
 
-  describe('open', function(){
-    beforeEach(function(){
-      spyOn(optionSelect, "isClosed").and.returnValue(true);
+  describe('open', function () {
+    beforeEach(function () {
+      spyOn(optionSelect, 'isClosed').and.returnValue(true);
     });
 
-    it ('calls isClosed() and opens if isClosed is true', function(){
+    it('calls isClosed() and opens if isClosed is true', function () {
       optionSelect.open();
       expect(optionSelect.isClosed.calls.count()).toBe(1);
       expect($optionSelectHTML.hasClass('js-closed')).toBe(false);
     });
 
-    it('opens the option-select', function(){
+    it('opens the option-select', function () {
       optionSelect.open();
       expect($optionSelectHTML.hasClass('js-closed')).toBe(false);
     });
 
-    it ('calls setupHeight() if a height has not been set', function(){
+    it('calls setupHeight() if a height has not been set', function () {
       $optionSelectHTML.find('.js-options-container').attr('style', '');
-      spyOn(optionSelect, "setupHeight");
+      spyOn(optionSelect, 'setupHeight');
       optionSelect.open();
       expect(optionSelect.setupHeight.calls.count()).toBe(1);
     });
 
-    it ('doesn\'t call setupHeight() if a height has already been set', function(){
+    it('doesn\'t call setupHeight() if a height has already been set', function () {
       optionSelect.setContainerHeight(100);
-      spyOn(optionSelect, "setupHeight");
+      spyOn(optionSelect, 'setupHeight');
       optionSelect.open();
       expect(optionSelect.setupHeight.calls.count()).toBe(0);
     });
 
-    it ('updates aria-expanded to true', function(){
+    it('updates aria-expanded to true', function () {
       $optionSelectHTML.find('button').attr('aria-expanded', 'false');
       optionSelect.open();
       expect($optionSelectHTML.find('button').attr('aria-expanded')).toBe('true');
     });
-
   });
 
-  describe('close', function(){
-    it('closes the option-select', function(){
+  describe('close', function () {
+    it('closes the option-select', function () {
       optionSelect.open();
       expect(optionSelect.isClosed()).toBe(false);
       optionSelect.close();
       expect(optionSelect.isClosed()).toBe(true);
     });
 
-    it ('updates aria-expanded to false', function(){
+    it('updates aria-expanded to false', function () {
       $optionSelectHTML.find('button').attr('aria-expanded', 'true');
       optionSelect.close();
       expect($optionSelectHTML.find('button').attr('aria-expanded')).toBe('false');
     });
   });
 
-  describe('isClosed', function(){
-    it('returns true if the optionSelect has the class `.js-closed`', function(){
+  describe('isClosed', function () {
+    it('returns true if the optionSelect has the class `.js-closed`', function () {
       $optionSelectHTML.addClass('js-closed');
       expect(optionSelect.isClosed()).toBe(true);
     });
 
-    it('returns false if the optionSelect doesnt have the class `.js-closed`', function(){
+    it('returns false if the optionSelect doesnt have the class `.js-closed`', function () {
       $optionSelectHTML.removeClass('js-closed');
       expect(optionSelect.isClosed()).toBe(false);
     });
   });
 
-  describe ('setContainerHeight', function(){
-    it('can have its height set', function(){
+  describe ('setContainerHeight', function () {
+    it('can have its height set', function () {
       optionSelect.setContainerHeight(200);
       expect(optionSelect.$optionsContainer.height()).toBe(200);
     });
   });
 
-  describe ('isCheckboxVisible', function(){
+  describe ('isCheckboxVisible', function () {
     var firstCheckbox, lastCheckbox;
 
-    beforeEach(function(){
+    beforeEach(function () {
       optionSelect.setContainerHeight(100);
       optionSelect.$optionsContainer.width(100);
       firstCheckbox = optionSelect.$allCheckboxes[0];
       lastCheckbox = optionSelect.$allCheckboxes[optionSelect.$allCheckboxes.length -1];
     });
 
-    it('returns true if a label is visible', function(){
+    it('returns true if a label is visible', function () {
       expect(optionSelect.isCheckboxVisible.call(optionSelect, 0, firstCheckbox)).toBe(true);
     });
 
-    it('returns true if a label is outside its container', function(){
+    it('returns true if a label is outside its container', function () {
       expect(optionSelect.isCheckboxVisible.call(optionSelect, 0, lastCheckbox)).toBe(false);
     });
-
   });
 
-  describe ('getvisibleCheckboxes', function(){
-    var visibleCheckboxes, lastLabelForAttribute, lastVisibleLabelForAttribute;
+  describe ('getvisibleCheckboxes', function () {
+    var lastLabelForAttribute, lastVisibleLabelForAttribute;
 
-    it('returns all the checkboxes if the container doesn\'t overflow', function(){
+    it('returns all the checkboxes if the container doesn\'t overflow', function () {
       expect(optionSelect.$allCheckboxes.length).toBe(optionSelect.getVisibleCheckboxes().length);
     });
 
-    it('only returns some of the first checkboxes if the container\'s dimensions are constricted', function(){
+    it('only returns some of the first checkboxes if the container\'s dimensions are constricted', function () {
       optionSelect.setContainerHeight(100);
       optionSelect.$optionsContainer.width(100);
 
       var visibleCheckboxes = optionSelect.getVisibleCheckboxes();
       expect(visibleCheckboxes.length).toBeLessThan(optionSelect.$allCheckboxes.length);
 
-      lastLabelForAttribute = optionSelect.$allCheckboxes[optionSelect.$allCheckboxes.length - 1].getElementsByClassName('govuk-checkboxes__input')[0].getAttribute("id");
-      lastVisibleLabelForAttribute = visibleCheckboxes[visibleCheckboxes.length - 1].getAttribute("id");
+      lastLabelForAttribute = optionSelect.$allCheckboxes[optionSelect.$allCheckboxes.length - 1].getElementsByClassName('govuk-checkboxes__input')[0].getAttribute('id');
+      lastVisibleLabelForAttribute = visibleCheckboxes[visibleCheckboxes.length - 1].getAttribute('id');
       expect(lastLabelForAttribute).not.toBe(lastVisibleLabelForAttribute);
     });
   });
 
-  describe ('setupHeight', function(){
+  describe ('setupHeight', function () {
     var $checkboxList, $checkboxListInner;
 
-    beforeEach(function(){
+    beforeEach(function () {
       // Set some visual properties which are done in the CSS IRL
       $checkboxList = $optionSelectHTML.find('.js-options-container');
       $checkboxList.css({
@@ -273,7 +271,7 @@ describe('GOVUK.OptionSelect', function() {
       $checkboxListInner = $checkboxList.find(' > .js-auto-height-inner');
     });
 
-    it('expands the checkbox-container to fit checkbox list if the list is < 50px larger than the container', function(){
+    it('expands the checkbox-container to fit checkbox list if the list is < 50px larger than the container', function () {
       $checkboxListInner.height(201);
       optionSelect.setupHeight();
 
@@ -282,10 +280,10 @@ describe('GOVUK.OptionSelect', function() {
       expect($checkboxList.height()).toBe($checkboxListInner.height() + 1);
     });
 
-    it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
+    it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function () {
       $checkboxList.css({
-        "max-height": 200,
-        "width": 600
+        'max-height': 200,
+        'width': 600
       });
       optionSelect.setupHeight();
 
@@ -294,38 +292,38 @@ describe('GOVUK.OptionSelect', function() {
     });
   });
 
-  describe('initialising when the parent is hidden', function(){
-    beforeEach(function(){
+  describe('initialising when the parent is hidden', function () {
+    beforeEach(function () {
       $('body').find('.app-c-option-select').remove();
       var wrapper = $('<div/>').hide().html($optionSelectHTML);
       $('body').append(wrapper);
-      optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
+      optionSelect = new GOVUK.OptionSelect({ $el: $optionSelectHTML });
     });
 
-    afterEach(function(){
+    afterEach(function () {
       $('.wrapper').remove();
     });
 
-    it('sets the height of the container sensibly', function(){
+    it('sets the height of the container sensibly', function () {
       var containerHeight = $('.js-options-container').height();
       expect(containerHeight).toBe(201);
     });
   });
 
-  describe('initialising when the parent is hidden and data-closed-on-load is true', function(){
-    beforeEach(function(){
+  describe('initialising when the parent is hidden and data-closed-on-load is true', function () {
+    beforeEach(function () {
       $('body').find('.app-c-option-select').remove();
       $optionSelectHTML.attr('data-closed-on-load', true);
       var wrapper = $('<div/>').hide().html($optionSelectHTML);
       $('body').append(wrapper);
-      optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
+      optionSelect = new GOVUK.OptionSelect({ $el: $optionSelectHTML });
     });
 
-    afterEach(function(){
+    afterEach(function () {
       $('.wrapper').remove();
     });
 
-    it('sets the height of the container sensibly when the option select is opened', function(){
+    it('sets the height of the container sensibly when the option select is opened', function () {
       $('.wrapper').show();
       $optionSelectHTML.find('button').click();
 
@@ -335,10 +333,10 @@ describe('GOVUK.OptionSelect', function() {
     });
   });
 
-  describe('filtering checkboxes', function(){
+  describe('filtering checkboxes', function () {
     var $filterInput, $count;
 
-    beforeEach(function(){
+    beforeEach(function () {
       var filterMarkup =
             '&lt;label for=&quot;input-b7f768b7&quot; class=&quot;gem-c-label govuk-label&quot;&gt;'+
               'Filter Countries'+
@@ -349,18 +347,18 @@ describe('GOVUK.OptionSelect', function() {
 
       $('body').find('.app-c-option-select').attr('data-filter-element', filterMarkup);
       $('body').find('.gem-c-checkboxes').prepend($(filterSpan));
-      optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
+      optionSelect = new GOVUK.OptionSelect({ $el: $optionSelectHTML });
 
       jasmine.clock().install();
       $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $count = $('#checkboxes-9b7ecc25-count');
     });
 
-    afterEach(function() {
+    afterEach(function () {
       jasmine.clock().uninstall();
     });
 
-    it('filters the checkboxes and updates the filter count correctly', function(){
+    it('filters the checkboxes and updates the filter count correctly', function () {
       expect($('.govuk-checkboxes__input:visible').length).toBe(12);
 
       $filterInput.val('in').keyup();
@@ -379,14 +377,14 @@ describe('GOVUK.OptionSelect', function() {
       expect($count.html()).toBe('0 options found, 0 selected');
     });
 
-    it('does not propagate keypresses up', function(){
-      var e = jQuery.Event("keyup", { keyCode: 13 }); // enter
+    it('does not propagate keypresses up', function () {
+      var e = jQuery.Event('keyup', { keyCode: 13 }); // enter
       $filterInput.trigger(e);
 
       expect(e.isDefaultPrevented()).toBe(true);
     });
 
-    it('shows checked checkboxes regardless of whether they match the filter', function(){
+    it('shows checked checkboxes regardless of whether they match the filter', function () {
       $('#building-and-construction').prop('checked', true).change();
       $('#chemicals').prop('checked', true).change();
       jasmine.clock().tick(100);
@@ -402,7 +400,7 @@ describe('GOVUK.OptionSelect', function() {
       expect($count.html()).toBe('2 options found, 2 selected');
     });
 
-    it('matches a filter regardless of text case', function(){
+    it('matches a filter regardless of text case', function () {
       $filterInput.val('electroNICS industry').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -414,7 +412,7 @@ describe('GOVUK.OptionSelect', function() {
       expect($count.html()).toBe('1 option found, 0 selected');
     });
 
-    it('matches ampersands correctly', function(){
+    it('matches ampersands correctly', function () {
       $filterInput.val('Distribution & Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -426,28 +424,28 @@ describe('GOVUK.OptionSelect', function() {
       expect($count.html()).toBe('0 options found, 0 selected');
     });
 
-    it('ignores whitespace around the user input', function(){
+    it('ignores whitespace around the user input', function () {
       $filterInput.val('   Clothing, footwear and fashion    ').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found, 0 selected');
     });
 
-    it('ignores duplicate whitespace in the user input', function(){
+    it('ignores duplicate whitespace in the user input', function () {
       $filterInput.val('Clothing,     footwear      and      fashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found, 0 selected');
     });
 
-    it('ignores common punctuation characters', function(){
+    it('ignores common punctuation characters', function () {
       $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
       expect($count.html()).toBe('1 option found, 0 selected');
     });
 
-    it('normalises & and and', function(){
+    it('normalises & and and', function () {
       $filterInput.val('cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -460,7 +458,7 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     // there was a bug in cleanString() where numbers were being ignored
-    it('does not strip out numbers', function(){
+    it('does not strip out numbers', function () {
       $filterInput.val('1st and 2nd Military Courts').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -2,6 +2,13 @@ describe('GOVUK.OptionSelect', function() {
 
   var $optionSelectHTML, optionSelect;
 
+  function optionSelectWithAttrs(attrs) {
+    return '<div class="app-c-option-select" ' + attrs + '>' +
+      '<div class="app-c-option-select__container-head js-container-head"></div>' +
+      '<div class="app-c-option-select__container js-options-container"></div>'+
+    '</div>';
+  }
+
   beforeEach(function(){
     optionSelectFixture = '<div class="app-c-option-select">'+
       '<div class="app-c-option-select__title js-container-head">'+
@@ -77,10 +84,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates a closed option-select if data-closed-on-load is true', function(){
-    closedOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=true>' +
-                            '<div class="app-c-option-select__container-head js-container-head"></div>' +
-                            '<div class="app-c-option-select__container js-options-container"></div>'+
-                          '</div>';
+    closedOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=true');
     $closedOnLoadFixture = $(closedOnLoadFixture);
 
     $('body').append($closedOnLoadFixture);
@@ -90,10 +94,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is false', function(){
-    openOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=false>' +
-                            '<div class="app-c-option-select__container-head js-container-head"></div>' +
-                            '<div class="app-c-option-select__container js-options-container"></div>'+
-                          '</div>';
+    openOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=false');
     $openOnLoadFixture = $(openOnLoadFixture);
 
     $('body').append($openOnLoadFixture);
@@ -103,10 +104,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is not present', function(){
-    openOnLoadFixture = '<div class="app-c-option-select">' +
-                          '<div class="app-c-option-select__container-head js-container-head"></div>' +
-                            '<div class="app-c-option-select__container js-options-container"></div>'+
-                        '</div>';
+    openOnLoadFixture = optionSelectWithAttrs('');
     $openOnLoadFixture = $(openOnLoadFixture);
 
     $('body').append($openOnLoadFixture);
@@ -120,9 +118,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it ('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function(){
-    closedOnLoadFixture = '<div class="app-c-option-select" data-closed-on-load=true>' +
-                            '<div class="app-c-option-select__container js-options-container"></div>' +
-                          '</div>';
+    closedOnLoadFixture = optionSelectWithAttrs('data-closed-on-load=true');
     $closedOnLoadFixture = $(closedOnLoadFixture);
 
     $('body').append($closedOnLoadFixture);

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -336,7 +336,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   describe('filtering checkboxes', function(){
-    var $count;
+    var $filterInput, $count;
 
     beforeEach(function(){
       var filterMarkup =
@@ -353,6 +353,7 @@ describe('GOVUK.OptionSelect', function() {
 
       jasmine.createSpy("timerCallback");
       jasmine.clock().install();
+      $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $count = $('#checkboxes-9b7ecc25-count');
     });
 
@@ -361,7 +362,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('filters the checkboxes and updates the filter count correctly', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       expect($('.govuk-checkboxes__input:visible').length).toBe(12);
 
       $filterInput.val('in').keyup();
@@ -381,8 +381,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('does not propagate keypresses up', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
-
       var e = jQuery.Event("keyup", { keyCode: 13 }); // enter
       $filterInput.trigger(e);
 
@@ -390,7 +388,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('shows checked checkboxes regardless of whether they match the filter', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $('#building-and-construction').prop('checked', true).change();
       $('#chemicals').prop('checked', true).change();
       jasmine.clock().tick(100);
@@ -407,7 +404,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('matches a filter regardless of text case', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('electroNICS industry').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -420,7 +416,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('matches ampersands correctly', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('Distribution & Service Industries').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -433,7 +428,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('ignores whitespace around the user input', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('   Clothing, footwear and fashion    ').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -441,7 +435,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('ignores duplicate whitespace in the user input', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('Clothing,     footwear      and      fashion').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -449,7 +442,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('ignores common punctuation characters', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('closed organisation department for Fisheries War Widows pay Farmers rights sheep and goats Farmers rights cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -457,7 +449,6 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('normalises & and and', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('cows & llamas').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);
@@ -471,7 +462,6 @@ describe('GOVUK.OptionSelect', function() {
 
     // there was a bug in cleanString() where numbers were being ignored
     it('does not strip out numbers', function(){
-      var $filterInput = $optionSelectHTML.find('[name="option-select-filter"]');
       $filterInput.val('1st and 2nd Military Courts').keyup();
       jasmine.clock().tick(400);
       expect($('.govuk-checkboxes__input:visible').length).toBe(1);

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -83,7 +83,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates a closed option-select if data-closed-on-load is true', function(){
-    $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
+    var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
@@ -92,7 +92,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is false', function(){
-    $openOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=false'));
+    var $openOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=false'));
 
     $('body').append($openOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
@@ -101,7 +101,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it('instantiates an open option-select if data-closed-on-load is not present', function(){
-    $openOnLoadFixture = $(optionSelectWithAttrs(''));
+    var $openOnLoadFixture = $(optionSelectWithAttrs(''));
 
     $('body').append($openOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
@@ -114,7 +114,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   it ('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function(){
-    $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
+    var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'));
 
     $('body').append($closedOnLoadFixture);
     optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
@@ -246,7 +246,7 @@ describe('GOVUK.OptionSelect', function() {
       optionSelect.setContainerHeight(100);
       optionSelect.$optionsContainer.width(100);
 
-      visibleCheckboxes = optionSelect.getVisibleCheckboxes();
+      var visibleCheckboxes = optionSelect.getVisibleCheckboxes();
       expect(visibleCheckboxes.length).toBeLessThan(optionSelect.$allCheckboxes.length);
 
       lastLabelForAttribute = optionSelect.$allCheckboxes[optionSelect.$allCheckboxes.length - 1].getElementsByClassName('govuk-checkboxes__input')[0].getAttribute("id");
@@ -256,7 +256,7 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   describe ('setupHeight', function(){
-    var checkboxContainerHeight, stretchMargin;
+    var $checkboxList, $checkboxListInner;
 
     beforeEach(function(){
       // Set some visual properties which are done in the CSS IRL
@@ -266,13 +266,11 @@ describe('GOVUK.OptionSelect', function() {
         'position': 'relative',
         'overflow': 'scroll'
       });
-      $listItems = $checkboxList.find('label');
-      $listItems.css({
+      $checkboxList.find('label').css({
         'display': 'block'
       });
 
       $checkboxListInner = $checkboxList.find(' > .js-auto-height-inner');
-      listItem = "<input type='checkbox' name='ca98'id='ca89'><label for='ca89'>CA89</label>";
     });
 
     it('expands the checkbox-container to fit checkbox list if the list is < 50px larger than the container', function(){
@@ -351,7 +349,7 @@ describe('GOVUK.OptionSelect', function() {
       $('body').find('.gem-c-checkboxes').prepend($(filterSpan));
       optionSelect = new GOVUK.OptionSelect({$el:$optionSelectHTML});
 
-      var timerCallback = jasmine.createSpy("timerCallback");
+      jasmine.createSpy("timerCallback");
       jasmine.clock().install();
     });
 


### PR DESCRIPTION
## What

- tidies up formatting across the file
- removes repetition through caching variables & hoisting, and through creation of a `optionSelectWithAttrs` function
- removes unused variables and `spyOn` declarations

## Why

Because I worked on this file in #1073 (before taking a different route) and spotted a number of ways we can tidy up the file so that it's easier to work with next time unit tests need to be added or changed.