### PR TITLE
Option select code improvements

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -18,10 +18,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
     this.$toggleButton.addEventListener('click', this.$module.toggleContent)
   }
 
-  Expander.prototype.collapseContent = function () {
-    this.$content.style.display = 'none'
-  }
-
   Expander.prototype.replaceTitleWithButton = function (expanded) {
     var toggleHtml = this.$toggle.innerHTML
     var $button = document.createElement('button')

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -6,7 +6,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   /* This JavaScript provides two functional enhancements to option-select components:
     1) A count that shows how many results have been checked in the option-container
-    2) Open/closing of the list of checkboxes - this is not provided for ie6 and 7 as the performance is too janky.
+    2) Open/closing of the list of checkboxes
   */
   OptionSelect.prototype.start = function ($module) {
     this.$optionSelect = $module;
@@ -55,29 +55,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       });
     }
 
-    // Performance in ie 6/7 is not good enough to support animating the opening/closing
-    // so do not allow option-selects to be collapsible in this case
-    var allowCollapsible = (typeof ieVersion == "undefined" || ieVersion > 7) ? true : false;
-    if(allowCollapsible){
+    // Attach listener to update checked count
+    this.$optionSelect.on('change', "input[type='checkbox']", this.updateCheckedCount.bind(this));
 
-      // Attach listener to update checked count
-      this.$optionSelect.on('change', "input[type='checkbox']", this.updateCheckedCount.bind(this));
+    // Replace div.container-head with a button
+    this.replaceHeadWithButton();
 
-      // Replace div.container-head with a button
-      this.replaceHeadWithButton();
+    // Add js-collapsible class to parent for CSS
+    this.$optionSelect.addClass('js-collapsible');
 
-      // Add js-collapsible class to parent for CSS
-      this.$optionSelect.addClass('js-collapsible');
+    // Add open/close listeners
+    this.$optionSelect.find('.js-container-head').on('click', this.toggleOptionSelect.bind(this));
 
-      // Add open/close listeners
-      this.$optionSelect.find('.js-container-head').on('click', this.toggleOptionSelect.bind(this));
-
-      if (this.$optionSelect.data('closed-on-load') === true) {
-        this.close();
-      }
-      else {
-        this.setupHeight();
-      }
+    if (this.$optionSelect.data('closed-on-load') === true) {
+      this.close();
+    }
+    else {
+      this.setupHeight();
     }
 
     var checkedString = this.checkedString();

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -21,6 +21,18 @@
     }
   }
 
+  &.js-closed {
+    .app-c-option-select__filter,
+    .app-c-option-select__container,
+    .app-c-option-select__icon--up {
+      display: none;
+    }
+
+    .app-c-option-select__icon--down {
+      display: block;
+    }
+  }
+
   .gem-c-checkboxes {
     margin: 0;
   }
@@ -33,12 +45,47 @@
 }
 
 .app-c-option-select__button {
+  z-index: 100;
   padding-right: 40px;
   width: 100%;
   background: none;
   border: 0;
   text-align: left;
   cursor: pointer;
+
+  &:hover,
+  &:hover + .app-c-option-select__selected-counter {
+    background-color: govuk-colour("grey-2");
+  }
+
+  &:hover ~ .app-c-option-select__container,
+  &:hover ~ .app-c-option-select__selected-counter,
+  &:hover ~ .app-c-option-select__filter {
+    border-color: govuk-colour("grey-2");
+  }
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
+  &:focus {
+    outline: none;
+
+    &:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      outline: solid 3px govuk-colour('yellow');
+    }
+  }
+
+  &[disabled] {
+    background-image: none;
+    color: inherit;
+  }
 }
 
 .app-c-option-select__icon {
@@ -101,68 +148,9 @@
   }
 }
 
-// styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse
-.js-collapsible {
-  .app-c-option-select__button {
-    z-index: 100;
-
-    &:hover,
-    &:hover + .app-c-option-select__selected-counter {
-      background-color: govuk-colour("grey-2");
-    }
-
-    &:hover ~ .app-c-option-select__container,
-    &:hover ~ .app-c-option-select__selected-counter,
-    &:hover ~ .app-c-option-select__filter {
-      border-color: govuk-colour("grey-2");
-    }
-
-    &::-moz-focus-inner {
-      border: 0;
-    }
-
-    &:focus {
-      outline: none;
-
-      &:after {
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        outline: solid 3px govuk-colour('yellow');
-      }
-    }
-
-    &[disabled] {
-      background-image: none;
-      color: inherit;
-    }
-  }
-
-  .app-c-option-select__selected-counter {
-    margin-top: -3px;
-    padding: 0 8px 3px 18px;
-  }
-
-  &.js-closed {
-    .app-c-option-select__filter {
-      display: none;
-    }
-
-    .app-c-option-select__container {
-      display: none;
-    }
-
-    .app-c-option-select__icon--up {
-      display: none;
-    }
-
-    .app-c-option-select__icon--down {
-      display: block;
-    }
-  }
+.app-c-option-select__selected-counter {
+  margin-top: -3px;
+  padding: 0 8px 3px 18px;
 }
 
 .app-c-option-select--expander {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -187,7 +187,8 @@
   }
 
   .app-c-option-select__selected-counter {
-    padding-top: 3px;
+    margin: 0;
+    padding-top: govuk-spacing(1);
     padding-left: 0;
     padding-right: 0;
   }
@@ -198,7 +199,7 @@
 
   .app-c-option-select__filter {
     padding: 0;
-    padding-top: 3px;
+    padding-top: govuk-spacing(1);
     padding-bottom: govuk-spacing(2);
     border: 0;
   }


### PR DESCRIPTION
This PR:

- removes the IE6/7 specific code on the option select
- fixes a minor styling issue (see below)
- BONUS: removes an unused function from the expander component

Before:

![Screen Shot 2019-05-01 at 12 00 01](https://user-images.githubusercontent.com/861310/57014807-9b72ac80-6c09-11e9-8f29-483f2438db5b.png)

After:

![Screen Shot 2019-05-01 at 12 02 14](https://user-images.githubusercontent.com/861310/57014819-a4637e00-6c09-11e9-8575-3d2de66790d6.png)

Trello card: https://trello.com/c/N16toILy/572-fix-minor-option-select-issues