### PR TITLE
Restore hiding of appear_in_find_eu_exit_guidance_buisness_finder checkbox

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -113,6 +113,6 @@ private
   end
 
   def ignore_facet?(facet_id)
-    %W(facet_groups).include?(facet_id)
+    %W(appear_in_find_eu_exit_guidance_business_finder facet_groups).include?(facet_id)
   end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -705,6 +705,7 @@ Then("I see the email subscription page") do
 end
 
 Then("I cannot select any filters") do
+  find("input[name='filter[appear_in_find_eu_exit_guidance_business_finder][]']", visible: false)
   find("input[name='filter[facet_groups][]']", visible: false)
 end
 


### PR DESCRIPTION
The `appear_in_find_eu_exit_guidance_buisness_finder` field was previously a hidden field in the email alert signup form.  The hiding was inadvertently removed in 9ee0aa6d5.  This restores the hiding of the field and restores the related test.

Behaviour now (not hiding the field):
<img width="611" alt="Screen Shot 2019-05-01 at 13 42 30" src="https://user-images.githubusercontent.com/6329861/57017413-04145600-6c17-11e9-8128-f6bcf7835c70.png">

Expected behaviour (with hiding of field):
<img width="619" alt="Screen Shot 2019-05-01 at 13 44 01" src="https://user-images.githubusercontent.com/6329861/57017428-1bebda00-6c17-11e9-842d-4a6cf9892014.png">

Trello card: https://trello.com/c/hKKTZdoj/48-update-the-email-signup-link-in-the-finder