### PR TITLE
Changes search input on all content finder

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -408,3 +408,8 @@
     }
   }
 }
+
+// NOTE: Reset from element level styles inherited from the deprecated `govuk-template`.
+.app-patch--search-input-override input[type="search"] {
+  box-sizing: border-box;
+}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -43,13 +43,12 @@
           <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
         <% end %>
         <div id="keywords" class="app-patch--search-input-override">
-          <%= render "govuk_publishing_components/components/label", {
-            html_for: "finder-keyword-search",
-            text: label_text,
-          } %>
           <%= render "govuk_publishing_components/components/input", {
             controls: "js-search-results-info",
             id: "finder-keyword-search",
+            label: {
+              text: label_text,
+            },
             name: "keywords",
             search_icon: true,
             type: 'search',

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -42,15 +42,18 @@
         <% label_text = capture do %>
           <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
         <% end %>
-        <div id="keywords">
-          <%= render "govuk_publishing_components/components/search", {
-              inline_label: false,
-              label_text: label_text,
-              name: "keywords",
-              hide_search_button: true,
-              value: @results.user_supplied_keywords,
-              id: "finder-keyword-search",
-              controls: "js-search-results-info"
+        <div id="keywords" class="app-patch--search-input-override">
+          <%= render "govuk_publishing_components/components/label", {
+            html_for: "finder-keyword-search",
+            text: label_text,
+          } %>
+          <%= render "govuk_publishing_components/components/input", {
+            controls: "js-search-results-info",
+            id: "finder-keyword-search",
+            name: "keywords",
+            search_icon: true,
+            type: 'search',
+            value: @results.user_supplied_keywords,
           } %>
         </div>
       <% else %>


### PR DESCRIPTION
The current large search bar on the all content finder looks slightly out of place - it doesn't fit with the other input styles on the page:

<img src="https://user-images.githubusercontent.com/1732331/57026650-32535f00-6c32-11e9-81b5-1a389c1af084.png" alt="" width="75%">

This pull request changes the search component for a label component and a form input component with a search icon :

<img src="https://user-images.githubusercontent.com/1732331/57026729-557e0e80-6c32-11e9-8de3-15e72a4316cb.png" alt="" width="75%">

There is a nasty overwrite: any `input[type="search"]` inherits a style set in from (the deprecated, but still used) `govuk-template`. For the time being an obvious and specific override with comments is probably the best way of handling this until `govuk-template` is removed.