### PR TITLE
Add icon to sidebar search input

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -5,13 +5,14 @@
         Search <span class="govuk-visually-hidden"><%= finder.name %></span>
       <% end %>
       <%= render "govuk_publishing_components/components/input", {
+        controls: "js-search-results-info",
+        id: "finder-keyword-search",
         label: {
           text: label_text
         },
         name: "keywords",
+        search_icon: true,
         value: @results.user_supplied_keywords,
-        id: "finder-keyword-search",
-        controls: "js-search-results-info"
       }  %>
     </div>
   <% end %>


### PR DESCRIPTION
Search input now has a magnifying glass icon in it. Uses the change in [`govuk_publishing_components` PR 824](https://github.com/alphagov/govuk_publishing_components/pull/824).

Trello card: https://trello.com/c/Lz7q6QyA/684-add-search-icon-to-keyword-search

Before:
![image](https://user-images.githubusercontent.com/1732331/57028135-33868b00-6c36-11e9-9da3-82a695b3b1c4.png)

After:

![image](https://user-images.githubusercontent.com/1732331/57028082-0cc85480-6c36-11e9-9a22-56705c4b866b.png)