### PR TITLE
Dont render sorter on finders without sort options

### DIFF
--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -10,6 +10,8 @@ class SortPresenter
   end
 
   def to_hash
+    return nil unless has_options?
+
     {
       options: options_as_hashes,
       default_value: default_value,

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe SortPresenter do
       end
     end
 
-    it "returns an empty array when sort is not present" do
-      expect(presenter_without_sort.to_hash[:options]).to eql([])
+    it "returns nil when the finder doesn't have sort options" do
+      expect(presenter_without_sort.to_hash).to eql(nil)
     end
 
     context "an unacceptable order is provided" do


### PR DESCRIPTION
This is a bugfix following 612ef74ee4847d9834d6eacd0cb24f6087967a3f.

The returned nil is required so that mustache doesn't render the sort options if there are no options. Once we move away from mustache we could handle this better.

Verify the fix:

1. View https://gov.uk/government/topical-events
2. See that sort options is an empty select box
3. Compare this to https://finder-frontend-pr-1102.herokuapp.com/government/topical-events

Trello: https://trello.com/c/LPzxbmqk/701