### PR TITLE
Pass `default_frequency` to email-alert-frontend

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -67,6 +67,7 @@ private
       facets: signup_presenter.choices,
       finder_format: finder_format,
       subscriber_list_title: subscriber_list_title,
+      default_frequency: signup_presenter.default_frequency,
     )
   end
 

--- a/app/helpers/eu_exit_finder_helper.rb
+++ b/app/helpers/eu_exit_finder_helper.rb
@@ -1,0 +1,9 @@
+module EuExitFinderHelper
+  def self.eu_exit_finder?(content_id)
+    content_id == "42ce66de-04f3-4192-bf31-8394538e0734"
+  end
+
+  def self.eu_exit_finder_email_signup?(content_id)
+    content_id == "2818d67a-029a-4899-a438-a543d5c6a20d"
+  end
+end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -218,7 +218,7 @@ class FinderPresenter
   # FIXME: This should be removed once we have a way to determine
   # whether to display metadata in the finder definition
   def eu_exit_finder?
-    self.content_item['content_id'] == "42ce66de-04f3-4192-bf31-8394538e0734"
+    EuExitFinderHelper.eu_exit_finder? self.content_item['content_id']
   end
 
 private

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -16,6 +16,12 @@ class SignupPresenter
     content_item['title']
   end
 
+  def default_frequency
+    # return 'nil' if NOT the business finder email signup page to avoid `default_frequency` appearing in other URLs
+    # as this may not be expected and could have some side-effects
+    EuExitFinderHelper.eu_exit_finder_email_signup?(@content_item['content_id']) ? 'daily' : nil
+  end
+
   def body
     content_item['description']
   end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,19 +1,31 @@
 class EmailAlertSignupAPI
-  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:)
+  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil)
     @applied_filters = applied_filters.deep_symbolize_keys
     @default_filters = default_filters.deep_symbolize_keys
     @facets = facets
     @subscriber_list_title = subscriber_list_title
     @finder_format = finder_format
+    @default_frequency = default_frequency
   end
 
   def signup_url
-    subscriber_list['subscription_url']
+    if @default_frequency
+      add_url_param(subscriber_list['subscription_url'], default_frequency: @default_frequency)
+    else
+      subscriber_list['subscription_url']
+    end
   end
 
 private
 
   attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format
+
+  def add_url_param(url, param)
+    # this method safely adds a URL parameter using the correct one of '?' or '&'
+    parsed_uri = Addressable::URI.parse(url)
+    parsed_uri.query_values = (parsed_uri.query_values || {}).merge(param)
+    parsed_uri.to_s
+  end
 
   def subscriber_list
     Services.email_alert_api.find_or_create_subscriber_list(subscriber_list_options).dig('subscriber_list')

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -23,21 +23,25 @@ describe EmailAlertSignupAPI do
   let(:finder_format) {}
   let(:default_frequency) { nil }
 
+  def init_simple_email_alert_api(subscription_url)
+    email_alert_api_has_subscriber_list(
+      "tags" => {},
+      "subscription_url" => subscription_url
+    )
+
+    expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+      "tags" => {},
+      "title" => subscriber_list_title,
+    ).and_call_original
+  end
+
   describe "default_attributes" do
     context "no default_attributes or attributes" do
       describe "#signup_url" do
         let(:subscription_url) { "http://gov.uk/email" }
 
         it "returns the url email-alert-api gives back" do
-          email_alert_api_has_subscriber_list(
-            "tags" => {},
-            "subscription_url" => subscription_url
-          )
-
-          expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-            "tags" => {},
-            "title" => subscriber_list_title,
-          ).and_call_original
+          init_simple_email_alert_api(subscription_url)
 
           expect(subject.signup_url).to eql subscription_url
         end
@@ -73,33 +77,13 @@ describe EmailAlertSignupAPI do
 
     it "returns the url email-alert-api gives back, and appends the default_frequency param" do
       subscription_url = "http://gov.uk/email/some-subscription"
-
-      email_alert_api_has_subscriber_list(
-        "tags" => {},
-        "subscription_url" => subscription_url
-      )
-
-      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-        "tags" => {},
-        "title" => subscriber_list_title,
-      ).and_call_original
-
+      init_simple_email_alert_api(subscription_url)
       expect(subject.signup_url).to eql "http://gov.uk/email/some-subscription?default_frequency=daily"
     end
 
     it "appends the default_frequency param with an ampersand if other URL parameters exist" do
       subscription_url = "http://gov.uk/email/some-subscription?foo=bar"
-
-      email_alert_api_has_subscriber_list(
-        "tags" => {},
-        "subscription_url" => subscription_url
-      )
-
-      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-        "tags" => {},
-        "title" => subscriber_list_title,
-      ).and_call_original
-
+      init_simple_email_alert_api(subscription_url)
       url_params = Rack::Utils.parse_query(URI.parse(subject.signup_url).query)
       expect(url_params).to eq("foo" => "bar", "default_frequency" => "daily")
     end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -12,6 +12,7 @@ describe EmailAlertSignupAPI do
       facets: facets,
       subscriber_list_title: subscriber_list_title,
       finder_format: finder_format,
+      default_frequency: default_frequency,
     )
   end
 
@@ -20,6 +21,7 @@ describe EmailAlertSignupAPI do
   let(:facets) { [] }
   let(:subscriber_list_title) { "Subscriber list title" }
   let(:finder_format) {}
+  let(:default_frequency) { nil }
 
   describe "default_attributes" do
     context "no default_attributes or attributes" do
@@ -63,6 +65,43 @@ describe EmailAlertSignupAPI do
           expect(subject.signup_url).to eql subscription_url
         end
       end
+    end
+  end
+
+  context "when a default_frequency is provided" do
+    let(:default_frequency) { "daily" }
+
+    it "returns the url email-alert-api gives back, and appends the default_frequency param" do
+      subscription_url = "http://gov.uk/email/some-subscription"
+
+      email_alert_api_has_subscriber_list(
+        "tags" => {},
+        "subscription_url" => subscription_url
+      )
+
+      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+        "tags" => {},
+        "title" => subscriber_list_title,
+      ).and_call_original
+
+      expect(subject.signup_url).to eql "http://gov.uk/email/some-subscription?default_frequency=daily"
+    end
+
+    it "appends the default_frequency param with an ampersand if other URL parameters exist" do
+      subscription_url = "http://gov.uk/email/some-subscription?foo=bar"
+
+      email_alert_api_has_subscriber_list(
+        "tags" => {},
+        "subscription_url" => subscription_url
+      )
+
+      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+        "tags" => {},
+        "title" => subscriber_list_title,
+      ).and_call_original
+
+      url_params = Rack::Utils.parse_query(URI.parse(subject.signup_url).query)
+      expect(url_params).to eq("foo" => "bar", "default_frequency" => "daily")
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/f7DWeg4q

Whilst there's nothing stopping us merging this, we may want to wait until we have a working E2E test: https://github.com/alphagov/publishing-e2e-tests/pull/319

## What & why

- Passes `default_frequency` parameter to email-alert-frontend (complementing https://github.com/alphagov/email-alert-frontend/pull/461) so that we can tell the email-alert-frontend to select a different frequency by default.
- Only does this for the Business Finder, through a [check in the signup_presenter.rb](https://github.com/alphagov/finder-frontend/pull/1104/commits/1ef9bbbf5e558d75e58422aa4f88ef8977682b74#diff-913d6f25b5b0d15e67e374c07c896ff4R21). All other finders should pass `nil`, which does not add a `default_frequency` parameter to the signup URL in the first place. Whilst we could explicitly set a default of `immediately` for all other finders, this would change the signup URL and could have unintended side-effects.
- I did have reservations about adding an additional parameter to `EmailAlertSignupAPI` when it's not actually used by the upstream API to determine which subscriber list is returned. However, this particular class is more of a 'wrapper' around the upstream API and is Finder-Frontend specific. Therefore it _does_ seem a fair place to encapsulate the decision around the passing of the `default_frequency` parameter. And it just so happens to be easier to test than putting it in the controller! 