### PR TITLE
Fix flaky jasmine test by defining $element

### DIFF
--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -299,8 +299,8 @@ describe('An option select component', function () {
     beforeEach(function () {
       $element = $(html)
       $element.attr('data-closed-on-load', true)
-      var wrapper = $('<div/>').addClass('wrapper').hide().html($element)
-      $('body').append(wrapper)
+      var $wrapper = $('<div/>').addClass('wrapper').hide().html($element)
+      $('body').append($wrapper)
       optionSelect.start($element)
     })
 


### PR DESCRIPTION
We were missing the '$element = $(html)' call here, which is applied to all of the other beforeEach callbacks. Consequently, the value of '$element' was subject to race conditions, leading to errors such as:

- `TypeError: undefined is not an object (evaluating '$element.attr')` (Happened locally)
- `An option select component initialising when the parent is hidden and data-closed-on-load is true sets the height of the container sensibly when the option select is opened. Expected 200 to be greater than 200`. (Happened locally)
- `Error: Expected 100 to be greater than 200`. (See https://ci.integration.publishing.service.gov.uk/job/finder-frontend/job/pass-default-frequency-rspec/15/console)

...and so on.