### PR TITLE
Only show a breadcrumb on the business finder

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -25,8 +25,8 @@
 
 <% if @breadcrumbs.breadcrumbs %>
   <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
-<% else %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item, prioritise_taxon_breadcrumbs: finder.eu_exit_finder?  %>
+<% elsif finder.eu_exit_finder? %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item %>
 <% end %>
 
 <% if finder.government? %>


### PR DESCRIPTION
# What
We added a change in PR #1094 to show the taxonomy breadcrumb on business finder, but the guard added to the wrong place, and now the taxonomy breadcrumb is showing on all finders.

## Before
<img width="1532" alt="Screen Shot 2019-05-09 at 10 27 32" src="https://user-images.githubusercontent.com/5793815/57443278-97680f80-7245-11e9-8f25-76baf041e5e9.png">

## After
<img width="1532" alt="Screen Shot 2019-05-09 at 10 37 59" src="https://user-images.githubusercontent.com/5793815/57445916-51ae4580-724b-11e9-8a0a-c1dfd6536904.png">


[Heroku preview](https://finder-frontend-pr-1110.herokuapp.com/cma-cases)