### PR TITLE
Metadata presenter

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -49,7 +49,9 @@ private
   end
 
   def results
-    @results ||= result_set_presenter_class.new(finder, filter_params, view_context, sort_presenter, show_top_result?)
+    @results ||= result_set_presenter_class.new(
+      finder, filter_params, view_context, sort_presenter, content_item.metadata_class, show_top_result?
+    )
   end
 
   def finder

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -26,6 +26,12 @@ class ContentItem
     SortPresenter
   end
 
+  def metadata_class
+    return StatisticsMetadataPresenter if is_research_and_statistics?
+    
+    MetadataPresenter
+  end
+
 private
 
   attr_reader :base_path

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -28,7 +28,7 @@ class ContentItem
 
   def metadata_class
     return StatisticsMetadataPresenter if is_research_and_statistics?
-    
+
     MetadataPresenter
   end
 

--- a/app/presenters/advanced_search_result_set_presenter.rb
+++ b/app/presenters/advanced_search_result_set_presenter.rb
@@ -9,8 +9,9 @@ class AdvancedSearchResultSetPresenter < ResultSetPresenter
 
   def documents
     results.each_with_index.map do |result, index|
+      metadata = metadata_presenter_class.new(result.metadata).present
       {
-        document: AdvancedSearchResultPresenter.new(result).to_hash,
+        document: AdvancedSearchResultPresenter.new(result, metadata).to_hash,
         document_index: index + 1,
       }
     end

--- a/app/presenters/metadata_presenter.rb
+++ b/app/presenters/metadata_presenter.rb
@@ -1,0 +1,40 @@
+class MetadataPresenter
+  def initialize(raw_metadata)
+    @raw_metadata = raw_metadata
+  end
+
+  def present
+    raw_metadata.map { |datum|
+      case datum.fetch(:type)
+      when 'date'
+        build_date_metadata(datum)
+      when 'text', 'content_id'
+        build_text_metadata(datum)
+      end
+    }
+  end
+
+private
+
+  attr_reader :raw_metadata
+
+  def build_text_metadata(data)
+    {
+      id: data[:id],
+      label: data.fetch(:name),
+      value: data.fetch(:value),
+      labels: data[:labels],
+      is_text: true,
+    }
+  end
+
+  def build_date_metadata(data)
+    date = Date.parse(data.fetch(:value))
+    {
+      label: data.fetch(:name),
+      is_date: true,
+      machine_date: date.iso8601,
+      human_date: date.strftime("%-d %B %Y"),
+    }
+  end
+end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -10,7 +10,7 @@ class ResultSetPresenter
            :atom_url,
            to: :finder
 
-  def initialize(finder, filter_params, view_context, sort_presenter, show_top_result = false)
+  def initialize(finder, filter_params, view_context, sort_presenter, metadata_presenter_class, show_top_result = false)
     @finder = finder
     @results = finder.results.documents
     @total = finder.results.total
@@ -18,6 +18,7 @@ class ResultSetPresenter
     @view_context = view_context
     @sort_presenter = sort_presenter
     @show_top_result = show_top_result
+    @metadata_presenter_class = metadata_presenter_class
   end
 
   def to_hash
@@ -54,7 +55,8 @@ class ResultSetPresenter
 
   def documents
     results.each_with_index.map do |result, index|
-      doc = SearchResultPresenter.new(result).to_hash
+      metadata = metadata_presenter_class.new(result.metadata).present
+      doc = SearchResultPresenter.new(result, metadata).to_hash
       if  index === 0 && highlight_top_result?
         doc[:top_result] = true
         doc[:summary] = result.truncated_description
@@ -84,7 +86,7 @@ class ResultSetPresenter
 
 private
 
-  attr_reader :view_context, :sort_presenter
+  attr_reader :view_context, :metadata_presenter_class
 
   def highlight_top_result?
     @show_top_result &&

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -86,7 +86,7 @@ class ResultSetPresenter
 
 private
 
-  attr_reader :view_context, :metadata_presenter_class
+  attr_reader :view_context, :metadata_presenter_class, :sort_presenter
 
   def highlight_top_result?
     @show_top_result &&

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -9,8 +9,9 @@ class SearchResultPresenter
            :es_score,
            to: :search_result
 
-  def initialize(search_result)
+  def initialize(search_result, metadata)
     @search_result = search_result
+    @metadata = metadata
   end
 
   def to_hash
@@ -32,42 +33,7 @@ class SearchResultPresenter
     search_result.path
   end
 
-  def metadata
-    raw_metadata.map { |datum|
-      case datum.fetch(:type)
-      when 'date'
-        build_date_metadata(datum)
-      when 'text', 'content_id'
-        build_text_metadata(datum)
-      end
-    }
-  end
-
-  def build_text_metadata(data)
-    {
-      id: data[:id],
-      label: data.fetch(:name),
-      value: data.fetch(:value),
-      labels: data[:labels],
-      is_text: true,
-    }
-  end
-
-  def build_date_metadata(data)
-    date = Date.parse(data.fetch(:value))
-    {
-      label: data.fetch(:name),
-      is_date: true,
-      machine_date: date.iso8601,
-      human_date: date.strftime("%-d %B %Y"),
-    }
-  end
-
 private
 
-  attr_reader :search_result
-
-  def raw_metadata
-    search_result.metadata
-  end
+  attr_reader :search_result, :metadata
 end

--- a/app/presenters/statistics_metadata_presenter.rb
+++ b/app/presenters/statistics_metadata_presenter.rb
@@ -1,0 +1,24 @@
+class StatisticsMetadataPresenter < MetadataPresenter
+  def present
+    formatted_metadata =
+      raw_metadata.map { |datum|
+        case datum.fetch(:type)
+        when 'date'
+          build_date_metadata(datum)
+        when 'text', 'content_id'
+          build_text_metadata(datum)
+        end
+      }
+    select_date_key(formatted_metadata)
+  end
+
+private
+
+  def select_date_key(metadata)
+    multiple_date_fields? ? metadata.reject { |key| key[:label] == "Updated" } : metadata
+  end
+
+  def multiple_date_fields?
+    raw_metadata.pluck(:name).include?("Release date")
+  end
+end

--- a/spec/presenters/advanced_search_result_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_presenter_spec.rb
@@ -31,14 +31,15 @@ RSpec.describe AdvancedSearchResultPresenter do
       public_timestamp: public_timestamp,
     }, finder)
   }
+  let(:formatted_metadata) { [{ label: "Public timestamp", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" }] }
 
-  subject(:instance) { described_class.new(search_result) }
+  subject(:instance) { described_class.new(search_result, formatted_metadata) }
 
   describe "#to_hash" do
     it "includes document_type, organisations and publication_date" do
       expect(instance.to_hash[:document_type]).to eq("Guidance")
       expect(instance.to_hash[:organisations]).to eq("Ministry of Defence")
-      expect(instance.to_hash[:publication_date][:machine_date]).to eq("2018-03-26")
+      expect(instance.to_hash[:publication_date][:machine_date]).to eq("2006-07-14")
     end
   end
 

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AdvancedSearchResultSetPresenter do
     MetadataPresenter
   end
 
-  subject(:instance) { described_class.new(finder, filter_params, view_context, metadata_presenter_class) }
+  subject(:instance) { described_class.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class) }
 
   before do
     allow(Services.content_store).to receive(:content_item)

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -39,8 +39,11 @@ RSpec.describe AdvancedSearchResultSetPresenter do
       "total_pages" => 1,
     }
   }
+  let(:metadata_presenter_class) do
+    MetadataPresenter
+  end
 
-  subject(:instance) { described_class.new(finder, filter_params, view_context, sort_presenter) }
+  subject(:instance) { described_class.new(finder, filter_params, view_context, metadata_presenter_class) }
 
   before do
     allow(Services.content_store).to receive(:content_item)

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 RSpec.describe AtomPresenter do
   subject(:instance) { described_class.new(finder, results) }
 
-  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
-
+  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  let(:metadata_presenter_class) do
+    MetadataPresenter
+  end
   let(:finder) do
     double(
       FinderPresenter,

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe AtomPresenter do
   subject(:instance) { described_class.new(finder, results) }
 
-  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class) }
   let(:metadata_presenter_class) do
     MetadataPresenter
   end

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -1,7 +1,21 @@
 require 'spec_helper'
 
 RSpec.describe GroupedResultSetPresenter do
-  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
+  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  let(:metadata_presenter_class) do
+    MetadataPresenter
+  end
+  let(:metadata) do
+    [
+      { id: 'case-state', name: 'Case state', value: 'Open', type: 'text', labels: %W(open) },
+      { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
+      { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text', labels: %W(ca98-and-civil-cartels) },
+      { id: 'personal-data', name: 'personal-data', value: 'personal-digital-data', type: 'text', labels: %W(personal-digital-data) },
+    ]
+  end
+  let(:formatted_metadata) do
+    metadata_presenter_class.new(metadata).present
+  end
 
   let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
 
@@ -97,12 +111,16 @@ RSpec.describe GroupedResultSetPresenter do
       Document,
       title: 'Investigation into the distribution of road fuels in parts of Scotland',
       path: 'slug-1',
+<<<<<<< HEAD
       metadata: [
         { id: 'case-state', name: 'Case state', value: 'Open', type: 'text', labels: %W(open) },
         { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
         { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text', labels: %W(ca98-and-civil-cartels) },
         { id: 'organisation_activity', name: 'Organisation activity', value: 'buying', type: 'text', labels: %W(buying) },
       ],
+=======
+      metadata: metadata,
+>>>>>>> Refactor to use MetadataPresenter for search results
       summary: 'I am a document',
       is_historic: false,
       government_name: 'The Government!',
@@ -191,6 +209,10 @@ RSpec.describe GroupedResultSetPresenter do
       ]
     }
 
+    let(:formatted_tagged_metadata) {
+      metadata_presenter_class.new(tagging_metadata).present
+    }
+
     let(:tagged_document) {
       double(
         Document,
@@ -208,10 +230,10 @@ RSpec.describe GroupedResultSetPresenter do
     }
 
     let(:primary_tagged_result) {
-      SearchResultPresenter.new(tagged_document).to_hash
+      SearchResultPresenter.new(tagged_document, formatted_tagged_metadata).to_hash
     }
 
-    let(:document_result) { SearchResultPresenter.new(document).to_hash }
+    let(:document_result) { SearchResultPresenter.new(document, formatted_metadata).to_hash }
 
     context "when not grouping results" do
       let(:filter_params) { { order: 'a-z' } }

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GroupedResultSetPresenter do
-  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class) }
   let(:metadata_presenter_class) do
     MetadataPresenter
   end
@@ -10,7 +10,7 @@ RSpec.describe GroupedResultSetPresenter do
       { id: 'case-state', name: 'Case state', value: 'Open', type: 'text', labels: %W(open) },
       { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
       { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text', labels: %W(ca98-and-civil-cartels) },
-      { id: 'personal-data', name: 'personal-data', value: 'personal-digital-data', type: 'text', labels: %W(personal-digital-data) },
+      { id: 'organisation_activity', name: 'Organisation activity', value: 'buying', type: 'text', labels: %W(buying) }
     ]
   end
   let(:formatted_metadata) do
@@ -111,16 +111,7 @@ RSpec.describe GroupedResultSetPresenter do
       Document,
       title: 'Investigation into the distribution of road fuels in parts of Scotland',
       path: 'slug-1',
-<<<<<<< HEAD
-      metadata: [
-        { id: 'case-state', name: 'Case state', value: 'Open', type: 'text', labels: %W(open) },
-        { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
-        { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text', labels: %W(ca98-and-civil-cartels) },
-        { id: 'organisation_activity', name: 'Organisation activity', value: 'buying', type: 'text', labels: %W(buying) },
-      ],
-=======
       metadata: metadata,
->>>>>>> Refactor to use MetadataPresenter for search results
       summary: 'I am a document',
       is_historic: false,
       government_name: 'The Government!',

--- a/spec/presenters/metadata_presenter_spec.rb
+++ b/spec/presenters/metadata_presenter_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe MetadataPresenter do
+  subject(:presenter) { described_class.new(raw_metadata) }
+
+  let(:raw_metadata) {
+    [
+      { id: 'case-state', name: 'Case state', value: 'Open', type: 'text' },
+      { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
+      { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text' },
+    ]
+  }
+  let(:formatted_metadata) {
+    [
+      { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil },
+      { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
+      { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
+    ]
+  }
+
+  describe '#present' do
+    it 'presents the metadata' do
+      expect(subject.present).to eq(formatted_metadata)
+    end
+  end
+end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe ResultSetPresenter do
-  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class) }
   let(:metadata_presenter_class) do
     MetadataPresenter
   end
@@ -365,11 +365,7 @@ RSpec.describe ResultSetPresenter do
     end
 
     context 'check top result' do
-<<<<<<< HEAD
-      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, true) }
-=======
-      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class, true) }
->>>>>>> Refactor to use MetadataPresenter for search results
+      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class, true) }
 
       before(:each) do
         allow(finder).to receive(:eu_exit_finder?).and_return(true)
@@ -439,7 +435,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       context 'top result not set if show top result is false' do
-        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class, false) }
+        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class, false) }
 
         it 'has no top result' do
           search_result_objects = presenter.documents

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe ResultSetPresenter do
-  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
-
+  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class) }
+  let(:metadata_presenter_class) do
+    MetadataPresenter
+  end
   let(:finder) do
     double(
       FinderPresenter,
@@ -363,7 +365,11 @@ RSpec.describe ResultSetPresenter do
     end
 
     context 'check top result' do
+<<<<<<< HEAD
       subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, true) }
+=======
+      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class, true) }
+>>>>>>> Refactor to use MetadataPresenter for search results
 
       before(:each) do
         allow(finder).to receive(:eu_exit_finder?).and_return(true)
@@ -433,7 +439,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       context 'top result not set if show top result is false' do
-        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, false) }
+        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, metadata_presenter_class, false) }
 
         it 'has no top result' do
           search_result_objects = presenter.documents

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe SearchResultPresenter do
-  subject(:presenter) { SearchResultPresenter.new(document) }
+  subject(:presenter) { SearchResultPresenter.new(document, metadata) }
 
   let(:document) {
     double(
@@ -19,102 +19,28 @@ RSpec.describe SearchResultPresenter do
     )
   }
 
-  let(:title) { 'Investigation into the distribution of road fuels in parts of Scotland' }
-  let(:link) { 'link-1' }
-
   let(:metadata) {
     [
-      { id: 'case-state', name: 'Case state', value: 'Open', type: 'text' },
-      { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
-      { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text' },
+      { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil },
+      { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
+      { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
     ]
   }
+
+  let(:title) { 'Investigation into the distribution of road fuels in parts of Scotland' }
+  let(:link) { 'link-1' }
 
   describe "#to_hash" do
     it "returns a hash" do
       expect(subject.to_hash.is_a?(Hash)).to be_truthy
     end
 
-    let(:formatted_metadata) {
-      [
-        { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil },
-        { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
-        { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
-      ]
-    }
-
     it "returns a hash of the data we need to show the document" do
       hash = subject.to_hash
       expect(hash[:title]).to eql(title)
       expect(hash[:link]).to eql(link)
-      expect(hash[:metadata]).to eql(formatted_metadata)
+      expect(hash[:metadata]).to eql(metadata)
       expect(hash[:es_score]).to eql(0.005)
-    end
-  end
-
-  describe '#metadata' do
-    it 'returns an array' do
-      expect(subject.metadata.is_a?(Array)).to be_truthy
-    end
-
-    it 'formats metadata' do
-      allow(presenter).to receive(:build_text_metadata).and_call_original
-      allow(presenter).to receive(:build_date_metadata).and_call_original
-
-      subject.metadata
-      expect(subject).to have_received(:build_date_metadata).with(
-        id: "opened-date",
-        name: "Opened date",
-        value: "2006-7-14",
-        type: "date"
-      )
-      expect(subject).to have_received(:build_text_metadata).with(
-        id: "case-state",
-        name: "Case state",
-        value: "Open",
-        type: "text"
-      )
-      expect(subject).to have_received(:build_text_metadata).with(
-        id: "case-state",
-        name: "Case state",
-        value: "Open",
-        type: "text"
-      )
-    end
-  end
-
-  describe '#build_text_metadata' do
-    let(:data) {
-      { name: 'some name', value: 'some value' }
-    }
-    it 'returns a hash' do
-      expect(subject.build_text_metadata(data).is_a?(Hash)).to be_truthy
-    end
-    it 'sets the type to text' do
-      expect(subject.build_text_metadata(data).fetch(:is_text)).to be_truthy
-    end
-  end
-
-  describe '#build_date_metadata' do
-    let(:data) {
-      { name: 'some name', value: raw_date }
-    }
-    let(:raw_date) { '2003-12-01' }
-    let(:formatted_date) { '1 December 2003' }
-    let(:iso_date) { '2003-12-01' }
-
-    it 'returns a hash' do
-      expect(subject.build_date_metadata(data).is_a?(Hash)).to be_truthy
-    end
-
-    it 'sets the type to date' do
-      expect(subject.build_date_metadata(data).fetch(:is_date)).to be_truthy
-    end
-
-    it 'formats the date' do
-      date_metadata = subject.build_date_metadata(data)
-      expect(date_metadata.fetch(:human_date)).to eql(formatted_date)
-      expect(date_metadata.fetch(:machine_date)).to eql(iso_date)
     end
   end
 end

--- a/spec/presenters/statistics_metadata_presenter_spec.rb
+++ b/spec/presenters/statistics_metadata_presenter_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe StatisticsMetadataPresenter do
+  let(:raw_metadata_announcement) {
+    [
+      { name: 'Updated', value: '2000-01-02T13:54:00.000+01:00', type: 'date' },
+      { name: 'Release date', value: '2004-05-06T09:30:00.000+01:00', type: 'date' }
+    ]
+  }
+
+  let(:raw_metadata_published) {
+    [
+      { name: 'Updated', value: '2000-01-02T13:54:00.000+01:00', type: 'date' }
+    ]
+  }
+
+  let(:formatted_metadata_announcement) {
+    [
+      { label: 'Release date', is_date: true, machine_date: "2004-05-06", human_date: "6 May 2004" }
+    ]
+  }
+
+  let(:formatted_metadata_published) {
+    [
+      { label: 'Updated', is_date: true, machine_date: "2000-01-02", human_date: "2 January 2000" }
+    ]
+  }
+
+  describe '#present' do
+    context 'when both release date and updated dates' do
+      it 'formats the metadata' do
+        presenter = described_class.new(raw_metadata_announcement)
+        expect(presenter.present).to eq(formatted_metadata_announcement)
+      end
+    end
+
+    context 'when only updated date' do
+      it 'formats the metadata' do
+        presenter = described_class.new(raw_metadata_published)
+        expect(presenter.present).to eq(formatted_metadata_published)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR composes the metadata presentation logic, and creates a new Statistics Metadata Presenter class. This allows us to customise the metadata that is presented for statistics announcements and published statistics. 

The addition of public time stamp (Trello [#649](https://trello.com/c/TV5xhCBX/649-give-stats-announcement-doc-types-publictimestamp-so-date-sort-works-in-faceted-search)) to stats announcements results in the display of two dates for up upcoming stats announcements:

<img width="972" alt="before" src="https://user-images.githubusercontent.com/17908089/57624316-9870a800-7589-11e9-8e67-2a57ade5e6db.png">

The desired behaviour is to display only `Release date` for stat announcements, and `Updated` date for published statistics:

<img width="789" alt="after" src="https://user-images.githubusercontent.com/17908089/57625207-5183b200-758b-11e9-916e-b78b01abbcc5.png">




 

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1114.herokuapp.com/search/all
- http://finder-frontend-pr-1114.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1114.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1114.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1114.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
