### PR TITLE
Explicitly require addressable API

### DIFF
--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class EmailAlertSignupAPI
   def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil)
     @applied_filters = applied_filters.deep_symbolize_keys


### PR DESCRIPTION
Whilst this feature worked locally and on CI in https://github.com/alphagov/finder-frontend/pull/1104, the deployment Jenkins complains of a 'NameError uninitialized constant EmailAlertSignupAPI::Addressable' which can only be resolved through requiring the library explicitly.

Work needs to be done to establish why this wasn't an issue locally or on CI, but in the meantime this hotfix should allow us to deploy.