### PR TITLE
Remove human readable format text

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -44,10 +44,6 @@ class FinderPresenter
     content_item['details']['hide_facets_by_default'] || false
   end
 
-  def human_readable_finder_format
-    content_item['details']['human_readable_finder_format']
-  end
-
   def filter
     content_item['details']['filter']
   end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -57,7 +57,6 @@
         </div>
       <% else %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
-            context: finder.human_readable_finder_format,
             title: finder.name
         } %>
       <% end %>

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -67,12 +67,6 @@ A boolean. Optional.
 
 Used to decide whether a generic description of "X publications matched your critera" should be displayed in place of the normal filter description which concatenates all selected filters into a sentence (for example, X documents of type Y for organisation Z).
 
-## `human_readable_finder_format`
-
-A string. Optional.
-
-Human readable version of the content format. Passed as the context to the [title](http://govuk-static.herokuapp.com/component-guide/title) component.
-
 ## `default_order`
 
 A string. Optional.


### PR DESCRIPTION
This field is not present on any finders so can be removed.

You can check all of the finders for this value using a modified version of this script: https://gist.github.com/bilbof/dc41df6dd783668fcf2692c9ac44b917

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1116.herokuapp.com/search/all
- http://finder-frontend-pr-1116.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1116.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1116.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1116.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
