### PR TITLE
Remove unused page metadata

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -148,8 +148,7 @@ class FinderPresenter
 
   def page_metadata
     metadata = {
-      part_of: part_of,
-      from: from,
+      from: organisations,
     }
 
     metadata.reject { |_, links| links.blank? }
@@ -219,22 +218,6 @@ class FinderPresenter
 private
 
   attr_reader :search_results, :sort_presenter
-
-  def part_of
-    content_item['links']['part_of'] || []
-  end
-
-  def people
-    content_item['links']['people'] || []
-  end
-
-  def working_groups
-    content_item['links']['working_groups'] || []
-  end
-
-  def from
-    organisations + people + working_groups
-  end
 
   def is_external?(href)
     URI.parse(href).host != "www.gov.uk"


### PR DESCRIPTION
No finders currently have working groups, people or part of fields, so we can remove this stuff.

You can check all of the finders for this value using a modified version of this script: https://gist.github.com/bilbof/dc41df6dd783668fcf2692c9ac44b917

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1117.herokuapp.com/search/all
- http://finder-frontend-pr-1117.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1117.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1117.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1117.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
