### PR TITLE
Refactor pagination

### DIFF
--- a/app/controllers/concerns/publishing_components_helper.rb
+++ b/app/controllers/concerns/publishing_components_helper.rb
@@ -1,0 +1,17 @@
+# The PublishingComponentsHelper module is responsible for rendering
+# ERB partials (particularly govuk_publishing_components) as HTML for use
+# in both JSON and HTML responses. It's a bit of glue code we can remove
+# with the introduction of a show.json.erb template file.
+module PublishingComponentsHelper
+  def component_to_html(component:, locals: {})
+    return unless can_render_component_html?
+
+    render_to_string(partial: component, locals: locals, formats: %w[html])
+  end
+
+private
+
+  def can_render_component_html?
+    %w(html json).include? request.format
+  end
+end

--- a/app/lib/url_builder.rb
+++ b/app/lib/url_builder.rb
@@ -1,0 +1,19 @@
+# The UrlBuilder class is responsible for creating URLs to be rendered as
+# HTML links.
+class UrlBuilder
+  def initialize(path, query_params = {})
+    @path = path
+    @query_params = query_params
+  end
+
+  def url(additional_params = {})
+    [
+      path,
+      query_params.merge(additional_params).to_query,
+    ].reject(&:blank?).join("?")
+  end
+
+private
+
+  attr_reader :path, :query_params
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,6 @@
 class ContentItem
+  attr_reader :base_path
+
   def initialize(base_path)
     @base_path = base_path
     @content_item = fetch_content_item
@@ -26,16 +28,20 @@ class ContentItem
     SortPresenter
   end
 
+  def default_documents_per_page
+    content_item.dig('details', 'default_documents_per_page')
+  end
+
 private
 
-  attr_reader :base_path
+  attr_reader :content_item
 
   def is_research_and_statistics?
     base_path == '/search/research-and-statistics'
   end
 
   def document_type
-    @content_item['document_type']
+    content_item['document_type']
   end
 
   def fetch_content_item

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -60,20 +60,6 @@ class FinderPresenter
     content_item['details']['summary']
   end
 
-  def pagination
-    documents_per_page = content_item['details']['default_documents_per_page']
-
-    return nil unless documents_per_page
-
-    start_offset = search_results['start']
-    total_results = search_results['total']
-
-    {
-      'current_page' => (start_offset / documents_per_page) + 1,
-      'total_pages' => (total_results / documents_per_page.to_f).ceil,
-    }
-  end
-
   def email_alert_signup
     if content_item['links']['email_alert_signup']
       content_item['links']['email_alert_signup'].first

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,0 +1,60 @@
+# The PaginationPresenter class is responsible for creating the next and
+# previous links to be displayed on finders.
+class PaginationPresenter
+  def initialize(per_page:, start_offset:, total_results:, url_builder:)
+    @per_page = per_page
+    @start_offset = start_offset
+    @total_results = total_results
+    @url_builder = url_builder
+  end
+
+  def next_and_prev_links
+    return unless can_paginate?
+
+    { previous_page: previous_page, next_page: next_page }.compact
+  end
+
+private
+
+  attr_reader :per_page, :start_offset, :total_results, :url_builder
+
+  def can_paginate?
+    per_page.present? && has_other_pages?
+  end
+
+  def has_other_pages?
+    previous_page.present? || next_page.present?
+  end
+
+  def page_links
+    { previous_page: previous_page, next_page: next_page }.compact
+  end
+
+  def current_page
+    (start_offset / per_page) + 1
+  end
+
+  def total_pages
+    (total_results / per_page.to_f).ceil
+  end
+
+  def next_page
+    return unless current_page < total_pages
+
+    build_page_link("Next page", current_page + 1)
+  end
+
+  def previous_page
+    return unless current_page > 1
+
+    build_page_link("Previous page", current_page - 1)
+  end
+
+  def build_page_link(page_label, page)
+    {
+      title: page_label,
+      label: "#{page} of #{total_pages}",
+      url: url_builder.url(page: page),
+    }
+  end
+end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -10,14 +10,14 @@ class ResultSetPresenter
            :atom_url,
            to: :finder
 
-  def initialize(finder, filter_params, view_context, sort_presenter, show_top_result = false)
+  def initialize(finder, filter_params, sort_presenter, next_and_prev_links, show_top_result = false)
     @finder = finder
     @results = finder.results.documents
     @total = finder.results.total
     @filter_params = filter_params
-    @view_context = view_context
     @sort_presenter = sort_presenter
     @show_top_result = show_top_result
+    @next_and_prev_links = next_and_prev_links
   end
 
   def to_hash
@@ -84,7 +84,7 @@ class ResultSetPresenter
 
 private
 
-  attr_reader :view_context, :sort_presenter
+  attr_reader :sort_presenter, :next_and_prev_links
 
   def highlight_top_result?
     @show_top_result &&
@@ -99,28 +99,6 @@ private
     if results[0].es_score && results[1].es_score
       (results[0].es_score / results[1].es_score) > 7
     end
-  end
-
-  def next_and_prev_links
-    return unless finder.pagination
-
-    current_page = finder.pagination['current_page']
-    previous_page = current_page - 1 if current_page > 1
-    next_page = current_page + 1 if current_page < finder.pagination['total_pages']
-    pages = {}
-
-    pages[:previous_page] = build_page_link("Previous page", previous_page) if previous_page
-    pages[:next_page] = build_page_link("Next page", next_page) if next_page
-
-    view_context.render(formats: %w[html], partial: 'govuk_publishing_components/components/previous_and_next_navigation', locals: pages) if pages
-  end
-
-  def build_page_link(page_label, page)
-    {
-      url: [finder.slug, finder.values.merge(page: page).to_query].reject(&:blank?).join("?"),
-      title: page_label,
-      label: "#{page} of #{finder.pagination['total_pages']}",
-    }
   end
 
   def selected_filters

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -279,7 +279,6 @@ describe FindersController, type: :controller do
     end
 
     let(:filter_params) { double(:filter_params, keywords: '') }
-    let(:view_context) { double(:view_context) }
     let(:finder_presenter) { FinderPresenter.new(breakfast_finder, {}, filter_params) }
 
     before do

--- a/spec/lib/url_builder_spec.rb
+++ b/spec/lib/url_builder_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe UrlBuilder do
+  let(:builder) { described_class.new(path, query_params) }
+  let(:extra_params) { {} }
+  let(:path) { '/search/all' }
+
+  describe "#url_builder" do
+    context "when given a path and query params" do
+      subject(:url) { builder.url }
+
+      let(:query_params) {
+        {
+          keywords: 'harry potter',
+          order: 'relevance',
+          public_timestamp: {
+            from: 2005,
+            to: 2015,
+          },
+          organisations: [
+            'ministry-of-magic',
+            'hogwarts',
+          ]
+        }
+      }
+
+      it "builds a url with a query" do
+        expect(url).to eq('/search/all?' + query_params.to_query)
+      end
+    end
+
+    context "when given a path, query params, and additional params" do
+      subject(:url) { builder.url(page: 20) }
+      let(:query_params) { { keywords: 'dumbledore' } }
+
+      it "builds a url that includes the additional params" do
+        expect(url).to eq('/search/all?keywords=dumbledore&page=20')
+      end
+    end
+  end
+end

--- a/spec/presenters/advanced_search_result_set_presenter_spec.rb
+++ b/spec/presenters/advanced_search_result_set_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AdvancedSearchResultSetPresenter do
   let(:group) { "news_and_communications" }
   let(:filter_params) { { "topic" => "/education", "group" => group } }
   let(:finder) { AdvancedSearchFinderPresenter.new(finder_api, search_results, sort_presenter, filter_params) }
-  let(:view_context) { double(:view_context, render: nil) }
+  let(:next_and_prev_links) { double(:next_and_prev_links) }
   let(:sort_presenter) {
     double(
       SortPresenter,
@@ -40,7 +40,7 @@ RSpec.describe AdvancedSearchResultSetPresenter do
     }
   }
 
-  subject(:instance) { described_class.new(finder, filter_params, view_context, sort_presenter) }
+  subject(:instance) { described_class.new(finder, filter_params, sort_presenter, next_and_prev_links) }
 
   before do
     allow(Services.content_store).to receive(:content_item)
@@ -88,42 +88,6 @@ RSpec.describe AdvancedSearchResultSetPresenter do
       it "contains selected subgroups and date filters" do
         expected = "in News published after 1 February 2017"
         expect(instance.to_hash[:applied_filters]).to eq(expected)
-      end
-    end
-
-    context "next and previous links" do
-      let(:search_results) {
-        {
-          "results" => [],
-          "total" => 30,
-          "start" => 0,
-          "current_page" => 1,
-          "total_pages" => 2,
-        }
-      }
-      let(:view_context) { ActionView::Base.new }
-      let(:filter_params) {
-        {
-          "topic" => "/education",
-          "group" => "news_and_communications",
-        }
-      }
-
-      it "contains valid topic (base_path) filtering params" do
-        expect(view_context).to receive(:render)
-          .with(
-            formats: %w(html),
-            partial: 'govuk_publishing_components/components/previous_and_next_navigation',
-            locals: {
-              next_page: {
-                label: "2 of 2",
-                title: "Next page",
-                url: "/search/advanced?group=news_and_communications&page=2&topic=%2Feducation"
-              }
-            }
-          )
-
-        instance.to_hash
       end
     end
   end

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe AtomPresenter do
   subject(:instance) { described_class.new(finder, results) }
 
-  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
+  let(:results) { ResultSetPresenter.new(finder, filter_params, sort_presenter, next_and_prev_links) }
 
   let(:finder) do
     double(
@@ -19,13 +19,12 @@ RSpec.describe AtomPresenter do
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},
-      pagination: { 'current_page' => 1, 'total_pages' => 2 },
       sort: {},
     )
   end
 
   let(:filter_params) { double(:filter_params, keywords: '') }
-  let(:view_context) { double(:view_context) }
+  let(:next_and_prev_links) { double(:next_and_prev_links) }
   let(:sort_presenter) { double(:sort_presenter) }
 
   let(:a_facet) do

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe GroupedResultSetPresenter do
-  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
-
-  let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
+  subject(:presenter) { GroupedResultSetPresenter.new(finder, filter_params, sort_presenter, next_and_prev_links) }
 
   let(:filter_params) { { keywords: 'test' } }
 
-  let(:view_context) { double(:view_context) }
+  let(:next_and_prev_links) { double(:next_and_prev_links) }
 
   let(:finder) do
     double(
@@ -23,7 +21,6 @@ RSpec.describe GroupedResultSetPresenter do
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},
-      pagination: pagination,
       sort: {},
       filters: facet_filters
     )
@@ -160,7 +157,7 @@ RSpec.describe GroupedResultSetPresenter do
     before(:each) do
       allow(presenter).to receive(:selected_filter_descriptions)
       allow(presenter).to receive(:any_filters_applied?).and_return(true)
-      allow(view_context).to receive(:render)
+      allow(presenter).to receive(:next_and_prev_links)
       allow(presenter).to receive(:grouped_display?).and_return(true)
       allow(presenter).to receive(:grouped_documents).and_return(key: 'value')
     end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe PaginationPresenter do
+  subject(:links) { presenter.next_and_prev_links }
+  let(:presenter) {
+    described_class.new(
+      per_page: per_page,
+      start_offset: start_offset,
+      total_results: total_results,
+      url_builder: url_builder,
+    )
+  }
+  let(:per_page) {}
+  let(:start_offset) {}
+  let(:total_results) {}
+  let(:url_builder) { UrlBuilder.new('/search') }
+
+  describe "#next_and_prev_links" do
+    context "when per_page is unset" do
+      it "returns nil" do
+        expect(subject).to be nil
+      end
+    end
+
+    context "when there are no other pages with results" do
+      let(:per_page) { 20 }
+      let(:total_results) { 20 }
+      let(:start_offset) { 1 }
+
+      it "returns nil" do
+        expect(subject).to be nil
+      end
+    end
+
+    context "when there are only next pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 1 }
+
+      it "returns a next page link" do
+        expect(subject).to eq(
+          next_page: {
+            label: "2 of 5",
+            title: "Next page",
+            url: "/search?page=2",
+          }
+        )
+      end
+    end
+
+    context "when there are only previous pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 80 }
+
+      it "returns a previous page link" do
+        expect(subject).to eq(
+          previous_page: {
+            label: "4 of 5",
+            title: "Previous page",
+            url: "/search?page=4",
+          }
+        )
+      end
+    end
+
+    context "when there are next and previous pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 20 }
+
+      it "returns next and previous page links" do
+        expect(subject).to eq(
+          next_page: {
+            label: "3 of 5",
+            title: "Next page",
+            url: "/search?page=3",
+          },
+          previous_page: {
+            label: "1 of 5",
+            title: "Previous page",
+            url: "/search?page=1",
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe ResultSetPresenter do
-  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter) }
+  subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, next_and_prev_links) }
 
   let(:finder) do
     double(
@@ -16,7 +16,6 @@ RSpec.describe ResultSetPresenter do
       keywords: keywords,
       default_documents_per_page: 10,
       values: {},
-      pagination: pagination,
       sort: [
         {
           "name" => "Most viewed",
@@ -40,11 +39,9 @@ RSpec.describe ResultSetPresenter do
     )
   end
 
-  let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
-
   let(:filter_params) { { keywords: 'test' } }
 
-  let(:view_context) { double(:view_context) }
+  let(:next_and_prev_links) { '<nav></nav>' }
 
   let(:a_facet) do
     double(
@@ -241,7 +238,7 @@ RSpec.describe ResultSetPresenter do
       allow(presenter).to receive(:documents).and_return(key: 'value')
       allow(presenter).to receive(:any_filters_applied?).and_return(true)
       allow(presenter).to receive(:grouped_display?).and_return(false)
-      allow(view_context).to receive(:render).and_return('<nav></nav>')
+      allow(presenter).to receive(:next_and_prev_links).and_return(next_and_prev_links)
 
       allow(finder).to receive(:atom_url).and_return("/finder.atom")
       allow(finder).to receive(:email_alert_signup_url).and_return("/email_signup")
@@ -363,7 +360,7 @@ RSpec.describe ResultSetPresenter do
     end
 
     context 'check top result' do
-      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, true) }
+      subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, next_and_prev_links, true) }
 
       before(:each) do
         allow(finder).to receive(:eu_exit_finder?).and_return(true)
@@ -433,7 +430,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       context 'top result not set if show top result is false' do
-        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, view_context, false) }
+        subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, next_and_prev_links, false) }
 
         it 'has no top result' do
           search_result_objects = presenter.documents


### PR DESCRIPTION
This extracts the pagination logic out of the `FinderPresenter` and `ResultSetPresenter` classes.

Ideally we can extra the logic from these two presenters and put them into smaller more well defined presenters.

It also adds some tests for the behaviour.

I've added in a `UrlBuilder` class, as I think this can be used elsewhere where we also combine query params and a path (e.g. feed/email links).

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1119.herokuapp.com/search/all
- http://finder-frontend-pr-1119.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1119.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1119.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1119.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
