### PR TITLE
Adds StandardJS linter to Rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ If you are using the GDS development virtual machine then the application will b
 
 ## Running the test suite
 
-Before you can run the test suite you'll need the [govuk-content-schemas]
-repository locally. See
-[`lib/govuk_content_schema_examples.rb`][content_schema_examples] for more
-details.
+Before you can run the test suite you'll need the [govuk-content-schemas] repository locally. See [`lib/govuk_content_schema_examples.rb`][content_schema_examples] for more details.
+
+The StandardJS JavaScript linter needs to be installed separately before running the default `rake` task. To make sure that it's been installed run:
+
+```sh
+$ yarn install
+```
 
 The default `rake` task runs all the tests:
 
@@ -66,6 +69,7 @@ $ bundle exec rake
 ```
 
 The application has jasmine tests, which can be accessed at `/specs` when the application is running in development mode. These are also run when `rake`, above, is run.
+
 To run JavaScript tests separately: `bundle exec rake spec:javascript`
 
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
@@ -112,6 +116,4 @@ See the [documentation on the Q&A frontend](docs/q-and-a.md) and how it relates 
   1. Value objects used to wrap up responses from API calls.
   2. Facet objects which wrap up the behaviour of different types of facet --
      eg radios, selects, etc.
-* `app/presenters` contains objects which serialise the value objects to hashes
-  for display via mustache.
 * `app/parsers` contains objects which transform API responses into models.

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,6 @@
 task default: :lint
-desc "Run govuk-lint with similar params to CI"
+desc "Run govuk-lint and StandardJS with similar params to CI"
 task :lint do
   sh "bundle exec govuk-lint-ruby --format clang app config features Gemfile lib spec"
+  sh "yarn run lint"
 end

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+yarn install
 bundle check || bundle install
 
 if [[ $1 == "--live" ]] ; then


### PR DESCRIPTION
StandardJS lints the JavaScript in Jenkins, but not when running `bundle exec rake` locally. 

This pull request adds `npm run lint` (which is an alias listed `package.json`) to the lint rake task so that it's easier to run all checks prior to pushing.

Since StandardJS is installed using npm, the `npm install` command has been added to the `startup.sh` script to make sure that it is installed before anything is run.
