### PR TITLE
Add names to anonymous functions.

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -111,7 +111,7 @@
     }
   }
 
-  LiveSearch.prototype.setRelevantResultCustomDimension = function () {
+  LiveSearch.prototype.setRelevantResultCustomDimension = function setRelevantResultCustomDimension () {
     if (this.canSetCustomDimension()) {
       var $mostRelevantDocumentLink = $('.finder-results').find('.document__link--top')
       var dimensionValue = $mostRelevantDocumentLink.length ? 'yes' : 'no'
@@ -119,7 +119,7 @@
     }
   }
 
-  LiveSearch.prototype.trackingInit = function () {
+  LiveSearch.prototype.trackingInit = function trackingInit () {
     GOVUK.modules.start($('.js-live-search-results-block'))
     this.indexTrackingData()
   }
@@ -170,7 +170,7 @@
     }
   }
 
-  LiveSearch.prototype.fireTextAnalyticsEvent = function (event) {
+  LiveSearch.prototype.fireTextAnalyticsEvent = function fireTextAnalyticsEvent (event) {
     if (this.canTrackPageview()) {
       var options = {
         transport: 'beacon',
@@ -187,11 +187,11 @@
     }
   }
 
-  LiveSearch.prototype.canTrackPageview = function () {
+  LiveSearch.prototype.canTrackPageview = function canTrackPageview () {
     return GOVUK.analytics && GOVUK.analytics.trackPageview
   }
 
-  LiveSearch.prototype.canSetCustomDimension = function () {
+  LiveSearch.prototype.canSetCustomDimension = function canSetCustomDimension () {
     return GOVUK.analytics && GOVUK.analytics.setDimension
   }
 

--- a/app/assets/javascripts/modules/enable-aria-controls.js
+++ b/app/assets/javascripts/modules/enable-aria-controls.js
@@ -6,7 +6,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (GOVUK) {
   'use strict'
 
-  GOVUK.Modules.EnableAriaControls = function () {
+  GOVUK.Modules.EnableAriaControls = function EnableAriaControls () {
     this.start = function (element) {
       element.find('[data-aria-controls]').each(enableAriaControls)
 

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -6,7 +6,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (global, GOVUK) {
   'use strict'
 
-  GOVUK.Modules.RemoveFilter = function () {
+  GOVUK.Modules.RemoveFilter = function RemoveFilter () {
     var onChangeSuppressAnalytics = {
       type: 'change',
       suppressAnalytics: true

--- a/app/assets/javascripts/support.js
+++ b/app/assets/javascripts/support.js
@@ -1,6 +1,6 @@
 if (typeof window.GOVUK === 'undefined') { window.GOVUK = {} }
 if (typeof window.GOVUK.support === 'undefined') { window.GOVUK.support = {} }
 
-window.GOVUK.support.history = function () {
+window.GOVUK.support.history = function history () {
   return window.history && window.history.pushState && window.history.replaceState
 }

--- a/app/assets/javascripts/taxonomy-select.js
+++ b/app/assets/javascripts/taxonomy-select.js
@@ -46,7 +46,7 @@
     subtaxon.append(taxons)
   }
 
-  TaxonomySelect.prototype.instantiateOptions = function () {
+  TaxonomySelect.prototype.instantiateOptions = function instantiateOptions () {
     var options = {}
 
     this.$subTaxon().find('option').each(function () {


### PR DESCRIPTION
Fixes part of the [frontend technical debt card](https://trello.com/c/l0DjvG2M/124-frontend-technical-debt) to investigate why `live_search.js` creates some anonymous and some named functions.

Both named and anonymous functions are being used throughout the JavaScript files. There's little difference when running, but using named functions should give a better debugging experience and choosing one way will give better consistency.