### PR TITLE
noindex searches that use keywords

### DIFF
--- a/app/views/layouts/advanced_search_layout.html.erb
+++ b/app/views/layouts/advanced_search_layout.html.erb
@@ -10,6 +10,10 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= yield :head %>
+
+    <% if params[:page] || params[:keywords] %>
+      <meta name="robots" content="noindex">
+    <% end %>
   </head>
 
   <body class="full-width">

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -11,7 +11,7 @@
     <%= csrf_meta_tags %>
     <%= yield :head %>
 
-    <% if params[:page] %>
+    <% if params[:page] || params[:keywords] || params[:q] %>
       <meta name="robots" content="noindex">
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -28,6 +28,7 @@ Feature: Filtering documents
     Then I see all documents which contain the keywords
     And there is not a zero results message
     And the page title is updated
+    And I can see that Google won't index the page
 
   Scenario: Filter document by keyword with q parameter
     Given a collection of documents exist


### PR DESCRIPTION
We may want to noindex all search pages, but this will require some further thought.

This stops spurious search terms from being indexed by external search engines and limits search indexer access to search results pages which only use the facets we've defined (or just paginating through unfaceted results.)

I've tested the primary path, but haven't worried about being too comprehensive as it's a pretty trivial change.  I'll be pushing for [noindexing these altogether](https://yoast.com/blocking-your-sites-search-results/) anyway so this will likely change soon.

Relevant card is https://trello.com/c/4EAytHVV/165-plan-noindexing-of-finder-pages

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1126.herokuapp.com/search/all
- http://finder-frontend-pr-1126.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1126.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1126.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1126.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
