### PR TITLE
Remove legacy fields

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -35,15 +35,7 @@ class ResultSetPresenter
       facet_tags: facet_tags_markup,
       search_results: search_results_markup,
       sort_options_markup: sort_options_markup,
-    }.merge(legacy_attributes)
-  end
-
-  # Provided for backwards compatibility
-  def legacy_attributes
-    {
-      pluralised_document_noun: pluralised_document_noun,
-      sort_options: sort_options_content,
-    }.merge(facet_tags_content).merge(search_results_content)
+    }
   end
 
   def search_results_content


### PR DESCRIPTION
These fields were added briefly, so we could deploy a
change to the application templates (and expected Ajax
call response) without requiring users who already had
the search pages loaded to reload the page.

These fields are no longer needed, so can be removed.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1129.herokuapp.com/search/all
- http://finder-frontend-pr-1129.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1129.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1129.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1129.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
