### PR TITLE
Make debug parameters work again

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -233,6 +233,18 @@
     .finder-results {
       list-style-type: none;
       padding-left: 0;
+
+      .debug-link {
+        color: green;
+        word-wrap: break-word;
+      }
+      .debug-info {
+        color: red;
+        span {
+          display: block;
+          min-width: 150px;
+        }
+      }
     }
 
     .filtered-results__group {

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -50,7 +50,7 @@ private
 
   def results
     @results ||= result_set_presenter_class.new(
-      finder, filter_params, view_context, sort_presenter, content_item.metadata_class, show_top_result?
+      finder, filter_params, view_context, sort_presenter, content_item.metadata_class, show_top_result?, debug_score?
     )
   end
 
@@ -111,5 +111,9 @@ private
   def remove_search_box
     hide_site_serch = params['slug'] == 'search/all'
     set_slimmer_headers(remove_search: hide_site_serch)
+  end
+
+  def debug_score?
+    params[:debug_score]
   end
 end

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -25,6 +25,7 @@ class SearchQueryBuilder
       reject_query,
       order_query,
       facet_query,
+      debug_query,
     ].reduce(&:merge)
 
     return [base_query] if filter_queries.empty?
@@ -199,6 +200,12 @@ private
     @facet_params ||= FacetQueryBuilder.new(
       facets: raw_facets,
     ).call
+  end
+
+  def debug_query
+    {
+      "debug" => params["debug"],
+    }.compact
   end
 
   def stopwords

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -79,6 +79,7 @@ private
       public_timestamp
       popularity
       content_purpose_supergroup
+      format
     )
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,7 @@
 class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
               :content_purpose_supergroup, :document_type, :organisations,
-              :release_timestamp, :es_score
+              :release_timestamp, :es_score, :format
 
   def initialize(rummager_document, finder)
     rummager_document = rummager_document.with_indifferent_access
@@ -16,6 +16,7 @@ class Document
     @is_historic = rummager_document.fetch(:is_historic, false)
     @government_name = rummager_document.fetch(:government_name, nil)
     @es_score = rummager_document.fetch(:es_score, nil)
+    @format = rummager_document.fetch(:format, nil)
     @finder = finder
     @facet_content_ids = rummager_document.fetch(:facet_values, [])
     @rummager_document = rummager_document.slice(*metadata_keys)

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -2,14 +2,14 @@ class ResultSetPresenter
   include ERB::Util
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :finder, :results, :total, :pluralised_document_noun
+  attr_reader :finder, :results, :total, :pluralised_document_noun, :debug_score
 
   delegate :filters,
            :keywords,
            :atom_url,
            to: :finder
 
-  def initialize(finder, filter_params, view_context, sort_presenter, metadata_presenter_class, show_top_result = false)
+  def initialize(finder, filter_params, view_context, sort_presenter, metadata_presenter_class, show_top_result = false, debug_score = false)
     @finder = finder
     @results = finder.results.documents
     @total = finder.results.total
@@ -19,6 +19,7 @@ class ResultSetPresenter
     @sort_presenter = sort_presenter
     @show_top_result = show_top_result
     @metadata_presenter_class = metadata_presenter_class
+    @debug_score = debug_score
   end
 
   def to_hash
@@ -51,7 +52,8 @@ class ResultSetPresenter
       documents: documents,
       zero_results: total.zero?,
       page_count: documents.count,
-      finder_name: finder.name
+      finder_name: finder.name,
+      debug_score: debug_score,
     }
   end
 

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -6,6 +6,7 @@ class SearchResultPresenter
            :promoted_summary,
            :show_metadata,
            :government_name,
+           :format,
            :es_score,
            to: :search_result
 
@@ -25,6 +26,7 @@ class SearchResultPresenter
       promoted: promoted,
       promoted_summary: promoted_summary,
       show_metadata: show_metadata,
+      format: format,
       es_score: es_score,
     }
   end

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -22,6 +22,14 @@
               <% if result[:is_historic] %>
                 <p class="historic">First published during the <%= result[:government_name] %></p>
               <% end %>
+
+              <% if debug_score %>
+                <p class="debug-link"><%= result[:link] %></p>
+                <p class="debug-info">
+                  <span>Score: <%= result[:es_score] || "no score (sort by relevance)" %></span>
+                  <span>Format: <%= result[:format] %></span>
+                </p>
+              <% end %>
             </li>
           <% end %>
         </ul>
@@ -60,6 +68,14 @@
         <% end %>
         <% if result[:is_historic] %>
           <p class="historic">First published during the <%= result[:government_name] %></p>
+        <% end %>
+
+        <% if debug_score %>
+          <p class="debug-link"><%= result[:link] %></p>
+          <p class="debug-info">
+            <span>Score: <%= result[:es_score] || "no score (sort by relevance)" %></span>
+            <span>Format: <%= result[:format] %></span>
+          </p>
         <% end %>
       </li>
     <% end %>

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -23,7 +23,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
     "facet_content_purpose_subgroup" => "1500,order:value.title",
     "fields" => %w(
       title link description public_timestamp popularity
-      content_purpose_supergroup
+      content_purpose_supergroup format
       content_store_document_type organisations
       content_purpose_subgroup part_of_taxonomy_tree
     ).join(","),

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -192,6 +192,7 @@ module RummagerUrlHelper
       public_timestamp
       popularity
       content_purpose_supergroup
+      format
     )
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -52,7 +52,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
+        url = "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-public_timestamp&search[][0][start]=0"
 
         stub_request(:get, url)
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -139,7 +139,7 @@ describe FindersController, type: :controller do
           ]
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
+        stub_request(:get, "#{Plek.current.find('search')}/batch_search.json?search[][0][count]=10&search[][0][fields]=title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator&search[][0][filter_document_type]=mosw_report&search[][0][order]=-closing_date&search[][0][start]=0").
           to_return(status: 200, body: rummager_response, headers: {})
       end
 
@@ -242,7 +242,7 @@ describe FindersController, type: :controller do
                 {
                   "0" => {
                     "count" => "10",
-                    "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,walk_type,place_of_origin,date_of_introduction,creator",
+                    "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
                     "filter_document_type" => "mosw_report",
                     "order" => "-public_timestamp",
                     "start" => "0"

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -59,7 +59,7 @@ describe SearchQueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format",
       )
     end
   end
@@ -86,7 +86,7 @@ describe SearchQueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,alpha,beta",
       )
     end
 
@@ -103,7 +103,7 @@ describe SearchQueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,zeta,beta",
         )
       end
     end

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -322,6 +322,24 @@ describe SearchQueryBuilder do
     end
   end
 
+  context "with debug parameters" do
+    let(:params) {
+      {
+        "debug" => "yes",
+      }
+    }
+
+    it "should include a debug query" do
+      expect(query).to include("debug" => "yes")
+    end
+  end
+
+  context "without debug parameters" do
+    it "should not include a debug query" do
+      expect(query).not_to include("debug")
+    end
+  end
+
   context "with a base filter" do
     let(:filter) { { "document_type" => "news_story" } }
 

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe GroupedResultSetPresenter do
       promoted: false,
       promoted_summary: nil,
       show_metadata: false,
+      format: 'transaction',
       es_score: nil
     )
   end
@@ -201,6 +202,7 @@ RSpec.describe GroupedResultSetPresenter do
         promoted: false,
         promoted_summary: nil,
         show_metadata: false,
+        format: 'transaction',
         es_score: nil
       )
     }

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe ResultSetPresenter do
       promoted: false,
       promoted_summary: nil,
       show_metadata: false,
+      format: 'transaction',
       es_score: 0.005
     )
   end
@@ -358,6 +359,7 @@ RSpec.describe ResultSetPresenter do
           promoted: false,
           promoted_summary: nil,
           show_metadata: false,
+          format: 'transaction',
           es_score: 1000.0,
           )
       end
@@ -374,6 +376,7 @@ RSpec.describe ResultSetPresenter do
           promoted: false,
           promoted_summary: nil,
           show_metadata: false,
+          format: 'transaction',
           es_score: 100.0,
           )
       end

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SearchResultPresenter do
       promoted: false,
       promoted_summary: 'I am a document',
       show_metadata: false,
+      format: 'cake',
       es_score: 0.005
     )
   }
@@ -40,6 +41,7 @@ RSpec.describe SearchResultPresenter do
       expect(hash[:title]).to eql(title)
       expect(hash[:link]).to eql(link)
       expect(hash[:metadata]).to eql(metadata)
+      expect(hash[:format]).to eql('cake')
       expect(hash[:es_score]).to eql(0.005)
     end
   end


### PR DESCRIPTION
The debug parameters (`debug=...` and `debug_score=...`) control how finder-frontend behaves: `debug` is passed straight on to search-api, so it can be used to do things like disable best bets or format boosting, the `debug_score` parameter makes the search results include the link, score, and format.

These parameters were never implemented for finders, so we lost this functionality when site search became a finder.  With this PR, they'll work for all finders.

---

## Search page examples to sanity check:

Try out the [debug parameters](https://gov-uk.atlassian.net/wiki/spaces/GS/pages/8126751/Search+debug+bookmarklets).

- http://finder-frontend-pr-1130.herokuapp.com/search/all
- http://finder-frontend-pr-1130.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1130.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1130.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1130.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/BpCv2XSc/731-debug-parameters-no-longer-working)