### PR TITLE
[DO NOT MERGE] Replace Sass Rails with SassC Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rails', '~> 5.2.3'
 gem 'slimmer', '~> 13.1.0'
 
 gem 'govuk_frontend_toolkit', '~> 8.2'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '>= 2.1.1'
 gem 'uglifier', '~> 4.1'
 
 group :doc do

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'slimmer', '~> 13.1.0'
 gem 'govuk_frontend_toolkit', '~> 8.2'
 gem 'sassc-rails', '>= 2.1.1'
 gem 'uglifier', '~> 4.1'
+gem 'yui-compressor', '~> 0.12.0'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,7 +396,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   rspec-rails (~> 3.8.2)
-  sass-rails (~> 5.0)
+  sassc-rails (>= 2.1.1)
   sdoc
   simplecov (~> 0.16.1)
   slimmer (~> 13.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,12 +295,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -369,6 +363,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yui-compressor (0.12.0)
 
 PLATFORMS
   ruby
@@ -403,6 +398,7 @@ DEPENDENCIES
   timecop
   uglifier (~> 4.1)
   webmock (~> 3.5.1)
+  yui-compressor (~> 0.12.0)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,8 +22,6 @@ FinderFrontend::Application.configure do
   # number of complex assets.
   config.assets.debug = false
 
-  config.assets.css_compressor = nil
-
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,8 @@ FinderFrontend::Application.configure do
   # number of complex assets.
   config.assets.debug = false
 
+  config.assets.css_compressor = nil
+
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,4 +21,5 @@ FinderFrontend::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.assets.css_compressor = nil
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,5 +21,5 @@ FinderFrontend::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-  config.assets.css_compressor = :scss
+  config.assets.css_compressor = nil
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,4 +21,5 @@ FinderFrontend::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.assets.css_compressor = :scss
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,5 +21,4 @@ FinderFrontend::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-  config.assets.css_compressor = nil
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,5 +21,5 @@ FinderFrontend::Application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-  config.assets.css_compressor = nil
+  config.assets.css_compressor = :yui
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,9 @@ FinderFrontend::Application.configure do
   config.action_dispatch.show_exceptions = false
   config.action_controller.allow_forgery_protection = false
   config.active_support.deprecation = :stderr
+
+  # Set a css_compressor so SassC Rails does not overwrite the compressor when
+  # running the tests. See https://github.com/sass/sassc-rails/issues/93 for
+  # more information.
+  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
Thhis pull request will swap Sass Rails for SassC Rails. This is because Ruby Sass is [deprecated](http://sass.logdown.com/posts/7828841) and  Sass Rails relied on Ruby Sass.

This replaces Sass Rails with [SassC Rails](https://github.com/sass/sassc-rails/), which uses [SassC Ruby](https://github.com/sass/sassc-ruby), which uses [Libsass](https://github.com/sass/libsass). 

As well as removing a deprecated dependency, it promises a speed increase for the Sass compilation.

Note: there will still be a warning that Ruby Sass is deprecated. This is because GOV.UK Frontend Toolkit is a dependency and it uses Ruby Sass.

Fixes #1124.

## Search page examples to sanity check:

- http://finder-frontend-pr-1132.herokuapp.com/search/all
- http://finder-frontend-pr-1132.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1132.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1132.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1132.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
