### PR TITLE
Refactor Sass and CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,4 +2,3 @@
 @import 'views/advanced-search';
 @import 'views/email';
 @import 'views/qa';
-@import 'views/overrides';

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -66,15 +66,15 @@
   }
 }
 
+.metadata-summary {
+  @include govuk-font(19);
+  margin-bottom: govuk-spacing(6);
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
 
   header {
-    .summary {
-      margin-bottom: govuk-spacing(6);
-      @include govuk-font(19);
-    }
-
     .logo {
       margin: govuk-spacing(6) 0;
     }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -6,44 +6,37 @@
 .document {
   border-bottom: solid 1px $govuk-border-colour;
   padding: govuk-spacing(3) 0;
+}
 
-  .document__link {
-    @include govuk-font(19, $weight: bold);
-    margin: 0;
-    text-decoration: none;
+.document__link {
+  @include govuk-font(19, $weight: bold);
+  margin: 0;
+  text-decoration: none;
 
-    &.document-heading--pinned {
-      @include govuk-font($size: 24, $weight: bold);
-    }
+  &.document-heading--pinned {
+    @include govuk-font($size: 24, $weight: bold);
   }
+}
 
-  dl {
-    margin: 0;
+.historic {
+  @include govuk-font(14);
+  padding: 0 0 3px;
+  color: $govuk-secondary-text-colour;
+}
 
-    dt, dd {
-      @include govuk-font(14);
-      margin-left: 0;
-    }
+.document-metadata {
+  margin: 0;
+}
 
-    dt {
-      display: none;
+.document-metadata__label,
+.document-metadata__value {
+  @include govuk-font(14);
+  display: inline-block;
+  margin-left: 0;
+}
 
-      &.metadata-label {
-        display: inline-block;
-      }
-    }
-
-    dd {
-      margin-right: govuk-spacing(2);
-      display: inline-block;
-    }
-  }
-
-  p.historic {
-    @include govuk-font(14);
-    padding: 0 0 3px;
-    color: $govuk-secondary-text-colour;
-  }
+.document-metadata__value {
+  margin-right: govuk-spacing(2);
 }
 
 .document--top {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -69,10 +69,6 @@
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
 
-  strong {
-    font-weight: 600;
-  }
-
   header {
     .summary {
       margin-bottom: govuk-spacing(6);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -56,26 +56,18 @@
   margin-top: govuk-spacing(2);
 }
 
+.signup-content p {
+  margin: govuk-spacing(3) 0;
+  @include govuk-font(19);
+
+  @include media(tablet) {
+    margin: govuk-spacing(6) 0;
+    max-width: $two-thirds;
+  }
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
-
-  .signup-content p {
-    margin: govuk-spacing(3) 0;
-    @include govuk-font(19);
-
-    @include media(tablet) {
-      margin: govuk-spacing(6) 0;
-      max-width: $two-thirds;
-    }
-  }
-
-  legend {
-    color: $govuk-text-colour;
-    margin-bottom: govuk-spacing(3);
-    @include media(tablet) {
-      margin-bottom: govuk-spacing(4);
-    }
-  }
 
   strong {
     font-weight: 600;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -5,26 +5,27 @@
 .feed {
   display: none;
 }
-header {
-  @include govuk-clearfix;
 
-  dt {
-    float: left;
-    clear: left;
-    width: auto;
-    min-width: 40px;
-    padding-right: 10px;
-  }
-  dd {
-    float: left;
-    width: 70%;
-  }
+header,
+.document-metadata {
+  @include govuk-clearfix;
 }
+
+.document-metadata__label {
+  display: none;
+}
+
+.document-metadata__value {
+  display: inline-block;
+  margin-left: 0;
+  margin-right: 10px;
+}
+
 .filtered-results {
   margin-top: 20px;
   clear: both;
 
-  a, dl, dd, ul, li {
+  a, dl, ul, li {
     margin: 0;
   }
   ul {
@@ -39,12 +40,5 @@ header {
   a {
     font-weight: bold;
     margin-bottom: 5px;
-  }
-  dt {
-    display: none;
-  }
-  dd {
-    margin-right: 10px;
-    display: inline-block;
   }
 }

--- a/app/assets/stylesheets/views/_overrides.scss
+++ b/app/assets/stylesheets/views/_overrides.scss
@@ -1,8 +1,0 @@
-/* Overrides styling of legends in finder-frontend.scss */
-legend.gem-c-title--margin-bottom-5 {
-  margin-bottom: govuk-spacing(3) !important;
-
-  @include media(tablet) {
-    margin-bottom: govuk-spacing(8) !important;
-  }
-}

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -11,10 +11,6 @@ main.search {
     padding-bottom: 10px;
   }
 
-  strong {
-    font-weight: 600;
-  }
-
   .search-header {
     position: relative;
     margin: 0;

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -49,23 +49,35 @@
             data-track-label='<%= result[:link] %>'
             data-track-options='{"dimension28":"<%= page_count %>","dimension29":"<%= result[:title] %>"}'
         ><%= result[:title] %></a>
+
         <% if result[:summary] %>
           <p><%= result[:summary] %></p>
         <% end %>
+
         <% if result[:show_metadata] %>
-          <dl class="metadata-wrapper">
+          <dl class="document-metadata">
             <% result[:metadata].each do |metadata| %>
               <% if metadata[:is_text] %>
-                <dt class="metadata-label<%= ' govuk-visually-hidden' if metadata[:hide_label] %>"><%= metadata[:label] %>:</dt>
-                <dd class='metadata-text-value'><%= metadata[:value] %></dd>
+                <dt class="document-metadata__label<%= ' govuk-visually-hidden' if metadata[:hide_label] %>">
+                  <%= metadata[:label] %>:
+                </dt>
+                <dd class='document-metadata__value'>
+                  <%= metadata[:value] %>
+                </dd>
               <% end %>
+
               <% if metadata[:is_date] %>
-                <dt class="metadata-label<%= ' govuk-visually-hidden' if metadata[:hide_label] %>"><%= metadata[:label] %>:</dt>
-                <dd class='metadata-date-value'><time datetime='<%= metadata[:machine_date] %>'><%= metadata[:human_date] %></time></dd>
+                <dt class="document-metadata__label<%= ' govuk-visually-hidden' if metadata[:hide_label] %>">
+                  <%= metadata[:label] %>:
+                </dt>
+                <dd class='document-metadata__value'>
+                  <time datetime='<%= metadata[:machine_date] %>'><%= metadata[:human_date] %></time>
+                </dd>
               <% end %>
             <% end %>
-            </dl>
+          </dl>
         <% end %>
+
         <% if result[:is_historic] %>
           <p class="historic">First published during the <%= result[:government_name] %></p>
         <% end %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -63,7 +63,7 @@
       <% end %>
 
       <% if finder.summary %>
-        <div class="summary">
+        <div class="metadata-summary">
           <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
         </div>
       <% end %>

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -101,8 +101,8 @@ Then(/^I only see documents tagged to the taxon tree within the supergroup and s
 end
 
 Then(/^The correct metadata is displayed for the search results$/) do
-  expect(page).to have_css(".metadata-text-value", text: "Guidance")
-  expect(page).not_to have_css(".metadata-text-value", text: "Guide")
+  expect(page).to have_css(".document-metadata__value", text: "Guidance")
+  expect(page).not_to have_css(".document-metadata__value", text: "Guide")
 end
 
 And(/^the correct metadata is displayed for the dates$/) do

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -38,12 +38,12 @@ describe('liveSearch', function () {
         '<a href="aaib-reports/test-report" class="document__link" data-track-category="navFinderLinkClicked" data-track-action="" data-track-label="">Test report</a>' +
         '<p></p>' +
         '<dl>' +
-          '<dt class="metadata-label">Aircraft category:</dt>' +
-          '<dd class="metadata-text-value">General aviation - rotorcraft</dd>' +
-          '<dt class="metadata-label">Report type:</dt>' +
-          '<dd class="metadata-text-value">Annual safety report</dd>' +
-          '<dt class="metadata-label">Occurred:</dt>' +
-          '<dd class="metadata-date-value"><time datetime="2013-11-03">3 November 2013</time></dd>' +
+          '<dt class="document-metadata__label">Aircraft category:</dt>' +
+          '<dd class="document-metadata__value">General aviation - rotorcraft</dd>' +
+          '<dt class="document-metadata__label">Report type:</dt>' +
+          '<dd class="document-metadata__value">Annual safety report</dd>' +
+          '<dt class="document-metadata__label">Occurred:</dt>' +
+          '<dd class="document-metadata__value"><time datetime="2013-11-03">3 November 2013</time></dd>' +
         '</dl>' +
       '</li>' +
     '</ul>'


### PR DESCRIPTION
This PR restructures finder-frontend's Sass to generally improve readability and structuring but also specifically to solve the problem of most of the CSS being nested underneath the `#finder-frontend` id, which can override any styles set by our components.

As this is clearly a large task, I'm going to approach it in chunks in order to make reviewing the changes easier. This PR is only the beginning of this work.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1134.herokuapp.com/search/all
- http://finder-frontend-pr-1134.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1134.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1134.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1134.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
