### PR TITLE
Add machine readable metadata to finders

### DIFF
--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -7,3 +7,6 @@
 <link rel="alternate" type="application/json" href="/api/content<%= finder.slug %>">
 
 <%= render 'govuk_publishing_components/components/meta_tags', content_item: finder.content_item %>
+<%= render 'govuk_publishing_components/components/machine_readable_metadata',
+           schema: :search_results_page,
+           content_item: finder.content_item %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -6,9 +6,6 @@
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, @results.signup_links[:feed_link]) %>
   <%= render 'finder_meta', finder: finder %>
-  <% if finder.canonical_link? %>
-    <link rel="canonical" href="<%= "#{ENV['GOVUK_WEBSITE_ROOT']}#{finder.slug}" %>">
-  <% end %>
 
   <% if @results.to_hash[:documents].present? && @results.to_hash[:documents].first[:document][:top_result] %>
     <meta name="govuk:relevant-result-shown" content="yes">

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -65,6 +65,7 @@ Feature: Filtering documents
   Scenario: Visit a finder with paginated results
     Given a finder with paginated results exists
     Then I can see pagination
+    And there is machine readable information
     And I can see that Google can index the page
     And I can browse to the next page
     And I can see that Google won't index the page

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -388,6 +388,17 @@ Then(/^I browse to a huge page number and get an appropriate error$/) do
   expect(page.status_code).to eq(422)
 end
 
+And("there is machine readable information") do
+  schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+  schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+  org_schema = schemas.detect { |schema| schema["@type"] == "SearchResultsPage" }
+  expect(org_schema["name"]).to eq @title
+
+  tag = "link[rel='canonical']"
+  expect(page).to have_css(tag, visible: false)
+end
+
 Then(/^I can see that Google won't index the page$/) do
   tag = "meta[name='robots'][content='noindex']"
   expect(page).to have_css(tag, visible: false)

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -79,38 +79,6 @@ describe FindersController, type: :controller do
         expect(response.content_type).to eq("application/json")
       end
 
-      describe "canonical links" do
-        let(:canonical_finder) do
-          finder = govuk_content_schema_example('finder').to_hash.merge(
-            'title' => 'Canonical Finder',
-            'base_path' => '/canonical-finder',
-          )
-
-          finder['details']['canonical_link'] = true
-          finder["details"]["default_documents_per_page"] = 10
-          finder["details"]["sort"] = nil
-          finder
-        end
-
-        before do
-          content_store_has_item(
-            '/canonical_finder',
-            canonical_finder
-          )
-        end
-
-        it "are not shown if the finder does not have a canonical_link field" do
-          get :show, params: { slug: "lunch-finder" }
-          expect(response.body).not_to include('<link rel="canonical"')
-        end
-
-        it "are shown if the finder has a canonical_link field" do
-          get :show, params: { slug: "canonical_finder" }
-
-          expect(response.body).to include("<link rel=\"canonical\" href=\"#{ENV['GOVUK_WEBSITE_ROOT']}/canonical-finder\">")
-        end
-      end
-
       it "returns a 406 if an invalid format is requested" do
         request.headers["Accept"] = "text/plain"
         get :show, params: { slug: "lunch-finder" }


### PR DESCRIPTION
This adds canonical URLs for all finders, the SearchResultsPage schema, and open graph and twitter metadata.

You can see the effect of this by looking at the metadata checkers:

## Before
- https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Fgov.uk%2Fdrug-device-alerts (only the breadcrumb schema)
- https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fwww.gov.uk%2Ffind-eu-exit-guidance-business (missing some properties)

## After
- https://search.google.com/structured-data/testing-tool/u/0/#url=http%3A%2F%2Ffinder-frontend-pr-1136.herokuapp.com%2Fdrug-device-alerts (search results page schema too)
- https://www.linkedin.com/post-inspector/inspect/http:%2F%2Ffinder-frontend-pr-1136.herokuapp.com%2Ffind-eu-exit-guidance-business (more properties defined)

See https://github.com/alphagov/govuk_publishing_components/pull/861/files for
details of what is added in the SearchResultsPage schema.

See https://github.com/alphagov/govuk_publishing_components/blob/master/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb
for details of what other metadata is included.

https://trello.com/c/OVkRpKDk/735-add-metadata-for-finders

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1136.herokuapp.com/search/all
- http://finder-frontend-pr-1136.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1136.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1136.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1136.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
