### PR TITLE
Refactor pagination

### DIFF
--- a/app/lib/url_builder.rb
+++ b/app/lib/url_builder.rb
@@ -1,0 +1,19 @@
+# The UrlBuilder class is responsible for creating URLs to be rendered as
+# HTML links.
+class UrlBuilder
+  def initialize(path, query_params = {})
+    @path = path
+    @query_params = query_params
+  end
+
+  def url(additional_params = {})
+    [
+      path,
+      query_params.merge(additional_params).to_query,
+    ].reject(&:blank?).join("?")
+  end
+
+private
+
+  attr_reader :path, :query_params
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,6 @@
 class ContentItem
+  attr_reader :base_path
+
   def initialize(base_path)
     @base_path = base_path
     @content_item = fetch_content_item
@@ -32,16 +34,20 @@ class ContentItem
     MetadataPresenter
   end
 
+  def default_documents_per_page
+    content_item.dig('details', 'default_documents_per_page')
+  end
+
 private
 
-  attr_reader :base_path
+  attr_reader :content_item
 
   def is_research_and_statistics?
     base_path == '/search/research-and-statistics'
   end
 
   def document_type
-    @content_item['document_type']
+    content_item['document_type']
   end
 
   def fetch_content_item

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -56,20 +56,6 @@ class FinderPresenter
     content_item['details']['summary']
   end
 
-  def pagination
-    documents_per_page = content_item['details']['default_documents_per_page']
-
-    return nil unless documents_per_page
-
-    start_offset = search_results['start']
-    total_results = search_results['total']
-
-    {
-      'current_page' => (start_offset / documents_per_page) + 1,
-      'total_pages' => (total_results / documents_per_page.to_f).ceil,
-    }
-  end
-
   def email_alert_signup
     if content_item['links']['email_alert_signup']
       content_item['links']['email_alert_signup'].first

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,0 +1,60 @@
+# The PaginationPresenter class is responsible for creating the next and
+# previous links to be displayed on finders.
+class PaginationPresenter
+  def initialize(per_page:, start_offset:, total_results:, url_builder:)
+    @per_page = per_page
+    @start_offset = start_offset
+    @total_results = total_results
+    @url_builder = url_builder
+  end
+
+  def next_and_prev_links
+    return unless can_paginate?
+
+    { previous_page: previous_page, next_page: next_page }.compact
+  end
+
+private
+
+  attr_reader :per_page, :start_offset, :total_results, :url_builder
+
+  def can_paginate?
+    per_page.present? && has_other_pages?
+  end
+
+  def has_other_pages?
+    previous_page.present? || next_page.present?
+  end
+
+  def page_links
+    { previous_page: previous_page, next_page: next_page }.compact
+  end
+
+  def current_page
+    (start_offset / per_page) + 1
+  end
+
+  def total_pages
+    (total_results / per_page.to_f).ceil
+  end
+
+  def next_page
+    return unless current_page < total_pages
+
+    build_page_link("Next page", current_page + 1)
+  end
+
+  def previous_page
+    return unless current_page > 1
+
+    build_page_link("Previous page", current_page - 1)
+  end
+
+  def build_page_link(page_label, page)
+    {
+      title: page_label,
+      label: "#{page} of #{total_pages}",
+      url: url_builder.url(page: page),
+    }
+  end
+end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -65,20 +65,6 @@ class ResultSetPresenter
     @signup_links ||= fetch_signup_links
   end
 
-  def next_and_prev_links
-    return unless finder.pagination
-
-    current_page = finder.pagination['current_page']
-    previous_page = current_page - 1 if current_page > 1
-    next_page = current_page + 1 if current_page < finder.pagination['total_pages']
-    pages = {}
-
-    pages[:previous_page] = build_page_link("Previous page", previous_page) if previous_page
-    pages[:next_page] = build_page_link("Next page", next_page) if next_page
-
-    pages
-  end
-
 private
 
   attr_reader :metadata_presenter_class, :sort_presenter, :total
@@ -96,14 +82,6 @@ private
     if results[0].es_score && results[1].es_score
       (results[0].es_score / results[1].es_score) > 7
     end
-  end
-
-  def build_page_link(page_label, page)
-    {
-      url: [finder.slug, finder.values.merge(page: page).to_query].reject(&:blank?).join("?"),
-      title: page_label,
-      label: "#{page} of #{finder.pagination['total_pages']}",
-    }
   end
 
   def sort_option

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -71,7 +71,7 @@
             </div>
 
             <div id="js-pagination">
-              <%= @results.next_and_prev_links %>
+              <%= @pagination.next_and_prev_links %>
             </div>
           </div>
         </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -123,7 +123,7 @@
       </div>
 
       <div id="js-pagination">
-        <%= render "govuk_publishing_components/components/previous_and_next_navigation", @results.next_and_prev_links %>
+        <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
       </div>
     </div>
   </div>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -247,7 +247,6 @@ describe FindersController, type: :controller do
     end
 
     let(:filter_params) { double(:filter_params, keywords: '') }
-    let(:view_context) { double(:view_context) }
     let(:finder_presenter) { FinderPresenter.new(breakfast_finder, {}, filter_params) }
 
     before do

--- a/spec/lib/url_builder_spec.rb
+++ b/spec/lib/url_builder_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe UrlBuilder do
+  let(:builder) { described_class.new(path, query_params) }
+  let(:extra_params) { {} }
+  let(:path) { '/search/all' }
+
+  describe "#url_builder" do
+    context "when given a path and query params" do
+      subject(:url) { builder.url }
+
+      let(:query_params) {
+        {
+          keywords: 'harry potter',
+          order: 'relevance',
+          public_timestamp: {
+            from: 2005,
+            to: 2015,
+          },
+          organisations: [
+            'ministry-of-magic',
+            'hogwarts',
+          ]
+        }
+      }
+
+      it "builds a url with a query" do
+        expect(url).to eq('/search/all?' + query_params.to_query)
+      end
+    end
+
+    context "when given a path, query params, and additional params" do
+      subject(:url) { builder.url(page: 20) }
+      let(:query_params) { { keywords: 'dumbledore' } }
+
+      it "builds a url that includes the additional params" do
+        expect(url).to eq('/search/all?keywords=dumbledore&page=20')
+      end
+    end
+  end
+end

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe AtomPresenter do
   subject(:instance) { described_class.new(finder, results, facet_tags) }
 
-  let(:results) { ResultSetPresenter.new(finder, filter_params, view_context, sort_presenter, metadata_presenter_class) }
+  let(:results) { ResultSetPresenter.new(finder, filter_params, sort_presenter, metadata_presenter_class) }
   let(:metadata_presenter_class) do
     MetadataPresenter
   end
@@ -21,7 +21,6 @@ RSpec.describe AtomPresenter do
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},
-      pagination: { 'current_page' => 1, 'total_pages' => 2 },
       sort: {},
     )
   end
@@ -31,7 +30,6 @@ RSpec.describe AtomPresenter do
   }
 
   let(:filter_params) { double(:filter_params, keywords: '') }
-  let(:view_context) { double(:view_context) }
   let(:sort_presenter) { double(:sort_presenter, selected_option: nil) }
 
   let(:a_facet) do

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe GroupedResultSetPresenter do
     metadata_presenter_class.new(metadata).present
   end
 
-  let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
-
   let(:filter_params) { { keywords: 'test' } }
 
   let(:finder) do
@@ -35,7 +33,6 @@ RSpec.describe GroupedResultSetPresenter do
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},
-      pagination: pagination,
       sort: {},
       filters: facet_filters
     )

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+describe PaginationPresenter do
+  subject(:links) { presenter.next_and_prev_links }
+  let(:presenter) {
+    described_class.new(
+      per_page: per_page,
+      start_offset: start_offset,
+      total_results: total_results,
+      url_builder: url_builder,
+    )
+  }
+  let(:per_page) {}
+  let(:start_offset) {}
+  let(:total_results) {}
+  let(:url_builder) { UrlBuilder.new('/search') }
+
+  describe "#next_and_prev_links" do
+    context "when per_page is unset" do
+      it "returns nil" do
+        expect(subject).to be nil
+      end
+    end
+
+    context "when there are no other pages with results" do
+      let(:per_page) { 20 }
+      let(:total_results) { 20 }
+      let(:start_offset) { 1 }
+
+      it "returns nil" do
+        expect(subject).to be nil
+      end
+    end
+
+    context "when there are only next pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 1 }
+
+      it "returns a next page link" do
+        expect(subject).to eq(
+          next_page: {
+            label: "2 of 5",
+            title: "Next page",
+            url: "/search?page=2",
+          }
+        )
+      end
+    end
+
+    context "when there are only previous pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 80 }
+
+      it "returns a previous page link" do
+        expect(subject).to eq(
+          previous_page: {
+            label: "4 of 5",
+            title: "Previous page",
+            url: "/search?page=4",
+          }
+        )
+      end
+    end
+
+    context "when there are next and previous pages" do
+      let(:per_page) { 20 }
+      let(:total_results) { 100 }
+      let(:start_offset) { 20 }
+
+      it "returns next and previous page links" do
+        expect(subject).to eq(
+          next_page: {
+            label: "3 of 5",
+            title: "Next page",
+            url: "/search?page=3",
+          },
+          previous_page: {
+            label: "1 of 5",
+            title: "Previous page",
+            url: "/search?page=1",
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe ResultSetPresenter do
       keywords: keywords,
       default_documents_per_page: 10,
       values: {},
-      pagination: pagination,
       sort: [
         {
           "name" => "Most viewed",
@@ -44,8 +43,6 @@ RSpec.describe ResultSetPresenter do
       filters: a_facet_collection.filters
     )
   end
-
-  let(:pagination) { { 'current_page' => 1, 'total_pages' => 2 } }
 
   let(:filter_params) { { keywords: 'test' } }
 


### PR DESCRIPTION
This extracts the pagination logic out of the `FinderPresenter` and `ResultSetPresenter` classes.

Ideally we can extra the logic from these two presenters and put them into smaller more well defined presenters.

It also adds some tests for the behaviour.

I've added in a `UrlBuilder` class, as I think this can be used elsewhere where we also combine query params and a path (e.g. feed/email links).

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1137.herokuapp.com/search/all
- http://finder-frontend-pr-1137.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1137.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1137.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1137.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
