### PR TITLE
HTML Safe Content Item Phase Message

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -64,6 +64,7 @@ private
   FINDERS_IN_DEVELOPMENT = {
     "/review-search/all" => 'all_content',
     "/review-search/news-and-communications" => 'news_and_communications',
+    "/review-search/research-and-statistics" => 'statistics',
   }.freeze
 
   def development_env_finder_json

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -21,7 +21,9 @@ class FinderPresenter
   end
 
   def phase_message
-    content_item['details']['beta_message'] || content_item['details']['alpha_message']
+    message = content_item['details']['beta_message'] || content_item['details']['alpha_message'] || ""
+
+    message.html_safe
   end
 
   def phase

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -9,7 +9,7 @@
   "government_document_supertype":"other",
   "locale":"en",
   "navigation_document_supertype":"other",
-  "phase":"alpha",
+  "phase":"beta",
   "public_updated_at":"2019-01-15T14:47:48.000+00:00",
   "publishing_app":"finder-frontend",
   "rendering_app":"finder-frontend",
@@ -40,6 +40,7 @@
   },
   "description":"Find statistics from government",
   "details":{
+    "beta_message": "This is in beta. Please take our <a href='https://www.gov.uk'>survey</a>.",
     "document_noun":"result",
     "filter":{},
     "format_name":"statistic",


### PR DESCRIPTION
This lets us render HTML links in phase messages.

We trust this text as it comes from the content store.

Pair programming effort with Jessica Jones (@hannako).

Associated work on search api on branch [add_beta_message](https://github.com/alphagov/search-api/tree/add_beta_message)

Check it at http://finder-frontend-pr-1140.herokuapp.com/review-search/research-and-statistics

Trello: https://trello.com/c/GU9oNJot/722.
