### PR TITLE
Render all manuals as Facet Tags

### DIFF
--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -33,7 +33,7 @@ module Registries
 
     def fetch_manuals_from_rummager
       params = {
-          filter_document_type: 'manual',
+          filter_document_type: %w(manual service_manual_homepage service_manual_guide),
           fields: %w(title),
           count: 1500,
       }

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -88,7 +88,7 @@ module RegistrySpecHelper
   def stub_manuals_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
       .with(query: {
-          filter_document_type: 'manual',
+          filter_document_type: %w(manual service_manual_homepage service_manual_guide),
           fields: %w(title),
           count: 1500,
       })

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Registries::ManualsRegistry do
   let(:slug) { '/guidance/care-and-use-of-a-nimbus-2000' }
   let(:rummager_params) {
     {
-      filter_document_type: 'manual',
+      filter_document_type: %w(manual service_manual_homepage service_manual_guide),
       fields: %w(title),
       count: 1500
     }
@@ -29,6 +29,11 @@ RSpec.describe Registries::ManualsRegistry do
               'slug' => slug
            }
        )
+    end
+
+    it "will fetch the correct types of document" do
+      described_class.new[slug]
+      assert_requested :get, rummager_url
     end
   end
 


### PR DESCRIPTION
We left out a couple of manuals from the manuals registry which are required to render facet tags.

This meant that https://www.gov.uk/service-manual was not rendered as a facet tag when filtering by manual (https://www.gov.uk/search/all?manual=/service-manual), unlike others: https://www.gov.uk/search/all?manual=/guidance/the-highway-code.

This fixes that: http://finder-frontend-pr-1144.herokuapp.com/search/all?manual=/service-manual