### PR TITLE
Remove email signup link from advanced search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       rubocop-rspec (~> 1.28)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (1.16.2)
+    govuk_app_config (1.16.3)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -94,21 +94,6 @@
       @include govuk-font(19);
     }
 
-    .email-link {
-      margin-bottom: govuk-spacing(6);
-
-      a {
-        @include govuk-font(19, $weight: bold);
-        text-decoration:none;
-        background: image-url('mail-icon.png') 0 40% no-repeat;
-        @include device-pixel-ratio(2.0) {
-          background-image: image-url('mail-icon-retina.png');
-          background-size: govuk-spacing(4) 14px;
-        }
-        padding-left: govuk-spacing(6);
-      }
-    }
-
     .logo {
       margin: govuk-spacing(6) 0;
     }

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -2,7 +2,6 @@
 @import "govuk_publishing_components/all_components_print";
 
 .filter-form,
-.email-link,
 .feed {
   display: none;
 }

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -20,12 +20,6 @@
       <div class="govuk-grid-column-two-thirds">
         <%= finder.taxon_link %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: { title: finder.title, inverse: true } %>
-
-        <% if finder.email_alert_signup_url %>
-          <p class='email-link'>
-            <%= link_to 'Subscribe to email alerts', finder.email_alert_signup_url %>
-          </p>
-        <% end %>
       </div>
 
       <% if finder.logo_path %>


### PR DESCRIPTION
Removing the code for 'subscribe to email alerts' link, as apparently it doesn't appear in any of the advanced search pages. It would look like this:

<img width="874" alt="Screen Shot 2019-05-28 at 10 49 51" src="https://user-images.githubusercontent.com/861310/58475254-5f1d6800-8145-11e9-9857-ae715d4c971f.png">

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1151.herokuapp.com/search/all
- http://finder-frontend-pr-1151.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1151.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1151.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1151.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
