### PR TITLE
Stop json endpoint being being used as a link

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -54,7 +54,8 @@ private
     {
       title: page_label,
       label: "#{page} of #{total_pages}",
-      url: url_builder.url(page: page),
+      # FIXME - This is horrible. Fix this properly when Bill is back from holiday.
+      url: url_builder.url(page: page).sub('advanced.json', 'advanced'),
     }
   end
 end


### PR DESCRIPTION
Fixes a bug with the pagination on the advanced finder in a not-very-nice-but-it-works kind of way.

To replicate the bug:

- go to the [advanced search finder](https://www.gov.uk/search/advanced?keywords=&subgroup%5B%5D=news&subgroup%5B%5D=speeches_and_statements&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&topic=%2Feducation&group=news_and_communications&organisations=)
- double check the ‘next page’ link at the bottom (don’t click) - it should start with `gov.uk/search/advanced/` before the query string
- scroll to top, remove either the ‘news’ or ‘speeches and statements’ tag
- check next page link at the bottom; the link now starts with `gov.uk/search/advanced.json?`. Clicking it will load a JSON file.

This fixes it by a quick `gsub` on the page link to replace 'advanced.json' with 'advanced'.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1153.herokuapp.com/search/all
- http://finder-frontend-pr-1153.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1153.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1153.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1153.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
