### PR TITLE
Fix pagination issue on Advanced Search

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,8 +1,6 @@
 class ContentItem
-  attr_reader :base_path
-
-  def initialize(base_path)
-    @base_path = base_path
+  def initialize(request_path)
+    @request_path = request_path
     @content_item = fetch_content_item
   end
 
@@ -38,9 +36,13 @@ class ContentItem
     content_item.dig('details', 'default_documents_per_page')
   end
 
+  def base_path
+    content_item.dig('base_path')
+  end
+
 private
 
-  attr_reader :content_item
+  attr_reader :content_item, :request_path
 
   def is_research_and_statistics?
     base_path == '/search/research-and-statistics'
@@ -54,7 +56,7 @@ private
     if development_env_finder_json
       JSON.parse(File.read(development_env_finder_json))
     else
-      Services.cached_content_item(base_path)
+      Services.cached_content_item(request_path)
     end
   end
 
@@ -80,10 +82,10 @@ private
   end
 
   def development_json
-    "features/fixtures/#{FINDERS_IN_DEVELOPMENT[base_path]}.json"
+    "features/fixtures/#{FINDERS_IN_DEVELOPMENT[request_path]}.json"
   end
 
   def is_development_json?
-    base_path.present? && FINDERS_IN_DEVELOPMENT[base_path].present?
+    request_path.present? && FINDERS_IN_DEVELOPMENT[request_path].present?
   end
 end

--- a/features/advanced_search.feature
+++ b/features/advanced_search.feature
@@ -15,6 +15,13 @@ Feature: Advanced Search
     Then I only see documents tagged to the taxon tree within the supergroup
     And The correct metadata is displayed for the search results
 
+  @javascript
+  Scenario: Permits pagination
+    Given a collection of tagged documents in supergroup 'news_and_communications'
+    When I filter by taxon and by supergroup
+    And I enter a search query
+    Then the pagination links have been updated correctly
+
   Scenario: Filters documents by taxon, supergroup and dates
     Given a collection of tagged documents with dates in supergroup 'news_and_communications'
     When I filter by taxon, supergroup and dates

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -48,7 +48,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
     body: {
       results: [
         results: @results,
-        total: 2,
+        total: 200,
         start: 0,
         facets: {},
         suggested_queries: []
@@ -86,7 +86,7 @@ Then(/^I only see documents tagged to the taxon tree within the supergroup$/) do
   @results.each do |result|
     expect(page).to have_title("News and communications - GOV.UK")
     expect(page).to have_link("Taxon", href: "/taxon")
-    expect(page).to have_text("2 results")
+    expect(page).to have_text("200 results")
     expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
   end
 end
@@ -95,7 +95,7 @@ Then(/^I only see documents tagged to the taxon tree within the supergroup and s
   @results.each do |result|
     expect(page).to have_title("News and communications - GOV.UK")
     expect(page).to have_link("Taxon", href: "/taxon")
-    expect(page).to have_text("2 results")
+    expect(page).to have_text("200 results")
     expect(page).to have_link(result["title_with_highlighting"], href: result["link"])
   end
 end
@@ -107,7 +107,7 @@ end
 
 And(/^the correct metadata is displayed for the dates$/) do
   within(".result-info") do
-    expect(page).to have_content("2 results")
+    expect(page).to have_content("200 results")
     expect(page).to have_content("1 January 2005")
     expect(page).to have_content("1 January 2025")
   end
@@ -115,4 +115,16 @@ end
 
 Then(/^The page is not found$/) do
   expect(page.status_code).to eq(404)
+end
+
+And(/^I enter a search query$/) do
+  within '#keywords' do
+    fill_in("Search", with: "harry potter")
+  end
+end
+
+Then(/^the pagination links have been updated correctly$/) do
+  within("#js-pagination") do
+    expect(page).to have_link("Next page", href: "/search/advanced?group=news_and_communications&page=2&topic=%2Ftaxon")
+  end
 end


### PR DESCRIPTION
We were rendering the request_path rather than the base_path of a finder, so when a change is made to pagination via Ajax it would link to the wrong page (.json rather than .html)

With Ian James (@injms), we fixed this.

https://trello.com/c/uM0XyfKK/771

To replicate the bug:

- go to the [advanced search finder](https://www.gov.uk/search/advanced?keywords=&subgroup%5B%5D=news&subgroup%5B%5D=speeches_and_statements&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&topic=%2Feducation&group=news_and_communications&organisations=)
- double check the ‘next page’ link at the bottom (don’t click) - it should start with `gov.uk/search/advanced/` before the query string
- scroll to top, remove either the ‘news’ or ‘speeches and statements’ tag
- check next page link at the bottom; the link now starts with `gov.uk/search/advanced.json?`. Clicking it will load a JSON file.

The [preview version](http://finder-frontend-pr-1155.herokuapp.com/search/advanced?keywords=&subgroup%5B%5D=news&subgroup%5B%5D=speeches_and_statements&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&topic=%2Feducation&group=news_and_communications&organisations=) should be fixed - it should no longer load the json when the same steps are taken.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1155.herokuapp.com/search/all
- http://finder-frontend-pr-1155.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1155.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1155.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1155.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)