### PR TITLE
Adds combine_mode param to email signups

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -68,6 +68,7 @@ private
       finder_format: finder_format,
       subscriber_list_title: subscriber_list_title,
       default_frequency: signup_presenter.default_frequency,
+      combine_mode: signup_presenter.combine_mode,
     )
   end
 

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -30,6 +30,10 @@ class SignupPresenter
     content_item['details']['beta']
   end
 
+  def combine_mode
+    content_item['details'].fetch('combine_mode', nil)
+  end
+
   def can_modify_choices?
     choices? && choices_formatted.any?
   end

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -14,6 +14,7 @@
         "prechecked": true
       }
     ],
-    "subscription_list_title_prefix": "Find EU Exit guidance for your business"
+    "subscription_list_title_prefix": "Find EU Exit guidance for your business",
+    "combine_mode": "or"
   }
 }

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,13 +1,14 @@
 require 'addressable/uri'
 
 class EmailAlertSignupAPI
-  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil)
+  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil, combine_mode: nil)
     @applied_filters = applied_filters.deep_symbolize_keys
     @default_filters = default_filters.deep_symbolize_keys
     @facets = facets
     @subscriber_list_title = subscriber_list_title
     @finder_format = finder_format
     @default_frequency = default_frequency
+    @combine_mode = combine_mode
   end
 
   def signup_url
@@ -20,7 +21,7 @@ class EmailAlertSignupAPI
 
 private
 
-  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format
+  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format, :combine_mode
 
   def add_url_param(url, param)
     # this method safely adds a URL parameter using the correct one of '?' or '&'
@@ -34,17 +35,14 @@ private
   end
 
   def subscriber_list_options
-    options = if facet_groups?
-                {
-                  "links" => facet_groups,
-                }
-              else
-                {
-                  "tags" => tags,
-                }
-              end
-
-    options.merge("title" => subscriber_list_title)
+    options = { "title" => subscriber_list_title }
+    options["combine_mode"] = combine_mode if combine_mode
+    if facet_groups?
+      options["links"] = facet_groups
+    else
+      options["tags"] = tags
+    end
+    options
   end
 
   def facet_groups?

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -13,6 +13,7 @@ describe EmailAlertSignupAPI do
       subscriber_list_title: subscriber_list_title,
       finder_format: finder_format,
       default_frequency: default_frequency,
+      combine_mode: combine_mode,
     )
   end
 
@@ -22,6 +23,7 @@ describe EmailAlertSignupAPI do
   let(:subscriber_list_title) { "Subscriber list title" }
   let(:finder_format) {}
   let(:default_frequency) { nil }
+  let(:combine_mode) { nil }
 
   def init_simple_email_alert_api(subscription_url)
     email_alert_api_has_subscriber_list(
@@ -86,6 +88,27 @@ describe EmailAlertSignupAPI do
       init_simple_email_alert_api(subscription_url)
       url_params = Rack::Utils.parse_query(URI.parse(subject.signup_url).query)
       expect(url_params).to eq("foo" => "bar", "default_frequency" => "daily")
+    end
+  end
+
+  context "when combine_mode is provided" do
+    let(:combine_mode) { "or" }
+
+    it "returns the url email-alert-api gives back, and appends the combine_mode param" do
+      subscription_url = "http://gov.uk/email/some-subscription"
+
+      email_alert_api_has_subscriber_list(
+        "tags" => {},
+        "subscription_url" => subscription_url
+      )
+
+      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
+        "tags" => {},
+        "title" => subscriber_list_title,
+        "combine_mode" => combine_mode
+        ).and_call_original
+
+      expect(subject.signup_url).to eql "http://gov.uk/email/some-subscription"
     end
   end
 


### PR DESCRIPTION
email_alert_api can now join facets with 'or' logic
this is off by default so the business finder needs
to send the requisite value for the parameter

Trello: https://trello.com/c/vLZ7zTdR/132-add-parameter-to-finder-frontend-to-make-email-alert-api-know-this-finder-is-special
---

## Search page examples to sanity check:

- http://finder-frontend-pr-1156.herokuapp.com/search/all
- http://finder-frontend-pr-1156.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1156.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1156.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1156.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
