### PR TITLE
Remove remaining mustache code

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,17 +33,11 @@ jQuery(function ($) {
   $elementsRequiringJavascript.show()
 
   if ($form.length && $results.length) {
-    var templateDir = 'finders/'
-    if (window.location.pathname === '/search/advanced') {
-      templateDir = 'advanced_search_finder/'
-    }
-
     // eslint-disable-next-line
     new GOVUK.LiveSearch({
       $form: $form,
       $results: $results,
-      $atomAutodiscoveryLink: $atomAutodiscoveryLink,
-      templateDir: templateDir
+      $atomAutodiscoveryLink: $atomAutodiscoveryLink
     })
   }
 })

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -9,7 +9,6 @@
     this.state = false
     this.previousState = false
     this.resultCache = {}
-    this.templateDir = options.templateDir || 'finders/'
 
     this.$form = options.$form
     this.$resultsBlock = options.$results.find('#js-results')

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,6 +3,5 @@ Rails.application.config.assets.precompile += [
   "application-ie7.css",
   "application-ie8.css",
   "application.js",
-  "print.css",
-  "hogan-2.0.0.js"
+  "print.css"
 ]


### PR DESCRIPTION
I missed a couple of small things when removing `shared_mustache`, this should be the last of them. 

The after-shave, if you will (thanks @koetsier).

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1160.herokuapp.com/search/all
- http://finder-frontend-pr-1160.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1160.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1160.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1160.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
