### PR TITLE
De-nest finder-frontend styles

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -112,7 +112,7 @@
 
   LiveSearch.prototype.setRelevantResultCustomDimension = function setRelevantResultCustomDimension () {
     if (this.canSetCustomDimension()) {
-      var $mostRelevantDocumentLink = $('.finder-results').find('.document__link--top')
+      var $mostRelevantDocumentLink = $('.js-finder-results').find('.document__link--top')
       var dimensionValue = $mostRelevantDocumentLink.length ? 'yes' : 'no'
       GOVUK.analytics.setDimension(83, dimensionValue)
     }
@@ -157,7 +157,7 @@
       })
     }
 
-    var $results = $('.finder-results')
+    var $results = $('.js-finder-results')
     if ($results.length > 0) {
       var $mostRelevantDocumentLink = $results.find('.document__link--top')
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,4 @@
 @import 'finder_frontend';
 @import 'views/search';
 @import 'views/advanced-search';
-@import 'views/email';
 @import 'views/qa';

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -132,11 +132,6 @@
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
 
-  .search-results-title {
-    border-bottom: 1px solid govuk-colour('black');
-    padding-bottom: govuk-spacing(4);
-  }
-
   .live-search-loading-message {
     margin-bottom: govuk-spacing(4);
     display: none;

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -119,15 +119,6 @@
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
 
-  .help-text {
-    @include govuk-font(14);
-    display:block;
-    padding: govuk-spacing(2)/2 0;
-    @include media(tablet) {
-      padding: govuk-spacing(2) 0;
-    }
-  }
-
   .form {
     @include govuk-font(19);
     @include media(tablet) {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -56,16 +56,6 @@
   margin-top: govuk-spacing(2);
 }
 
-.signup-content p {
-  margin: govuk-spacing(3) 0;
-  @include govuk-font(19);
-
-  @include media(tablet) {
-    margin: govuk-spacing(6) 0;
-    max-width: $two-thirds;
-  }
-}
-
 .metadata-summary {
   @include govuk-font(19);
   margin-bottom: govuk-spacing(6);
@@ -116,33 +106,31 @@
   }
 }
 
+.signup-choices {
+  @include govuk-font(19);
+  margin-top: 50px;
+
+  @include media(tablet) {
+    max-width: $two-thirds;
+  }
+
+  fieldset.invalid {
+    border-left: solid 4px $govuk-error-colour;
+    padding-left: govuk-spacing(3);
+    margin-left: -govuk-spacing(3) - 4;
+  }
+}
+
+.signup-choices__message {
+  margin-bottom: govuk-spacing(3);
+  padding: govuk-spacing(3);
+  color: $govuk-error-colour;
+  font-weight: bold;
+  border-left: solid 4px $govuk-error-colour;
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
-
-  .form {
-    @include govuk-font(19);
-    @include media(tablet) {
-      max-width: $two-thirds;
-    }
-
-    p {
-      max-width: $full-width;
-    }
-
-    fieldset.invalid {
-      border-left: solid 4px $govuk-error-colour;
-      padding-left: govuk-spacing(3);
-      margin-left: -govuk-spacing(3) - 4;
-    }
-
-    .validation-message {
-      color: $govuk-error-colour;
-      font-weight: bold;
-      padding: govuk-spacing(3);
-      margin-left: -govuk-spacing(3) - 4;
-      border-left: solid 4px $govuk-error-colour;
-    }
-  }
 
   .search-results-title {
     border-bottom: 1px solid govuk-colour('black');

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -71,18 +71,18 @@
   margin-bottom: govuk-spacing(6);
 }
 
+.finder-logo {
+  margin: govuk-spacing(6) 0;
+}
+
+.finder-logo__image {
+  max-width: 100%;
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
 
   header {
-    .logo {
-      margin: govuk-spacing(6) 0;
-    }
-
-    #logo-image{
-      max-width: 100%
-    }
-
     .related-links {
       @include govuk-font(16, $weight: bold);
       margin-top: govuk-spacing(8);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -79,32 +79,31 @@
   max-width: 100%;
 }
 
+.related-links {
+  margin-top: govuk-spacing(8);
+  margin-bottom: govuk-spacing(8);
+}
+
+.related-links__item {
+  margin-bottom: 4px;
+  list-style: none;
+
+  @include media(tablet) {
+    margin-bottom: 8px;
+  }
+}
+
+.related-links__link {
+  @include govuk-font(16, $weight: bold);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
-
-  header {
-    .related-links {
-      @include govuk-font(16, $weight: bold);
-      margin-top: govuk-spacing(8);
-      margin-bottom: govuk-spacing(8);
-      list-style:none;
-
-      li {
-        margin-bottom:4px;
-        @include media(tablet) {
-          margin-bottom:8px;
-        }
-
-        a:link,
-        a:visited {
-          text-decoration: none;
-        }
-        a:hover {
-          text-decoration: underline;
-        }
-      }
-    }
-  }
 
   .filter-form {
     .js-enabled & .button__wrapper {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -129,13 +129,13 @@
   border-left: solid 4px $govuk-error-colour;
 }
 
+.live-search-loading-message {
+  margin-bottom: govuk-spacing(4);
+  display: none;
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
-
-  .live-search-loading-message {
-    margin-bottom: govuk-spacing(4);
-    display: none;
-  }
 
   .filtered-results {
     .result-info {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -102,28 +102,22 @@
   }
 }
 
+.filter-form {
+  .js-enabled & .button__wrapper {
+    display:none;
+  }
+
+  .js-required {
+    display: none;
+  }
+
+  .govuk-select {
+    width: 100%;
+  }
+}
+
 #finder-frontend {
   margin-bottom: govuk-spacing(8);
-
-  .filter-form {
-    .js-enabled & .button__wrapper {
-      display:none;
-    }
-
-    .js-required {
-      display: none;
-    }
-
-    p {
-      max-width: $full-width;
-      @include govuk-font(16);
-      margin-bottom: govuk-spacing(6);
-    }
-
-    .govuk-select {
-      width: 100%;
-    }
-  }
 
   .help-text {
     @include govuk-font(14);

--- a/app/assets/stylesheets/views/_email.scss
+++ b/app/assets/stylesheets/views/_email.scss
@@ -1,3 +1,0 @@
-.signup-choices {
-  margin-top: 50px;
-}

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -32,7 +32,9 @@
         <div class="related-links govuk-grid-column-one-third">
           <ul>
             <% finder.related.each do |link| %>
-              <li><%= link_to link['title'], link['web_url'] %></li>
+              <li class="related-links__item">
+                <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+              </li>
             <% end %>
           </ul>
         </div>

--- a/app/views/advanced_search_finder/show.html.erb
+++ b/app/views/advanced_search_finder/show.html.erb
@@ -23,8 +23,8 @@
       </div>
 
       <% if finder.logo_path %>
-        <div class="logo govuk-grid-column-one-third">
-          <%= image_tag finder.logo_path, id: "logo-image" %>
+        <div class="finder-logo govuk-grid-column-one-third">
+          <%= image_tag finder.logo_path, class: "finder-logo__image" %>
         </div>
       <% end %>
 

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -7,46 +7,41 @@
   <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 
-<div class="outer-block">
-  <div class="signup-content">
-    <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices form' do %>
-      <% if @signup_presenter.hidden_choices.any? %>
-        <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: @signup_presenter.name,
-          context: "Email alert subscription"
-        } %>
-        <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
-          <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
-        <% end %>
-      <% elsif @signup_presenter.can_modify_choices? %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: nil,
-          heading: @signup_presenter.name,
-          hint_text: "Select the email alerts you need.",
-          items: @signup_presenter.choices_formatted,
-          is_page_heading: true,
-        } %>
-        <% if @error_message.present? %>
-          <p class="validation-message"><%= @error_message %></p>
-        <% end %>
-      <% else %>
-        <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: @signup_presenter.name,
-          context: "Email alert subscription"
-        } %>
-      <% end %>
-
-      <% if @signup_presenter.body %>
-        <div class="govspeak-wrapper">
-          <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
-        </div>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Create subscription",
-        margin_bottom: true
-      } %>
+<%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+  <% if @signup_presenter.hidden_choices.any? %>
+    <%= render partial: 'govuk_publishing_components/components/title', locals: {
+      title: @signup_presenter.name,
+      context: "Email alert subscription"
+    } %>
+    <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
+      <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
     <% end %>
+  <% elsif @signup_presenter.can_modify_choices? %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: nil,
+      heading: @signup_presenter.name,
+      hint_text: "Select the email alerts you need.",
+      items: @signup_presenter.choices_formatted,
+      is_page_heading: true,
+    } %>
+    <% if @error_message.present? %>
+      <p class="signup-choices__message"><%= @error_message %></p>
+    <% end %>
+  <% else %>
+    <%= render partial: 'govuk_publishing_components/components/title', locals: {
+      title: @signup_presenter.name,
+      context: "Email alert subscription"
+    } %>
+  <% end %>
 
-  </div>
-</div>
+  <% if @signup_presenter.body %>
+    <div class="govspeak-wrapper">
+      <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+    </div>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Create subscription",
+    margin_bottom: true
+  } %>
+<% end %>

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -1,11 +1,11 @@
-<ul class="finder-results" data-module="track-click">
+<ul class="finder-results js-finder-results" data-module="track-click">
   <% if local_assigns[:display_grouped_results] %>
     <% local_assigns[:grouped_documents].each do |group| %>
       <li class="filtered-results__group">
         <% if group[:facet_name] %>
           <h2 class="filtered-results__facet-heading"><%= group[:facet_name] %></h2>
         <% end %>
-        <ul class="finder-results">
+        <ul class="finder-results js-finder-results">
           <% group[:documents].each do |document| %>
             <% result = document[:document] %>
             <li class="document">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -70,8 +70,8 @@
     </div>
 
     <% if finder.logo_path %>
-      <div class="logo govuk-grid-column-one-third">
-        <%= image_tag finder.logo_path, id: "logo-image" %>
+      <div class="finder-logo govuk-grid-column-one-third">
+        <%= image_tag finder.logo_path, class: "finder-logo__image" %>
       </div>
     <% end %>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -77,9 +77,11 @@
 
     <% if finder.related.any? %>
       <div class="related-links govuk-grid-column-one-third">
-        <ul class="finder-results">
+        <ul class="js-finder-results">
           <% finder.related.each do |link| %>
-            <li><%= link_to link['title'], link['web_url'] %></li>
+            <li class="related-links__item">
+              <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+            </li>
           <% end %>
         </ul>
       </div>

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -33,7 +33,7 @@ describe('liveSearch', function () {
         'document_index': 1
       }
     ],
-    'search_results': '<ul class="finder-results" data-module="track-click">' +
+    'search_results': '<ul class="finder-results js-finder-results" data-module="track-click">' +
       '<li class="document">' +
         '<a href="aaib-reports/test-report" class="document__link" data-track-category="navFinderLinkClicked" data-track-action="" data-track-label="">Test report</a>' +
         '<p></p>' +
@@ -393,10 +393,10 @@ describe('liveSearch', function () {
   describe('indexTrackingData', function () {
     var groupedResponse = {
       'search_results':
-        '<ul class="finder-results" data-module="track-click">' +
+        '<ul class="finder-results js-finder-results" data-module="track-click">' +
           '<li class="filtered-results__group">' +
             '<h2 class="filtered-results__facet-heading">Primary group</h2>' +
-            '<ul class="finder-results">' +
+            '<ul class="finder-results js-finder-results">' +
               '<li class="document">' +
                 '<a href="/reports/test-report-1" class="document-heading--pinned document__link" data-track-category="navFinderLinkClicked" data-track-action="foo" data-track-label="">Test report 1</a>' +
                 '<p>This is important</p>' +
@@ -409,7 +409,7 @@ describe('liveSearch', function () {
           '</li>' +
           '<li class="filtered-results__group">' +
             '<h2 class="filtered-results__facet-heading">Default group</h2>' +
-            '<ul class="finder-results">' +
+            '<ul class="finder-results js-finder-results">' +
               '<li class="document">' +
                 '<a href="/reports/test-report-3" class="document__link" data-track-category="navFinderLinkClicked" data-track-action="foo" data-track-label="">Test report 3</a>' +
                 '<p>This is important</p>' +


### PR DESCRIPTION
Continuing my mission to de-nest all the styles in finder-frontend from underneath a single id.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1163.herokuapp.com/search/research-and-statistics/email-signup
- http://finder-frontend-pr-1163.herokuapp.com/search/all
- http://finder-frontend-pr-1163.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1163.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1163.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1163.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)

Trello card: https://trello.com/c/geNECHkE/788-restructure-finder-frontend-css-to-not-all-sit-under-a-single-id