### PR TITLE
Fixes deprecation notice by calling GdsApi::Search

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -16,7 +16,7 @@ module Services
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
+    @rummager ||= GdsApi::Search.new(Plek.find("search"))
   end
 
   def self.email_alert_api


### PR DESCRIPTION
Otherwise when running tests we see:

```
.............................................................GdsApi::Rummager is deprecated.  Use GdsApi::Search instead.
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
```
