### PR TITLE
Fix screenreader text on Research and Statistics finder

### DIFF
--- a/app/lib/filters/radio_filter_for_multiple_fields.rb
+++ b/app/lib/filters/radio_filter_for_multiple_fields.rb
@@ -15,15 +15,15 @@ module Filters
     end
 
     def default_value
-      filter_hashes.find { |filter| filter['default'] }.fetch('key')
+      filter_hashes.find { |filter| filter['default'] }.fetch('value')
     end
 
     def validated_value(value)
-      filter_hashes.map { |filter| filter['key'] }.include?(value) ? value : default_value
+      filter_hashes.map { |filter| filter['value'] }.include?(value) ? value : default_value
     end
 
-    def find_filter(key)
-      filter_hashes.find { |filter| filter['key'] == key }
+    def find_filter(value)
+      filter_hashes.find { |filter| filter['value'] == value }
     end
   end
 end

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -4,6 +4,7 @@ module Filters
       [
         {
           'key' => 'upcoming_statistics',
+          'value' => 'upcoming_statistics',
           'label' => 'Statistics (upcoming)',
           'filter' => {
             'release_timestamp' => "from:#{Time.zone.today}",
@@ -12,6 +13,7 @@ module Filters
         },
         {
           'key' => 'published_statistics',
+          'value' => 'published_statistics',
           'label' => 'Statistics (published)',
           'filter' => {
             'content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics)
@@ -20,6 +22,7 @@ module Filters
         },
         {
           'key' => 'research',
+          'value' => 'research',
           'label' => 'Research',
           'filter' => {
             'content_store_document_type' => %w(dfid_research_output independent_report research)
@@ -34,6 +37,7 @@ module Filters
       [
         {
           'key' => 'command_or_act_papers',
+          'value' => 'command_or_act_papers',
           'label' => 'Command or act papers',
           'filter' => {
             'has_official_document' => true
@@ -42,6 +46,7 @@ module Filters
         },
         {
           'key' => 'command_papers',
+          'value' => 'command_papers',
           'label' => 'Command papers only',
           'filter' => {
             'has_command_paper' => true,
@@ -50,6 +55,7 @@ module Filters
         },
         {
           'key' => 'act_papers',
+          'value' => 'act_papers',
           'label' => 'Act papers only',
           'filter' => {
             'has_act_paper' => true,

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -3,7 +3,6 @@ module Filters
     def call
       [
         {
-          'key' => 'upcoming_statistics',
           'value' => 'upcoming_statistics',
           'label' => 'Statistics (upcoming)',
           'filter' => {
@@ -12,7 +11,6 @@ module Filters
           }
         },
         {
-          'key' => 'published_statistics',
           'value' => 'published_statistics',
           'label' => 'Statistics (published)',
           'filter' => {
@@ -21,7 +19,6 @@ module Filters
           'default' => true
         },
         {
-          'key' => 'research',
           'value' => 'research',
           'label' => 'Research',
           'filter' => {
@@ -36,7 +33,6 @@ module Filters
     def call
       [
         {
-          'key' => 'command_or_act_papers',
           'value' => 'command_or_act_papers',
           'label' => 'Command or act papers',
           'filter' => {
@@ -45,7 +41,6 @@ module Filters
             'default' => true
         },
         {
-          'key' => 'command_papers',
           'value' => 'command_papers',
           'label' => 'Command papers only',
           'filter' => {
@@ -54,7 +49,6 @@ module Filters
           }
         },
         {
-          'key' => 'act_papers',
           'value' => 'act_papers',
           'label' => 'Act papers only',
           'filter' => {

--- a/app/models/radio_facet_for_multiple_filters.rb
+++ b/app/models/radio_facet_for_multiple_filters.rb
@@ -1,4 +1,5 @@
 class RadioFacetForMultipleFilters < FilterableFacet
+  attr_reader :value
   def initialize(facet, value, filter_hashes)
     @filter_hashes = filter_hashes
     @value = validated_value(value, @filter_hashes)
@@ -29,6 +30,10 @@ class RadioFacetForMultipleFilters < FilterableFacet
 
   def to_partial_path
     "radio_facet"
+  end
+
+  def allowed_values
+    @filter_hashes
   end
 
 private

--- a/app/models/radio_facet_for_multiple_filters.rb
+++ b/app/models/radio_facet_for_multiple_filters.rb
@@ -9,9 +9,9 @@ class RadioFacetForMultipleFilters < FilterableFacet
   def options
     @filter_hashes.map do |filter_hash|
       {
-        value: filter_hash['key'],
+        value: filter_hash['value'],
         text: filter_hash['label'],
-        checked: @value == filter_hash['key'],
+        checked: @value == filter_hash['value'],
       }
     end
   end
@@ -41,10 +41,10 @@ private
   attr_reader :filter_hashes
 
   def validated_value(value, filter_hashes)
-    filter_hashes.map { |f| f['key'] }.include?(value) ? value : default_value
+    filter_hashes.map { |f| f['value'] }.include?(value) ? value : default_value
   end
 
   def default_value
-    @filter_hashes.find { |hash_hash| hash_hash['default'] }.fetch('key')
+    @filter_hashes.find { |hash_hash| hash_hash['default'] }.fetch('value')
   end
 end

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -1,3 +1,10 @@
+<% if local_assigns[:screen_reader_filter_description] %>
+  <span class="govuk-visually-hidden">
+    <%= result_set_presenter.displayed_total %>
+    <%= local_assigns[:screen_reader_filter_description] %>
+  </span>
+<% end %>
+
 <% if local_assigns[:applied_filters] %>
   <div class="facet-tags" data-module="track-click">
     <% local_assigns[:applied_filters].each do |applied_filter| %>
@@ -21,11 +28,4 @@
       </div>
     <% end %>
   </div>
-<% end %>
-
-<% if local_assigns[:screen_reader_filter_description] %>
-  <span class="govuk-visually-hidden">
-    <%= result_set_presenter.displayed_total %>
-    <%= local_assigns[:screen_reader_filter_description] %>
-  </span>
 <% end %>

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -24,6 +24,8 @@
 <% end %>
 
 <% if local_assigns[:screen_reader_filter_description] %>
-  <span class="visually-hidden"><%= local_assigns[:screen_reader_filter_description] %></span>
+  <span class="govuk-visually-hidden">
+    <%= result_set_presenter.displayed_total %>
+    <%= local_assigns[:screen_reader_filter_description] %>
+  </span>
 <% end %>
-

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -42,7 +42,7 @@
       </div>
 
       <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder_presenter.name %> search results">
-        <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter" class="result-info">
+        <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <h2 class="result-region-header__counter" id="js-result-count">
@@ -55,7 +55,7 @@
               </div>
             <% end %>
           </div>
-          <div id="js-facet-tag-wrapper">
+          <div id="js-facet-tag-wrapper" aria-live="assertive">
             <%= render "facet_tags", facet_tags.present %>
           </div>
         </div>

--- a/spec/lib/filters/radio_filter_for_multiple_fields_spec.rb
+++ b/spec/lib/filters/radio_filter_for_multiple_fields_spec.rb
@@ -6,14 +6,14 @@ describe Filters::RadioFilterForMultipleFields do
     def filter_hashes
       [
         {
-          'key' => 'key_1',
+          'value' => 'value_1',
           'label' => 'label_1',
           'filter' => {
             'field' => 'value_1',
           }
         },
         {
-          'key' => 'default_key',
+          'value' => 'default_value',
           'label' => 'default_label',
           'filter' => {
             'field' => 'default_value'
@@ -53,7 +53,7 @@ describe Filters::RadioFilterForMultipleFields do
     end
 
     context 'valid parameter' do
-      let(:params_value) { "key_1" }
+      let(:params_value) { "value_1" }
 
       it 'returns valid query hash' do
         expect(filter.query_hash).to eq('field' => 'value_1')

--- a/spec/models/radio_facet_for_multiple_filters_spec.rb
+++ b/spec/models/radio_facet_for_multiple_filters_spec.rb
@@ -14,21 +14,21 @@ describe RadioFacetForMultipleFilters do
   let(:filter_hashes) {
     [
       {
-        'key' => 'key_1',
+        'value' => 'value_1',
         'label' => 'label_1',
         'filter' => {
           'field' => "value_1",
         }
       },
       {
-        'key' => 'key_2',
+        'value' => 'value_2',
         'label' => 'label_2',
         'filter' => {
           'field' => "value_2"
         }
       },
       {
-        'key' => 'default_key',
+        'value' => 'default_value',
         'label' => 'default_label',
         'filter' => {
           'field' => "default_feld"
@@ -40,21 +40,21 @@ describe RadioFacetForMultipleFilters do
 
   describe "#options" do
     context 'valid value' do
-      subject { described_class.new(facet_data, "key_1", filter_hashes) }
+      subject { described_class.new(facet_data, "value_1", filter_hashes) }
       it 'sets the options, selecting the correct value' do
         expect(subject.options).to eq([
                                         {
-                                          value: 'key_1',
+                                          value: 'value_1',
                                           text: 'label_1',
                                           checked: true,
                                         },
                                         {
-                                          value: 'key_2',
+                                          value: 'value_2',
                                           text: 'label_2',
                                           checked: false,
                                         },
                                         {
-                                          value: 'default_key',
+                                          value: 'default_value',
                                           text: 'default_label',
                                           checked: false
                                         }
@@ -66,7 +66,7 @@ describe RadioFacetForMultipleFilters do
       subject { described_class.new(facet_data, "something", filter_hashes) }
       it 'sets the options, selecting the default value' do
         expect(subject.options).to include(
-          value: 'default_key',
+          value: 'default_value',
           text: 'default_label',
           checked: true,
                                    )
@@ -76,9 +76,9 @@ describe RadioFacetForMultipleFilters do
 
   describe "#query_params" do
     context "value selected" do
-      subject { described_class.new(facet_data, "key_1", filter_hashes) }
+      subject { described_class.new(facet_data, "value_1", filter_hashes) }
       specify {
-        expect(subject.query_params).to eq("type" => "key_1")
+        expect(subject.query_params).to eq("type" => "value_1")
       }
     end
   end

--- a/spec/presenters/screen_reader_filter_description_presenter_spec.rb
+++ b/spec/presenters/screen_reader_filter_description_presenter_spec.rb
@@ -57,15 +57,18 @@ RSpec.describe ScreenReaderFilterDescriptionPresenter do
       allowed_values: [
           {
               'value' => 'statistics_published',
+              'key' => 'statistics_published',
               'label' => 'Statistics (published)',
               'default' => true
           },
           {
               'value' => 'statistics_upcoming',
+              'key' => 'statistics_upcoming',
               'label' => 'Statistics (upcoming)'
           },
           {
               'value' => 'research',
+              'key' => 'research',
               'label' => 'Research'
           },
       ],

--- a/spec/presenters/screen_reader_filter_description_presenter_spec.rb
+++ b/spec/presenters/screen_reader_filter_description_presenter_spec.rb
@@ -57,18 +57,15 @@ RSpec.describe ScreenReaderFilterDescriptionPresenter do
       allowed_values: [
           {
               'value' => 'statistics_published',
-              'key' => 'statistics_published',
               'label' => 'Statistics (published)',
               'default' => true
           },
           {
               'value' => 'statistics_upcoming',
-              'key' => 'statistics_upcoming',
               'label' => 'Statistics (upcoming)'
           },
           {
               'value' => 'research',
-              'key' => 'research',
               'label' => 'Research'
           },
       ],


### PR DESCRIPTION
When filtering results using the facets, a screenreader should read out 
- the filters that are being used
- how many results

When using the Research and Statistics finder, when the results being filtered by 'Statistics (upcoming)', 'Statistics (published)', or 'Research' is now announced.

Relates to: 
https://trello.com/c/iyd3UY3z/734-fix-hidden-text-for-screen-readers-on-finders)
https://trello.com/c/okfLseFa/895-hidden-text-for-screen-readers-is-in-the-wrong-place

Testing required in:
- [x] VoiceOver on Mac OS
- [x] VoiceOver on iOS
- [x] NVDA with Mozilla Firefox
- [x] JAWS with Internet Explorer 11

Source: [testing with assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test) 





---

## Search page examples to sanity check:

- http://finder-frontend-pr-1170.herokuapp.com/search/all
- http://finder-frontend-pr-1170.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1170.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1170.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1170.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)