### PR TITLE
Track which dynamic facets are being used

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -191,8 +191,13 @@ private
   end
 
   def facet_query
-    facet_params.reduce({}) { |query, (k, v)|
-      query.merge("facet_#{k}" => v)
+    count_dynamic_facets(facet_params.keys)
+    facet_params.reduce({}) { |query, (k, v)| query.merge("facet_#{k}" => v) }
+  end
+
+  def count_dynamic_facets(facet_names)
+    facet_names.each { |name|
+      GovukStatsd.increment "search_with_#{name}_facet"
     }
   end
 


### PR DESCRIPTION
We're currently faceting on things that we don't use in the frontend.

For example, searches from https://www.gov.uk/search/all facets on `organisation`,
`manual`, `topic`, `person` and `world_location`.  These are all retrieved from registries instead of the search result.

This greatly increases the payload retrieved from search-api and performs
unnecessary queries in elasticsearch.

I want to do something like this:

```
def facet_query
  dynamic_facet_params = facet_params.reject { |k, _v| Services.registries.all.has_key?(k) }

  dynamic_facet_params.reduce({}) { |query, (k, v)| query.merge("facet_#{k}" => v) }
end
```

but just want to check that we know exactly which facets are being used so I
don't inadvertently break something.  Faceting isn't amazingly well covered
in the test suite, which is something we'll need to fix.

This will also make it easier for us to reintroduce dynamic faceting at a later
date as we'll be able to see it spring into life.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1172.herokuapp.com/search/all
- http://finder-frontend-pr-1172.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1172.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1172.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1172.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
