### PR TITLE
Don't facet on things that will be ignored

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -191,8 +191,14 @@ private
   end
 
   def facet_query
-    count_dynamic_facets(facet_params.keys)
-    facet_params.reduce({}) { |query, (k, v)| query.merge("facet_#{k}" => v) }
+    dynamic_facet_params = facets_not_overridden_by_registries(facet_params)
+    count_dynamic_facets(dynamic_facet_params.keys)
+
+    dynamic_facet_params.reduce({}) { |query, (k, v)| query.merge("facet_#{k}" => v) }
+  end
+
+  def facets_not_overridden_by_registries(facet_params)
+    facet_params.reject { |k, _v| Services.registries.all.has_key?(k) }
   end
 
   def count_dynamic_facets(facet_names)

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -29,4 +29,8 @@ module Services
   def self.worldwide_api
     @worldwide_api ||= GdsApi::Worldwide.new(Plek.find('whitehall-admin'))
   end
+
+  def self.registries
+    @registries ||= Registries::BaseRegistries.new
+  end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -161,6 +161,7 @@ When(/^I view the policy papers and consultations finder$/) do
     }
   ])
   content_store_has_policy_and_engagement_finder
+  stub_organisations_registry_request
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_policy_papers_results
   stub_rummager_api_request_with_filtered_policy_papers_results
@@ -180,6 +181,8 @@ When(/^I view the research and statistics finder$/) do
                                 }
                             ])
   content_store_has_statistics_finder
+  stub_organisations_registry_request
+  stub_manuals_registry_request
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_research_and_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
@@ -189,6 +192,7 @@ end
 When(/^I view the all content finder with a manual filter$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
+  stub_organisations_registry_request
   stub_whitehall_api_world_location_request
   stub_people_registry_request
   stub_manuals_registry_request
@@ -210,8 +214,10 @@ end
 When(/^I view the all content finder$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
+  stub_organisations_registry_request
   stub_whitehall_api_world_location_request
   stub_people_registry_request
+  stub_manuals_registry_request
   stub_rummager_api_request_with_all_content_results
 
   visit finder_path('search/all')


### PR DESCRIPTION
Piggy backs off https://github.com/alphagov/finder-frontend/pull/1172

Faceting on things that are populated from local registries just adds load to the system for no benefit.

On a search from https://www.gov.uk/search/all we go from a query like:

https://www.gov.uk/api/search.json?count=20&start=0&fields=title%2Clink%2Cdescription%2Cpublic_timestamp%2Cpopularity%2Ccontent_purpose_supergroup%2Cformat%2Cpart_of_taxonomy_tree%2Cmanual%2Corganisations%2Cpeople%2Cworld_locations&q=government&reject_link[]=%2Fsearch%2Fall&facet_manual=1500%2Corder%3Avalue.title&facet_organisations=1500%2Corder%3Avalue.title&facet_people=1500%2Corder%3Avalue.title&facet_world_locations=1500%2Corder%3Avalue.title&filter_all_part_of_taxonomy_tree[]&filter_all_part_of_taxonomy_tree[]

to

https://www.gov.uk/api/search.json?count=20&start=0&fields=title%2Clink%2Cdescription%2Cpublic_timestamp%2Cpopularity%2Ccontent_purpose_supergroup%2Cformat%2Cpart_of_taxonomy_tree%2Cmanual%2Corganisations%2Cpeople%2Cworld_locations&q=government&reject_link[]=%2Fsearch%2Fall&filter_all_part_of_taxonomy_tree[]&filter_all_part_of_taxonomy_tree[]

which is a reduction in response payload from 559kb to 29.5kb, and in response time
from ~650ms to ~250ms (cold) and from ~200ms to ~25ms (warm - ie submitting
the same query to search-api again).


I deployed this to staging for a test - the initial low period is because traffic replay was not hitting finder frontend.  
The high spike is current master, and the low part afterwards is the improvement due to this PR being deployed.
<img width="1552" alt="Screenshot 2019-06-07 09 38 31" src="https://user-images.githubusercontent.com/773037/59091823-0cdc0400-8908-11e9-916d-e0f173b68617.png">

I'm all for dynamic faceting, but we should only use it when it's useful.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1174.herokuapp.com/search/all
- http://finder-frontend-pr-1174.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1174.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1174.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1174.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
