### PR TITLE
[DO NOT MERGE] Add A/B test for search-api elasticsearch cluster

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -12,6 +12,16 @@ class FindersController < ApplicationController
 
   # rubocop:disable Metrics/BlockLength
   def show
+    ab_test = GovukAbTesting::AbTest.new(
+      "SearchClusterABTest",
+      dimension: 24601, # todo: talk to a PA
+      allowed_variants: %w(A B),
+      control_variant: 'A'
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+    @ab_params = { cluster: @requested_variant.variant_name }
+
     respond_to do |format|
       format.html do
         @finder_api = initialise_finder_api
@@ -98,6 +108,7 @@ private
     finder_api_class.new(
       content_item.as_hash,
       filter_params,
+      ab_params: @ab_params,
       override_sort_for_feed: is_for_feed,
     )
   end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -15,12 +15,18 @@ class FindersController < ApplicationController
     ab_test = GovukAbTesting::AbTest.new(
       "SearchClusterABTest",
       dimension: 24601, # todo: talk to a PA
-      allowed_variants: %w(A B),
-      control_variant: 'A'
+      allowed_variants: %w(A B C),
+      control_variant: 'B'
     )
     @requested_variant = ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
-    @ab_params = { cluster: @requested_variant.variant_name }
+
+    @ab_params =
+      if @requested_variant.variant?('A') || @requested_variant.variant?('B')
+        { cluster: 'A' }
+      else
+        { cluster: 'B' }
+      end
 
     respond_to do |format|
       format.html do

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -3,9 +3,10 @@
 class FinderApi
   attr_reader :content_item
 
-  def initialize(content_item, filter_params, override_sort_for_feed: false)
+  def initialize(content_item, filter_params, ab_params: {}, override_sort_for_feed: false)
     @content_item = content_item
     @filter_params = filter_params
+    @ab_params = ab_params
     @override_sort_for_feed = override_sort_for_feed
     @order =
       if override_sort_for_feed
@@ -26,7 +27,7 @@ class FinderApi
 
 private
 
-  attr_reader :filter_params, :override_sort_for_feed
+  attr_reader :ab_params, :filter_params, :override_sort_for_feed
 
   def merge_and_deduplicate(search_response)
     results = search_response.fetch("results")
@@ -75,6 +76,7 @@ private
   def fetch_search_response(content_item)
     queries = query_builder_class.new(
       finder_content_item: content_item,
+      ab_params: ab_params,
       params: filter_params,
       override_sort_for_feed: override_sort_for_feed,
     ).call

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -11,9 +11,10 @@ class SearchQueryBuilder
   # find anything useful, too much noise.
   MAX_QUERY_LENGTH = 512
 
-  def initialize(finder_content_item:, params: {}, override_sort_for_feed: false)
+  def initialize(finder_content_item:, params: {}, ab_params: {}, override_sort_for_feed: false)
     @finder_content_item = finder_content_item
     @params = params
+    @ab_params = ab_params
     @override_sort_for_feed = override_sort_for_feed
   end
 
@@ -27,6 +28,7 @@ class SearchQueryBuilder
       order_query,
       facet_query,
       debug_query,
+      ab_params,
     ].reduce(&:merge)
 
     return [base_query] if filter_queries.empty?
@@ -38,7 +40,7 @@ class SearchQueryBuilder
 
 private
 
-  attr_reader :finder_content_item, :params, :override_sort_for_feed
+  attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed
 
   def order_query_builder_class
     OrderQueryBuilder

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,3 +1,5 @@
+<%= @requested_variant.analytics_meta_tag.html_safe %>
+
 <% if @results.user_supplied_keywords.length > 0 %>
   <% content_for :title, "#{@results.user_supplied_keywords} - #{finder.name}" %>
 <% else %>

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -85,6 +85,7 @@ module RummagerUrlHelper
     {
       "count" => "1500",
       "start" => "0",
+      "cluster" => 'A',
     }
   end
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -326,7 +326,39 @@ describe FindersController, type: :controller do
       assert_requested stub
     end
 
-    it "B variant should make a request to the B cluster" do
+    it "B variant should make a request to the A cluster" do
+      rummager_response = %|{
+        "results": [],
+        "total": 11,
+        "start": 0,
+        "facets": {},
+        "suggested_queries": []
+      }|
+
+      url = "#{Plek.current.find('search')}/search.json"
+
+      stub = stub_request(:get, url)
+        .with(
+          query: {
+            count: 10,
+            fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
+            filter_document_type: "mosw_report",
+            order: "-public_timestamp",
+            cluster: 'A',
+            start: 0
+          }
+        )
+        .to_return(status: 200, body: rummager_response, headers: {})
+
+      with_variant SearchClusterABTest: 'B' do
+        get :show, params: { slug: 'lunch-finder' }
+      end
+
+      expect(response.status).to eq(200)
+      assert_requested stub
+    end
+
+    it "C variant should make a request to the B cluster" do
       rummager_response = %|{
         "results": [],
         "total": 11,
@@ -350,7 +382,7 @@ describe FindersController, type: :controller do
         )
         .to_return(status: 200, body: rummager_response, headers: {})
 
-      with_variant SearchClusterABTest: 'B' do
+      with_variant SearchClusterABTest: 'C' do
         get :show, params: { slug: 'lunch-finder' }
       end
 


### PR DESCRIPTION
We're going to run elasticsearch 5 and 6 in parallel and gradually switch between them, A/B style.  This will let us monitor machine performance, and any effects in changes to the result ordering.

This PR implements the finder-frontend bit of the test.  We *don't* want to make this live until both clusters are up and running in production and we're confident they're in sync.
