### PR TITLE
Make a small change to email subscription wording

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -10,36 +10,36 @@
 <div class="outer-block">
   <div class="signup-content">
     <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices form' do %>
-      <% if @signup_presenter.hidden_choices.any? %>
-        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+      <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: @signup_presenter.name,
           context: "Email alert subscription"
         } %>
-        <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
-          <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
-        <% end %>
-      <% elsif @signup_presenter.can_modify_choices? %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: nil,
-          heading: @signup_presenter.name,
-          hint_text: "Choose the email alerts you need. You can decide how often you want to get updates on the next page.",
-          items: @signup_presenter.choices_formatted,
-          is_page_heading: true,
-        } %>
-        <% if @error_message.present? %>
-          <p class="validation-message"><%= @error_message %></p>
-        <% end %>
-      <% else %>
-        <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: @signup_presenter.name,
-          context: "Email alert subscription"
-        } %>
+
+      <% if !@signup_presenter.hidden_choices.any? && @signup_presenter.can_modify_choices? %>
+        <p class="govuk-hint">
+          Choose the email alerts you need. You can decide how often you want to get updates on the next page.
+        </p>
       <% end %>
 
       <% if @signup_presenter.body %>
         <div class="govspeak-wrapper">
           <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
         </div>
+      <% end %>
+
+      <% if @signup_presenter.hidden_choices.any? %>
+        <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
+          <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
+        <% end %>
+      <% elsif @signup_presenter.can_modify_choices? %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: nil,
+          items: @signup_presenter.choices_formatted,
+        } %>
+
+        <% if @error_message.present? %>
+          <p class="validation-message"><%= @error_message %></p>
+        <% end %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -22,7 +22,7 @@
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: nil,
           heading: @signup_presenter.name,
-          hint_text: "Select the email alerts you need.",
+          hint_text: "Choose the email alerts you need. You can decide how often you want to get updates on the next page.",
           items: @signup_presenter.choices_formatted,
           is_page_heading: true,
         } %>


### PR DESCRIPTION
What
=====
Change the sentence 'You'll get an email each time EU exit guidance is published' in the email subscription sign-up.

From Bruce:
The text is hardcoded in https://github.com/alphagov/search-api/blob/master/config/find-eu-exit-guidance-business-email-signup.yml#L10, so it should be  simple to update then republish the finder.

This is where the text is displayed: https://www.gov.uk/find-eu-exit-guidance-business/email-signup (after clicking 'Get email alerts' on business finder)


Why
====
It's not correct.

Background
====

- should not make reference to any particular frequency (daily, weekly, immediately) as the user won't have chosen their frequency yet.
- it's not about all EU exit guidance - it's specifically things tagged to the finder and could cover new things added or things updated
---

## Search page examples to sanity check:

- http://finder-frontend-pr-1181.herokuapp.com/search/all
- http://finder-frontend-pr-1181.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1181.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1181.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1181.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
