### PR TITLE
Make change to email subscription wording & layout

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -8,29 +8,29 @@
 <% end %>
 
 <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+  <%= render partial: 'govuk_publishing_components/components/title', locals: {
+    title: @signup_presenter.name,
+    context: "Email alert subscription"
+  } %>
+
   <% if @signup_presenter.can_modify_choices? %>
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: nil,
       heading: @signup_presenter.name,
       hint_text: "Choose the email alerts you need.",
       items: @signup_presenter.choices_formatted,
-      is_page_heading: true,
+      visually_hide_heading: true
     } %>
     <% if @error_message.present? %>
       <p class="signup-choices__message"><%= @error_message %></p>
     <% end %>
-  <% else %>
-    <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup_presenter.name,
-      context: "Email alert subscription"
-    } %>
   <% end %>
 
   <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
     <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
   <% end %>
 
-  <% if @signup_presenter.body %>
+  <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
     <div class="govspeak-wrapper">
       <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
     </div>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -12,7 +12,7 @@
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: nil,
       heading: @signup_presenter.name,
-      hint_text: "Select the email alerts you need.",
+      hint_text: "Choose the email alerts you need.",
       items: @signup_presenter.choices_formatted,
       is_page_heading: true,
     } %>


### PR DESCRIPTION
What
=====
Change the sentence 'You'll get an email each time EU exit guidance is published' in the email subscription sign-up.

From Bruce:
The text is hardcoded in https://github.com/alphagov/search-api/blob/master/config/find-eu-exit-guidance-business-email-signup.yml#L10, so it should be  simple to update then republish the finder.

This is where the text is displayed: https://www.gov.uk/find-eu-exit-guidance-business/email-signup (after clicking 'Get email alerts' on business finder)


Why
====
It's not correct.

Background
====

- should not make reference to any particular frequency (daily, weekly, immediately) as the user won't have chosen their frequency yet.
- it's not about all EU exit guidance - it's specifically things tagged to the finder and could cover new things added or things updated
---

## Email signup page examples:

### With checkboxes
- http://finder-frontend-pr-1182.herokuapp.com/find-eu-exit-guidance-business/email-signup
- http://finder-frontend-pr-1182.herokuapp.com/cma-cases/email-signup

### Without checkboxes
- http://finder-frontend-pr-1182.herokuapp.com/search/guidance-and-regulation/email-signup

## Before
![Screen Shot 2019-06-14 at 17 09 18 1](https://user-images.githubusercontent.com/4599889/59522702-3c21e080-8ec7-11e9-948c-249bec74fd95.png)

## After
<img width="814" alt="Screen Shot 2019-06-17 at 12 30 01" src="https://user-images.githubusercontent.com/4599889/59676137-c36c9e00-91be-11e9-9012-c20855ff9ed9.png">


## Search page examples to sanity check:

- http://finder-frontend-pr-1182.herokuapp.com/search/all
- http://finder-frontend-pr-1182.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1182.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1182.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1182.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)

https://trello.com/c/8RrtgrmZ/128-make-a-small-change-to-email-subscription-wording
