### PR TITLE
Allow atom feeds for all finders

### DIFF
--- a/app/controllers/concerns/finder_top_result_ab_testable.rb
+++ b/app/controllers/concerns/finder_top_result_ab_testable.rb
@@ -27,7 +27,7 @@ module FinderTopResultAbTestable
   end
 
   def test_in_scope?
-    content_item.is_finder? && finder.eu_exit_finder?
+    content_item.is_finder? && finder_api && finder.eu_exit_finder?
   end
 
   def show_top_result?

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -10,9 +10,11 @@ class FindersController < ApplicationController
 
   ATOM_FEED_MAX_AGE = 300
 
+  # rubocop:disable Metrics/BlockLength
   def show
     respond_to do |format|
       format.html do
+        finder_api
         @results = results
         @raw_content_item = content_item.as_hash
         @breadcrumbs = fetch_breadcrumbs
@@ -21,6 +23,7 @@ class FindersController < ApplicationController
         @pagination = pagination_presenter
       end
       format.json do
+        finder_api
         if content_item.is_search? || content_item.is_finder?
           render json: json_response
         else
@@ -28,6 +31,7 @@ class FindersController < ApplicationController
         end
       end
       format.atom do
+        finder_api(is_for_feed: true)
         if content_item.is_redirect?
           redirect_to_destination
         else
@@ -39,6 +43,7 @@ class FindersController < ApplicationController
   rescue ActionController::UnknownFormat
     render plain: 'Not acceptable', status: :not_acceptable
   end
+  # rubocop:enable Metrics/BlockLength
 
 private
 
@@ -87,8 +92,12 @@ private
     )
   end
 
-  def finder_api
-    @finder_api ||= finder_api_class.new(content_item.as_hash, filter_params)
+  def finder_api(is_for_feed: false)
+    @finder_api ||= finder_api_class.new(
+      content_item.as_hash,
+      filter_params,
+      override_sort_for_feed: is_for_feed,
+    )
   end
 
   def raw_finder

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -30,11 +30,9 @@ class FindersController < ApplicationController
       format.atom do
         if content_item.is_redirect?
           redirect_to_destination
-        elsif finder.atom_feed_enabled?
+        else
           expires_in(ATOM_FEED_MAX_AGE, public: true)
           @feed = AtomPresenter.new(finder, results, facet_tags)
-        else
-          render plain: 'Not found', status: :not_found
         end
       end
     end
@@ -85,7 +83,6 @@ private
     @finder ||= finder_presenter_class.new(
       raw_finder,
       search_results,
-      sort_presenter,
       filter_params,
     )
   end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -14,7 +14,7 @@ class FindersController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        finder_api
+        @finder_api = initialise_finder_api
         @results = results
         @raw_content_item = content_item.as_hash
         @breadcrumbs = fetch_breadcrumbs
@@ -23,7 +23,7 @@ class FindersController < ApplicationController
         @pagination = pagination_presenter
       end
       format.json do
-        finder_api
+        @finder_api = initialise_finder_api
         if content_item.is_search? || content_item.is_finder?
           render json: json_response
         else
@@ -31,7 +31,7 @@ class FindersController < ApplicationController
         end
       end
       format.atom do
-        finder_api(is_for_feed: true)
+        @finder_api = initialise_finder_api(is_for_feed: true)
         if content_item.is_redirect?
           redirect_to_destination
         else
@@ -46,6 +46,8 @@ class FindersController < ApplicationController
   # rubocop:enable Metrics/BlockLength
 
 private
+
+  attr_accessor :finder_api
 
   helper_method :finder, :facet_tags
 
@@ -92,8 +94,8 @@ private
     )
   end
 
-  def finder_api(is_for_feed: false)
-    @finder_api ||= finder_api_class.new(
+  def initialise_finder_api(is_for_feed: false)
+    finder_api_class.new(
       content_item.as_hash,
       filter_params,
       override_sort_for_feed: is_for_feed,

--- a/app/lib/finder_api.rb
+++ b/app/lib/finder_api.rb
@@ -3,10 +3,16 @@
 class FinderApi
   attr_reader :content_item
 
-  def initialize(content_item, filter_params)
+  def initialize(content_item, filter_params, override_sort_for_feed: false)
     @content_item = content_item
     @filter_params = filter_params
-    @order = filter_params['order']
+    @override_sort_for_feed = override_sort_for_feed
+    @order =
+      if override_sort_for_feed
+        'most-recent'
+      else
+        filter_params['order']
+      end
   end
 
   def search_results
@@ -20,7 +26,7 @@ class FinderApi
 
 private
 
-  attr_reader :filter_params
+  attr_reader :filter_params, :override_sort_for_feed
 
   def merge_and_deduplicate(search_response)
     results = search_response.fetch("results")
@@ -70,6 +76,7 @@ private
     queries = query_builder_class.new(
       finder_content_item: content_item,
       params: filter_params,
+      override_sort_for_feed: override_sort_for_feed,
     ).call
 
     if queries.one?

--- a/app/lib/order_query_builder.rb
+++ b/app/lib/order_query_builder.rb
@@ -1,13 +1,15 @@
 class OrderQueryBuilder
-  def initialize(content_item, keywords, params)
+  def initialize(content_item, keywords, params, override_sort_for_feed: false)
     @content_item = content_item
     @params = params
     @keywords = keywords
+    @override_sort_for_feed = override_sort_for_feed
   end
 
   def call
     return order_by_release_timestamp if sort_option.present? && order_by_release_timestamp?(sort_option)
 
+    return order_by_public_timestamp if override_sort_for_feed
     return order_by_public_timestamp if sort_option.present? && order_by_public_timestamp?(sort_option)
 
     return order_by_relevance_query if sort_option.present? && order_by_relevance?(sort_option)
@@ -21,7 +23,7 @@ class OrderQueryBuilder
 
 private
 
-  attr_reader :content_item, :params, :keywords
+  attr_reader :content_item, :params, :keywords, :override_sort_for_feed
 
   def order_by_relevance?(sort_option)
     %w(relevance -relevance topic -topic).include?(sort_option.dig('key'))

--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -11,9 +11,10 @@ class SearchQueryBuilder
   # find anything useful, too much noise.
   MAX_QUERY_LENGTH = 512
 
-  def initialize(finder_content_item:, params: {})
+  def initialize(finder_content_item:, params: {}, override_sort_for_feed: false)
     @finder_content_item = finder_content_item
     @params = params
+    @override_sort_for_feed = override_sort_for_feed
   end
 
   def call
@@ -37,7 +38,7 @@ class SearchQueryBuilder
 
 private
 
-  attr_reader :finder_content_item, :params
+  attr_reader :finder_content_item, :params, :override_sort_for_feed
 
   def order_query_builder_class
     OrderQueryBuilder
@@ -101,7 +102,12 @@ private
   end
 
   def order_query
-    order_query_builder_class.new(finder_content_item, keywords, params).call
+    order_query_builder_class.new(
+      finder_content_item,
+      keywords,
+      params,
+      override_sort_for_feed: override_sort_for_feed,
+    ).call
   end
 
   def keyword_query

--- a/app/presenters/advanced_search_finder_presenter.rb
+++ b/app/presenters/advanced_search_finder_presenter.rb
@@ -1,8 +1,8 @@
 class AdvancedSearchFinderPresenter < FinderPresenter
   include AdvancedSearchParams
 
-  def initialize(content_item, search_results, sorter, values = {})
-    super(content_item, search_results, sorter, values)
+  def initialize(content_item, search_results, values = {})
+    super(content_item, search_results, values)
     # Restore the original topic param value as this is used in pagination links.
     @values[TAXON_SEARCH_FILTER] = taxon['base_path']
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -4,9 +4,7 @@ class FinderPresenter
 
   attr_reader :content_item, :name, :slug, :organisations, :values, :keywords, :links, :facets
 
-  MOST_RECENT_FIRST = "-public_timestamp".freeze
-
-  def initialize(content_item, search_results, sort_presenter, values = {})
+  def initialize(content_item, search_results, values = {})
     @content_item = content_item
     @search_results = search_results
     @name = content_item['title']
@@ -17,7 +15,6 @@ class FinderPresenter
     @facet_hashes = facet_hashes(@content_item)
     @facets = facet_collection(@facet_hashes, @values)
     @keywords = values["keywords"].presence
-    @sort_presenter = sort_presenter
   end
 
   def phase_message
@@ -169,16 +166,8 @@ class FinderPresenter
     end
   end
 
-  def atom_feed_enabled?
-    if sort_presenter.has_options?
-      sort_presenter.default_option.blank? || sort_presenter.default_option.key == MOST_RECENT_FIRST
-    else
-      default_order.blank? || default_order == MOST_RECENT_FIRST
-    end
-  end
-
   def atom_url
-    "#{slug}.atom#{alert_query_string}" if atom_feed_enabled?
+    "#{slug}.atom#{alert_query_string}"
   end
 
   def description
@@ -205,7 +194,7 @@ class FinderPresenter
 
 private
 
-  attr_reader :search_results, :sort_presenter
+  attr_reader :search_results
 
   def is_external?(href)
     URI.parse(href).host != "www.gov.uk"

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -92,7 +92,7 @@ describe FindersController, type: :controller do
     end
 
     describe "a finder content item with a default order exists" do
-      before do
+      it "sorts the finder results by public timestamp" do
         sort_options = [{ 'name' => 'Closing date', 'key' => '-closing_date', 'default' => true, }]
 
         content_store_has_item(
@@ -108,22 +108,21 @@ describe FindersController, type: :controller do
           "suggested_queries": []
         }|
 
-        stub_request(:get, "#{Plek.current.find('search')}/search.json")
+        stub = stub_request(:get, "#{Plek.current.find('search')}/search.json")
           .with(
             query: {
               count: 10,
               fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
-              order: "-closing_date",
+              order: "-public_timestamp",
               start: 0
             }
           )
           .to_return(status: 200, body: rummager_response, headers: {})
-      end
 
-      it "returns a 404 when requesting an atom feed, rather than a 500" do
         get :show, params: { format: :atom, slug: 'lunch-finder' }
-        expect(response.status).to eq(404)
+        expect(stub).to have_been_requested
+        expect(response.status).to eq(200)
       end
     end
 

--- a/spec/presenters/advanced_search_finder_presenter_spec.rb
+++ b/spec/presenters/advanced_search_finder_presenter_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AdvancedSearchFinderPresenter do
   include ActionView::Helpers::UrlHelper
 
-  subject(:presenter) { described_class.new(content_item_response, search_results, SortPresenter, values) }
+  subject(:presenter) { described_class.new(content_item_response, search_results, values) }
 
   let(:finder_item) {
     JSON.parse(File.read(Rails.root.join("features", "fixtures", "advanced-search.json")))

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
   include TaxonomySpecHelper
 
-  subject(:presenter) { described_class.new(content_item, {}, sort_presenter, values) }
-  let(:sort_presenter) { SortPresenter.new(content_item, values) }
+  subject(:presenter) { described_class.new(content_item, {}, values) }
   let(:content_item) { create_content_item }
   let(:values) { {} }
 
@@ -256,54 +255,6 @@ RSpec.describe FinderPresenter do
                                    "people" => %w[me you],
                                    "topic" => %w[hiding],
                                    "manual" => %w[my_manual])
-      end
-    end
-  end
-
-  describe "#atom_feed_enabled?" do
-    context "with no sort options and no default sort" do
-      let(:content_item) { create_content_item(details: { sort: nil }) }
-      it "is true" do
-        expect(subject.atom_feed_enabled?).to be true
-      end
-    end
-
-    context "with default sort option set to descending public_timestamp" do
-      let(:content_item) {
-        create_content_item(sort_options: [
-          { "name" => "Most viewed" },
-          { "name" => "Updated (newest)", "key" => "-public_timestamp", "default" => true }
-        ])
-      }
-      it "is true" do
-        expect(subject.atom_feed_enabled?).to be true
-      end
-    end
-
-    context "with sort options but no default order" do
-      let(:content_item) {
-        create_content_item(details: { sort: sort_options_with_relevance })
-      }
-      it "is true" do
-        expect(subject.atom_feed_enabled?).to be true
-      end
-    end
-
-    context "with no sort options but a changeable default order" do
-      let(:content_item) {
-        create_content_item(details: { sort: nil, default_order: "relevance" })
-      }
-      it "is false" do
-        expect(subject.atom_feed_enabled?).to be false
-      end
-    end
-
-    context "with no sort options but a default order of most recent first" do
-      let(:content_item) {
-        create_content_item(details: { sort: nil, default_order: "-public_timestamp" })
-      }
-      it "is true" do
-        expect(subject.atom_feed_enabled?).to be true
       end
     end
   end


### PR DESCRIPTION
Currently finder-frontend refuses to render an atom feed if the default sort order isn't suitable.  This means that /search/all.atom returns a 404, even though the route is published.  A feed *is* useless if not sorted by date, but disallowing non-date-ordered finders seems like the wrong solution to me.

We only publish a route for a feed if we want the feed to be served.  Therefore finder-frontend should make the feed work.  This PR achieves that by making finder-frontend use either release (preferred if the finder allows it) or public (fallback) timestamp order.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1184.herokuapp.com/search/all.atom
- http://finder-frontend-pr-1184.herokuapp.com/search/research-and-statistics.atom
- http://finder-frontend-pr-1184.herokuapp.com/drug-device-alerts.atom
- http://finder-frontend-pr-1184.herokuapp.com/find-eu-exit-guidance-business.atom

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/kd6iAV1I/794-allow-atom-feeds-on-the-all-content-finder-s)
