### PR TITLE
Send cluster param to search-api

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -26,6 +26,7 @@ class SearchQueryBuilder
       order_query,
       facet_query,
       debug_query,
+      cluster_query,
     ].reduce(&:merge)
 
     return [base_query] if filter_queries.empty?
@@ -217,6 +218,10 @@ private
     {
       "debug" => params["debug"],
     }.compact
+  end
+
+  def cluster_query
+    { "cluster" => params["cluster"] }.compact
   end
 
   def stopwords

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -340,6 +340,24 @@ describe SearchQueryBuilder do
     end
   end
 
+  context "with cluster parameters" do
+    let(:params) {
+      {
+        "cluster" => "B",
+      }
+    }
+
+    it "should include a cluster query" do
+      expect(query).to include("cluster" => "B")
+    end
+  end
+
+  context "without cluster parameters" do
+    it "should not include a cluster query" do
+      expect(query).not_to include("cluster")
+    end
+  end
+
   context "with a base filter" do
     let(:filter) { { "document_type" => "news_story" } }
 


### PR DESCRIPTION
This will permit end users to specify which cluster they would like to use.

This isn't intended to be the primary way the cluster is set (this will come from some form of A/B testing), but it's a nice debug tool.

Trello: https://trello.com/c/gRe2XQGx/796.

Should be merged after https://github.com/alphagov/search-api/pull/1569 is deployed.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1185.herokuapp.com/search/all
- http://finder-frontend-pr-1185.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1185.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1185.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1185.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
