### PR TITLE
Disable end-to-end tests as a required status check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node {
       }
     },
     sassLint: false,
-    publishingE2ETests: true,
+    publishingE2ETests: false,
     brakeman: true,
     rubyLintDiff: false
   )


### PR DESCRIPTION
Temporarily removing end-to-end tests for finder-frontend until the tests are fixed.