### PR TITLE
Replace gem sass-rails with sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rails', '~> 5.2.3'
 gem 'slimmer', '~> 13.1.0'
 
 gem 'govuk_frontend_toolkit', '~> 8.2'
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '~> 2.1.1'
 gem 'uglifier', '~> 4.1'
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,12 +295,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -396,7 +390,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   rspec-rails (~> 3.8.2)
-  sass-rails (~> 5.0)
+  sassc-rails (~> 2.1.1)
   sdoc
   simplecov (~> 0.16.1)
   slimmer (~> 13.1.0)


### PR DESCRIPTION
This gem has been deprecated and the recommended replacement is the sassc-rails gem.

The new gem is a drop in replacement for the old one; we don't need to do anything else.

For context see https://github.com/rails/sass-rails/issues/420.

It seems v6 of the gem we are using will make it a wrapper for the other gem. We can upgrade already so there's no need to wait for this.

Trello: https://trello.com/c/hcmzrcot/772

Resolves https://github.com/alphagov/finder-frontend/issues/1124

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1187.herokuapp.com/search/all
- http://finder-frontend-pr-1187.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1187.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1187.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1187.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
