### PR TITLE
Creates new topic taxonomy registry

### DIFF
--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -10,10 +10,15 @@ module Registries
         'people' => people,
         'organisations' => organisations,
         'manual' => manuals,
+        'full_topic_taxonomy' => full_topic_taxonomy
       }
     end
 
   private
+
+    def full_topic_taxonomy
+      @full_topic_taxonomy ||= FullTopicTaxonomyRegistry.new
+    end
 
     def world_locations
       @world_locations ||= WorldLocationsRegistry.new

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -1,0 +1,57 @@
+module Registries
+  class FullTopicTaxonomyRegistry
+    CACHE_KEY = "#{NAMESPACE}/full_topic_taxonomy".freeze
+
+    def [](base_path)
+      taxonomy[base_path]
+    end
+
+    def taxonomy
+      @taxonomy ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+        taxonomy_hash
+      end
+    rescue GdsApi::HTTPServerError
+      GovukStatsd.increment("#{NAMESPACE}.full_topic_taxonomy_api_errors")
+      {}
+    end
+
+  private
+
+    def format_taxon(taxon)
+      {
+        'title' => taxon['title'],
+        'content_id' => taxon['content_id']
+      }
+    end
+
+    def level_one_taxons
+      @level_one_taxons ||= fetch_level_one_taxons_from_api
+    end
+
+    def flatten_taxonomy(taxons, output_hash)
+      taxons.each do |taxon|
+        output_hash[taxon['base_path']] = format_taxon(taxon)
+        unless taxon.dig('links', 'child_taxons').nil?
+          flatten_taxonomy(taxon['links']['child_taxons'], output_hash)
+        end
+      end
+    end
+
+    def taxonomy_hash
+      GovukStatsd.time("registries.full_topic_taxonomy.request_time") do
+        output_hash = {}
+        flatten_taxonomy(level_one_taxons, output_hash)
+        output_hash
+      end
+    end
+
+    def fetch_level_one_taxons_from_api
+      taxons = fetch_taxon.dig('links', 'level_one_taxons') || []
+      taxons.map { |taxon| fetch_taxon(taxon['base_path']) }
+    end
+
+    def fetch_taxon(base_path = '/')
+      Services.cached_content_item(base_path)
+    end
+  end
+end

--- a/features/fixtures/level_one_taxon.json
+++ b/features/fixtures/level_one_taxon.json
@@ -1,0 +1,116 @@
+[
+  {
+    "base_path": "/environment",
+    "content_id": "3cf97f69-84de-41ae-bc7b-7e2cc238fa58",
+    "title": "Environment",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/environment/food-and-farming",
+          "content_id": "52ff5c99-a17b-42c4-a9d7-2cc92cccca39",
+          "title": "Food and farming",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/environment/farming-food-grants-payments",
+                "content_id": "2368b8b1-9405-4e66-b396-a5d54b777a0a",
+                "title": "Farming and food grants and payments",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/environment/farming-food-grants-payments-rural-grants-payments",
+                      "content_id": "8d99749f-e2c5-43a3-a283-0faef4ee8a5d",
+                      "title": "Rural grants and payments",
+                      "links": {
+                        "child_taxons": [
+                          {
+                            "base_path": "/environment/countryside-stewardship",
+                            "content_id": "013fc5e0-280c-4f73-9598-47de68f13dcd",
+                            "title": "Countryside stewardship",
+                            "links": {}
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+        "base_path": "/environment/chemicals",
+        "content_id": "22ad4441-9fb5-447b-950c-bf33466b31bb",
+        "title": "Chemicals",
+        "links": {
+          "child_taxons": [
+            {
+              "base_path": "/environment/environmental-management-chemicals-reach-regulations",
+              "content_id": "3deb7ca6-27ad-4aa1-b1b2-e9187c601740",
+              "title": "REACH regulations",
+              "links": {}
+            }
+          ]
+        }
+        }
+      ]
+    }
+  },
+  {
+    "base_path": "/education",
+    "content_id": "3cf97f69-84de-41ae-bc7b-7e2cc238f123",
+    "title": "Education",
+    "links": {
+      "child_taxons": [
+        {
+          "base_path": "/education/education-and-farming",
+          "content_id": "52ff5c99-a17b-42c4-a9d7-2cc92cccc123",
+          "title": "Education and farming",
+          "links": {
+            "child_taxons": [
+              {
+                "base_path": "/education/farming-education-grants-payments",
+                "content_id": "2368b8b1-9405-4e66-b396-a5d54b777123",
+                "title": "Education and food grants and payments",
+                "links": {
+                  "child_taxons": [
+                    {
+                      "base_path": "/education/farming-food-grants-payments-rural-grants-payments",
+                      "content_id": "8d99749f-e2c5-43a3-a283-0faef4ee8123",
+                      "title": "Education grants and payments",
+                      "links": {
+                        "child_taxons": [
+                          {
+                            "base_path": "/education/countryside-stewardship",
+                            "content_id": "013fc5e0-280c-4f73-9598-47de68f13123",
+                            "title": "Education stewardship",
+                            "links": {}
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+        "base_path": "/education/chemicals",
+        "content_id": "22ad4441-9fb5-447b-950c-bf33466b3123",
+        "title": "Chemicals",
+        "links": {
+          "child_taxons": [
+            {
+              "base_path": "/education/educational-management-chemicals-reach-regulations",
+              "content_id": "3deb7ca6-27ad-4aa1-b1b2-e9187c601123",
+              "title": "REACH regulations",
+              "links": {}
+            }
+          ]
+        }
+        }
+      ]
+    }
+  }
+]

--- a/spec/helpers/taxonomy_spec_helper.rb
+++ b/spec/helpers/taxonomy_spec_helper.rb
@@ -40,8 +40,25 @@ module TaxonomySpecHelper
     taxons
   end
 
+  def stub_root_taxon(taxons)
+    content_store_has_item("/", root_taxon(taxons))
+  end
+
+  def full_topic_taxonomy_has_taxons(taxons)
+    taxons.each do |taxon|
+      content_store_has_item(taxon['base_path'], taxon)
+      unless taxon['links'].empty?
+        full_topic_taxonomy_has_taxons(taxon['links']['child_taxons'])
+      end
+    end
+  end
+
   def clear_taxon_cache
     Rails.cache.delete(taxon_cache_key)
+  end
+
+  def clear_full_taxon_cache
+    Rails.cache.delete('test/registries/full_topic_taxonomy')
   end
 
   def taxon_cache_key

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -1,0 +1,48 @@
+require "securerandom"
+require 'spec_helper'
+require "helpers/taxonomy_spec_helper"
+
+RSpec.describe Registries::FullTopicTaxonomyRegistry do
+  include TaxonomySpecHelper
+  let(:level_one_taxons) {
+    JSON.parse(File.read(Rails.root.join("features", "fixtures", "level_one_taxon.json")))
+  }
+
+  let(:base_path) { "/basepath" }
+
+  describe "when topic taxonomy API is unavailable" do
+    it "will return an (uncached) empty hash" do
+      clear_full_taxon_cache
+      topic_taxonomy_api_is_unavailable
+      expect(described_class.new[base_path]).to be_nil
+      expect(described_class.new.taxonomy).to eql({})
+      expect(Rails.cache.fetch(taxon_cache_key)).to be_nil
+    end
+  end
+
+  describe "when topic taxonomy api is available" do
+    before :each do
+      clear_full_taxon_cache
+      stub_root_taxon(level_one_taxons)
+      full_topic_taxonomy_has_taxons(level_one_taxons)
+    end
+
+    after { clear_full_taxon_cache }
+
+    let(:registry) { described_class.new }
+    let(:child_base_path) { "/environment/countryside-stewardship" }
+    let(:first_level_base_path) { "/environment" }
+    let(:child_content_id) { "013fc5e0-280c-4f73-9598-47de68f13dcd" }
+    let(:first_level_content_id) { "3cf97f69-84de-41ae-bc7b-7e2cc238fa58" }
+
+    it "can look up a child taxon by basepath" do
+      fetched_document = registry[child_base_path]
+      expect(fetched_document['content_id']).to eq(child_content_id)
+    end
+
+    it "can look up a level one taxon by basepath" do
+      fetched_document = registry[first_level_base_path]
+      expect(fetched_document['content_id']).to eq(first_level_content_id)
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a new registry to import all topic taxons to the Rails cache. It provides look up by base_path.

Ref trello: https://trello.com/c/XTODr8sm/784-create-new-topic-registry-in-finder-frontend-m

🍐 effort with @barrucadu 



---

## Search page examples to sanity check:

- http://finder-frontend-pr-1190.herokuapp.com/search/all
- http://finder-frontend-pr-1190.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1190.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1190.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1190.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
