### PR TITLE
Add placeholder rake task registries:cache_refresh

### DIFF
--- a/lib/tasks/registries.rake
+++ b/lib/tasks/registries.rake
@@ -1,0 +1,13 @@
+namespace :registries do
+  desc "
+  Fetch data for registries and add to cache
+  Fetching registry data takes a while. Rather than have a user
+  experience a delay while we read-through an empty cache, we write ahead to
+  the cache with this job at regular intervals (and as part of the deploy).
+  "
+  task cache_refresh: :environment do
+    puts "Refreshing registry cache..."
+    # TODO: refresh caches.
+    puts "Finished refreshing registry cache."
+  end
+end


### PR DESCRIPTION
This is a placeholder rake task, which will be completed in a later commit. We want the deploy script to call this rake task, but want to call an empty rake task for now. This way, the changes can be made in stages.

https://github.com/alphagov/govuk-app-deployment/pull/315

https://trello.com/c/uwm4BnOT/787