### PR TITLE
Refresh registries upon deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,14 @@
 
 require File.expand_path('config/application', __dir__)
 
+if Rails.env.development? && ENV['LIVE']
+  puts 'Pointing application at live dependencies...'
+  ENV['GOVUK_APP_DOMAIN'] = 'www.gov.uk'
+  ENV['GOVUK_WEBSITE_ROOT'] = 'https://www.gov.uk'
+  ENV['PLEK_SERVICE_SEARCH_URI'] = 'https://www.gov.uk/api'
+  ENV['PLEK_SERVICE_CONTENT_STORE_URI'] = 'https://www.gov.uk/api'
+  ENV['PLEK_SERVICE_STATIC_URI'] = 'assets.publishing.service.gov.uk'
+  ENV['PLEK_SERVICE_WHITEHALL_ADMIN_URI'] = 'https://www.gov.uk'
+end
+
 FinderFrontend::Application.load_tasks

--- a/app/lib/healthchecks/registries_cache.rb
+++ b/app/lib/healthchecks/registries_cache.rb
@@ -1,0 +1,45 @@
+module Healthchecks
+  class RegistriesCache
+    def name
+      :registries_have_data
+    end
+
+    def status
+      if in_warning_state?
+        :warning
+      else
+        :ok
+      end
+    end
+
+    # Optional
+    def message
+      if in_warning_state?
+        "The following registry caches are empty: #{empty_registries.keys.join(', ')}."
+      else
+        "OK"
+      end
+    end
+
+    # Optional
+    def enabled?
+      true # false if the check is not relevant at this time
+    end
+
+  private
+
+    def in_warning_state?
+      empty_registries.any?
+    end
+
+    def empty_registries
+      @empty_registries ||= registries.select { |_key, registry|
+        Rails.cache.fetch(registry.cache_key).nil?
+      }
+    end
+
+    def registries
+      Registries::BaseRegistries.new.all
+    end
+  end
+end

--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -48,6 +48,4 @@ module Registries
       @manuals ||= ManualsRegistry.new
     end
   end
-
-  class RefreshOperationFailed < StandardError; end
 end

--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -16,7 +16,7 @@ module Registries
 
     def refresh_cache
       all.values.each { |registry|
-        if registry.respond_to?(:refresh_cache)
+        if registry.can_refresh_cache?
           registry.refresh_cache
         end
       }

--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -14,6 +14,14 @@ module Registries
       }
     end
 
+    def refresh_cache
+      all.values.each { |registry|
+        if registry.respond_to?(:refresh_cache)
+          registry.refresh_cache
+        end
+      }
+    end
+
   private
 
     def full_topic_taxonomy
@@ -40,4 +48,6 @@ module Registries
       @manuals ||= ManualsRegistry.new
     end
   end
+
+  class RefreshOperationFailed < StandardError; end
 end

--- a/app/lib/registries/cacheable_registry.rb
+++ b/app/lib/registries/cacheable_registry.rb
@@ -11,6 +11,15 @@ module Registries
       false
     end
 
+    def fetch_from_cache
+      Rails.cache.fetch(cache_key) do
+        cacheable_data
+      end
+    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
+      report_error
+      {}
+    end
+
     def cacheable_data
       raise NotImplementedError, "Please supply a cacheable_data method"
     end

--- a/app/lib/registries/cacheable_registry.rb
+++ b/app/lib/registries/cacheable_registry.rb
@@ -1,18 +1,14 @@
 module Registries
-  class RefreshOperationFailed < StandardError; end
-
   module CacheableRegistry
     def can_refresh_cache?
       true
     end
 
     def refresh_cache
-      success = Rails.cache.write(cache_key, cacheable_data)
-
-      raise RefreshOperationFailed unless success
-    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway, RefreshOperationFailed
+      Rails.cache.write(cache_key, cacheable_data)
+    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
       report_error
-      raise RefreshOperationFailed
+      false
     end
 
     def cacheable_data

--- a/app/lib/registries/cacheable_registry.rb
+++ b/app/lib/registries/cacheable_registry.rb
@@ -1,4 +1,6 @@
 module Registries
+  class RefreshOperationFailed < StandardError; end
+
   module CacheableRegistry
     def can_refresh_cache?
       true

--- a/app/lib/registries/cacheable_registry.rb
+++ b/app/lib/registries/cacheable_registry.rb
@@ -1,0 +1,28 @@
+module Registries
+  module CacheableRegistry
+    def can_refresh_cache?
+      true
+    end
+
+    def refresh_cache
+      success = Rails.cache.write(cache_key, cacheable_data)
+
+      raise RefreshOperationFailed unless success
+    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway, RefreshOperationFailed
+      report_error
+      raise RefreshOperationFailed
+    end
+
+    def cacheable_data
+      raise NotImplementedError, "Please supply a cacheable_data method"
+    end
+
+    def cache_key
+      raise NotImplementedError, "Please supply a cache_key method"
+    end
+
+    def report_error
+      raise NotImplementedError, "Please supply a report_error method"
+    end
+  end
+end

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -7,12 +7,7 @@ module Registries
     end
 
     def taxonomy
-      @taxonomy ||= Rails.cache.fetch(cache_key) do
-        cacheable_data
-      end
-    rescue GdsApi::HTTPServerError
-      report_error
-      {}
+      @taxonomy ||= fetch_from_cache
     end
 
     def cache_key

--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -1,7 +1,5 @@
 module Registries
-  class ManualsRegistry
-    CACHE_KEY = 'registries/manuals'.freeze
-
+  class ManualsRegistry < Registry
     def [](base_url)
       manuals[base_url]
     end
@@ -10,10 +8,14 @@ module Registries
       manuals
     end
 
+    def cache_key
+      'registries/manuals'
+    end
+
   private
 
     def manuals
-      @manuals ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+      @manuals ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
         manuals_as_hash
       end
     rescue GdsApi::HTTPServerError

--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -1,5 +1,7 @@
 module Registries
   class ManualsRegistry < Registry
+    include CacheableRegistry
+
     def [](base_url)
       manuals[base_url]
     end
@@ -14,9 +16,13 @@ module Registries
 
   private
 
+    def cacheable_data
+      manuals_as_hash
+    end
+
     def manuals
-      @manuals ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-        manuals_as_hash
+      @manuals ||= Rails.cache.fetch(cache_key) do
+        cacheable_data
       end
     rescue GdsApi::HTTPServerError
       GovukStatsd.increment('registries.manuals_api_errors')

--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -21,12 +21,11 @@ module Registries
     end
 
     def manuals
-      @manuals ||= Rails.cache.fetch(cache_key) do
-        cacheable_data
-      end
-    rescue GdsApi::HTTPServerError
+      @manuals ||= fetch_from_cache
+    end
+
+    def report_error
       GovukStatsd.increment('registries.manuals_api_errors')
-      {}
     end
 
     def manuals_as_hash

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -1,11 +1,13 @@
 module Registries
   class OrganisationsRegistry < Registry
+    include CacheableRegistry
+
     def [](slug)
       organisations[slug]
     end
 
     def organisations
-      @organisations ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+      @organisations ||= Rails.cache.fetch(cache_key) do
         organisations_as_hash
       end
     rescue GdsApi::HTTPServerError
@@ -22,6 +24,10 @@ module Registries
     end
 
   private
+
+    def cacheable_data
+      organisations_as_hash
+    end
 
     def organisations_as_hash
       GovukStatsd.time("registries.organisations.request_time") do

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -1,13 +1,11 @@
 module Registries
-  class OrganisationsRegistry
-    CACHE_KEY = "registries/organisations".freeze
-
+  class OrganisationsRegistry < Registry
     def [](slug)
       organisations[slug]
     end
 
     def organisations
-      @organisations ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+      @organisations ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
         organisations_as_hash
       end
     rescue GdsApi::HTTPServerError
@@ -17,6 +15,10 @@ module Registries
 
     def values
       organisations
+    end
+
+    def cache_key
+      "registries/organisations"
     end
 
   private

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -7,12 +7,7 @@ module Registries
     end
 
     def organisations
-      @organisations ||= Rails.cache.fetch(cache_key) do
-        organisations_as_hash
-      end
-    rescue GdsApi::HTTPServerError
-      GovukStatsd.increment("registries.organisations_api_errors")
-      {}
+      @organisations ||= fetch_from_cache
     end
 
     def values
@@ -24,6 +19,10 @@ module Registries
     end
 
   private
+
+    def report_error
+      GovukStatsd.increment("registries.organisations_api_errors")
+    end
 
     def cacheable_data
       organisations_as_hash

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -7,12 +7,7 @@ module Registries
     end
 
     def people
-      @people ||= Rails.cache.fetch(cache_key) do
-        people_as_hash
-      end
-    rescue GdsApi::HTTPServerError
-      GovukStatsd.increment("registries.people_api_errors")
-      {}
+      @people ||= fetch_from_cache
     end
 
     def values
@@ -24,6 +19,10 @@ module Registries
     end
 
   private
+
+    def report_error
+      GovukStatsd.increment("registries.people_api_errors")
+    end
 
     def cacheable_data
       people_as_hash

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -1,13 +1,11 @@
 module Registries
-  class PeopleRegistry
-    CACHE_KEY = "#{NAMESPACE}/people".freeze
-
+  class PeopleRegistry < Registry
     def [](slug)
       people[slug]
     end
 
     def people
-      @people ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
+      @people ||= Rails.cache.fetch(cache_key) do
         people_as_hash
       end
     rescue GdsApi::HTTPServerError
@@ -19,7 +17,15 @@ module Registries
       people
     end
 
+    def cache_key
+      "#{NAMESPACE}/people"
+    end
+
   private
+
+    def cacheable_data
+      people_as_hash
+    end
 
     def people_as_hash
       GovukStatsd.time("registries.people.request_time") do

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -1,5 +1,7 @@
 module Registries
   class PeopleRegistry < Registry
+    include CacheableRegistry
+
     def [](slug)
       people[slug]
     end

--- a/app/lib/registries/registry.rb
+++ b/app/lib/registries/registry.rb
@@ -1,0 +1,7 @@
+module Registries
+  class Registry
+    def can_refresh_cache?
+      false
+    end
+  end
+end

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -1,6 +1,6 @@
 module Registries
   class TopicTaxonomyRegistry
-    CACHE_KEY = "#{NAMESPACE}/topic_taxonomy".freeze
+    CACHE_KEY = "registries/topic_taxonomy".freeze
 
     def [](content_id)
       taxonomy_tree[content_id]
@@ -11,7 +11,7 @@ module Registries
         taxonomy_tree_as_hash
       end
     rescue GdsApi::HTTPServerError
-      GovukStatsd.increment("#{NAMESPACE}.topic_taxonomy_api_errors")
+      GovukStatsd.increment("registries.topic_taxonomy_api_errors")
       {}
     end
 

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -7,12 +7,7 @@ module Registries
     end
 
     def taxonomy_tree
-      @taxonomy_tree ||= Rails.cache.fetch(cache_key) do
-        cacheable_data
-      end
-    rescue GdsApi::HTTPServerError
-      GovukStatsd.increment("registries.topic_taxonomy_api_errors")
-      {}
+      @taxonomy_tree ||= fetch_from_cache
     end
 
     def cache_key
@@ -20,6 +15,10 @@ module Registries
     end
 
   private
+
+    def report_error
+      GovukStatsd.increment("registries.topic_taxonomy_api_errors")
+    end
 
     def cacheable_data
       taxonomy_tree_as_hash

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -1,21 +1,29 @@
 module Registries
-  class TopicTaxonomyRegistry
-    CACHE_KEY = "registries/topic_taxonomy".freeze
+  class TopicTaxonomyRegistry < Registry
+    include CacheableRegistry
 
     def [](content_id)
       taxonomy_tree[content_id]
     end
 
     def taxonomy_tree
-      @taxonomy_tree ||= Rails.cache.fetch(CACHE_KEY, expires_in: 1.hour) do
-        taxonomy_tree_as_hash
+      @taxonomy_tree ||= Rails.cache.fetch(cache_key) do
+        cacheable_data
       end
     rescue GdsApi::HTTPServerError
       GovukStatsd.increment("registries.topic_taxonomy_api_errors")
       {}
     end
 
+    def cache_key
+      "#{NAMESPACE}/topic_taxonomy"
+    end
+
   private
+
+    def cacheable_data
+      taxonomy_tree_as_hash
+    end
 
     def taxonomy_tree_as_hash
       GovukStatsd.time("registries.topic_taxonomy.request_time") do

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -3,12 +3,7 @@ module Registries
     include CacheableRegistry
 
     def [](slug)
-      begin
-        cached_locations[slug]
-      rescue TypeError
-        # The cached data was at one point an array, this can be removed later.
-        retry if cached_locations.is_a?(Array) && uncache_locations
-      end
+      cached_locations[slug]
     end
 
     def values
@@ -30,16 +25,7 @@ module Registries
     end
 
     def cached_locations
-      @cached_locations ||= Rails.cache.fetch(cache_key) do
-        cacheable_data
-      end
-    rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
-      report_error
-      {}
-    end
-
-    def uncache_locations
-      Rails.cache.delete(cache_key)
+      @cached_locations ||= fetch_from_cache
     end
 
     def locations

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,7 +4,7 @@ FinderFrontend::Application.configure do
   #
   # More details:
   # https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore
-  config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true }
 
   config.cache_classes = true
   config.eager_load = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ FinderFrontend::Application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  get '/healthcheck.json', to: GovukHealthcheck.rack_response(
+    Healthchecks::RegistriesCache,
+  )
   get '/healthcheck', to: proc { [200, {}, %w[OK]] }
 
   get "/search" => "search#index", as: :search

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,3 +66,11 @@ ActionController::Base.allow_rescue = false
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+Before do
+  Rails.cache.clear
+end
+
+After do
+  Rails.cache.clear
+end

--- a/lib/tasks/registries.rake
+++ b/lib/tasks/registries.rake
@@ -7,7 +7,7 @@ namespace :registries do
   "
   task cache_refresh: :environment do
     puts "Refreshing registry cache..."
-    # TODO: refresh caches.
+    Registries::BaseRegistries.new.refresh_cache
     puts "Finished refreshing registry cache."
   end
 end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -20,6 +20,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
   let(:top_level_taxon_one_title) { "Magical Education" }
   let(:top_level_taxon_two_title) { "Herbology" }
 
+  before { Rails.cache.clear }
+  after { Rails.cache.clear }
+
   before :each do
     topic_taxonomy_has_taxons([
       {

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -23,8 +23,10 @@ describe FindersController, type: :controller do
   end
 
   before do
+    Rails.cache.clear
     content_store_has_item("/", "links" => { "level_one_taxons" => [] })
   end
+  after { Rails.cache.clear }
 
   describe "GET show" do
     let(:all_content_finder) do

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'json'
+
+describe 'Healthcheck' do
+  before do
+    Rails.cache.clear
+  end
+
+  after do
+    Rails.cache.clear
+  end
+
+  context 'when everything is fine', type: :request do
+    before do
+      fill_registries
+    end
+
+    it "returns an OK status" do
+      get '/healthcheck.json'
+      expect(JSON.parse(response.body)).to eq(
+        "checks" => {
+          "registries_have_data" => {
+            "message" => "OK",
+            "status" => "ok",
+          }
+        },
+        "status" => "ok",
+      )
+    end
+  end
+
+  context 'when registries have no data', type: :request do
+    before do
+      Rails.cache.clear
+    end
+
+    it "returns a warning status" do
+      get '/healthcheck.json'
+      expect(JSON.parse(response.body)).to eq(
+        "checks" => {
+          "registries_have_data" => {
+            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, organisations, manual, full_topic_taxonomy.",
+            "status" => "warning",
+          }
+        },
+        "status" => "warning",
+      )
+    end
+  end
+
+  def fill_registries
+    cache_keys = Registries::BaseRegistries.new.all.values.map(&:cache_key)
+    cache_keys.each { |key| Rails.cache.write(key, cached: "data") }
+  end
+end

--- a/spec/controllers/qa_controller_spec.rb
+++ b/spec/controllers/qa_controller_spec.rb
@@ -16,7 +16,11 @@ describe QaController, type: :controller do
       end
     end
 
-    before { allow_any_instance_of(QaController).to receive(:qa_config).and_return(aaib_reports_qa_config_yaml) }
+    before {
+      Rails.cache.clear
+      allow_any_instance_of(QaController).to receive(:qa_config).and_return(aaib_reports_qa_config_yaml)
+    }
+    after { Rails.cache.clear }
 
     describe "a finder content item exists" do
       let(:base_path)        { aaib_reports_qa_config_yaml["base_path"] }

--- a/spec/helpers/taxonomy_spec_helper.rb
+++ b/spec/helpers/taxonomy_spec_helper.rb
@@ -26,13 +26,10 @@ module TaxonomySpecHelper
   def topic_taxonomy_has_taxons(topics = default_taxons)
     clear_taxon_cache
 
-    taxons = []
-
-    topics.map { |topic|
+    taxons = topics.map { |topic|
       taxon = level_one_taxon(topic)
-      taxons.unshift(taxon)
-
       content_store_has_item("/#{topic[:content_id]}", taxon)
+      taxon
     }
 
     content_store_has_item("/", root_taxon(taxons))
@@ -58,11 +55,11 @@ module TaxonomySpecHelper
   end
 
   def clear_full_taxon_cache
-    Rails.cache.delete('test/registries/full_topic_taxonomy')
+    Rails.cache.delete('registries/full_topic_taxonomy')
   end
 
   def taxon_cache_key
-    'test/registries/topic_taxonomy'
+    'registries/topic_taxonomy'
   end
 
   def root_taxon(taxons)

--- a/spec/lib/advanced_search_finder_api_spec.rb
+++ b/spec/lib/advanced_search_finder_api_spec.rb
@@ -30,6 +30,9 @@ describe AdvancedSearchFinderApi do
 
   subject(:instance) { described_class.new(finder_item, filter_params) }
 
+  before { Rails.cache.clear }
+  after { Rails.cache.clear }
+
   describe "content_item_with_search_results" do
     before do
       allow(Services.content_store).to receive(:content_item)

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require "gds_api/test_helpers/worldwide"
+require "helpers/taxonomy_spec_helper"
+require "helpers/registry_spec_helper"
+
+RSpec.describe Healthchecks::RegistriesCache do
+  include GdsApi::TestHelpers::Worldwide
+  include TaxonomySpecHelper
+  include GdsApi::TestHelpers::ContentStore
+  include GovukContentSchemaExamples
+  include RegistrySpecHelper
+
+  subject(:check) { described_class.new }
+
+  before :each do
+    Rails.cache.clear
+  end
+
+  after { Rails.cache.clear }
+
+  context "All Registries have cached data" do
+    before do
+      worldwide_api_has_locations %w(hogwarts privet-drive diagon-alley)
+      stub_root_taxon(topic_taxonomy_has_taxons)
+      stub_people_registry_request
+      stub_manuals_registry_request
+      stub_organisations_registry_request
+
+      Registries::BaseRegistries.new.refresh_cache
+    end
+
+    it "has an OK status" do
+      expect(check.status).to eq :ok
+      expect(check.message).to eq "OK"
+    end
+  end
+
+  context "Registries caches are empty" do
+    it "has an OK status" do
+      expect(check.status).to eq :warning
+      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, organisations, manual, full_topic_taxonomy."
+    end
+  end
+end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Registries::BaseRegistries do
         registry.respond_to? :refresh_cache
       }
 
-      registries.map { |registry| registry.class::CACHE_KEY }
+      registries.map { |registry| registry.class.new.cache_key }
     end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -1,16 +1,25 @@
 require 'spec_helper'
 require "gds_api/test_helpers/worldwide"
+require "helpers/taxonomy_spec_helper"
 
 RSpec.describe Registries::BaseRegistries do
   include GdsApi::TestHelpers::Worldwide
+  include TaxonomySpecHelper
+  include GdsApi::TestHelpers::ContentStore
+  include GovukContentSchemaExamples
 
   before do
-    worldwide_api_has_selection_of_locations
+    worldwide_api_has_locations %w(hogwarts privet-drive diagon-alley)
   end
 
   let(:subject) { described_class.new }
+  let(:level_one_taxons) {
+    JSON.parse(File.read(Rails.root.join("features", "fixtures", "level_one_taxon.json")))
+  }
 
   it "fetches all registries" do
+    expect(subject.all).to have_key('manual')
+    expect(subject.all).to have_key('full_topic_taxonomy')
     expect(subject.all).to have_key('world_locations')
     expect(subject.all).to have_key('part_of_taxonomy_tree')
     expect(subject.all).to have_key('organisations')
@@ -23,5 +32,40 @@ RSpec.describe Registries::BaseRegistries do
 
   it "provides topic_taxonomy registry as part_of_taxonomy_tree" do
     expect(subject.all['part_of_taxonomy_tree']).to be_instance_of Registries::TopicTaxonomyRegistry
+  end
+
+  describe "#refresh_cache" do
+    before do
+      clear_cache
+      stub_root_taxon(level_one_taxons)
+      full_topic_taxonomy_has_taxons(level_one_taxons)
+    end
+    after { clear_cache }
+
+    it "refreshes the cache of all registries that implement refresh_cache" do
+      registry_cache_keys.each { |cache_key|
+        expect(Rails.cache.fetch(cache_key)).to be nil
+      }
+
+      described_class.new.refresh_cache
+
+      registry_cache_keys.each { |cache_key|
+        expect(Rails.cache.fetch(cache_key)).not_to be nil
+      }
+    end
+  end
+
+  def clear_cache
+    Rails.cache.clear
+  end
+
+  def registry_cache_keys
+    @registry_cache_keys ||= begin
+      registries = described_class.new.all.values.select { |registry|
+        registry.respond_to? :refresh_cache
+      }
+
+      registries.map { |registry| registry.class::CACHE_KEY }
+    end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Registries::BaseRegistries do
       full_topic_taxonomy_has_taxons(level_one_taxons)
       stub_people_registry_request
       stub_manuals_registry_request
+      stub_organisations_registry_request
     end
     after { clear_cache }
 
@@ -65,11 +66,7 @@ RSpec.describe Registries::BaseRegistries do
 
   def registry_cache_keys
     @registry_cache_keys ||= begin
-      registries = described_class.new.all.values.select { |registry|
-        registry.respond_to? :refresh_cache
-      }
-
-      registries.map { |registry| registry.class.new.cache_key }
+      described_class.new.all.values.map(&:cache_key)
     end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Registries::BaseRegistries do
       stub_root_taxon(level_one_taxons)
       full_topic_taxonomy_has_taxons(level_one_taxons)
       stub_people_registry_request
+      stub_manuals_registry_request
     end
     after { clear_cache }
 

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 require "gds_api/test_helpers/worldwide"
 require "helpers/taxonomy_spec_helper"
+require "helpers/registry_spec_helper"
 
 RSpec.describe Registries::BaseRegistries do
   include GdsApi::TestHelpers::Worldwide
   include TaxonomySpecHelper
   include GdsApi::TestHelpers::ContentStore
   include GovukContentSchemaExamples
+  include RegistrySpecHelper
 
   before do
     worldwide_api_has_locations %w(hogwarts privet-drive diagon-alley)
@@ -39,6 +41,7 @@ RSpec.describe Registries::BaseRegistries do
       clear_cache
       stub_root_taxon(level_one_taxons)
       full_topic_taxonomy_has_taxons(level_one_taxons)
+      stub_people_registry_request
     end
     after { clear_cache }
 

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -10,24 +10,28 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
 
   let(:base_path) { "/basepath" }
 
+  before :each do
+    clear_cache
+  end
+
+  after :each do
+    clear_cache
+  end
+
   describe "when topic taxonomy API is unavailable" do
     it "will return an (uncached) empty hash" do
-      clear_full_taxon_cache
       topic_taxonomy_api_is_unavailable
       expect(described_class.new[base_path]).to be_nil
       expect(described_class.new.taxonomy).to eql({})
-      expect(Rails.cache.fetch(taxon_cache_key)).to be_nil
+      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
     end
   end
 
   describe "when topic taxonomy api is available" do
     before :each do
-      clear_full_taxon_cache
       stub_root_taxon(level_one_taxons)
       full_topic_taxonomy_has_taxons(level_one_taxons)
     end
-
-    after { clear_full_taxon_cache }
 
     let(:registry) { described_class.new }
     let(:child_base_path) { "/environment/countryside-stewardship" }
@@ -44,5 +48,9 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
       fetched_document = registry[first_level_base_path]
       expect(fetched_document['content_id']).to eq(first_level_content_id)
     end
+  end
+
+  def clear_cache
+    Rails.cache.clear
   end
 end

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
       topic_taxonomy_api_is_unavailable
       expect(described_class.new[base_path]).to be_nil
       expect(described_class.new.taxonomy).to eql({})
-      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
     end
   end
 

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Registries::ManualsRegistry do
     it "will return an (uncached) empty hash" do
       manual = described_class.new[slug]
       expect(manual).to be_nil
-      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe Registries::ManualsRegistry do
   end
 
   def clear_cache
-    Rails.cache.delete(described_class::CACHE_KEY)
+    Rails.cache.delete(described_class.new.cache_key)
   end
 
   def rummager_results

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Registries::OrganisationsRegistry do
     it "will return an (uncached) empty hash" do
       organisation = described_class.new[slug]
       expect(organisation).to be_nil
-      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Registries::OrganisationsRegistry do
   end
 
   def clear_cache
-    Rails.cache.delete(described_class::CACHE_KEY)
+    Rails.cache.delete(described_class.new.cache_key)
   end
 
   def rummager_results

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Registries::PeopleRegistry do
     it "will return an (uncached) empty hash" do
       person = described_class.new[slug]
       expect(person).to be_nil
-      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe Registries::PeopleRegistry do
   end
 
   def clear_cache
-    Rails.cache.delete(described_class::CACHE_KEY)
+    Rails.cache.delete(described_class.new.cache_key)
   end
 
   def rummager_results

--- a/spec/lib/registries/registry_spec.rb
+++ b/spec/lib/registries/registry_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Registries::Registry do
+  subject(:registry) { described_class.new }
+
+  describe '#can_refresh_cache?' do
+    it 'returns false' do
+      expect(registry.can_refresh_cache?).to be false
+    end
+  end
+end

--- a/spec/lib/registries/topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/topic_taxonomy_registry_spec.rb
@@ -10,9 +10,16 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
   let(:top_level_taxon_one) { level_one_taxon(content_id: content_id_one, title: content_id_one) }
   let(:top_level_taxon_two) { level_one_taxon(content_id: content_id_two, title: content_id_two) }
 
+  before :each do
+    Rails.cache.clear
+  end
+
+  after :each do
+    Rails.cache.clear
+  end
+
   describe "when topic taxonomy API is unavailable" do
     it "will return an (uncached) empty hash" do
-      clear_taxon_cache
       topic_taxonomy_api_is_unavailable
       expect(described_class.new[content_id_one]).to be_nil
       expect(described_class.new.taxonomy_tree).to eql({})
@@ -22,7 +29,6 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
 
   describe "when topic taxonomy api is available" do
     before :each do
-      clear_taxon_cache
       topic_taxonomy_has_taxons([
         {
           content_id: content_id_one,
@@ -34,8 +40,6 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
         }
       ])
     end
-
-    after { clear_taxon_cache }
 
     subject(:registry) { described_class.new }
 

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Registries::WorldLocationsRegistry do
       clear_cache
       world_locations_api_is_unavailable
       expect(described_class.new[slug]).to be_nil
-      expect(Rails.cache.fetch(described_class::CACHE_KEY)).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
     end
   end
 
@@ -48,6 +48,6 @@ RSpec.describe Registries::WorldLocationsRegistry do
   end
 
   def clear_cache
-    Rails.cache.delete(described_class::CACHE_KEY)
+    Rails.cache.delete(described_class.new.cache_key)
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -14,6 +14,14 @@ describe ContentItem do
       .and_return(finder_content_item)
   end
 
+  before :each do
+    Rails.cache.clear
+  end
+
+  after :each do
+    Rails.cache.clear
+  end
+
   describe "as_hash" do
     it "returns a content item as a hash" do
       expect(subject.as_hash).to eql(finder_content_item)

--- a/spec/models/facet_collection_spec.rb
+++ b/spec/models/facet_collection_spec.rb
@@ -13,6 +13,9 @@ describe FacetCollection do
                               ])
   end
 
+  before { Rails.cache.clear }
+  after { Rails.cache.clear }
+
   context "with facets with values" do
     it "should accept a hash of key/value pairs, and set the facet values for each" do
       facet_hashes = [

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -5,6 +5,7 @@ describe TaxonFacet do
   include TaxonomySpecHelper
 
   before do
+    Rails.cache.clear
     topic_taxonomy_has_taxons([
       {
         content_id: "allowed-value-1",
@@ -15,6 +16,10 @@ describe TaxonFacet do
         title: "allowed-value-2"
       }
     ])
+  end
+
+  after do
+    Rails.cache.clear
   end
 
   let(:allowed_values) {

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe FinderPresenter do
     ]
   }
 
+  before { Rails.cache.clear }
+  after { Rails.cache.clear }
+
   describe "facets" do
     it "returns the correct facets" do
       expect(subject.facets.count { |f| f.type == "date" }).to eql(1)


### PR DESCRIPTION
We store data for facets in the local cache (memcached), with 'registry' classes that manage them.

Currently, when a user visits a search page, and the 1 hour cache has expired on a registry, fresh data will be fetched for the registry and added to the cache as part of the same request.

This means that some requests by users are unfairly slow. The first request to a newly started application is especially slow because all of the registry caches will be empty.

This change does the following:

- Adds a rake task to refresh the cache, which will be called during the deploy, so the caches aren't empty when the first request comes in. Call it with `LIVE=true` set if you want to point it at live things.
- Sets `expires_in` to the default, which is 'never': no expiry on the registry caches. Once you add registry data, you must use the rake task to refresh it.
- Adds a healthcheck endpoint, which reports a warning if any caches are empty.

**Note:** Will be merged in after https://github.com/alphagov/govuk-app-deployment/pull/315 and https://github.com/alphagov/govuk-puppet/pull/9282 have been merged/run.

Trello: https://trello.com/c/uwm4BnOT/787

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1193.herokuapp.com/search/all
- http://finder-frontend-pr-1193.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1193.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1193.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1193.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
