### PR TITLE
Cron job to refresh registry caches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'slimmer', '~> 13.1.0'
 gem 'govuk_frontend_toolkit', '~> 8.2'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '~> 4.1'
+gem 'whenever', "~> 0.11.0"
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.11.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -403,6 +405,7 @@ DEPENDENCIES
   timecop
   uglifier (~> 4.1)
   webmock (~> 3.6.0)
+  whenever (~> 0.11.0)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,29 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+set :output, { error: 'log/cron.error.log', standard: 'log/cron.log' }
+
+bundler_prefix = ENV.fetch('BUNDLER_PREFIX', '/usr/local/bin/govuk_setenv finder-frontend')
+job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
+
+every 1.hours do
+  rake "registries:cache_refresh"
+end
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,7 +3,7 @@
 # It's helpful, but not entirely necessary to understand cron before proceeding.
 # http://en.wikipedia.org/wiki/Cron
 
-set :output, { error: 'log/cron.error.log', standard: 'log/cron.log' }
+set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
 
 bundler_prefix = ENV.fetch('BUNDLER_PREFIX', '/usr/local/bin/govuk_setenv finder-frontend')
 job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -1,0 +1,45 @@
+# Registries
+
+The registries module (lib/registries) provides datasets from other
+applications.
+
+These registries are intended to be used when rendering facets.
+For example, the OrganisationsRegistry provides the data for the organisations
+facet.
+
+Each registry fetches data from another application (such as search-api
+or whitehall), and caches it locally.
+
+## Motivation for registries
+
+Frontend applications like finder-frontend, according to GOV.UK architecture
+guidelines, should not have a data store.
+
+We have slightly broken this rule to decrease page load times. If we don't
+make additional requests for facets, and if our queries request less data,
+then we can return search results to users faster.
+
+## Caching
+
+We cache the data for each registry in memcached, using the dalli gem.
+
+There is a separate instance of memcached running on each machine, so the
+stores can be out of sync.
+
+We refresh the cache using the `registries:cache_refresh` rake task.
+
+The cached data is refreshed routinely using a cron job, defined in
+`config/schedule.rb` and administrated with the [whenever](https://github.com/javan/whenever)
+gem.
+
+The cache is refreshed during a deploy, too.
+
+Both the deploy time and routine cache refreshes are called in the
+`govuk-app-deployment` deploy. The capistrano deploy process supplies data to
+the cache and sets up the cron job.
+
+## Alerts
+
+We have a healthcheck for the registry caches, so we know when
+there are empty registries. Poor health will be reported in Icinga.
+They are defined in `lib/healthchecks`.


### PR DESCRIPTION
This adds a cron job that will refresh the registry caches every hour. The cron job will be started during the deploy: https://github.com/alphagov/govuk-app-deployment/pull/316.

https://trello.com/c/knffA0Fb/786-import-the-new-topic-registry-on-a-schedule-s

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1195.herokuapp.com/search/all
- http://finder-frontend-pr-1195.herokuapp.com/search/research-and-statistics

[Other finders](https://live-stuff.herokuapp.com/finders)
