### PR TITLE
Mainstream content no longer displays organisation metadata.

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -81,6 +81,7 @@ private
       public_timestamp
       popularity
       content_purpose_supergroup
+      content_store_document_type
       format
     )
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,7 +82,7 @@ private
   def tag_metadata_keys
     keys = finder.text_metadata_keys
     keys.reject do |key|
-      key == :organisations && is_mainstream_content?
+      key == 'organisations' && is_mainstream_content?
     end
   end
 

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -23,9 +23,8 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
     "facet_content_purpose_subgroup" => "1500,order:value.title",
     "fields" => %w(
       title link description public_timestamp popularity
-      content_purpose_supergroup format
-      content_store_document_type organisations
-      content_purpose_subgroup part_of_taxonomy_tree
+      content_purpose_supergroup content_store_document_type format
+      organisations content_purpose_subgroup part_of_taxonomy_tree
     ).join(","),
     "order" => "-public_timestamp",
     "reject_content_store_document_type" => %w[browse],

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -186,6 +186,7 @@ module RummagerUrlHelper
       public_timestamp
       popularity
       content_purpose_supergroup
+      content_store_document_type
       format
     )
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -58,7 +58,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -116,7 +116,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -217,7 +217,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -59,7 +59,7 @@ describe SearchQueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format",
       )
     end
   end
@@ -86,7 +86,7 @@ describe SearchQueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,alpha,beta",
       )
     end
 
@@ -103,7 +103,7 @@ describe SearchQueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,format,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,zeta,beta",
         )
       end
     end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -95,8 +95,8 @@ describe Document do
 
     let(:finder) do
       double(:finder,
-             date_metadata_keys: [:foo],
-             text_metadata_keys: [:organisations],
+             date_metadata_keys: %w[foo],
+             text_metadata_keys: %w[organisations],
              "display_metadata?": true,
              display_key_for_metadata_key: 'title')
     end
@@ -120,7 +120,7 @@ describe Document do
 
     context "There is an organisations metadata key" do
       before :each do
-        allow(finder).to receive(:label_for_metadata_key).with(:organisations).and_return('org_label')
+        allow(finder).to receive(:label_for_metadata_key).with('organisations').and_return('org_label')
       end
       it "Remove organisations metadata for mainstream content only" do
         expect(mainstream_document.metadata).to be_empty


### PR DESCRIPTION
A few bugs had crept in:
- the metadata tag 'organisations' is no longer a symbol and
should be treated as a string
- content_store_document_type was not requested from search-api
so we could not determine if a document is mainstream or not. This
has now been added to the default fields to retrieve from search.

Paired with @SamJamCul 

Trello: https://trello.com/c/HM2DqNQb/785-hide-org-metadata-on-mainstream-results-m

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1197.herokuapp.com/search/all
- http://finder-frontend-pr-1197.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1197.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1197.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1197.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
