### PR TITLE
Add is_historic and government_name to fields requested from search

### DIFF
--- a/app/lib/search_query_builder.rb
+++ b/app/lib/search_query_builder.rb
@@ -83,6 +83,8 @@ private
       content_purpose_supergroup
       content_store_document_type
       format
+      is_historic
+      government_name
     )
   end
 

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -24,6 +24,7 @@ Given(/^a collection of tagged documents(.*?)$/) do |categorisation|
     "fields" => %w(
       title link description public_timestamp popularity
       content_purpose_supergroup content_store_document_type format
+      is_historic government_name
       organisations content_purpose_subgroup part_of_taxonomy_tree
     ).join(","),
     "order" => "-public_timestamp",

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -98,6 +98,8 @@ module RummagerUrlHelper
       content_purpose_supergroup
       content_store_document_type
       format
+      is_historic
+      government_name
     )
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -60,7 +60,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -118,7 +118,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -219,7 +219,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0

--- a/spec/lib/search_query_builder_spec.rb
+++ b/spec/lib/search_query_builder_spec.rb
@@ -59,7 +59,7 @@ describe SearchQueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name",
       )
     end
   end
@@ -86,7 +86,7 @@ describe SearchQueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,alpha,beta",
       )
     end
 
@@ -103,7 +103,7 @@ describe SearchQueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,zeta,beta",
         )
       end
     end


### PR DESCRIPTION
The "first published under the X government" feature is currently
broken because we're not getting this metadata.

There's dead code in the rummager URL helpers (and possibly other parts of the feature tests) which I'll remove in a follow-up PR.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1198.herokuapp.com/search/all
http://finder-frontend-pr-1198.herokuapp.com/search/all?parent=&keywords=%22every+child+matters%22&level_one_taxon=&manual=&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=relevance
- http://finder-frontend-pr-1198.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1198.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1198.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1198.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/fOA18Ei7/804-fix-first-published-under-the-x-government-metadata-in-search)
