### PR TITLE
Add blue header bar for users from topics

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -323,3 +323,15 @@
 .app-patch--search-input-override input[type="search"] {
   box-sizing: border-box;
 }
+
+// NOTE: Used to remove the blue global header bar for the topic finder header.
+
+// scss-lint:disable IdSelector
+.full-width #global-header-bar {
+  display: none;
+}
+// scss-lint:enable IdSelector
+
+.topic-finder__taxon-link {
+    @include govuk-font(24, $weight: bold);
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -335,3 +335,11 @@
 .topic-finder__taxon-link {
     @include govuk-font(24, $weight: bold);
 }
+
+// NOTE: used to override govspeak component when it's used on an inverse header
+
+.gem-c-inverse-header {
+  .gem-c-govspeak {
+    color: govuk-colour("white");
+  }
+}

--- a/app/assets/stylesheets/views/_advanced-search.scss
+++ b/app/assets/stylesheets/views/_advanced-search.scss
@@ -26,3 +26,7 @@
   display: none;
 }
 // scss-lint:enable IdSelector
+
+.topic-finder__taxon-link {
+    @include govuk-font(24, $weight: bold);
+}

--- a/app/assets/stylesheets/views/_advanced-search.scss
+++ b/app/assets/stylesheets/views/_advanced-search.scss
@@ -21,12 +21,3 @@
   max-width: 100%;
   width: auto;
 }
-
-.full-width #global-header-bar {
-  display: none;
-}
-// scss-lint:enable IdSelector
-
-.topic-finder__taxon-link {
-    @include govuk-font(24, $weight: bold);
-}

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -6,6 +6,19 @@ module Registries
       taxonomy[base_path]
     end
 
+    def find_parent_by_id id
+      topic = taxonomy.select { |_, value|
+        value['content_id'] == id
+      }
+
+      path = topic.keys[0]
+
+      {
+        path: path,
+        title: topic[path]['title'],
+      }
+    end
+
     def taxonomy
       @taxonomy ||= fetch_from_cache
     end

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -6,17 +6,6 @@ module Registries
       taxonomy[base_path]
     end
 
-    def find_parent_by_id id
-      topic = taxonomy.find { |_, value|
-        value['content_id'] == id
-      }
-
-      title = topic.nil? ? nil : topic[1]['title']
-      path = topic.nil? ? nil : topic[0]
-
-      title.nil? ? nil : { path: path, title: title }
-    end
-
     def taxonomy
       @taxonomy ||= fetch_from_cache
     end

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -11,10 +11,10 @@ module Registries
         value['content_id'] == id
       }
 
-      title = topic.second['title']
-      path = topic.first
+      title = topic.nil? ? nil : topic[1]['title']
+      path = topic.nil? ? nil : topic[0]
 
-      title.nil? ? nil : {path: path, title: title}
+      title.nil? ? nil : { path: path, title: title }
     end
 
     def taxonomy

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -7,16 +7,14 @@ module Registries
     end
 
     def find_parent_by_id id
-      topic = taxonomy.select { |_, value|
+      topic = taxonomy.find { |_, value|
         value['content_id'] == id
       }
 
-      path = topic.keys[0]
+      title = topic.second['title']
+      path = topic.first
 
-      {
-        path: path,
-        title: topic[path]['title'],
-      }
+      title.nil? ? nil : {path: path, title: title}
     end
 
     def taxonomy

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -186,6 +186,10 @@ class FinderPresenter
     self.content_item['content_id'] == 'dd395436-9b40-41f3-8157-740a453ac972'
   end
 
+  def topic_finder?
+    values.include?('topic-finder')
+  end
+
   # FIXME: This should be removed once we have a way to determine
   # whether to display metadata in the finder definition
   def eu_exit_finder?

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -187,13 +187,13 @@ class FinderPresenter
   end
 
   def topic_finder?
-    values.include?('parent') && topic_finder_parent_name.present?
+    values.include?('parent') && topic_finder_parent.present?
   end
 
-  def topic_finder_parent_name
-    registry = Registries::FullTopicTaxonomyRegistry.new
-    parent_address = values['parent']
-    registry[parent_address].nil? ? '' : registry[parent_address]['title']
+  def topic_finder_parent
+    registry = Services.registries.all['full_topic_taxonomy']
+    parent = registry.find_parent_by_id values['parent']
+    parent.nil? ? '' : parent
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -188,13 +188,12 @@ class FinderPresenter
   end
 
   def topic_finder?
-    values.include?('parent') && topic_finder_parent.present?
+    values.include?('topic') && topic_finder_parent.present?
   end
 
   def topic_finder_parent
     registry = Services.registries.all['full_topic_taxonomy']
-    parent = registry.find_parent_by_id values['parent']
-    parent
+    registry.find_parent_by_id values['topic']
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -187,7 +187,13 @@ class FinderPresenter
   end
 
   def topic_finder?
-    values.include?('topic-finder')
+    values.include?('parent') && topic_finder_parent_name.present?
+  end
+
+  def topic_finder_parent_name
+    registry = Registries::FullTopicTaxonomyRegistry.new
+    parent_address = values['parent']
+    registry[parent_address].nil? ? '' : registry[parent_address]['title']
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -193,7 +193,7 @@ class FinderPresenter
   def topic_finder_parent
     registry = Services.registries.all['full_topic_taxonomy']
     parent = registry.find_parent_by_id values['parent']
-    parent.nil? ? '' : parent
+    parent
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -134,6 +134,7 @@ class FinderPresenter
   def page_metadata
     metadata = {
       from: organisations,
+      inverse: true,
     }
 
     metadata.reject { |_, links| links.blank? }

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -192,8 +192,7 @@ class FinderPresenter
   end
 
   def topic_finder_parent
-    registry = Services.registries.all['full_topic_taxonomy']
-    registry.find_parent_by_id values['topic']
+    Services.registries.all['full_topic_taxonomy'][values['topic']]
   end
 
   # FIXME: This should be removed once we have a way to determine

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,0 +1,81 @@
+<div class="govuk-width-container">
+  <% if finder.show_phase_banner? %>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>
+  <% end %>
+
+  <% if @breadcrumbs.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
+  <% else %>
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item, prioritise_taxon_breadcrumbs: finder.eu_exit_finder?, inverse: inverse %>
+  <% end %>
+
+  <% if finder.government? %>
+    <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>
+  <% end %>
+</div>
+
+<header class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if finder.all_content_finder? %>
+        <% label_text = capture do %>
+          <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
+        <% end %>
+        <div id="keywords" class="app-patch--search-input-override">
+          <%= render "govuk_publishing_components/components/input", {
+            controls: "js-search-results-info",
+            id: "finder-keyword-search",
+            label: {
+              text: label_text,
+            },
+            name: "keywords",
+            search_icon: true,
+            type: 'search',
+            value: @results.user_supplied_keywords,
+          } %>
+        </div>
+      <% elsif finder.topic_finder? %>
+        <%= link_to 'thing', 'thing2', class: 'topic-finder__taxon-link' %>
+
+        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+          title: finder.name,
+          inverse: true,
+        } %>
+      <% else %>
+        <%= render partial: 'govuk_publishing_components/components/title', locals: {
+          title: finder.name
+        } %>
+      <% end %>
+
+      <div class="govuk-grid-column-two-thirds">
+        <% if finder.page_metadata.any? %>
+          <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
+        <% end %>
+
+        <% if finder.summary %>
+          <div class="metadata-summary">
+            <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
+          </div>
+        <% end %>
+      </div>
+
+      <% if finder.logo_path %>
+        <div class="finder-logo govuk-grid-column-one-third">
+          <%= image_tag finder.logo_path, class: "finder-logo__image" %>
+        </div>
+      <% end %>
+
+      <% if finder.related.any? %>
+        <div class="related-links govuk-grid-column-one-third">
+          <ul class="js-finder-results">
+            <% finder.related.each do |link| %>
+              <li class="related-links__item">
+                <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</header>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -12,9 +12,7 @@
   <% if finder.government? %>
     <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>
   <% end %>
-</div>
 
-<header class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if finder.all_content_finder? %>
@@ -78,4 +76,4 @@
       <% end %>
     </div>
   </div>
-</header>
+</div>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-width-container">
   <% if finder.show_phase_banner? %>
-    <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message, inverse: inverse %>
   <% end %>
 
   <% if @breadcrumbs.breadcrumbs %>
@@ -44,17 +44,18 @@
         } %>
       <% end %>
 
-      <div class="govuk-grid-column-two-thirds">
-        <% if finder.page_metadata.any? %>
-          <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
-        <% end %>
+      <% if finder.page_metadata.any? %>
+        <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
+      <% end %>
+    </div>
 
-        <% if finder.summary %>
-          <div class="metadata-summary">
+      <% if finder.summary %>
+        <div class="govuk-grid-column-two-thirds">
+          <div class="metadata-summary ">
             <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
           </div>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
 
       <% if finder.logo_path %>
         <div class="finder-logo govuk-grid-column-one-third">

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -33,7 +33,7 @@
           } %>
         </div>
       <% elsif finder.topic_finder? %>
-        <%= link_to finder.topic_finder_parent[:title], finder.topic_finder_parent[:path], class: 'topic-finder__taxon-link' %>
+        <%= link_to finder.topic_finder_parent['title'], finder.topic_finder_parent['base_path'], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: finder.name,
           inverse: true,

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -33,8 +33,7 @@
           } %>
         </div>
       <% elsif finder.topic_finder? %>
-        <%= link_to 'thing', 'thing2', class: 'topic-finder__taxon-link' %>
-
+        <%= link_to finder.topic_finder_parent_name, finder.values['parent'], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: finder.name,
           inverse: true,

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -49,31 +49,30 @@
       <% end %>
     </div>
 
-      <% if finder.summary %>
-        <div class="govuk-grid-column-two-thirds">
-          <div class="metadata-summary ">
-            <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
-          </div>
+    <% if finder.summary %>
+      <div class="govuk-grid-column-two-thirds">
+        <div class="metadata-summary ">
+          <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
         </div>
-      <% end %>
+      </div>
+    <% end %>
 
-      <% if finder.logo_path %>
-        <div class="finder-logo govuk-grid-column-one-third">
-          <%= image_tag finder.logo_path, class: "finder-logo__image" %>
-        </div>
-      <% end %>
+    <% if finder.logo_path %>
+      <div class="finder-logo govuk-grid-column-one-third">
+        <%= image_tag finder.logo_path, class: "finder-logo__image" %>
+      </div>
+    <% end %>
 
-      <% if finder.related.any? %>
-        <div class="related-links govuk-grid-column-one-third">
-          <ul class="js-finder-results">
-            <% finder.related.each do |link| %>
-              <li class="related-links__item">
-                <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
-    </div>
+    <% if finder.related.any? %>
+      <div class="related-links govuk-grid-column-one-third">
+        <ul class="js-finder-results">
+          <% finder.related.each do |link| %>
+            <li class="related-links__item">
+              <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -33,14 +33,14 @@
           } %>
         </div>
       <% elsif finder.topic_finder? %>
-        <%= link_to finder.topic_finder_parent_name, finder.values['parent'], class: 'topic-finder__taxon-link' %>
+        <%= link_to finder.topic_finder_parent[:title], finder.topic_finder_parent[:path], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: finder.name,
           inverse: true,
         } %>
       <% else %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: finder.name
+          title: finder.name,
         } %>
       <% end %>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -16,116 +16,58 @@
 
 <% content_for :meta_title, finder.name %>
 
-<% if finder.show_phase_banner? %>
-  <%= render 'govuk_publishing_components/components/phase_banner', phase: finder.phase, message: finder.phase_message%>
-<% end %>
-
-<% if @breadcrumbs.breadcrumbs %>
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
-<% else %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item, prioritise_taxon_breadcrumbs: finder.eu_exit_finder?  %>
-<% end %>
-
-<% if finder.government? %>
-  <%= render 'govuk_publishing_components/components/government_navigation', active: finder.government_content_section %>
+<% if finder.topic_finder? %>
+  <% content_for :body_classes, "full-width" %>
+  <% inverse = true %>
 <% end %>
 
 <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
-  <header class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if finder.all_content_finder? %>
-        <% label_text = capture do %>
-          <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
-        <% end %>
-        <div id="keywords" class="app-patch--search-input-override">
-          <%= render "govuk_publishing_components/components/input", {
-            controls: "js-search-results-info",
-            id: "finder-keyword-search",
-            label: {
-              text: label_text,
-            },
-            name: "keywords",
-            search_icon: true,
-            type: 'search',
-            value: @results.user_supplied_keywords,
-          } %>
-        </div>
-      <% else %>
-        <%= render partial: 'govuk_publishing_components/components/title', locals: {
-            title: finder.name
-        } %>
-      <% end %>
+  <div class="<%= "gem-c-inverse-header gem-c-inverse-header--full-width gem-c-inverse-header--padding-top" if finder.topic_finder? %>">
+    <%= render partial: 'show_header', locals: { inverse: inverse } %>
+  </div>
 
-      <% if finder.page_metadata.any? %>
-        <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder.page_metadata) %>
-      <% end %>
-
-      <% if finder.summary %>
-        <div class="metadata-summary">
-          <%= render 'govuk_publishing_components/components/govspeak', content: finder.summary.html_safe %>
-        </div>
-      <% end %>
-    </div>
-
-    <% if finder.logo_path %>
-      <div class="finder-logo govuk-grid-column-one-third">
-        <%= image_tag finder.logo_path, class: "finder-logo__image" %>
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= finder.name %>">
+        <%= render finder.facets %>
       </div>
-    <% end %>
 
-    <% if finder.related.any? %>
-      <div class="related-links govuk-grid-column-one-third">
-        <ul class="js-finder-results">
-          <% finder.related.each do |link| %>
-            <li class="related-links__item">
-              <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-  </header>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third" role="search" aria-label="<%= finder.name %>">
-      <%= render finder.facets %>
-    </div>
-
-    <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder.name %> search results">
-      <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
-        <div class="result-info">
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
-              <h2 class="result-region-header__counter" id="js-result-count">
-                <%= @results.displayed_total %>
-              </h2>
-            </div>
-            <% if @results.has_email_signup_link? %>
-              <div class="govuk-grid-column-two-thirds">
-                <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
+      <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder.name %> search results">
+        <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
+          <div class="result-info">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-one-third">
+                <h2 class="result-region-header__counter" id="js-result-count">
+                  <%= @results.displayed_total %>
+                </h2>
               </div>
-            <% end %>
-          </div>
-          <div id="js-facet-tag-wrapper">
-            <%= render "facet_tags", facet_tags.present %>
+              <% if @results.has_email_signup_link? %>
+                <div class="govuk-grid-column-two-thirds">
+                  <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
+                </div>
+              <% end %>
+            </div>
+            <div id="js-facet-tag-wrapper">
+              <%= render "facet_tags", facet_tags.present %>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
+        <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
 
-      <div id="js-sort-options">
-        <%= render "sort_options", @sort_presenter.to_hash %>
-      </div>
+        <div id="js-sort-options">
+          <%= render "sort_options", @sort_presenter.to_hash %>
+        </div>
 
-      <div id="js-results">
-        <%= render "search_results", @results.search_results_content %>
-      </div>
+        <div id="js-results">
+          <%= render "search_results", @results.search_results_content %>
+        </div>
 
-      <div id="js-pagination">
-        <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
+        <div id="js-pagination">
+          <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -24,9 +24,15 @@
 <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
-  <div class="<%= "gem-c-inverse-header gem-c-inverse-header--full-width gem-c-inverse-header--padding-top" if finder.topic_finder? %>">
+  <% if finder.topic_finder? %>
+    <%= render "govuk_publishing_components/components/inverse_header", {
+      full_width: true
+    } do %>
+      <%= render partial: 'show_header', locals: { inverse: inverse } %>
+    <% end %>
+  <% else %>
     <%= render partial: 'show_header', locals: { inverse: inverse } %>
-  </div>
+  <% end %>
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -35,23 +41,21 @@
       </div>
 
       <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder.name %> search results">
-        <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter">
-          <div class="result-info">
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-one-third">
-                <h2 class="result-region-header__counter" id="js-result-count">
-                  <%= @results.displayed_total %>
-                </h2>
+        <div aria-live="assertive" id="js-search-results-info" data-module="remove-filter" class="result-info">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              <h2 class="result-region-header__counter" id="js-result-count">
+                <%= @results.displayed_total %>
+              </h2>
+            </div>
+            <% if @results.has_email_signup_link? %>
+              <div class="govuk-grid-column-two-thirds">
+                <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
               </div>
-              <% if @results.has_email_signup_link? %>
-                <div class="govuk-grid-column-two-thirds">
-                  <%= render "govuk_publishing_components/components/subscription-links", @results.signup_links %>
-                </div>
-              <% end %>
-            </div>
-            <div id="js-facet-tag-wrapper">
-              <%= render "facet_tags", facet_tags.present %>
-            </div>
+            <% end %>
+          </div>
+          <div id="js-facet-tag-wrapper">
+            <%= render "facet_tags", facet_tags.present %>
           </div>
         </div>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -16,7 +16,7 @@
 
 <% content_for :meta_title, finder.name %>
 
-<% if finder.topic_finder? %>
+<% if finder.topic_finder? && !finder.all_content_finder? %>
   <% content_for :body_classes, "full-width" %>
   <% inverse = true %>
 <% end %>
@@ -24,7 +24,7 @@
 <form method="get" action="<%= finder.slug %>" class="js-live-search-form">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
-  <% if finder.topic_finder? %>
+  <% if finder.topic_finder? && !finder.all_content_finder? %>
     <%= render "govuk_publishing_components/components/inverse_header", {
       full_width: true
     } do %>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -17,8 +17,8 @@
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
   </head>
 
-  <body>
-    <div id="wrapper" class="govuk-width-container">
+  <body class="<%= yield :body_classes %>">
+    <div id="wrapper">
       <main id="content" role="main" class="finder-frontend-content">
         <div id="finder-frontend">
           <%= yield %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -327,6 +327,11 @@ Feature: Filtering documents
     And I should see a "Show more search options" link
 
   @javascript
+  Scenario: A Blue Banner should be displayed when navigating from a topic page
+    When I view the research and statistics finder with a topic param set
+    Then I should see a blue banner
+
+  @javascript
   Scenario: Facets should expand when clicking on the "Show more search options" link on all content
     When I view the all content finder
     And I should see a "Show more search options" link

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -273,6 +273,7 @@ end
 Then(/^I should see a blue banner$/) do
   expect(page).to have_css('.gem-c-inverse-header')
   expect(page).to have_content('Education, training and skills')
+  expect(page).to_not have_css('.app-taxonomy-select')
 end
 
 Then(/^I can see documents which are marked as being in history mode$/) do

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -156,6 +156,23 @@ When(/^I view the research and statistics finder$/) do
   visit finder_path('search/research-and-statistics')
 end
 
+When(/^I view the research and statistics finder with a topic param set$/) do
+  topic_taxonomy_has_taxons([
+                              FactoryBot.build(
+                                :level_one_taxon_hash,
+                                content_id: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                                title: "Education, training and skills"
+                              )
+                            ])
+  content_store_has_statistics_finder
+  stub_organisations_registry_request
+  stub_manuals_registry_request
+  stub_whitehall_api_world_location_request
+  stub_rummager_api_request_with_research_and_statistics_results
+  stub_rummager_api_request_with_filtered_research_and_statistics_results
+  visit finder_path('search/research-and-statistics', topic: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0')
+end
+
 When(/^I view the all content finder with a manual filter$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
@@ -251,6 +268,11 @@ end
 Then(/^I can see the government header$/) do
   visit finder_path('government/policies/benefits-reform')
   expect(page).to have_css('#proposition-menu')
+end
+
+Then(/^I should see a blue banner$/) do
+  expect(page).to have_css('.gem-c-inverse-header')
+  expect(page).to have_content('Education, training and skills')
 end
 
 Then(/^I can see documents which are marked as being in history mode$/) do

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -423,6 +423,7 @@ Given(/^an organisation finder exists$/) do
   stub_rummager_api_request_with_government_results
   stub_organisations_registry_request
   stub_people_registry_request
+  stub_taxonomy_api_request
 
   visit finder_path('government/policies/benefits-reform', parent: 'ministry-of-magic')
 end
@@ -433,6 +434,7 @@ Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   stub_rummager_api_request_with_government_results
   stub_organisations_registry_request
   stub_people_registry_request
+  stub_taxonomy_api_request
 
   visit finder_path('government/policies/benefits-reform', parent: 'bernard-cribbins')
 end

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -20,11 +20,14 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
   end
 
   describe "when topic taxonomy API is unavailable" do
+    let(:registry) { described_class.new }
+
     it "will return an (uncached) empty hash" do
       topic_taxonomy_api_is_unavailable
       expect(described_class.new[base_path]).to be_nil
       expect(described_class.new.taxonomy).to eql({})
       expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
+      expect(registry.find_parent_by_id("013fc5e0-280c-4f73-9598-47de68f13dcd")).to be_nil
     end
   end
 

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
       expect(described_class.new[base_path]).to be_nil
       expect(described_class.new.taxonomy).to eql({})
       expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
-      expect(registry.find_parent_by_id("013fc5e0-280c-4f73-9598-47de68f13dcd")).to be_nil
+      expect(registry["013fc5e0-280c-4f73-9598-47de68f13dcd"]).to be_nil
     end
   end
 
@@ -51,12 +51,6 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
     it "can look up a level one taxon by basepath" do
       fetched_document = registry[first_level_content_id]
       expect(fetched_document['base_path']).to eq(first_level_base_path)
-    end
-
-    it "can look up a taxon from the id" do
-      fetched_document = registry.find_parent_by_id(child_content_id)
-      expect(fetched_document[:path]).to eq(child_base_path)
-      expect(fetched_document[:title]).to eq(taxon_title)
     end
   end
 

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
     end
 
     let(:registry) { described_class.new }
+    let(:taxon_title) { "Countryside stewardship" }
     let(:child_base_path) { "/environment/countryside-stewardship" }
     let(:first_level_base_path) { "/environment" }
     let(:child_content_id) { "013fc5e0-280c-4f73-9598-47de68f13dcd" }
@@ -47,6 +48,12 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
     it "can look up a level one taxon by basepath" do
       fetched_document = registry[first_level_content_id]
       expect(fetched_document['base_path']).to eq(first_level_base_path)
+    end
+
+    it "can look up a taxon from the id" do
+      fetched_document = registry.find_parent_by_id(child_content_id)
+      expect(fetched_document[:path]).to eq(child_base_path)
+      expect(fetched_document[:title]).to eq(taxon_title)
     end
   end
 


### PR DESCRIPTION
The topic / advanced finder is being retired, but the aesthetic needs to remain.

The blue bar is turned on by the `topic` query string, which has to have the correct `content_id` in it.

For example:

- http://finder-frontend-pr-1204.herokuapp.com/search/research-and-statistics?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0

The all finder does not have a blue bar - even if the `topic` query string is present, it should display as normal.

Card: https://trello.com/c/A6eidvxn/799-implement-blue-topic-page-finder-headers-on-supergroup-finders-when-user-has-come-from-topic-page-m

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1204.herokuapp.com/search/all
- http://finder-frontend-pr-1204.herokuapp.com/search/all?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1204.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1204.herokuapp.com/search/research-and-statistics?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1204.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1204.herokuapp.com/drug-device-alerts?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1204.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1204.herokuapp.com/find-eu-exit-guidance-business?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0

[Other finders](https://live-stuff.herokuapp.com/finders)