### PR TITLE
Remove combine_mode from business finder email signup

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -68,13 +68,12 @@ private
       finder_format: finder_format,
       subscriber_list_title: subscriber_list_title,
       default_frequency: signup_presenter.default_frequency,
-      combine_mode: signup_presenter.combine_mode,
       email_filter_by: signup_presenter.email_filter_by,
     )
   end
 
   def subscriber_list_title
-    title_builder = signup_presenter.combine_mode == "or" ? EmailAlertListTitleBuilder : EmailAlertTitleBuilder
+    title_builder = signup_presenter.email_filter_by == "facet_values" ? EmailAlertListTitleBuilder : EmailAlertTitleBuilder
     title_builder.call(
       filter: applied_filters,
       subscription_list_title_prefix: content.dig('details', 'subscription_list_title_prefix'),

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -30,10 +30,6 @@ class SignupPresenter
     content_item['details']['beta']
   end
 
-  def combine_mode
-    content_item['details'].fetch('combine_mode', nil)
-  end
-
   def email_filter_by
     content_item['details'].fetch('email_filter_by', nil)
   end

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -5,7 +5,6 @@
   "title": "Find EU Exit guidance for your business",
   "description": "You'll get an email each time EU Exit guidance is published.",
   "details": {
-    "combine_mode": "or",
     "email_filter_by": "facet_values",
     "email_filter_facets": [
       {

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,14 +1,13 @@
 require 'addressable/uri'
 
 class EmailAlertSignupAPI
-  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil, combine_mode: nil, email_filter_by: nil)
+  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil, email_filter_by: nil)
     @applied_filters = applied_filters.deep_symbolize_keys
     @default_filters = default_filters.deep_symbolize_keys
     @facets = facets
     @subscriber_list_title = subscriber_list_title
     @finder_format = finder_format
     @default_frequency = default_frequency
-    @combine_mode = combine_mode
     @email_filter_by = email_filter_by
   end
 
@@ -22,7 +21,7 @@ class EmailAlertSignupAPI
 
 private
 
-  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format, :combine_mode, :email_filter_by
+  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format, :email_filter_by
 
   def add_url_param(url, param)
     # this method safely adds a URL parameter using the correct one of '?' or '&'
@@ -37,7 +36,6 @@ private
 
   def subscriber_list_options
     options = { "title" => subscriber_list_title }
-    options["combine_mode"] = combine_mode if combine_mode
     if facet_groups?
       options["links"] = facet_groups
     elsif facet_values?

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -201,7 +201,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
     end
   end
 
-  context "with combine_mode set to 'or'" do
+  context "with email_filter_by set to 'facet_values'" do
     describe 'POST "#create"' do
       let(:finder) { business_readiness_content_item }
       let(:signup_finder) { business_readiness_signup_content_item }
@@ -217,7 +217,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
             'facet_values' => { any: %w(aerospace) },
           },
           'subscription_url' => 'http://www.itstartshear.com',
-          'combine_mode' => 'or'
+          'email_filter_by' => 'facet_values'
         )
 
         allow(EmailAlertListTitleBuilder).to receive(:call)
@@ -234,7 +234,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
     end
   end
 
-  context "with blank combine_mode" do
+  context "with blank email_filter_by" do
     describe 'POST "#create"' do
       let(:finder) { govuk_content_schema_example('finder') }
       let(:signup_finder) {

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -13,7 +13,6 @@ describe EmailAlertSignupAPI do
       subscriber_list_title: subscriber_list_title,
       finder_format: finder_format,
       default_frequency: default_frequency,
-      combine_mode: combine_mode,
     )
   end
 
@@ -23,7 +22,6 @@ describe EmailAlertSignupAPI do
   let(:subscriber_list_title) { "Subscriber list title" }
   let(:finder_format) {}
   let(:default_frequency) { nil }
-  let(:combine_mode) { nil }
 
   def init_simple_email_alert_api(subscription_url)
     email_alert_api_has_subscriber_list(
@@ -88,28 +86,6 @@ describe EmailAlertSignupAPI do
       init_simple_email_alert_api(subscription_url)
       url_params = Rack::Utils.parse_query(URI.parse(subject.signup_url).query)
       expect(url_params).to eq("foo" => "bar", "default_frequency" => "daily")
-    end
-  end
-
-  context "when combine_mode is provided" do
-    let(:combine_mode) { "or" }
-
-    it "returns the url email-alert-api gives back, and appends the combine_mode param" do
-      subscription_url = "http://gov.uk/email/some-subscription"
-
-      email_alert_api_has_subscriber_list(
-        "tags" => {},
-        "subscription_url" => subscription_url,
-        "combine_mode" => combine_mode
-      )
-
-      expect(Services.email_alert_api).to receive(:find_or_create_subscriber_list).with(
-        "tags" => {},
-        "title" => subscriber_list_title,
-        "combine_mode" => combine_mode
-        ).and_call_original
-
-      expect(subject.signup_url).to eql "http://gov.uk/email/some-subscription"
     end
   end
 


### PR DESCRIPTION
The combine_mode value was added to enable the use of the OrJoinedFacetSubscriberList model when signing up to business finder email alerts. This model has been removed from email-alert-api, so the toggle parameter is no longer needed, since we can identify this type of finder using the email_filter_by value.

Trello card: https://trello.com/c/udPtHvz2/158-remove-orjoinedfacetsubscriberlist-from-email-alert-api