### PR TITLE
Adds topic parameters to fixtures.

### DIFF
--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -70,6 +70,16 @@
     "facets":[
       {
         "filter_key": "all_part_of_taxonomy_tree",
+        "key": "topic",
+        "name": "topic",
+        "short_name": "topic",
+        "type": "hidden",
+        "display_as_result_metadata": false,
+        "filterable":true,
+        "hide_facet_tag":true
+      },
+      {
+        "filter_key": "all_part_of_taxonomy_tree",
         "keys": ["level_one_taxon", "level_two_taxon"],
         "name": "topic",
         "short_name": "topic",

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -79,6 +79,16 @@
         "preposition": "about"
       },
       {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "key": "topic",
+        "name": "topic",
+        "short_name": "topic",
+        "type": "hidden",
+        "display_as_result_metadata": false,
+        "filterable":true,
+        "hide_facet_tag":true
+      },
+      {
         "key": "content_store_document_type",
         "name": "Document type",
         "preposition": "of type",

--- a/features/fixtures/services.json
+++ b/features/fixtures/services.json
@@ -22,6 +22,16 @@
         "type": "taxon"
       },
       {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "key": "topic",
+        "name": "topic",
+        "short_name": "topic",
+        "type": "hidden",
+        "display_as_result_metadata": false,
+        "filterable":true,
+        "hide_facet_tag":true
+      },
+      {
         "display_as_result_metadata": true,
         "filterable": true,
         "key": "organisations",

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -120,6 +120,16 @@
         "preposition": "about"
       },
       {
+        "filter_key": "all_part_of_taxonomy_tree",
+        "key": "topic",
+        "name": "topic",
+        "short_name": "topic",
+        "type": "hidden",
+        "display_as_result_metadata": false,
+        "filterable":true,
+        "hide_facet_tag":true
+      },
+      {
         "key":"content_store_document_type",
         "name":"Statistics",
         "type":"research_and_statistics",


### PR DESCRIPTION
This allows a topic (taxon content_id) to be specified to
filter the supergroup finders.

Trello: https://trello.com/c/rjrtLu4N/821-allow-topic-parameter-in-supergroup-finder
See also: https://github.com/alphagov/search-api/pull/1596


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
