### PR TITLE
Update sector list and business activity question for readiness finder

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -79,6 +79,11 @@ private
   end
   helper_method :single_wrapped_question?
 
+  def multiple_grouped_question?
+    question_type == "multiple_grouped"
+  end
+  helper_method :multiple_grouped_question?
+
   def multiple_question?
     question_type == "multiple"
   end

--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -19,7 +19,7 @@
         } %>
       <% end %>
 
-      <% if multiple_question? %>
+      <% if multiple_grouped_question? %>
         <% filter_groups.each do |filter_group| %>
           <%= render "govuk_publishing_components/components/checkboxes", {
             name: "#{current_facet['facet']['key']}[]",
@@ -28,6 +28,13 @@
             items: nested_options(filter_group)
           } %>
         <% end %>
+      <% elsif multiple_question? %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: "#{current_facet['facet']['key']}[]",
+          heading: "Select all that apply",
+          visually_hide_heading: true,
+          items: options
+        } %>
       <% elsif single_wrapped_question? %>
         <% checkboxes = render "govuk_publishing_components/components/checkboxes", {
           name: "#{current_facet['facet']['key']}[]",

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -243,6 +243,7 @@ Feature: Filtering documents
     Then I see Relevance order selected
 
   Scenario: Arrive at the business finder through Q&A
+    Given the business finder QA exists
     When I visit the business finder Q&A
     And I select choice "Aerospace"
     And I submit my answer

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -246,7 +246,7 @@ Feature: Filtering documents
     When I visit the business finder Q&A
     And I select choice "Aerospace"
     And I submit my answer
-    And I choose 'Yes' and select choice "Sell products or goods in the UK"
+    And I select choice "Sell goods or provide services in the UK"
     And I submit my answer
     And I skip the rest of the questions
     Then I should be on the business finder page

--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -199,7 +199,28 @@
           }
         ]
       },
-
+      {
+        "key":"multiple_report_type",
+        "name":"Multiple report type",
+        "type":"text",
+        "preposition":"of type",
+        "display_as_result_metadata":true,
+        "filterable":true,
+        "allowed_values":[
+          {
+            "label":"Annual safety report",
+            "value":"annual-safety-report"
+          },
+          {
+            "label":"Bulletin - Correspondence investigation",
+            "value":"correspondence-investigation"
+          },
+          {
+            "label":"Safety study",
+            "value":"safety-study"
+          }
+        ]
+      },
       {
         "key":"date_of_occurrence",
         "name":"Date of occurrence",

--- a/features/fixtures/aaib_reports_qa.yaml
+++ b/features/fixtures/aaib_reports_qa.yaml
@@ -5,7 +5,7 @@ title: "AAIB Reports Q&A"
 pages:
   aircraft_category:
     show_in_qa: true
-    question_type: "multiple"
+    question_type: "multiple_grouped"
     question: "What is the aircraft category?"
     description: "Description"
     hint_title: "Click for a hint"
@@ -31,6 +31,10 @@ pages:
     show_in_qa: true
     question_type: "single_wrapped"
     question: "What is the fake report type?"
+  multiple_report_type:
+    show_in_qa: true
+    question_type: "multiple"
+    question: "What is the multiple report type?"
   aircraft_type:
     show_in_qa: true
     question_type: "single"

--- a/features/fixtures/business_readiness.json
+++ b/features/fixtures/business_readiness.json
@@ -776,50 +776,50 @@
                 "facet_values": [
                   {
                     "content_id": "a55f04df-3877-4c73-bbfe-ad7339cdfccf",
-                    "title": "Sell products or goods in the UK",
+                    "title": "Sell goods or provide services in the UK ",
                     "schema_name": "facet_value",
                     "details": {
-                      "label": "Sell products or goods in the UK",
+                      "label": "Sell goods or provide services in the UK ",
                       "value": "products-or-goods"
                     },
                     "links": {}
                   },
                   {
                     "content_id": "d422aa2e-59ad-4986-8ef0-973959878912",
-                    "title": "Buy products or goods from abroad",
+                    "title": "Import from the EU",
                     "schema_name": "facet_value",
                     "details": {
-                      "label": "Buy products or goods from abroad",
+                      "label": "Import from the EU",
                       "value": "buying"
                     },
                     "links": {}
                   },
                   {
                     "content_id": "7283b8e1-840f-49da-967f-c0a512a3f531",
-                    "title": "Sell products or goods abroad",
+                    "title": "Export to the EU",
                     "schema_name": "facet_value",
                     "details": {
-                      "label": "Sell products or goods abroad",
+                      "label": "Export to the EU",
                       "value": "selling"
                     },
                     "links": {}
                   },
                   {
                     "content_id": "7ae8e57c-ea7a-42de-84fc-a084b5f64bca",
-                    "title": "Do other types of business in the EU",
+                    "title": "Provide services or do business in the EU",
                     "schema_name": "facet_value",
                     "details": {
-                      "label": "Do other types of business in the EU",
+                      "label": "Provide services or do business in the EU",
                       "value": "other-eu"
                     },
                     "links": {}
                   },
                   {
                     "content_id": "07398027-ee4d-4bda-b53e-2dc655734049",
-                    "title": "Transport goods abroad",
+                    "title": "Haulage of goods across EU borders",
                     "schema_name": "facet_value",
                     "details": {
-                      "label": "Transport goods abroad",
+                      "label": "Haulage of goods across EU borders",
                       "value": "transporting"
                     },
                     "links": {}

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -461,36 +461,36 @@
           {
             "key": "products-or-goods",
             "content_id": "a55f04df-3877-4c73-bbfe-ad7339cdfccf",
-            "radio_button_name": "Sell products or goods in the UK",
-            "topic_name": "Sell products or goods in the UK",
+            "radio_button_name": "Sell goods or provide services in the UK ",
+            "topic_name": "Sell goods or provide services in the UK ",
             "prechecked": false
           },
           {
             "key": "buying",
             "content_id": "d422aa2e-59ad-4986-8ef0-973959878912",
-            "radio_button_name": "Buy products or goods from abroad",
-            "topic_name": "Buy products or goods from abroad",
+            "radio_button_name": "Import from the EU",
+            "topic_name": "Import from the EU",
             "prechecked": false
           },
           {
             "key": "selling",
             "content_id": "7283b8e1-840f-49da-967f-c0a512a3f531",
-            "radio_button_name": "Sell products or goods abroad",
-            "topic_name": "Sell products or goods abroad",
+            "radio_button_name": "Export to the EU",
+            "topic_name": "Export to the EU",
             "prechecked": false
           },
           {
             "key": "other-eu",
             "content_id": "7ae8e57c-ea7a-42de-84fc-a084b5f64bca",
-            "radio_button_name": "Do other types of business in the EU",
-            "topic_name": "Do other types of business in the EU",
+            "radio_button_name": "Provide services or do business in the EU",
+            "topic_name": "Provide services or do business in the EU",
             "prechecked": false
           },
           {
             "key": "transporting",
             "content_id": "07398027-ee4d-4bda-b53e-2dc655734049",
-            "radio_button_name": "Transport goods abroad",
-            "topic_name": "Transport goods abroad",
+            "radio_button_name": "Haulage of goods across EU borders",
+            "topic_name": "Haulage of goods across EU borders",
             "prechecked": false
           }
         ]

--- a/features/fixtures/prepare_business_uk_leaving_eu.yaml
+++ b/features/fixtures/prepare_business_uk_leaving_eu.yaml
@@ -1,0 +1,149 @@
+---
+base_path: "/prepare-business-uk-leaving-eu"
+finder_base_path: "/find-eu-exit-guidance-business"
+title: "Prepare your business or organisation for the UK leaving the EU"
+pages:
+  sector_business_area:
+    show_in_qa: true
+    question_type: "multiple_grouped"
+    question: "What does your business or organisation do?"
+    description: |
+      <p>Choose all the sectors and areas that your business or organisation operates in.</p>
+    filter_groups:
+      - name: "Advanced manufacturing and services"
+        filters:
+          - "aerospace"
+          - "automotive"
+          - "electronics-parts-machinery"
+          - "installation-servicing-repair"
+          - "marine"
+          - "rail"
+          - "space"
+          - "other-advanced-manufacturing"
+      - name: "Agriculture, animals, fisheries and forestry"
+        filters:
+          - "agriculture"
+          - "fisheries"
+          - "food-and-drink"
+          - "veterinary"
+      - name: "Business and personal services"
+        filters:
+          - "personal-services"
+          - "professional-and-business-services"
+      - name: "Charities and voluntary organisation"
+        filters:
+          - "charities"
+          - "voluntary-community-organisations"
+      - name: "Construction and environmental services"
+        filters:
+          - "construction-contracting"
+          - "environmental-services"
+      - name: "Defence"
+        filters:
+          - "defence"
+      - name: "Energy"
+        filters:
+          - "electricity"
+          - "nuclear"
+          - "oil-gas-coal"
+          - "other-energy"
+      - name: "Entertainment"
+        filters:
+          - "broadcasting"
+          - "creative-industries"
+          - "gambling"
+          - "sports-recreation"
+          - "arts-culture-heritage"
+      - name: "Finance, insurance and real estate"
+        filters:
+          - "auxiliary-activities"
+          - "financial-services"
+          - "insurance"
+          - "real-estate-excl-imputed-rent"
+      - name: "Health and social care"
+        filters:
+          - "health-social-care-services"
+          - "medical-technology"
+          - "pharmaceuticals"
+      - name: "Information and communications"
+        filters:
+          - "computer-services"
+          - "telecoms"
+      - name: "Manufacturing"
+        filters:
+          - "clothing-consumer-goods-manufacturing"
+          - "furniture-manufacture"
+          - "repair-of-computers-consumer-goods"
+          - "other-manufacturing"
+      - name: "Materials and mining"
+        filters:
+          - "chemicals"
+          - "metals-manufacture"
+          - "mining"
+          - "non-metal-materials-manufacture"
+      - name: "Public administration"
+        filters:
+          - "justice-prisons"
+          - "public-administration"
+      - name: "Research and education"
+        filters:
+          - "education"
+          - "research"
+      - name: "Retail, wholesale and consumer goods"
+        filters:
+          - "clothing-consumer-goods"
+          - "food-drink-tobacco"
+          - "motor-trades"
+          - "retail"
+      - name: "Tourism and hospitality"
+        filters:
+          - "accommodation"
+          - "restaurants-bars-catering"
+          - "tourism"
+      - name: "Transport and logistics"
+        filters:
+          - "air-freight-air-passenger-services"
+          - "marine-transport"
+          - "ports-airports"
+          - "postal-courier-services"
+          - "rail-passenger-freight"
+          - "road-passengers-freight"
+          - "warehouses-services-pipelines"
+  business_activity:
+    show_in_qa: true
+    question_type: "multiple"
+    question: "Do you sell goods in the UK, import or do business abroad?"
+    description: |
+      <p>Doing business abroad includes exporting and going for meetings or taking goods to a trade fair.</p>
+  employ_eu_citizens:
+    show_in_qa: true
+    question_type: "single"
+    question: "Do you employ anyone from another European country?"
+    description: |
+      <p>This includes <a href="/eu-eea">countries that are in the EU</a> and Norway, Switzerland, Iceland and Liechtenstein.</p>
+  personal_data:
+    show_in_qa: true
+    question_type: "single_wrapped"
+    question: "Do you exchange personal data with another organisation in Europe?"
+    description: |
+      <p>This includes <a href="/eu-eea">organisations located in the EU</a> and Norway, Iceland and Liechtenstein.</p>
+      <p>Personal data includes customers’ addresses, staff working hours or information you give to a delivery company.</p>
+      <p>Skip this question if you’re not sure how you deal with personal data.</p>
+  intellectual_property:
+    show_in_qa: true
+    question_type: "single_wrapped"
+    question: "Do you use or rely on intellectual property (IP) protection?"
+    description: |
+      <p>Intellectual property protection includes copyright, trade marks and patents.</p>
+  public_sector_procurement:
+    show_in_qa: true
+    question_type: "single_wrapped"
+    question: "Do you sell to the public sector?"
+    description: |
+      <p>This includes if you sell products or services to organisations in central or local government, and some non-government organisations, such as hospitals or schools.</p>
+  eu_uk_government_funding:
+    show_in_qa: true
+    question_type: "single_wrapped"
+    question: "Do you get EU or UK government funding?"
+    description: |
+      <p>EU funding includes the Creative Europe Fund or Horizon 2020 scheme.</p>

--- a/features/qa.feature
+++ b/features/qa.feature
@@ -12,8 +12,8 @@ Feature: QA
       Given I am answering a single answer question
       Then I should see a collection of radio buttons
       When I select a radio button
-      When I select another radio button
-      When I submit my answer
+      And I select another radio button
+      And I submit my answer
       Then my options are persisted as url params
 
     Scenario: Answering a single_wrapped option question
@@ -22,31 +22,31 @@ Feature: QA
       When I select a radio button
       Then I should see a collection of checkboxes
       When I select multiple checkboxes
-      When I submit my answer
+      And I submit my answer
       Then my options are persisted as url params
 
     Scenario: Answering a multiple_grouped option question
       Given I am answering a multiple_grouped answer question
       Then I should see a collection of checkboxes
       When I select multiple checkboxes
-      When I submit my answer
+      And I submit my answer
       Then my options are persisted as url params
 
     Scenario: Answering a multiple option question
       Given I am answering a multiple answer question
       Then I should see a collection of checkboxes
       When I select multiple checkboxes
-      When I submit my answer
+      And I submit my answer
       Then my options are persisted as url params
 
     Scenario: Answering multiple questions
       Given I am answering a single answer question
       Then I should see a collection of radio buttons
       When I select a radio button
-      When I submit my answer
+      And I submit my answer
       Then I should see a collection of checkboxes
       When I select multiple checkboxes
-      When I submit my answer
+      And I submit my answer
       Then my options are persisted as url params
 
     Scenario: Skipping a question
@@ -55,5 +55,5 @@ Feature: QA
 
     Scenario: Answering the final question
       Given I am answering the final question
-      When I submit my answer
+      And I submit my answer
       Then I am redirected to the finder results page

--- a/features/qa.feature
+++ b/features/qa.feature
@@ -25,6 +25,13 @@ Feature: QA
       When I submit my answer
       Then my options are persisted as url params
 
+    Scenario: Answering a multiple_grouped option question
+      Given I am answering a multiple_grouped answer question
+      Then I should see a collection of checkboxes
+      When I select multiple checkboxes
+      When I submit my answer
+      Then my options are persisted as url params
+
     Scenario: Answering a multiple option question
       Given I am answering a multiple answer question
       Then I should see a collection of checkboxes

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -10,6 +10,10 @@ Given(/^no results$/) do
   stub_taxonomy_api_request
 end
 
+Given /^the business finder QA exists/ do
+  stub_business_finder_qa_config
+end
+
 When(/^I view the finder with no keywords and no facets$/) do
   visit finder_path('mosw-reports')
 end

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -78,7 +78,7 @@ When /^I visit the business finder Q&A/ do
     "filter_any_facet_values[0]" => "24fd50fa-6619-46ca-96cd-8ce90fa076ce",
     "filter_any_facet_values[1]" => "a55f04df-3877-4c73-bbfe-ad7339cdfccf"
   )
-  qa_url = mock_bus_finder_qa_config['base_path']
+  qa_url = business_readiness_qa_config['base_path']
   visit qa_url
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,10 +1,12 @@
 require_relative '../../lib/govuk_content_schema_examples'
 require_relative "../../spec/helpers/taxonomy_spec_helper"
 require_relative "../../spec/helpers/registry_spec_helper"
+require_relative '../../spec/support/fixtures_helper'
 require 'gds_api/test_helpers/email_alert_api'
 require 'gds_api/test_helpers/content_store'
 
 module DocumentHelper
+  include FixturesHelper
   include GovukContentSchemaExamples
   include TaxonomySpecHelper
   include RegistrySpecHelper
@@ -12,6 +14,10 @@ module DocumentHelper
   include GdsApi::TestHelpers::ContentStore
 
   SEARCH_ENDPOINT = "#{Plek.current.find('search')}/search.json".freeze
+
+  def stub_business_finder_qa_config
+    allow_any_instance_of(QaController).to receive(:qa_config).and_return(business_readiness_qa_config)
+  end
 
   def stub_taxonomy_api_request
     content_store_has_item("/", "links" => { "level_one_taxons" => [] })
@@ -262,7 +268,7 @@ module DocumentHelper
   end
 
   def content_store_has_business_finder_qa
-    content_store_has_item(mock_bus_finder_qa_config['base_path'], mock_bus_finder_qa_config)
+    content_store_has_item(business_readiness_qa_config['base_path'], business_readiness_qa_config)
   end
 
   def content_store_has_business_readiness_finder

--- a/features/support/qa_helper.rb
+++ b/features/support/qa_helper.rb
@@ -20,10 +20,6 @@ module QAHelper
     @mock_qa_config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
   end
 
-  def mock_bus_finder_qa_config
-    @mock_bus_finder_qa_config ||= YAML.load_file('./lib/prepare_business_uk_leaving_eu.yaml')
-  end
-
   def first_question
     mock_qa_config["pages"].values.first['question']
   end

--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -132,9 +132,9 @@ pages:
   public_sector_procurement:
     show_in_qa: true
     question_type: "single_wrapped"
-    question: "Do you sell to the public sector?"
+    question: "Do you sell your products or services to the public sector?"
     description: |
-      <p>This includes if you sell products or services to organisations in central or local government, and some non-government organisations, such as hospitals or schools.</p>
+      <p>This includes non-government organisations, such as hospitals and schools, and central or local government organisations.</p>
   eu_uk_government_funding:
     show_in_qa: true
     question_type: "single_wrapped"

--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -18,13 +18,12 @@ pages:
           - "installation-servicing-repair"
           - "marine"
           - "rail"
-          - "space"
-          - "other-advanced-manufacturing"
       - name: "Agriculture, animals, fisheries and forestry"
         filters:
-          - "agriculture"
+          - "agriculture-and-farming"
+          - "animals-and-animal-products"
           - "fisheries"
-          - "food-and-drink"
+          - "plants-and-forestry"
           - "veterinary"
       - name: "Business and personal services"
         filters:
@@ -56,7 +55,6 @@ pages:
           - "arts-culture-heritage"
       - name: "Finance, insurance and real estate"
         filters:
-          - "auxiliary-activities"
           - "financial-services"
           - "insurance"
           - "real-estate-excl-imputed-rent"
@@ -72,12 +70,10 @@ pages:
       - name: "Manufacturing"
         filters:
           - "clothing-consumer-goods-manufacturing"
-          - "furniture-manufacture"
-          - "repair-of-computers-consumer-goods"
-          - "other-manufacturing"
       - name: "Materials and mining"
         filters:
           - "chemicals"
+          - "diamonds"
           - "metals-manufacture"
           - "mining"
           - "non-metal-materials-manufacture"
@@ -91,10 +87,9 @@ pages:
           - "research"
       - name: "Retail, wholesale and consumer goods"
         filters:
-          - "clothing-consumer-goods"
-          - "food-drink-tobacco"
+          - "food-and-drink"
           - "motor-trades"
-          - retail
+          - "retail"
       - name: "Tourism and hospitality"
         filters:
           - "accommodation"
@@ -103,7 +98,6 @@ pages:
       - name: "Transport and logistics"
         filters:
           - "air-freight-air-passenger-services"
-          - "marine-transport"
           - "ports-airports"
           - "postal-courier-services"
           - "rail-passenger-freight"

--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -111,10 +111,10 @@ pages:
           - "warehouses-services-pipelines"
   business_activity:
     show_in_qa: true
-    question_type: "single_wrapped"
-    question: "Do you sell goods in the UK, import or do business abroad?"
+    question_type: "multiple"
+    question: "Does your business do any of the following activities?"
     description: |
-      <p>Doing business abroad includes exporting and going for meetings or taking goods to a trade fair.</p>
+      <p>Importing and exporting includes temporarily taking goods across the EU border, for example to a trade fair.</p>
   employ_eu_citizens:
     show_in_qa: true
     question_type: "single"

--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -5,7 +5,7 @@ title: "Prepare your business or organisation for the UK leaving the EU"
 pages:
   sector_business_area:
     show_in_qa: true
-    question_type: "multiple"
+    question_type: "multiple_grouped"
     question: "What does your business or organisation do?"
     description: |
       <p>Choose all the sectors and areas that your business or organisation operates in.</p>

--- a/spec/lib/email_alert_list_title_builder_spec.rb
+++ b/spec/lib/email_alert_list_title_builder_spec.rb
@@ -37,7 +37,7 @@ describe EmailAlertListTitleBuilder do
     end
 
     it "will join one choice from multiple facets in a list, separated with commas" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Buy products or goods from abroad'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Import from the EU'")
     end
   end
 
@@ -78,7 +78,7 @@ describe EmailAlertListTitleBuilder do
     end
 
     it "will join multiple choices from multiple facets in a list, separated with commas" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Electronics, parts and machinery', 'Buy products or goods from abroad', 'Sell products or goods abroad'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Electronics, parts and machinery', 'Import from the EU', 'Export to the EU'")
     end
   end
 end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -38,4 +38,8 @@ module FixturesHelper
   def business_readiness_signup_content_item
     JSON.parse(File.read(fixtures_path + "/business_readiness_email_signup.json"))
   end
+
+  def business_readiness_qa_config
+    YAML.load_file(fixtures_path + "/prepare_business_uk_leaving_eu.yaml")
+  end
 end


### PR DESCRIPTION
Flattens and updates the wording of the business activity question, public sector contracts question and sectors for the EU Exit Business Readiness Finder.

Details of changes requested: https://docs.google.com/document/d/1xdEkrkN4OZFLsN6xWTBLWPgmXaDTMxp4PxSLqqX0wQ4/edit#
https://docs.google.com/document/d/1NWADDxTfn3aaTGPYD8hPJ-vZfPg0fpPDcDdo2gur3FQ/edit

Also updates the fixtures, so the tests are not tied to the configuration used by the actual finder.  This meant we had to update the tests every time the the configuration was updated.

Before:
<img width="986" alt="Screen Shot 2019-06-21 at 10 21 17" src="https://user-images.githubusercontent.com/6329861/59912647-5cddbf00-940e-11e9-8668-70103ba69d32.png">

After (also with changes in https://github.com/alphagov/content-tagger/pull/941):
<img width="888" alt="Screen Shot 2019-06-21 at 13 30 01" src="https://user-images.githubusercontent.com/6329861/59922462-b9e66e80-9428-11e9-9ceb-deacef4d97da.png">

Merge and deploy at same time as https://github.com/alphagov/content-tagger/pull/941

Trello card: https://trello.com/c/VTKL8TXk