### PR TITLE
Clear cache before every top-level example group

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,4 +50,6 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
+
+  config.before(:each) { Rails.cache.clear }
 end


### PR DESCRIPTION
This will ensure we tear down the cache before every test.