### PR TITLE
Use topic param for topic page filtering

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -169,7 +169,7 @@ private
   end
 
   def i_am_a_topic_page_finder
-    @i_am_a_topic_page_finder ||= taxonomy_registry.taxonomy.key? parent
+    @i_am_a_topic_page_finder ||= taxonomy_registry.taxonomy.key? params[:topic]
   end
 
   def taxonomy_registry

--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -21,13 +21,13 @@ module Registries
     end
 
     def report_error
-      GovukStatsd.increment("#{NAMESPACE}.full_topic_taxonomy_api_errors")
+      GovukStatsd.increment("registries.full_topic_taxonomy_api_errors")
     end
 
     def format_taxon(taxon)
       {
         'title' => taxon['title'],
-        'content_id' => taxon['content_id']
+        'base_path' => taxon['base_path']
       }
     end
 
@@ -37,7 +37,7 @@ module Registries
 
     def flatten_taxonomy(taxons, output_hash)
       taxons.each do |taxon|
-        output_hash[taxon['base_path']] = format_taxon(taxon)
+        output_hash[taxon['content_id']] = format_taxon(taxon)
         unless taxon.dig('links', 'child_taxons').nil?
           flatten_taxonomy(taxon['links']['child_taxons'], output_hash)
         end

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -40,13 +40,13 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
     let(:first_level_content_id) { "3cf97f69-84de-41ae-bc7b-7e2cc238fa58" }
 
     it "can look up a child taxon by basepath" do
-      fetched_document = registry[child_base_path]
-      expect(fetched_document['content_id']).to eq(child_content_id)
+      fetched_document = registry[child_content_id]
+      expect(fetched_document['base_path']).to eq(child_base_path)
     end
 
     it "can look up a level one taxon by basepath" do
-      fetched_document = registry[first_level_base_path]
-      expect(fetched_document['content_id']).to eq(first_level_content_id)
+      fetched_document = registry[first_level_content_id]
+      expect(fetched_document['base_path']).to eq(first_level_base_path)
     end
   end
 


### PR DESCRIPTION
When a user comes from a topic page, we'll set topic=id
rather than parent=topic_id. This will work on all pages
that have a topic param in the content item.

Example for filtering by brexit

`/search/services?topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea`

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1224.herokuapp.com/search/all
- http://finder-frontend-pr-1224.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1224.herokuapp.com/search/research-and-statistics?topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea
- http://finder-frontend-pr-1224.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1224.herokuapp.com/drug-device-alerts?topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea
- http://finder-frontend-pr-1224.herokuapp.com/find-eu-exit-guidance-business?topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea

[Other finders](https://live-stuff.herokuapp.com/finders)
