### PR TITLE
Change wording for EU citizens

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -64,13 +64,16 @@ private
   def current_facet
     current_facet = facets[page - 1]
     current_facet_config = qa_config["pages"][current_facet["key"]]
-    {
+    config = {
       "question" => current_facet_config["question"],
       "description" => current_facet_config["description"],
       "hint_title" => current_facet_config["hint_title"],
       "hint_text" => current_facet_config["hint_text"],
       "facet" => current_facet
     }
+    config.merge!("custom_options" => current_facet_config["custom_options"]) if current_facet_config["custom_options"].present?
+
+    config
   end
   helper_method :current_facet
 
@@ -93,7 +96,16 @@ private
     @facet_grouped_allowed_values ||= current_facet["facet"]["allowed_values"].group_by { |filter| filter["value"] }
   end
 
+  def custom_options?
+    question_type == "single" && current_facet['custom_options'].present?
+  end
+
   def options
+    if custom_options?
+      return current_facet["custom_options"].map do |option|
+        { label: option["label"], text: option["label"], value: option["value"] }
+      end
+    end
     allowed_values = current_facet["facet"]["allowed_values"]
     allowed_values.map do |option|
       { label: option["label"], text: option["label"], value: option["value"] }

--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -222,6 +222,24 @@
         ]
       },
       {
+        "key":"report_with_custom_labels",
+        "name":"Reports with custom labels",
+        "type":"text",
+        "preposition":"reports",
+        "display_as_result_metadata":true,
+        "filterable":true,
+        "allowed_values":[
+          {
+            "label":"Report A",
+            "value":"report_a"
+          },
+          {
+            "label":"Report B",
+            "value":"report_b"
+          }
+        ]
+      },
+      {
         "key":"date_of_occurrence",
         "name":"Date of occurrence",
         "short_name":"Occurred",

--- a/features/fixtures/aaib_reports_qa.yaml
+++ b/features/fixtures/aaib_reports_qa.yaml
@@ -35,6 +35,15 @@ pages:
     show_in_qa: true
     question_type: "multiple"
     question: "What is the multiple report type?"
+  report_with_custom_labels:
+    show_in_qa: true
+    question_type: "single"
+    question: "What is the report name?"
+    custom_options:
+      - label: "Alpha report"
+        value: "report_a"
+      - label: "Beta report"
+        value: "report_b"
   aircraft_type:
     show_in_qa: true
     question_type: "single"

--- a/features/qa.feature
+++ b/features/qa.feature
@@ -16,6 +16,14 @@ Feature: QA
       And I submit my answer
       Then my options are persisted as url params
 
+    Scenario: Answering a single option question with custom options
+      Given I am on a single answer question with custom options
+      Then I should see a collection of radio buttons
+      When I select a radio button
+      And I select another radio button
+      And I submit my answer
+      Then my options are persisted as url params
+
     Scenario: Answering a single_wrapped option question
       Given I am answering a single_wrapped answer question
       Then I should see a collection of radio buttons

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -12,6 +12,13 @@ Then /^I should see the first question/ do
   expect(page).to have_content(first_question)
 end
 
+Given /^I am on a single answer question with custom options/ do
+  question = get_question_with_custom_options
+  page_number = get_page_number(question)
+  visit "#{qa_path}?page=#{page_number}"
+  expect(page).to have_content(question)
+end
+
 Given /^I am answering a (.*?) answer question/ do |type|
   question = get_question_by_type(type)
   page_number = get_page_number(question)

--- a/features/support/qa_helper.rb
+++ b/features/support/qa_helper.rb
@@ -31,6 +31,13 @@ module QAHelper
     selected_questions.values.first['question']
   end
 
+  def get_question_with_custom_options
+    selected_questions = mock_qa_config["pages"].select do |_key, value|
+      value["question_type"] == "single" && value["custom_options"].present?
+    end
+    selected_questions.values.first['question']
+  end
+
   def get_page_number(question)
     mock_qa_config["pages"].each_with_index do |(_key, value), index|
       return index + 1 if value["question"] == question

--- a/lib/prepare_business_uk_leaving_eu.yaml
+++ b/lib/prepare_business_uk_leaving_eu.yaml
@@ -114,7 +114,12 @@ pages:
     question_type: "single"
     question: "Do you employ anyone from another European country?"
     description: |
-      <p>This includes <a href="/eu-eea">countries that are in the EU</a> and Norway, Switzerland, Iceland and Liechtenstein.</p>
+      <p>This includes <a href="/eu-eea">countries in the EU</a> and Norway, Switzerland, Iceland and Liechtenstein.</p>
+    custom_options:
+      - label: "Yes"
+        value: "yes"
+      - label: "No"
+        value: "no"
   personal_data:
     show_in_qa: true
     question_type: "single_wrapped"


### PR DESCRIPTION
## What

Change the wording of the employing EU citizens in the business finder smart answer.

## Why

Research found that people were confused by the terminology of these questions. 


## Background

https://trello.com/c/uNWqplBr/165-change-wording-of-question-about-employing-eu-citizens


## Screenshots

### Before
<img width="1013" alt="Screen Shot 2019-06-27 at 10 50 05" src="https://user-images.githubusercontent.com/4599889/60256401-5ac1a780-98c9-11e9-907b-cb6456d34f00.png">

### After
<img width="1004" alt="Screen Shot 2019-06-27 at 10 49 00" src="https://user-images.githubusercontent.com/4599889/60256411-5f865b80-98c9-11e9-8385-84664caffc26.png">

## Demo
http://finder-frontend-pr-1228.herokuapp.com/prepare-business-uk-leaving-eu?business_activity-yesno=yes&sector_business_area%5B%5D=electronics-parts-machinery&page=3

https://trello.com/c/WDUH4kll/186-change-wording-for-eu-citizens