### PR TITLE
Do blue bar again but with minor fixes

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -7,37 +7,39 @@
   <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 
-<%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
-  <%= render partial: 'govuk_publishing_components/components/title', locals: {
-    title: @signup_presenter.name,
-    context: "Email alert subscription"
-  } %>
-
-  <% if @signup_presenter.can_modify_choices? %>
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: nil,
-      heading: @signup_presenter.name,
-      hint_text: "Choose the email alerts you need.",
-      items: @signup_presenter.choices_formatted,
-      visually_hide_heading: true
+<div class="govuk-width-container">
+  <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+    <%= render partial: 'govuk_publishing_components/components/title', locals: {
+      title: @signup_presenter.name,
+      context: "Email alert subscription"
     } %>
-    <% if @error_message.present? %>
-      <p class="signup-choices__message"><%= @error_message %></p>
+
+    <% if @signup_presenter.can_modify_choices? %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: nil,
+        heading: @signup_presenter.name,
+        hint_text: "Choose the email alerts you need.",
+        items: @signup_presenter.choices_formatted,
+        visually_hide_heading: true
+      } %>
+      <% if @error_message.present? %>
+        <p class="signup-choices__message"><%= @error_message %></p>
+      <% end %>
     <% end %>
-  <% end %>
 
-  <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
-    <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
-  <% end %>
+    <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
+      <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
+    <% end %>
 
-  <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
-    <div class="govspeak-wrapper">
-      <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
-    </div>
-  <% end %>
+    <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
+      <div class="govspeak-wrapper">
+        <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+      </div>
+    <% end %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Create subscription",
-    margin_bottom: true
-  } %>
-<% end %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Create subscription",
+      margin_bottom: true
+    } %>
+  <% end %>
+</div>


### PR DESCRIPTION
This PR makes changes to [this PR to add the blue banner](https://github.com/alphagov/finder-frontend/pull/1204) by fixing the following:

- [email subscription pages](http://finder-frontend-pr-1230.herokuapp.com//search/news-and-communications/email-signup) have the correct layout
