### PR TITLE
Add inverse option to breadcrumb

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if @breadcrumbs.breadcrumbs %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs, inverse: inverse %>
   <% else %>
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @raw_content_item, prioritise_taxon_breadcrumbs: finder.eu_exit_finder?, inverse: inverse %>
   <% end %>


### PR DESCRIPTION
Fixes the incorrect black text on the breadcrumb shown here:

<img width="754" alt="Screen Shot 2019-06-27 at 14 32 09" src="https://user-images.githubusercontent.com/861310/60270474-68d2f080-98e8-11e9-90c5-57d18568fa09.png">

Examples:

- [page with a blue bar](http://finder-frontend-pr-1231.herokuapp.com/search/services?parent=hm-treasury&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0)
- [page without a blue bar](http://finder-frontend-pr-1231.herokuapp.com/search/services?parent=hm-treasury)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1231.herokuapp.com/search/all
- http://finder-frontend-pr-1231.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1231.herokuapp.com/search/advanced?group=guidance_and_regulation&topic=%2Feducation
- http://finder-frontend-pr-1231.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1231.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
