### PR TITLE
Restore page width elements to finders

### DIFF
--- a/app/views/qa/show.html.erb
+++ b/app/views/qa/show.html.erb
@@ -5,86 +5,89 @@
   <% end %>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title" data-module="track-qa-choices">
-      <%= render "govuk_publishing_components/components/title", {
-        title: current_facet["question"],
-      } %>
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
 
-      <% if current_facet["description"] %>
-        <%= render "govuk_publishing_components/components/govspeak", {
-          content: current_facet["description"].html_safe
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="<%= next_page_url %>" method="get" id="finder-qa-facet-filter-selection" class="gem-c-title" data-module="track-qa-choices">
+        <%= render "govuk_publishing_components/components/title", {
+          title: current_facet["question"],
         } %>
-      <% end %>
 
-      <% if multiple_grouped_question? %>
-        <% filter_groups.each do |filter_group| %>
-          <%= render "govuk_publishing_components/components/checkboxes", {
-            name: "#{current_facet['facet']['key']}[]",
-            heading: filter_group["name"],
-            no_hint_text: true,
-            items: nested_options(filter_group)
+        <% if current_facet["description"] %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+            content: current_facet["description"].html_safe
           } %>
         <% end %>
-      <% elsif multiple_question? %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: "#{current_facet['facet']['key']}[]",
-          heading: "Select all that apply",
-          visually_hide_heading: true,
-          items: options
-        } %>
-      <% elsif single_wrapped_question? %>
-        <% checkboxes = render "govuk_publishing_components/components/checkboxes", {
-          name: "#{current_facet['facet']['key']}[]",
-          heading: "Select all that apply",
-          visually_hide_heading: true,
-          items: options
-        } %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "#{current_facet['facet']['key']}-yesno",
-          items: [
-            {
-              value: "yes",
-              text: "Yes",
-              conditional: checkboxes
-            },
-            {
-              value: "no",
-              text: "No"
-            }
-          ]
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "#{current_facet['facet']['key']}[]",
-          items: options
-        } %>
-      <% end %>
-      <% filtered_params.each_pair do |key, value| %>
-        <% if value.is_a?(Array) %>
-          <% value.each do |v| %>
-            <input type="hidden" name="<%= key %>[]" value="<%= v %>">
+
+        <% if multiple_grouped_question? %>
+          <% filter_groups.each do |filter_group| %>
+            <%= render "govuk_publishing_components/components/checkboxes", {
+              name: "#{current_facet['facet']['key']}[]",
+              heading: filter_group["name"],
+              no_hint_text: true,
+              items: nested_options(filter_group)
+            } %>
           <% end %>
+        <% elsif multiple_question? %>
+          <%= render "govuk_publishing_components/components/checkboxes", {
+            name: "#{current_facet['facet']['key']}[]",
+            heading: "Select all that apply",
+            visually_hide_heading: true,
+            items: options
+          } %>
+        <% elsif single_wrapped_question? %>
+          <% checkboxes = render "govuk_publishing_components/components/checkboxes", {
+            name: "#{current_facet['facet']['key']}[]",
+            heading: "Select all that apply",
+            visually_hide_heading: true,
+            items: options
+          } %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "#{current_facet['facet']['key']}-yesno",
+            items: [
+              {
+                value: "yes",
+                text: "Yes",
+                conditional: checkboxes
+              },
+              {
+                value: "no",
+                text: "No"
+              }
+            ]
+          } %>
         <% else %>
-          <input type="hidden" name="<%= key %>" value="<%= value %>">
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "#{current_facet['facet']['key']}[]",
+            items: options
+          } %>
         <% end %>
-      <% end %>
-        <input type="hidden" name="page" value="<%= next_page %>">
-      <% unless current_facet["hint_text"].nil? || current_facet["hint_title"].nil? %>
-        <%= render "govuk_publishing_components/components/details", {
-          title: current_facet["hint_title"]
-        } do %>
-          <%= current_facet["hint_text"] %>
+        <% filtered_params.each_pair do |key, value| %>
+          <% if value.is_a?(Array) %>
+            <% value.each do |v| %>
+              <input type="hidden" name="<%= key %>[]" value="<%= v %>">
+            <% end %>
+          <% else %>
+            <input type="hidden" name="<%= key %>" value="<%= value %>">
+          <% end %>
         <% end %>
-      <% end %>
-      <div class="govuk-form-footer">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Next"
-        } %>
-        <a class="govuk-form-footer__alt-cta-link" href="<%= skip_link_url %>">Skip this question</a>
-      </div>
-    </form>
+          <input type="hidden" name="page" value="<%= next_page %>">
+        <% unless current_facet["hint_text"].nil? || current_facet["hint_title"].nil? %>
+          <%= render "govuk_publishing_components/components/details", {
+            title: current_facet["hint_title"]
+          } do %>
+            <%= current_facet["hint_text"] %>
+          <% end %>
+        <% end %>
+        <div class="govuk-form-footer">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Next"
+          } %>
+          <a class="govuk-form-footer__alt-cta-link" href="<%= skip_link_url %>">Skip this question</a>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/app/views/qa_to_content/show.html.erb
+++ b/app/views/qa_to_content/show.html.erb
@@ -3,29 +3,31 @@
   <meta name="robots" content="noindex">
 <% end %>
 
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
 
-<%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <form action="" method="get">
+      <form action="" method="get">
 
-      <%= render "govuk_publishing_components/components/title", {
-        title: question["question"],
-        margin_bottom: 4
-      } %>
-      <%= render "govuk_publishing_components/components/hint", {
-        text: question["hint"].html_safe,
-        margin_bottom: 7
-      } %>
-      <%= render "govuk_publishing_components/components/radio", {
-        name: question["id"],
-        items: format_options(question["options"])
-      } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Next"
-      } %>
-    </form>
+        <%= render "govuk_publishing_components/components/title", {
+          title: question["question"],
+          margin_bottom: 4
+        } %>
+        <%= render "govuk_publishing_components/components/hint", {
+          text: question["hint"].html_safe,
+          margin_bottom: 7
+        } %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: question["id"],
+          items: format_options(question["options"])
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Next"
+        } %>
+      </form>
 
+    </div>
   </div>
 </div>


### PR DESCRIPTION
- were recently removed due to the blue bar work, need to be manually added into the show templates for these brexit finders

Links to check:

- http://finder-frontend-pr-1233.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1233.herokuapp.com/prepare-business-uk-leaving-eu

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1233.herokuapp.com/search/all
- http://finder-frontend-pr-1233.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1233.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1233.herokuapp.com/find-eu-exit-guidance-business

[Other finders](https://live-stuff.herokuapp.com/finders)
