### PR TITLE
Fix failing tests

### DIFF
--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -99,7 +99,7 @@ When(/^I view a list of news and communications$/) do
 end
 
 When(/^I view the news and communications finder$/) do
-  topic_taxonomy_has_taxons
+  stub_taxonomy_api_request
   content_store_has_news_and_communications_finder
   stub_whitehall_api_world_location_request
   stub_all_rummager_api_requests_with_news_and_communication_results


### PR DESCRIPTION
It looks like the taxon sequence number wasn't being reset:

```
Real HTTP connections are disabled. Unregistered request: GET http://content-store.dev.gov.uk/content/path/level_one_taxon_45 with headers {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'content-store.dev.gov.uk', 'User-Agent'=>'gds-api-adapters/59.5.1 ()'}

      You can stub this request with the following snippet:

      stub_request(:get, "http://content-store.dev.gov.uk/content/path/level_one_taxon_45").
        with(
          headers: {
      	  'Accept'=>'application/json',
      	  'Accept-Encoding'=>'gzip, deflate',
      	  'Host'=>'content-store.dev.gov.uk',
      	  'User-Agent'=>'gds-api-adapters/59.5.1 ()'
          }).
        to_return(status: 200, body: "", headers: {})
```

But the tests that use this step don't need specific taxons to exist, so they don't need to be stubbed.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
