### PR TITLE
Don't preprocess assets in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ FinderFrontend::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = false
+  config.assets.debug = true
 
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']


### PR DESCRIPTION
The "trick" to get finder-frontend to work locally is to set this value to "true".
As it's unlikely that a finder will have an unusually large number of assets,
perhaps it should always be set to true and disabled when needed.

We're already doing this in [government-frontend](https://github.com/alphagov/government-frontend/blob/7942c6f20dfac7f99c572b9a20e3c4fb7463c8c4/config/environments/development.rb)


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1242.herokuapp.com/search/all
- http://finder-frontend-pr-1242.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1242.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1242.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1242.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1242.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1242.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1242.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1242.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
