### PR TITLE
Allow passing A/B test parameters to search-api and set up SearchClusterABTest

### DIFF
--- a/app/controllers/concerns/finder_top_result_ab_testable.rb
+++ b/app/controllers/concerns/finder_top_result_ab_testable.rb
@@ -6,7 +6,7 @@ module FinderTopResultAbTestable
       :finder_top_result_variant,
       :show_top_result?
     )
-    base.after_action :set_test_response_header
+    base.after_action :set_finder_top_result_response_header
   end
 
   def finder_top_result_test
@@ -22,11 +22,11 @@ module FinderTopResultAbTestable
     @finder_top_result_variant ||= finder_top_result_test.requested_variant(request.headers)
   end
 
-  def set_test_response_header
-    finder_top_result_variant.configure_response(response) if test_in_scope?
+  def set_finder_top_result_response_header
+    finder_top_result_variant.configure_response(response) if finder_top_result_test_in_scope?
   end
 
-  def test_in_scope?
+  def finder_top_result_test_in_scope?
     content_item.is_finder? && search_query && finder_presenter.eu_exit_finder?
   end
 

--- a/app/controllers/concerns/search_cluster_ab_testable.rb
+++ b/app/controllers/concerns/search_cluster_ab_testable.rb
@@ -1,0 +1,48 @@
+module SearchClusterABTestable
+  CUSTOM_DIMENSION = 42
+
+  def self.included(base)
+    base.helper_method :search_cluster_variant
+    base.after_action :set_search_cluster_response_header
+  end
+
+  # A == use A cluster
+  # B == use B cluster
+  # anything else = use default cluster
+  def search_cluster_test
+    @search_cluster_test ||= GovukAbTesting::AbTest.new(
+      'SearchClusterABTest',
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w[Default A B],
+      control_variant: 'Default',
+    )
+  end
+
+  def search_cluster_variant
+    @search_cluster_variant ||= search_cluster_test.requested_variant(request.headers)
+  end
+
+  def search_cluster_ab_params
+    if use_default_cluster?
+      {}
+    else
+      { search_cluster: use_b_cluster? ? 'B' : 'A' }
+    end
+  end
+
+  def set_search_cluster_response_header
+    search_cluster_variant.configure_response(response) if search_cluster_test_in_scope?
+  end
+
+  def use_default_cluster?
+    !(search_cluster_variant.variant?('A') || search_cluster_variant.variant?('B'))
+  end
+
+  def use_b_cluster?
+    search_cluster_variant.variant? 'B'
+  end
+
+  def search_cluster_test_in_scope?
+    content_item.is_finder? && search_query
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
+  include SearchClusterABTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -101,6 +102,7 @@ private
       content_item.as_hash,
       filter_params,
       override_sort_for_feed: is_for_feed,
+      ab_params: search_cluster_ab_params,
     )
   end
 

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -4,9 +4,10 @@ module Search
   class Query
     attr_reader :content_item
 
-    def initialize(content_item, filter_params, override_sort_for_feed: false)
+    def initialize(content_item, filter_params, ab_params: {}, override_sort_for_feed: false)
       @content_item = content_item
       @filter_params = filter_params
+      @ab_params = ab_params
       @override_sort_for_feed = override_sort_for_feed
       @order =
         if override_sort_for_feed
@@ -27,7 +28,7 @@ module Search
 
   private
 
-    attr_reader :filter_params, :override_sort_for_feed
+    attr_reader :ab_params, :filter_params, :override_sort_for_feed
 
     def merge_and_deduplicate(search_response)
       results = search_response.fetch("results")
@@ -77,6 +78,7 @@ module Search
       queries = QueryBuilder.new(
         finder_content_item: content_item,
         params: filter_params,
+        ab_params: ab_params,
         override_sort_for_feed: override_sort_for_feed,
       ).call
 

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -12,9 +12,10 @@ module Search
     # find anything useful, too much noise.
     MAX_QUERY_LENGTH = 512
 
-    def initialize(finder_content_item:, params: {}, override_sort_for_feed: false)
+    def initialize(finder_content_item:, params: {}, ab_params: {}, override_sort_for_feed: false)
       @finder_content_item = finder_content_item
       @params = params
+      @ab_params = ab_params
       @override_sort_for_feed = override_sort_for_feed
     end
 
@@ -28,6 +29,7 @@ module Search
         order_query,
         facet_query,
         debug_query,
+        ab_query,
       ].reduce(&:merge)
 
       return [base_query] if filter_queries.empty?
@@ -39,7 +41,7 @@ module Search
 
   private
 
-    attr_reader :finder_content_item, :params, :override_sort_for_feed
+    attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed
 
     def order_query_builder_class
       OrderQueryBuilder
@@ -227,6 +229,10 @@ module Search
       {
         "debug" => params["debug"],
       }.compact
+    end
+
+    def ab_query
+      ab_params.any? ? { 'ab_tests' => ab_params.map { |k, v| "#{k}:#{v}" }.join(',') } : {}
     end
 
     def stopwords

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -12,6 +12,7 @@
   <% end %>
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if finder_presenter.eu_exit_finder? %>
+  <%= search_cluster_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :meta_title, finder_presenter.name %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -240,12 +240,12 @@ describe FindersController, type: :controller do
     end
   end
 
-  describe "Business finder top results AB tests" do
+  describe "Search cluster AB tests" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example('finder').to_hash.merge(
         'title' => 'Breakfast Finder',
         'base_path' => '/breakfast-finder',
-        'content_id' => '42ce66de-04f3-4192-bf31-8394538e0734' #business finder id
+        'content_id' => '42ce66de-04f3-4192-bf31-8394538e0734'
       )
 
       finder["details"]["default_documents_per_page"] = 10
@@ -268,17 +268,27 @@ describe FindersController, type: :controller do
       stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
     end
 
-    it "Finder variant A does not set show_top_result" do
-      with_variant FinderAnswerABTest: "A" do
+    it "Variant Default sets use_default_cluster? and not use_b_cluster?" do
+      with_variant SearchClusterABTest: 'Default' do
         get :show, params: { slug: path_for(breakfast_finder) }
-        expect(subject.show_top_result?).to eq(false)
+        expect(subject.use_default_cluster?).to eq(true)
+        expect(subject.use_b_cluster?).to eq(false)
       end
     end
 
-    it "Finder variant B does set show_top_result" do
-      with_variant FinderAnswerABTest: "B" do
+    it "Variant A does not set use_default_cluster? or use_b_cluster?" do
+      with_variant SearchClusterABTest: 'A' do
         get :show, params: { slug: path_for(breakfast_finder) }
-        expect(subject.show_top_result?).to eq(true)
+        expect(subject.use_default_cluster?).to eq(false)
+        expect(subject.use_b_cluster?).to eq(false)
+      end
+    end
+
+    it "Variant 'B' sets use_b_cluster? and not use_default_cluster?" do
+      with_variant SearchClusterABTest: 'B' do
+        get :show, params: { slug: path_for(breakfast_finder) }
+        expect(subject.use_default_cluster?).to eq(false)
+        expect(subject.use_b_cluster?).to eq(true)
       end
     end
   end

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -339,6 +339,24 @@ describe Search::QueryBuilder do
     end
   end
 
+  context "with A/B parameters" do
+    let(:ab_params) {
+      {
+        test_one: 'a',
+        test_two: 'b',
+      }
+    }
+
+    it "should include an A/B query" do
+      query = described_class.new(
+        finder_content_item: finder_content_item,
+        ab_params: ab_params,
+      ).call.first
+
+      expect(query).to include("ab_tests" => "test_one:a,test_two:b")
+    end
+  end
+
   context "with a base filter" do
     let(:filter) { { "document_type" => "news_story" } }
 


### PR DESCRIPTION
Allows passing A/B parameters to search-api (turns out that wasn't already supported), and sets up `SearchClusterABTest` for trying out ES6.

No traffic will be sent to ES6 until we set up the test headers in Fastly, as covered in the A/B docs.

---

[Trello card](https://trello.com/c/JO3Ihzcp/855-set-up-the-es6-a-b-test)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1255.herokuapp.com/search/all
- http://finder-frontend-pr-1255.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1255.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1255.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1255.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1255.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1255.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1255.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1255.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
