### PR TITLE
Add Enhanced Ecommerce tracking

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -54,11 +54,18 @@
       )
 
       this.indexTrackingData()
+      this.startEnhancedEcommerceTracking()
 
       $(window).on('popstate', this.popState.bind(this))
     } else {
       this.$form.find('.js-live-search-fallback').show()
     }
+  }
+
+  LiveSearch.prototype.startEnhancedEcommerceTracking = function startEnhancedEcommerceTracking () {
+    this.$form.attr('data-search-query', this.currentKeywords())
+    if (!GOVUK.Ecommerce || GOVUK.Ecommerce.ecLoaded) { return }
+    GOVUK.Ecommerce.start()
   }
 
   LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet () {
@@ -121,6 +128,7 @@
   LiveSearch.prototype.trackingInit = function trackingInit () {
     GOVUK.modules.start($('.js-live-search-results-block'))
     this.indexTrackingData()
+    this.startEnhancedEcommerceTracking()
   }
 
   LiveSearch.prototype.trackPageView = function trackPageView () {
@@ -202,7 +210,7 @@
   }
 
   LiveSearch.prototype.updateTitle = function updateTitle () {
-    var keywords = this.getTextInputValue('keywords', this.state)
+    var keywords = this.currentKeywords()
     var keywordsPresent = keywords !== ''
 
     if (keywordsPresent) {
@@ -224,12 +232,16 @@
     this.$relevanceOrderOptionIndex = this.$relevanceOrderOption.index()
   }
 
+  LiveSearch.prototype.currentKeywords = function currentKeywords () {
+    return this.getTextInputValue('keywords', this.state)
+  }
+
   LiveSearch.prototype.updateOrder = function updateOrder () {
     if (!this.$orderSelect.length) {
       return
     }
 
-    var keywords = this.getTextInputValue('keywords', this.state)
+    var keywords = this.currentKeywords()
     var previousKeywords = this.getTextInputValue('keywords', this.previousState)
 
     var keywordsPresent = keywords !== ''

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -88,6 +88,7 @@ module Search
         format
         is_historic
         government_name
+        content_id
       )
     end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,12 +1,13 @@
 class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
               :content_purpose_supergroup, :document_type, :organisations,
-              :release_timestamp, :es_score, :format
+              :release_timestamp, :es_score, :format, :content_id
 
   def initialize(rummager_document, finder)
     rummager_document = rummager_document.with_indifferent_access
     @title = rummager_document.fetch(:title)
     @link = rummager_document.fetch(:link)
+    @content_id = rummager_document.fetch(:content_id, nil)
     @description = rummager_document.fetch(:description, nil)
     @public_timestamp = rummager_document.fetch(:public_timestamp, nil)
     @release_timestamp = rummager_document.fetch(:release_timestamp, nil)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -151,6 +151,10 @@ class FinderPresenter
     )
   end
 
+  def start_offset
+    search_results.fetch('start', 0)
+  end
+
   def label_for_metadata_key(key)
     facet = metadata.find { |f| f.key == key }
 

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -152,7 +152,7 @@ class FinderPresenter
   end
 
   def start_offset
-    search_results.fetch('start', 0)
+    search_results.fetch('start', 0) + 1
   end
 
   def label_for_metadata_key(key)

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -27,6 +27,9 @@ class SearchResultPresenter
         path: link,
         description: summary_text,
         data_attributes: {
+          ecommerce_path: link,
+          ecommerce_content_id: search_result.content_id,
+          ecommerce_row: 1,
           track_category: "navFinderLinkClicked",
           track_action: "#{@finder_name}.#{@index}",
           track_label: link,

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -5,7 +5,6 @@
         <% if group[:group_name] %>
           <h2 class="filtered-results__facet-heading"><%= group[:group_name] %></h2>
         <% end %>
-
         <%= render "govuk_publishing_components/components/document_list", {
           items: group[:documents],
           remove_underline: true

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -22,7 +22,11 @@
   <% inverse = true %>
 <% end %>
 
-<form method="get" action="<%= finder_presenter.slug %>" class="js-live-search-form">
+<form method="get" action="<%= finder_presenter.slug %>" class="js-live-search-form"
+  data-analytics-ecommerce
+  data-ecommerce-start-index="<%= finder_presenter.start_offset %>"
+  data-list-title="<%= finder_presenter.name %>"
+  data-search-query="<%= result_set_presenter.user_supplied_keywords %>">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
   <% if finder_presenter.topic_finder? && !finder_presenter.all_content_finder? %>

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,24 @@
+# Analytics
+
+To improve the search user experience, we track user behaviour in Google
+Analytics.
+
+## What is tracked
+
+In addition to the default page view tracking that occurs on every page
+of GOV.UK, we have added additional tracking to finder-frontend.
+
+There are three kinds of tracking:
+
+- Enhanced Ecommerce: Provided by [static](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/ecommerce.js); provides analytics on views (impressions) and clicks of lists of items.
+- Event tracking: tracks usage of features such as facets.
+- Page view tracking: tracks each search that a user makes.
+
+## Testing analytics
+
+For Enhanced Ecommerce, the tracking functionality is tested in static.
+
+We have feature tests to check the correct attributes are used in
+[`features/analytics.feature`](features/analytics.feature).
+
+There are also unit tests, e.g. in [`spec/javascripts/live_search_spec.js`](spec/javascripts/live_search_spec.js).

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -1,0 +1,13 @@
+Feature: Analytics
+  In order to improve search performance
+  As a developer
+  I want to be able to track user behaviour
+
+  @javascript
+  Scenario: Ecommerce tracking
+    When I view the all content finder
+    Then the ecommerce tracking tags are present
+
+  Scenario: Link tracking
+    Given a government finder exists
+    Then the links on the page have tracking attributes

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -7,6 +7,9 @@ Feature: Analytics
   Scenario: Ecommerce tracking
     When I view the all content finder
     Then the ecommerce tracking tags are present
+    And I search for lunch
+    And I submit the form
+    Then the data-search-query has been updated to lunch
 
   Scenario: Link tracking
     Given a government finder exists

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -89,10 +89,6 @@ Feature: Filtering documents
     Given a finder with a no_index property exists
     Then I can see that the noindex tag is is present in the metadata
 
-  Scenario: Link tracking
-    Given a government finder exists
-    Then the links on the page have tracking attributes
-
   Scenario: Visit a finder from an organisation
     Given an organisation finder exists
     Then I can see a breadcrumb for home

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -26,7 +26,7 @@ Then(/^the ecommerce tracking tags are present$/) do
   expect(page).to have_selector('form[data-analytics-ecommerce]')
 
   form = page.find('form[data-analytics-ecommerce]')
-  expect(form['data-ecommerce-start-index']).to eq("0")
+  expect(form['data-ecommerce-start-index']).to eq("1")
   expect(form['data-list-title']).to eq('Search')
   expect(form['data-search-query']).to eq('breakfast')
 

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -18,8 +18,6 @@ Then(/^the links on the page have tracking attributes$/) do
   expect(options['dimension29']).to eq(first_link.text)
 end
 
-# TODO live update of tracking tags
-
 Then(/^the ecommerce tracking tags are present$/) do
   visit finder_path('search/all', q: 'breakfast')
 
@@ -37,4 +35,15 @@ Then(/^the ecommerce tracking tags are present$/) do
 
   expect(first_link['data-ecommerce-path']).to eq('/restrictions-on-usage-of-spells-within-school-grounds')
   expect(first_link['data-ecommerce-content-id']).to eq('1234')
+end
+
+And(/^I search for lunch$/) do
+  stub_rummager_api_request_with_query_param_no_results('lunch')
+
+  fill_in 'Search', with: "lunch"
+end
+
+Then(/^the data-search-query has been updated to (.*)$/) do |query|
+  form = page.find('form[data-analytics-ecommerce]')
+  expect(form['data-search-query']).to eq(query)
 end

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -17,3 +17,24 @@ Then(/^the links on the page have tracking attributes$/) do
   expect(options['dimension28']).to eq(document_links.count)
   expect(options['dimension29']).to eq(first_link.text)
 end
+
+# TODO live update of tracking tags
+
+Then(/^the ecommerce tracking tags are present$/) do
+  visit finder_path('search/all', q: 'breakfast')
+
+  expect(page).to have_selector('form[data-analytics-ecommerce]')
+
+  form = page.find('form[data-analytics-ecommerce]')
+  expect(form['data-ecommerce-start-index']).to eq("0")
+  expect(form['data-list-title']).to eq('Search')
+  expect(form['data-search-query']).to eq('breakfast')
+
+  results = page.all('a[data-ecommerce-row]')
+  expect(results.count).to be_positive
+
+  first_link = results.first
+
+  expect(first_link['data-ecommerce-path']).to eq('/restrictions-on-usage-of-spells-within-school-grounds')
+  expect(first_link['data-ecommerce-content-id']).to eq('1234')
+end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1787,6 +1787,7 @@ module DocumentHelper
         {
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
+          "content_id": "1234",
           "description": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -100,6 +100,7 @@ module RummagerUrlHelper
       format
       is_historic
       government_name
+      content_id
     )
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -60,7 +60,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -118,7 +118,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0
@@ -219,7 +219,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -58,7 +58,7 @@ describe Search::QueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id",
       )
     end
   end
@@ -85,7 +85,7 @@ describe Search::QueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,alpha,beta",
+        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,alpha,beta",
       )
     end
 
@@ -102,7 +102,7 @@ describe Search::QueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,zeta,beta",
+          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,zeta,beta",
         )
       end
     end

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe GroupedResultSetPresenter do
       default_documents_per_page: 10,
       values: {},
       sort: {},
-      filters: facet_filters
+      filters: facet_filters,
+      start_offset: 0,
     )
   end
 
@@ -114,7 +115,8 @@ RSpec.describe GroupedResultSetPresenter do
       government_name: 'The Government!',
       show_metadata: false,
       format: 'transaction',
-      es_score: nil
+      es_score: nil,
+      content_id: 'content_id',
     )
   end
 
@@ -190,7 +192,8 @@ RSpec.describe GroupedResultSetPresenter do
         government_name: 'The Government',
         show_metadata: false,
         format: 'transaction',
-        es_score: nil
+        es_score: nil,
+        content_id: 'content_id',
       )
     }
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ResultSetPresenter do
       keywords: keywords,
       default_documents_per_page: 10,
       values: {},
+      start_offset: 1,
       sort: [
         {
           "name" => "Most viewed",
@@ -79,7 +80,8 @@ RSpec.describe ResultSetPresenter do
       government_name: 'The Government!',
       show_metadata: true,
       format: 'transaction',
-      es_score: 0.005
+      es_score: 0.005,
+      content_id: 'content_id',
     )
   end
 
@@ -90,6 +92,9 @@ RSpec.describe ResultSetPresenter do
         path: 'slug-1',
         description: 'I am a document',
         data_attributes: {
+          ecommerce_path: 'slug-1',
+          ecommerce_content_id: 'content_id',
+          ecommerce_row: 1,
           track_category: 'navFinderLinkClicked',
           track_action: 'A finder.1',
           track_label: 'slug-1',
@@ -241,6 +246,7 @@ RSpec.describe ResultSetPresenter do
           show_metadata: false,
           format: 'transaction',
           es_score: 1000.0,
+          content_id: 'content_id',
         )
       end
 
@@ -256,6 +262,7 @@ RSpec.describe ResultSetPresenter do
           show_metadata: false,
           format: 'transaction',
           es_score: 100.0,
+          content_id: 'content_id',
         )
       end
 

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe SearchResultPresenter do
       government_name: 'Government!',
       show_metadata: false,
       format: 'cake',
-      es_score: 0.005
+      es_score: 0.005,
+      content_id: 'content_id'
     )
   }
 
@@ -61,6 +62,9 @@ RSpec.describe SearchResultPresenter do
         path: link,
         description: summary,
         data_attributes: {
+          ecommerce_path: link,
+          ecommerce_content_id: 'content_id',
+          ecommerce_row: 1,
           track_category: "navFinderLinkClicked",
           track_action: "#{finder_name}.1",
           track_label: link,


### PR DESCRIPTION
This adds tracking attributes to elements on search pages.

The new attributes will be used by `GOVUK.Ecommerce` ([component provided by static](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/ecommerce.js)).

Attributes added to the container:

```
data-analytics-ecommerce
data-ecommerce-start-index="0" # search_offset (e.g. 0, 20, 40)
data-list-title="Breakfast finder"
data-search-query="Cereal"
```

Results now have an attribute `data-ecommerce-row`, which signals this is a row we should track.

Results have a path and content id, which means we now fetch a content_id as part of the return fields from Search API.

With these attributes, the Ecommerce component will set up a bunch of event handlers, and then send tracking information to Google Analytics.

We call `GOVUK.Ecommerce.start()` after every new search. The intent is to make the component set up listeners on the new elements when a new search is created.

We now send two requests to GA when a user clicks a link. Does anyone know if we can make just one call to GA? From the looks of things it's not possible, but if we can I'd like to!

Note: This should be merged after https://github.com/alphagov/static/pull/1787 is deployed.

Trello: https://trello.com/c/YXkJcbBo/851.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1256.herokuapp.com/search/all
- http://finder-frontend-pr-1256.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1256.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1256.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1256.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1256.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1256.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1256.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1256.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
