### PR TITLE
Fix blue bar metadata

### DIFF
--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -131,10 +131,10 @@ class FinderPresenter
 
   def page_metadata
     metadata = {
-      from: organisations,
-      inverse: true,
+      from: organisations
     }
 
+    metadata[:inverse] = true if topic_finder?
     metadata.reject { |_, links| links.blank? }
   end
 

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -81,6 +81,14 @@ Feature: Filtering documents
     And I click the xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx remove control
     Then I should see results and pagination
 
+  Scenario: Visit a finder with metadata
+    Given a finder with metadata exists
+    Then I can see that the finder metadata is present
+
+  Scenario: Visit a finder with metadata with a topic param set
+    When I view the aaib reports finder with a topic param set
+    Then I can see that the finder metadata is present and inverted
+
   Scenario: Visit a finder with description
     Given a finder with description exists
     Then I can see that the description in the metadata is present

--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -52,6 +52,23 @@
         "web_url":"https://www.gov.uk/government/organisations/air-accidents-investigation-branch"
       }
     ],
+    "related": [
+      {
+        "api_path": "/api/content/drug-safety-update",
+        "base_path": "/drug-safety-update",
+        "content_id": "602be505-4cf4-4f8c-8bfc-7bc4b63a7f47",
+        "description": "Find drug safety updates issued by MHRA",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2019-06-26T13:50:02Z",
+        "schema_name": "finder",
+        "title": "Drug Safety Update",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/drug-safety-update",
+        "web_url": "https://www.gov.uk/drug-safety-update"
+      }
+    ],
     "available_translations":[
       {
         "title":"Air Accidents Investigation Branch reports",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -177,6 +177,22 @@ When(/^I view the research and statistics finder with a topic param set$/) do
   visit finder_path('search/research-and-statistics', topic: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0')
 end
 
+When(/^I view the aaib reports finder with a topic param set$/) do
+  topic_taxonomy_has_taxons([
+                              FactoryBot.build(
+                                :level_one_taxon_hash,
+                                content_id: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                                title: "Education, training and skills"
+                              )
+                            ])
+  content_store_has_aaib_reports_finder
+  stub_organisations_registry_request
+  stub_manuals_registry_request
+  stub_whitehall_api_world_location_request
+  stub_rummager_api_request_with_aaib_reports_results
+  visit finder_path('aaib-reports', topic: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0')
+end
+
 When(/^I view the all content finder with a manual filter$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
@@ -427,6 +443,30 @@ Given(/^a finder with a no_index property exists$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder_with_no_index
   stub_rummager_with_cma_cases
+end
+
+Given(/^a finder with metadata exists$/) do
+  stub_taxonomy_api_request
+  stub_content_store_with_cma_cases_finder_with_metadata
+  stub_rummager_with_cma_cases
+end
+
+Given(/^a finder with metadata with a topic param set exists$/) do
+  stub_taxonomy_api_request
+  stub_content_store_with_cma_cases_finder_with_metadata_with_topic_param
+  stub_rummager_with_cma_cases
+end
+
+When(/^I can see that the finder metadata is present$/) do
+  visit "/cma-cases"
+
+  expect(page).to have_css(".gem-c-metadata")
+  expect(page).to_not have_css(".gem-c-metadata.gem-c-metadata--inverse")
+end
+
+When(/^I can see that the finder metadata is present and inverted$/) do
+  expect(page).to have_css(".gem-c-metadata")
+  expect(page).to have_css(".gem-c-metadata.gem-c-metadata--inverse")
 end
 
 When(/^I can see that the description in the metadata is present$/) do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -155,6 +155,12 @@ module DocumentHelper
       .to_return(body: upcoming_statistics_results_for_statistics_json)
   end
 
+  def stub_rummager_api_request_with_aaib_reports_results
+    stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including({}))
+      .to_return(body: %|{ "results": [], "total": 0, "start": 0}|)
+  end
+
   def stub_all_rummager_api_requests_with_news_and_communication_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including({}))
@@ -255,6 +261,12 @@ module DocumentHelper
     content_store_has_item('/search/research-and-statistics', finder_fixture)
   end
 
+  def content_store_has_aaib_reports_finder
+    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'aaib_reports_example.json'))
+
+    content_store_has_item('/aaib-reports', finder_fixture)
+  end
+
   def content_store_has_all_content_finder
     finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'all_content.json'))
 
@@ -352,6 +364,27 @@ module DocumentHelper
   def stub_content_store_with_cma_cases_finder_with_no_index
     schema = govuk_content_schema_example("cma-cases", "finder")
     schema["details"]["no_index"] = true
+
+    content_store_has_item(
+      schema.fetch("base_path"),
+      schema.to_json,
+    )
+  end
+
+  def stub_content_store_with_cma_cases_finder_with_metadata
+    schema = govuk_content_schema_example("cma-cases", "finder")
+      .merge("from" => "An authority")
+
+    content_store_has_item(
+      schema.fetch("base_path"),
+      schema.to_json,
+    )
+  end
+
+  def stub_content_store_with_cma_cases_finder_with_metadata_with_topic_param
+    schema = govuk_content_schema_example("cma-cases", "finder")
+      .merge("from" => "An authority")
+    schema["content_id"] = "c58fdadd-7743-46d6-9629-90bb3ccc4ef0"
 
     content_store_has_item(
       schema.fetch("base_path"),


### PR DESCRIPTION
Fixes the appearance of metadata at the top of finders such as [drug device alerts](https://www.gov.uk/drug-device-alerts) where the component is being always inverted (white text) assuming it's inside a blue bar, when it isn't always.

Here's what it looks like currently:

<img width="1112" alt="Screen Shot 2019-07-16 at 08 28 41" src="https://user-images.githubusercontent.com/861310/61274534-eaa99180-a7a3-11e9-82bb-444090633e9b.png">

With all text highlighted, to show the hidden metadata:

<img width="1115" alt="Screen Shot 2019-07-16 at 08 28 50" src="https://user-images.githubusercontent.com/861310/61274556-f72dea00-a7a3-11e9-9112-4db52bb32f6e.png">

Now fixed and looks like this:

<img width="1149" alt="Screen Shot 2019-07-16 at 08 30 42" src="https://user-images.githubusercontent.com/861310/61274603-0f9e0480-a7a4-11e9-979b-69dd19c0cbd6.png">

And looks like this with the blue bar...

<img width="1133" alt="Screen Shot 2019-07-16 at 08 30 48" src="https://user-images.githubusercontent.com/861310/61274622-17f63f80-a7a4-11e9-909d-b1413074bafd.png">

Trello card: https://trello.com/c/kQN8cQon/866-fix-metadata-inversion-bug-on-drug-device-finders

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1260.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1260.herokuapp.com/search/all
- http://finder-frontend-pr-1260.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1260.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1260.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1260.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1260.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1260.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1260.herokuapp.com/prepare-business-uk-leaving-eu


[Other finders](https://live-stuff.herokuapp.com/finders)
