### PR TITLE
Fix facet tag removal when cookies disabled

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require support
 //
 //= require live_search
+//= require search-analytics
 //= require taxonomy-select
 //= require_tree ./modules
 //= require_tree ./components

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -111,11 +111,9 @@
   }
 
   LiveSearch.prototype.setRelevantResultCustomDimension = function setRelevantResultCustomDimension () {
-    if (this.canSetCustomDimension()) {
-      var $mostRelevantDocumentLink = $('.js-finder-results').find('.gem-c-document-list__item--highlight')
-      var dimensionValue = $mostRelevantDocumentLink.length ? 'yes' : 'no'
-      GOVUK.analytics.setDimension(83, dimensionValue)
-    }
+    var $mostRelevantDocumentLink = $('.js-finder-results').find('.gem-c-document-list__item--highlight')
+    var dimensionValue = $mostRelevantDocumentLink.length ? 'yes' : 'no'
+    GOVUK.SearchAnalytics.setDimension(83, dimensionValue)
   }
 
   LiveSearch.prototype.trackingInit = function trackingInit () {
@@ -124,10 +122,8 @@
   }
 
   LiveSearch.prototype.trackPageView = function trackPageView () {
-    if (this.canTrackPageview()) {
-      var newPath = window.location.pathname + '?' + $.param(this.state)
-      GOVUK.analytics.trackPageview(newPath)
-    }
+    var newPath = window.location.pathname + '?' + $.param(this.state)
+    GOVUK.SearchAnalytics.trackPageview(newPath)
   }
 
   /**
@@ -165,28 +161,18 @@
   }
 
   LiveSearch.prototype.fireTextAnalyticsEvent = function fireTextAnalyticsEvent (event) {
-    if (this.canTrackPageview()) {
-      var options = {
-        transport: 'beacon',
-        label: $(event.target)[0].value
-      }
-      var category = 'filterClicked'
-      var action = $('label[for="' + event.target.id + '"]')[0].innerText
-
-      GOVUK.analytics.trackEvent(
-        category,
-        action,
-        options
-      )
+    var options = {
+      transport: 'beacon',
+      label: $(event.target)[0].value
     }
-  }
+    var category = 'filterClicked'
+    var action = $('label[for="' + event.target.id + '"]')[0].innerText
 
-  LiveSearch.prototype.canTrackPageview = function canTrackPageview () {
-    return GOVUK.analytics && GOVUK.analytics.trackPageview
-  }
-
-  LiveSearch.prototype.canSetCustomDimension = function canSetCustomDimension () {
-    return GOVUK.analytics && GOVUK.analytics.setDimension
+    GOVUK.SearchAnalytics.trackEvent(
+      category,
+      action,
+      options
+    )
   }
 
   LiveSearch.prototype.cache = function cache (slug, data) {

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -77,13 +77,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var action = filterFacet
       var label = filterValue
 
-      if (GOVUK.hasOwnProperty('analytics')) {
-        GOVUK.analytics.trackEvent(
-          category,
-          action,
-          { label: label }
-        )
-      }
+      GOVUK.SearchAnalytics.trackEvent(
+        category,
+        action,
+        { label: label }
+      )
     }
 
     function decodeEntities (string) {

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -77,11 +77,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var action = filterFacet
       var label = filterValue
 
-      GOVUK.analytics.trackEvent(
-        category,
-        action,
-        { label: label }
-      )
+      if (GOVUK.hasOwnProperty('analytics')) {
+        GOVUK.analytics.trackEvent(
+          category,
+          action,
+          { label: label }
+        )
+      }
     }
 
     function decodeEntities (string) {

--- a/app/assets/javascripts/modules/track-qa-choices.js
+++ b/app/assets/javascripts/modules/track-qa-choices.js
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           eventLabel = $checkedOption.attr('name').replace('[]', '')
           options = { transport: 'beacon', label: eventLabel }
 
-          GOVUK.analytics.trackEvent('QA option chosen', $checkedOption.val(), options)
+          GOVUK.SearchAnalytics.trackEvent('QA option chosen', $checkedOption.val(), options)
         })
       })
     }

--- a/app/assets/javascripts/search-analytics.js
+++ b/app/assets/javascripts/search-analytics.js
@@ -1,0 +1,27 @@
+(function (global, GOVUK) {
+  'use strict'
+
+  window.GOVUK = window.GOVUK || {}
+
+  function canTrack () {
+    return !!GOVUK.analytics
+  }
+
+  // The SearchAnalytics module is a wrapper around GOVUK.analytics
+  GOVUK.SearchAnalytics = {
+    trackEvent: function trackEvent () {
+      if (!canTrack() || !GOVUK.analytics.trackEvent) { return }
+      return GOVUK.analytics.trackEvent.apply(GOVUK, arguments)
+    },
+
+    trackPageview: function trackPageview () {
+      if (!canTrack() || !GOVUK.analytics.trackPageview) { return }
+      return GOVUK.analytics.trackPageview.apply(GOVUK, arguments)
+    },
+
+    setDimension: function setDimension () {
+      if (!canTrack() || !GOVUK.analytics.setDimension) { return }
+      return GOVUK.analytics.setDimension.apply(GOVUK, arguments)
+    }
+  }
+})(window, window.GOVUK)

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -94,7 +94,6 @@ describe('liveSearch', function () {
     $('head').append('<meta name="govuk:base_title" content="All Content - GOV.UK">')
     _supportHistory = GOVUK.support.history
     GOVUK.support.history = function () { return true }
-    GOVUK.analytics = { trackPageview: function () { }, trackEvent: function () { } }
 
     liveSearch = new GOVUK.LiveSearch({ $form: $form, $results: $results, $atomAutodiscoveryLink: $atomAutodiscoveryLink })
   })
@@ -218,8 +217,6 @@ describe('liveSearch', function () {
 
   describe('with relevant DOM nodes set', function () {
     beforeEach(function () {
-      GOVUK.analytics.trackEvent = function () {}
-
       liveSearch.$form = $form
       liveSearch.$resultsBlock = $results
       liveSearch.$countBlock = $count
@@ -249,7 +246,7 @@ describe('liveSearch', function () {
     it('should trigger analytics trackpage when checkbox is changed', function () {
       var promise = jasmine.createSpyObj('promise', ['done'])
       spyOn(liveSearch, 'updateResults').and.returnValue(promise)
-      spyOn(GOVUK.analytics, 'trackPageview')
+      spyOn(GOVUK.SearchAnalytics, 'trackPageview')
       spyOn(liveSearch, 'trackingInit')
 
       liveSearch.state = []
@@ -258,8 +255,8 @@ describe('liveSearch', function () {
       promise.done.calls.mostRecent().args[0]()
 
       expect(liveSearch.trackingInit).toHaveBeenCalled()
-      expect(GOVUK.analytics.trackPageview).toHaveBeenCalled()
-      var trackArgs = GOVUK.analytics.trackPageview.calls.first().args[0]
+      expect(GOVUK.SearchAnalytics.trackPageview).toHaveBeenCalled()
+      var trackArgs = GOVUK.SearchAnalytics.trackPageview.calls.first().args[0]
       expect(trackArgs.split('?')[1], 'field=sheep')
     })
 
@@ -432,7 +429,6 @@ describe('liveSearch', function () {
     }
 
     beforeEach(function () {
-      GOVUK.analytics.trackEvent = function () {}
       liveSearch.$form = $form
       liveSearch.$resultsBlock = $results
       liveSearch.state = { search: 'state' }

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -8,7 +8,6 @@ describe('remove-filter', function () {
   var GOVUK = window.GOVUK
   var timeout = 500
   var removeFilter
-  GOVUK.analytics = GOVUK.analytics || {}
   var $checkbox = $(
     '<div data-module="remove-filter">' +
     '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter Brexit" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-track-label="Brexit" data-name="">✕</button>' +
@@ -72,14 +71,13 @@ describe('remove-filter', function () {
     '</div>'
 
   beforeEach(function () {
-    GOVUK.analytics.trackEvent = function () {}
     $(document.body).append($facets)
     removeFilter = new GOVUK.Modules.RemoveFilter()
-    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(GOVUK.SearchAnalytics, 'trackEvent')
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    GOVUK.SearchAnalytics.trackEvent.calls.reset()
   })
 
   it('deselects a selected checkbox', function (done) {
@@ -180,7 +178,7 @@ describe('remove-filter', function () {
 
       triggerRemoveFilterClick($facetTagOne)
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_one_taxon', {
+      expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_one_taxon', {
         label: 'A level one taxon'
       })
     })
@@ -192,7 +190,7 @@ describe('remove-filter', function () {
       triggerRemoveFilterClick($facetTagOne)
       triggerRemoveFilterClick($facetTagTwo)
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_two_taxon', {
+      expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_two_taxon', {
         label: 'Sub taxon'
       })
     })

--- a/spec/javascripts/modules/track-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-qa-choices.spec.js
@@ -7,11 +7,8 @@ describe('QA choices tracker', function () {
   var tracker
   var $element
 
-  GOVUK.analytics = GOVUK.analytics || {}
-
   beforeEach(function () {
-    GOVUK.analytics.trackEvent = function () {}
-    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(GOVUK.SearchAnalytics, 'trackEvent')
 
     $element = $(
       '<div>' +
@@ -29,7 +26,7 @@ describe('QA choices tracker', function () {
   })
 
   afterEach(function () {
-    GOVUK.analytics.trackEvent.calls.reset()
+    GOVUK.SearchAnalytics.trackEvent.calls.reset()
   })
 
   it('tracks checked checkboxes when clicking submit', function () {
@@ -37,10 +34,10 @@ describe('QA choices tracker', function () {
     $element.find('input[value="construction"]').trigger('click')
     $element.find('form').trigger('submit')
 
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'QA option chosen', 'accommodation', { transport: 'beacon', label: 'sector_business_area' }
     )
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'QA option chosen', 'construction', { transport: 'beacon', label: 'sector_business_area' }
     )
   })
@@ -48,6 +45,6 @@ describe('QA choices tracker', function () {
   it('does not track events when no choice is made', function () {
     $element.find('form').trigger('submit')
 
-    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+    expect(GOVUK.SearchAnalytics.trackEvent).not.toHaveBeenCalled()
   })
 })

--- a/spec/javascripts/search-analytics.spec.js
+++ b/spec/javascripts/search-analytics.spec.js
@@ -1,0 +1,66 @@
+/* eslint-env jasmine, jquery */
+
+describe('SearchAnalytics', function () {
+  'use strict'
+
+  var GOVUK = window.GOVUK || {}
+
+  describe('when GOVUK.analytics is undefined', function () {
+    beforeEach(function () {
+      GOVUK.analytics = undefined
+    })
+
+    describe('trackEvent', function () {
+      it('does not raise an error', function () {
+        expect(GOVUK.SearchAnalytics.trackEvent).not.toThrow()
+      })
+    })
+
+    describe('trackPageview', function () {
+      it('does not raise an error', function () {
+        expect(GOVUK.SearchAnalytics.trackPageview).not.toThrow()
+      })
+    })
+
+    describe('setDimension', function () {
+      it('does not raise an error', function () {
+        expect(GOVUK.SearchAnalytics.setDimension).not.toThrow()
+      })
+    })
+  })
+
+  describe('when GOVUK.analytics is defined', function () {
+    beforeEach(function () {
+      GOVUK.analytics = {
+        trackPageview: function () { },
+        trackEvent: function () { },
+        setDimension: function () {}
+      }
+    })
+
+    describe('trackEvent', function () {
+      it('forwards arguments to GOVUK.analytics', function () {
+        spyOn(GOVUK.analytics, 'trackEvent')
+        GOVUK.SearchAnalytics.trackEvent('category', 'action', {})
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+          'category', 'action', {})
+      })
+    })
+
+    describe('trackPageview', function () {
+      it('forwards arguments to GOVUK.analytics', function () {
+        spyOn(GOVUK.analytics, 'trackPageview')
+        GOVUK.SearchAnalytics.trackPageview('/breakfast')
+        expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith('/breakfast')
+      })
+    })
+
+    describe('setDimension', function () {
+      it('forwards arguments to GOVUK.analytics', function () {
+        spyOn(GOVUK.analytics, 'setDimension')
+        GOVUK.SearchAnalytics.setDimension(83, 'something')
+        expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(83, 'something')
+      })
+    })
+  })
+})


### PR DESCRIPTION
`GOVUK.analytics` can be undefined, so we need to guard against that.

Trello: https://trello.com/c/Ebmxi4AN/871-facet-tag-removal-broken-if-a-certain-cookie-policy-is-chosen

This extracts the tracking stuff into a new module for analytics.

Fixes https://github.com/alphagov/finder-frontend/issues/1261

A global fix is needed, since this isn't the only impacted app, but that'll be done by another team.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1262.herokuapp.com/search/all
- http://finder-frontend-pr-1262.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1262.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1262.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1262.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1262.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1262.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1262.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1262.herokuapp.com/prepare-business-uk-leaving-eu


[Other finders](https://live-stuff.herokuapp.com/finders)
