### PR TITLE
Compact serialized search query

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -67,8 +67,11 @@
   }
 
   LiveSearch.prototype.getSerializeForm = function getSerializeForm () {
-    var uncleanState = this.$form.serializeArray()
-    return uncleanState.filter(function (field) { return field.name !== 'option-select-filter' })
+    var serialized = this.$form.serializeArray()
+    var filtered = serialized.filter(function (field) {
+      return field.value !== '' && field.name !== 'option-select-filter'
+    })
+    return filtered
   }
 
   LiveSearch.prototype.saveState = function saveState (state) {

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -360,7 +360,7 @@ Feature: Filtering documents
     When I view the news and communications finder
     Then I see email and feed sign up links
     And I click button "Person" and select facet Rufus Scrimgeour
-    Then I see email and feed sign up links with filters applied with extra empty filters
+    Then I see email and feed sign up links with filters and order applied
 
   @javascript
   Scenario: Policy papers should have three options

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -83,9 +83,9 @@ And("I see email and feed sign up links with filters applied") do
   expect(page).to have_css('a[href="/search/news-and-communications.atom?people%5B%5D=rufus-scrimgeour"]')
 end
 
-And("I see email and feed sign up links with filters applied with extra empty filters") do
-  expect(page).to have_css('a[href="/search/news-and-communications/email-signup?parent=&keywords=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
-  expect(page).to have_css('a[href="/search/news-and-communications.atom?parent=&keywords=&level_one_taxon=&people%5B%5D=rufus-scrimgeour&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&order=updated-newest"]')
+And("I see email and feed sign up links with filters and order applied") do
+  expect(page).to have_css('a[href="/search/news-and-communications/email-signup?people%5B%5D=rufus-scrimgeour&order=updated-newest"]')
+  expect(page).to have_css('a[href="/search/news-and-communications.atom?people%5B%5D=rufus-scrimgeour&order=updated-newest"]')
 end
 
 When(/^I view a list of news and communications$/) do

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -83,6 +83,7 @@ describe('liveSearch', function () {
                 '<label for="published_at">Published at</label>' +
                 '<input type="text" name="published_at" value="2004" />' +
                 '<input type="text" name="option-select-filter" value="notincluded"/>' +
+                '<input type="text" name="unused_facet"/>' +
                 '<input type="submit" value="Filter results" class="button js-live-search-fallback"/>' +
               '</form>')
     $results = $('<div class="js-live-search-results-block"><div id="js-sort-options">' + sortList + '</div></div>')
@@ -105,9 +106,8 @@ describe('liveSearch', function () {
     GOVUK.support.history = _supportHistory
   })
 
-  it('should save initial state', function () {
+  it('should save initial state (serialized and compacted)', function () {
     expect(liveSearch.state).toEqual([{ name: 'field', value: 'sheep' }, { name: 'published_at', value: '2004' }])
-    expect(liveSearch.state).not.toEqual([{ name: 'field', value: 'sheep' }, { name: 'published_at', value: '2004' }, { name: 'option-select-filter', value: 'notincluded' }])
   })
 
   it('should detect a new state', function () {


### PR DESCRIPTION
This changes JS generated URLs from
`?parent=&keywords=&order=most-viewed`
to
`?order=most-viewed`

This is good for analyses (less junk in GA), and smaller queries are quicker to process. It'll also make nicer URLs.

Trello: https://trello.com/c/ZkT4jdoa/874


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1263.herokuapp.com/search/all
- http://finder-frontend-pr-1263.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1263.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1263.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1263.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1263.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1263.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1263.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1263.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
