### PR TITLE
Remove duplicated production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,6 @@ FinderFrontend::Application.configure do
   config.eager_load = true
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
-  config.public_file_server.enabled = false
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true


### PR DESCRIPTION
This setting is again [overwritten on line 22](https://github.com/alphagov/finder-frontend/pull/1265/files#diff-1d98f0039bbc6df92adee882ed99d993R22).

