### PR TITLE
Allow creation of link based subscriptions

### DIFF
--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -35,7 +35,7 @@ module Registries
           .sort_by { |result| result['title'].sub("Closed organisation: ", "ZZ").upcase }
           .each_with_object({}) { |result, orgs|
             slug = result['slug']
-            orgs[slug] = result.slice('title', 'slug', 'acronym')
+            orgs[slug] = result.slice('title', 'slug', 'acronym', 'content_id')
           }
       end
     end
@@ -43,7 +43,7 @@ module Registries
     def fetch_organisations_from_rummager
       params = {
         filter_format: 'organisation',
-        fields: %w(title slug acronym),
+        fields: %w(title slug acronym content_id),
         count: 1500,
         order: 'title'
       }

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -35,7 +35,7 @@ module Registries
         people.reject { |result| result.dig('value', 'slug').blank? || result.dig('value', 'title').blank? }
           .each_with_object({}) { |result, orgs|
             slug = result['value']['slug']
-            orgs[slug] = result['value'].slice('title', 'slug')
+            orgs[slug] = result['value'].slice('title', 'slug', 'content_id')
           }
       end
     end

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -40,7 +40,8 @@ module Registries
       fetch_locations_from_worldwide_api.map { |result|
         {
           'title' => result['title'],
-          'slug' => result.dig('details', 'slug')
+          'slug' => result.dig('details', 'slug'),
+          'content_id' => result['content_id']
         }
       }
     end

--- a/features/fixtures/cma_cases_content_item.json
+++ b/features/fixtures/cma_cases_content_item.json
@@ -1,0 +1,1071 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/cma-cases",
+  "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+  "document_type": "finder",
+  "first_published_at": "2015-08-17T13:28:37.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-06-26T13:50:02.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder",
+  "title": "Competition and Markets Authority cases",
+  "updated_at": "2019-07-19T12:07:56.916Z",
+  "withdrawn_notice": {
+
+  },
+  "publishing_request_id": "18905-1561557105.059-10.3.3.1-400",
+  "links": {
+    "email_alert_signup": [
+      {
+        "api_path": "/api/content/cma-cases/email-signup",
+        "base_path": "/cma-cases/email-signup",
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "description": "You'll get an email each time a case is updated or a new case is published.",
+        "document_type": "finder_email_signup",
+        "locale": "en",
+        "public_updated_at": "2019-06-26T13:50:02Z",
+        "schema_name": "finder_email_signup",
+        "title": "Competition and Markets Authority cases",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
+        "web_url": "https://www.gov.uk/cma-cases/email-signup"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D550",
+        "api_path": "/api/content/government/organisations/competition-and-markets-authority",
+        "base_path": "/government/organisations/competition-and-markets-authority",
+        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+        "description": "We work to promote competition for the benefit of consumers, both within and outside the UK. We have staff in London, Edinburgh, Belfast and Cardiff. CMA is a non-ministerial department.",
+        "document_type": "organisation",
+        "locale": "en",
+        "schema_name": "organisation",
+        "title": "Competition and Markets Authority",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Competition and <br/>Markets Authority",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/550/CMA_Logo_01.png",
+              "alt_text": "Competition and Markets Authority"
+            }
+          },
+          "brand": "department-for-business-innovation-skills",
+          "default_news_image": null
+        },
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
+      }
+    ],
+    "taxons": [
+      {
+        "api_path": "/api/content/business/competition-competition-act-cartels",
+        "base_path": "/business/competition-competition-act-cartels",
+        "content_id": "900ee60d-32ed-4dba-9834-09f54de01d5d",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2018-09-03T15:41:04Z",
+        "schema_name": "taxon",
+        "title": "Competition Act and cartels",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "Competition Act and cartels [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "api_path": "/api/content/business/competition",
+              "base_path": "/business/competition",
+              "content_id": "8db04387-9076-4287-ab46-6a6695b593d7",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2018-09-03T15:41:04Z",
+              "schema_name": "taxon",
+              "title": "Competition",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "Competition [T]",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "api_path": "/api/content/business-and-industry/business-regulation",
+                    "base_path": "/business-and-industry/business-regulation",
+                    "content_id": "33bc0eed-62c7-4b0b-9a93-626c9e10c025",
+                    "document_type": "taxon",
+                    "locale": "en",
+                    "public_updated_at": "2018-09-03T15:41:03Z",
+                    "schema_name": "taxon",
+                    "title": "Business regulation",
+                    "withdrawn": false,
+                    "details": {
+                      "internal_name": "Business regulation [P]",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "api_path": "/api/content/business-and-industry",
+                          "base_path": "/business-and-industry",
+                          "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+                          "description": "",
+                          "document_type": "taxon",
+                          "locale": "en",
+                          "public_updated_at": "2018-09-03T15:41:02Z",
+                          "schema_name": "taxon",
+                          "title": "Business and industry",
+                          "withdrawn": false,
+                          "details": {
+                            "internal_name": "Business and industry",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "description": "",
+                                "document_type": "homepage",
+                                "locale": "en",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "title": "GOV.UK homepage",
+                                "withdrawn": false,
+                                "links": {
+
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/business-and-industry",
+                          "web_url": "https://www.gov.uk/business-and-industry"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/business-and-industry/business-regulation",
+                    "web_url": "https://www.gov.uk/business-and-industry/business-regulation"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/business/competition",
+              "web_url": "https://www.gov.uk/business/competition"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/business/competition-competition-act-cartels",
+        "web_url": "https://www.gov.uk/business/competition-competition-act-cartels"
+      },
+      {
+        "api_path": "/api/content/business/competition-mergers",
+        "base_path": "/business/competition-mergers",
+        "content_id": "a3773f5e-f05e-48b0-b79a-46374dabbc30",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2018-09-03T15:41:04Z",
+        "schema_name": "taxon",
+        "title": "Mergers",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "Mergers [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "api_path": "/api/content/business/competition",
+              "base_path": "/business/competition",
+              "content_id": "8db04387-9076-4287-ab46-6a6695b593d7",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2018-09-03T15:41:04Z",
+              "schema_name": "taxon",
+              "title": "Competition",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "Competition [T]",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "api_path": "/api/content/business-and-industry/business-regulation",
+                    "base_path": "/business-and-industry/business-regulation",
+                    "content_id": "33bc0eed-62c7-4b0b-9a93-626c9e10c025",
+                    "document_type": "taxon",
+                    "locale": "en",
+                    "public_updated_at": "2018-09-03T15:41:03Z",
+                    "schema_name": "taxon",
+                    "title": "Business regulation",
+                    "withdrawn": false,
+                    "details": {
+                      "internal_name": "Business regulation [P]",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "api_path": "/api/content/business-and-industry",
+                          "base_path": "/business-and-industry",
+                          "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+                          "description": "",
+                          "document_type": "taxon",
+                          "locale": "en",
+                          "public_updated_at": "2018-09-03T15:41:02Z",
+                          "schema_name": "taxon",
+                          "title": "Business and industry",
+                          "withdrawn": false,
+                          "details": {
+                            "internal_name": "Business and industry",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "description": "",
+                                "document_type": "homepage",
+                                "locale": "en",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "title": "GOV.UK homepage",
+                                "withdrawn": false,
+                                "links": {
+
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/business-and-industry",
+                          "web_url": "https://www.gov.uk/business-and-industry"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/business-and-industry/business-regulation",
+                    "web_url": "https://www.gov.uk/business-and-industry/business-regulation"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/business/competition",
+              "web_url": "https://www.gov.uk/business/competition"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/business/competition-mergers",
+        "web_url": "https://www.gov.uk/business/competition-mergers"
+      },
+      {
+        "api_path": "/api/content/business/competition-markets",
+        "base_path": "/business/competition-markets",
+        "content_id": "fe8630e2-cc33-4b72-a180-d1875e860b58",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2018-09-03T15:41:04Z",
+        "schema_name": "taxon",
+        "title": "Markets",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "Markets [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "api_path": "/api/content/business/competition",
+              "base_path": "/business/competition",
+              "content_id": "8db04387-9076-4287-ab46-6a6695b593d7",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2018-09-03T15:41:04Z",
+              "schema_name": "taxon",
+              "title": "Competition",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "Competition [T]",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "api_path": "/api/content/business-and-industry/business-regulation",
+                    "base_path": "/business-and-industry/business-regulation",
+                    "content_id": "33bc0eed-62c7-4b0b-9a93-626c9e10c025",
+                    "document_type": "taxon",
+                    "locale": "en",
+                    "public_updated_at": "2018-09-03T15:41:03Z",
+                    "schema_name": "taxon",
+                    "title": "Business regulation",
+                    "withdrawn": false,
+                    "details": {
+                      "internal_name": "Business regulation [P]",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "api_path": "/api/content/business-and-industry",
+                          "base_path": "/business-and-industry",
+                          "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+                          "description": "",
+                          "document_type": "taxon",
+                          "locale": "en",
+                          "public_updated_at": "2018-09-03T15:41:02Z",
+                          "schema_name": "taxon",
+                          "title": "Business and industry",
+                          "withdrawn": false,
+                          "details": {
+                            "internal_name": "Business and industry",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "description": "",
+                                "document_type": "homepage",
+                                "locale": "en",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "title": "GOV.UK homepage",
+                                "withdrawn": false,
+                                "links": {
+
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/business-and-industry",
+                          "web_url": "https://www.gov.uk/business-and-industry"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/business-and-industry/business-regulation",
+                    "web_url": "https://www.gov.uk/business-and-industry/business-regulation"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/business/competition",
+              "web_url": "https://www.gov.uk/business/competition"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/business/competition-markets",
+        "web_url": "https://www.gov.uk/business/competition-markets"
+      },
+      {
+        "api_path": "/api/content/business/competition-regulatory-appeals-references",
+        "base_path": "/business/competition-regulatory-appeals-references",
+        "content_id": "8d110d4f-4c9b-424a-8c75-de0a15bbeaac",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2018-09-03T15:41:04Z",
+        "schema_name": "taxon",
+        "title": "Regulatory appeals and references",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "Regulatory appeals and references [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "api_path": "/api/content/business/competition",
+              "base_path": "/business/competition",
+              "content_id": "8db04387-9076-4287-ab46-6a6695b593d7",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2018-09-03T15:41:04Z",
+              "schema_name": "taxon",
+              "title": "Competition",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "Competition [T]",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "api_path": "/api/content/business-and-industry/business-regulation",
+                    "base_path": "/business-and-industry/business-regulation",
+                    "content_id": "33bc0eed-62c7-4b0b-9a93-626c9e10c025",
+                    "document_type": "taxon",
+                    "locale": "en",
+                    "public_updated_at": "2018-09-03T15:41:03Z",
+                    "schema_name": "taxon",
+                    "title": "Business regulation",
+                    "withdrawn": false,
+                    "details": {
+                      "internal_name": "Business regulation [P]",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "api_path": "/api/content/business-and-industry",
+                          "base_path": "/business-and-industry",
+                          "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+                          "description": "",
+                          "document_type": "taxon",
+                          "locale": "en",
+                          "public_updated_at": "2018-09-03T15:41:02Z",
+                          "schema_name": "taxon",
+                          "title": "Business and industry",
+                          "withdrawn": false,
+                          "details": {
+                            "internal_name": "Business and industry",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "description": "",
+                                "document_type": "homepage",
+                                "locale": "en",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "title": "GOV.UK homepage",
+                                "withdrawn": false,
+                                "links": {
+
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/business-and-industry",
+                          "web_url": "https://www.gov.uk/business-and-industry"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/business-and-industry/business-regulation",
+                    "web_url": "https://www.gov.uk/business-and-industry/business-regulation"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/business/competition",
+              "web_url": "https://www.gov.uk/business/competition"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/business/competition-regulatory-appeals-references",
+        "web_url": "https://www.gov.uk/business/competition-regulatory-appeals-references"
+      },
+      {
+        "api_path": "/api/content/business/competition-consumer-protection",
+        "base_path": "/business/competition-consumer-protection",
+        "content_id": "8c19f8a6-35c0-4e00-98fd-870fe219affd",
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2018-09-03T15:41:04Z",
+        "schema_name": "taxon",
+        "title": "Consumer protection",
+        "withdrawn": false,
+        "details": {
+          "internal_name": "Consumer protection [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "api_path": "/api/content/business/competition",
+              "base_path": "/business/competition",
+              "content_id": "8db04387-9076-4287-ab46-6a6695b593d7",
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2018-09-03T15:41:04Z",
+              "schema_name": "taxon",
+              "title": "Competition",
+              "withdrawn": false,
+              "details": {
+                "internal_name": "Competition [T]",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "api_path": "/api/content/business-and-industry/business-regulation",
+                    "base_path": "/business-and-industry/business-regulation",
+                    "content_id": "33bc0eed-62c7-4b0b-9a93-626c9e10c025",
+                    "document_type": "taxon",
+                    "locale": "en",
+                    "public_updated_at": "2018-09-03T15:41:03Z",
+                    "schema_name": "taxon",
+                    "title": "Business regulation",
+                    "withdrawn": false,
+                    "details": {
+                      "internal_name": "Business regulation [P]",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "api_path": "/api/content/business-and-industry",
+                          "base_path": "/business-and-industry",
+                          "content_id": "495afdb6-47be-4df1-8b38-91c8adb1eefc",
+                          "description": "",
+                          "document_type": "taxon",
+                          "locale": "en",
+                          "public_updated_at": "2018-09-03T15:41:02Z",
+                          "schema_name": "taxon",
+                          "title": "Business and industry",
+                          "withdrawn": false,
+                          "details": {
+                            "internal_name": "Business and industry",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "description": "",
+                                "document_type": "homepage",
+                                "locale": "en",
+                                "public_updated_at": "2019-06-21T11:52:37Z",
+                                "schema_name": "homepage",
+                                "title": "GOV.UK homepage",
+                                "withdrawn": false,
+                                "links": {
+
+                                },
+                                "api_url": "https://www.gov.uk/api/content/",
+                                "web_url": "https://www.gov.uk/"
+                              }
+                            ]
+                          },
+                          "api_url": "https://www.gov.uk/api/content/business-and-industry",
+                          "web_url": "https://www.gov.uk/business-and-industry"
+                        }
+                      ]
+                    },
+                    "api_url": "https://www.gov.uk/api/content/business-and-industry/business-regulation",
+                    "web_url": "https://www.gov.uk/business-and-industry/business-regulation"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/business/competition",
+              "web_url": "https://www.gov.uk/business/competition"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/business/competition-consumer-protection",
+        "web_url": "https://www.gov.uk/business/competition-consumer-protection"
+      }
+    ],
+    "topics": [
+      {
+        "api_path": "/api/content/topic/competition/markets",
+        "base_path": "/topic/competition/markets",
+        "content_id": "1433d403-333f-4d81-b83a-c5358412fd1b",
+        "description": "List of information about Markets.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2019-07-08T16:01:52Z",
+        "schema_name": "topic",
+        "title": "Markets",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/topic/competition/markets",
+        "web_url": "https://www.gov.uk/topic/competition/markets"
+      },
+      {
+        "api_path": "/api/content/topic/competition/regulatory-appeals-references",
+        "base_path": "/topic/competition/regulatory-appeals-references",
+        "content_id": "fd11e3b0-76bc-4197-b652-a030b57915be",
+        "description": "List of information about Regulatory appeals and references.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2019-07-08T16:02:50Z",
+        "schema_name": "topic",
+        "title": "Regulatory appeals and references",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/topic/competition/regulatory-appeals-references",
+        "web_url": "https://www.gov.uk/topic/competition/regulatory-appeals-references"
+      },
+      {
+        "api_path": "/api/content/topic/competition/consumer-protection",
+        "base_path": "/topic/competition/consumer-protection",
+        "content_id": "65a89136-2117-41aa-ba96-35feb9d821f5",
+        "description": "List of information about Consumer protection.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2019-07-08T15:06:20Z",
+        "schema_name": "topic",
+        "title": "Consumer protection",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/topic/competition/consumer-protection",
+        "web_url": "https://www.gov.uk/topic/competition/consumer-protection"
+      },
+      {
+        "api_path": "/api/content/topic/competition/mergers",
+        "base_path": "/topic/competition/mergers",
+        "content_id": "7aa3ec0c-683e-44ba-aa3f-cc9655651b9b",
+        "description": "List of information about Mergers.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2019-07-08T16:01:58Z",
+        "schema_name": "topic",
+        "title": "Mergers",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/topic/competition/mergers",
+        "web_url": "https://www.gov.uk/topic/competition/mergers"
+      },
+      {
+        "api_path": "/api/content/topic/competition/competition-act-cartels",
+        "base_path": "/topic/competition/competition-act-cartels",
+        "content_id": "4a6f14ad-baa1-4b15-8026-8282913ef693",
+        "description": "List of information about competition law and cartels.",
+        "document_type": "topic",
+        "locale": "en",
+        "public_updated_at": "2019-07-05T14:39:27Z",
+        "schema_name": "topic",
+        "title": "Competition law and cartels",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/topic/competition/competition-act-cartels",
+        "web_url": "https://www.gov.uk/topic/competition/competition-act-cartels"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Competition and Markets Authority cases",
+        "public_updated_at": "2019-06-26T13:50:02Z",
+        "document_type": "finder",
+        "schema_name": "finder",
+        "base_path": "/cma-cases",
+        "description": "Find reports and updates on current and historical CMA investigations",
+        "api_path": "/api/content/cma-cases",
+        "withdrawn": false,
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
+        "web_url": "https://www.gov.uk/cma-cases",
+        "links": {
+
+        }
+      }
+    ]
+  },
+  "description": "Find reports and updates on current and historical CMA investigations",
+  "details": {
+    "document_noun": "case",
+    "filter": {
+      "document_type": "cma_case"
+    },
+    "format_name": "Competition and Markets Authority case",
+    "show_summaries": false,
+    "facets": [
+      {
+        "key": "case_type",
+        "name": "Case type",
+        "type": "text",
+        "preposition": "of type",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "CA98 and civil cartels",
+            "value": "ca98-and-civil-cartels"
+          },
+          {
+            "label": "Competition disqualification",
+            "value": "competition-disqualification"
+          },
+          {
+            "label": "Criminal cartels",
+            "value": "criminal-cartels"
+          },
+          {
+            "label": "Markets",
+            "value": "markets"
+          },
+          {
+            "label": "Mergers",
+            "value": "mergers"
+          },
+          {
+            "label": "Consumer enforcement",
+            "value": "consumer-enforcement"
+          },
+          {
+            "label": "Regulatory references and appeals",
+            "value": "regulatory-references-and-appeals"
+          },
+          {
+            "label": "Reviews of orders and undertakings",
+            "value": "review-of-orders-and-undertakings"
+          }
+        ]
+      },
+      {
+        "key": "case_state",
+        "name": "Case state",
+        "type": "text",
+        "preposition": "which are",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Open",
+            "value": "open"
+          },
+          {
+            "label": "Closed",
+            "value": "closed"
+          }
+        ]
+      },
+      {
+        "key": "market_sector",
+        "name": "Market sector",
+        "type": "text",
+        "preposition": "about",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "Aerospace",
+            "value": "aerospace"
+          },
+          {
+            "label": "Agriculture, environment and natural resources",
+            "value": "agriculture-environment-and-natural-resources"
+          },
+          {
+            "label": "Building and construction",
+            "value": "building-and-construction"
+          },
+          {
+            "label": "Chemicals",
+            "value": "chemicals"
+          },
+          {
+            "label": "Clothing, footwear and fashion",
+            "value": "clothing-footwear-and-fashion"
+          },
+          {
+            "label": "Communications",
+            "value": "communications"
+          },
+          {
+            "label": "Defence",
+            "value": "defence"
+          },
+          {
+            "label": "Distribution and service industries",
+            "value": "distribution-and-service-industries"
+          },
+          {
+            "label": "Electronics",
+            "value": "electronics-industry"
+          },
+          {
+            "label": "Energy",
+            "value": "energy"
+          },
+          {
+            "label": "Engineering",
+            "value": "engineering"
+          },
+          {
+            "label": "Financial services",
+            "value": "financial-services"
+          },
+          {
+            "label": "Fire, police and security",
+            "value": "fire-police-and-security"
+          },
+          {
+            "label": "Food manufacturing",
+            "value": "food-manufacturing"
+          },
+          {
+            "label": "Giftware, jewellery and tableware",
+            "value": "giftware-jewellery-and-tableware"
+          },
+          {
+            "label": "Healthcare and medical equipment",
+            "value": "healthcare-and-medical-equipment"
+          },
+          {
+            "label": "Household goods, furniture and furnishings",
+            "value": "household-goods-furniture-and-furnishings"
+          },
+          {
+            "label": "Mineral extraction, mining and quarrying",
+            "value": "mineral-extraction-mining-and-quarrying"
+          },
+          {
+            "label": "Motor industry",
+            "value": "motor-industry"
+          },
+          {
+            "label": "Oil and gas refining and petrochemicals",
+            "value": "oil-and-gas-refining-and-petrochemicals"
+          },
+          {
+            "label": "Paper printing and packaging",
+            "value": "paper-printing-and-packaging"
+          },
+          {
+            "label": "Pharmaceuticals",
+            "value": "pharmaceuticals"
+          },
+          {
+            "label": "Public markets",
+            "value": "public-markets"
+          },
+          {
+            "label": "Recreation and leisure",
+            "value": "recreation-and-leisure"
+          },
+          {
+            "label": "Retail and wholesale",
+            "value": "retail-and-wholesale"
+          },
+          {
+            "label": "Telecommunications",
+            "value": "telecommunications"
+          },
+          {
+            "label": "Textiles",
+            "value": "textiles"
+          },
+          {
+            "label": "Transport",
+            "value": "transport"
+          },
+          {
+            "label": "Utilities",
+            "value": "utilities"
+          }
+        ]
+      },
+      {
+        "key": "outcome_type",
+        "name": "Outcome",
+        "type": "text",
+        "preposition": "with outcome",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "allowed_values": [
+          {
+            "label": "CA98 - no grounds for action",
+            "value": "ca98-no-grounds-for-action-non-infringement"
+          },
+          {
+            "label": "CA98 - infringement Chapter I",
+            "value": "ca98-infringement-chapter-i"
+          },
+          {
+            "label": "CA98 - infringement Chapter II",
+            "value": "ca98-infringement-chapter-ii"
+          },
+          {
+            "label": "CA98 - administrative priorities",
+            "value": "ca98-administrative-priorities"
+          },
+          {
+            "label": "CA98 - commitments",
+            "value": "ca98-commitment"
+          },
+          {
+            "label": "Competition disqualification - order granted",
+            "value": "competition-disqualification-order-granted"
+          },
+          {
+            "label": "Competition disqualification - undertaking given",
+            "value": "competition-disqualification-undertaking-given"
+          },
+          {
+            "label": "Competition disqualification - no order granted or undertaking given",
+            "value": "competition-disqualification-no-order-granted-or-undertaking-given"
+          },
+          {
+            "label": "Criminal cartels - verdict",
+            "value": "criminal-cartels-verdict"
+          },
+          {
+            "label": "Markets - phase 1 no enforcement action",
+            "value": "markets-phase-1-no-enforcement-action"
+          },
+          {
+            "label": "Markets - phase 1 undertakings in lieu of reference",
+            "value": "markets-phase-1-undertakings-in-lieu-of-reference"
+          },
+          {
+            "label": "Markets - phase 1 referral",
+            "value": "markets-phase-1-referral"
+          },
+          {
+            "label": "Mergers - phase 1 clearance",
+            "value": "mergers-phase-1-clearance"
+          },
+          {
+            "label": "Mergers - phase 1 clearance with undertakings in lieu",
+            "value": "mergers-phase-1-clearance-with-undertakings-in-lieu"
+          },
+          {
+            "label": "Mergers - phase 1 referral",
+            "value": "mergers-phase-1-referral"
+          },
+          {
+            "label": "Mergers - phase 1 found not to qualify",
+            "value": "mergers-phase-1-found-not-to-qualify"
+          },
+          {
+            "label": "Mergers - phase 1 public interest intervention",
+            "value": "mergers-phase-1-public-interest-interventions"
+          },
+          {
+            "label": "Markets - phase 2 clearance - no adverse effect on competition",
+            "value": "markets-phase-2-clearance-no-adverse-effect-on-competition"
+          },
+          {
+            "label": "Markets - phase 2 adverse effect on competition leading to remedies",
+            "value": "markets-phase-2-adverse-effect-on-competition-leading-to-remedies"
+          },
+          {
+            "label": "Markets - phase 2 decision to dispense with procedural obligations",
+            "value": "markets-phase-2-decision-to-dispense-with-procedural-obligations"
+          },
+          {
+            "label": "Mergers - phase 2 clearance",
+            "value": "mergers-phase-2-clearance"
+          },
+          {
+            "label": "Mergers - phase 2 clearance with remedies",
+            "value": "mergers-phase-2-clearance-with-remedies"
+          },
+          {
+            "label": "Mergers - phase 2 prohibition",
+            "value": "mergers-phase-2-prohibition"
+          },
+          {
+            "label": "Mergers - phase 2 cancellation",
+            "value": "mergers-phase-2-cancellation"
+          },
+          {
+            "label": "Consumer enforcement - no formal action",
+            "value": "consumer-enforcement-no-action"
+          },
+          {
+            "label": "Consumer enforcement - court order",
+            "value": "consumer-enforcement-court-order"
+          },
+          {
+            "label": "Consumer enforcement - undertakings",
+            "value": "consumer-enforcement-undertakings"
+          },
+          {
+            "label": "Consumer enforcement - changes to business practices agreed",
+            "value": "consumer-enforcement-changes-to-business-practices-agreed"
+          },
+          {
+            "label": "Regulatory references and appeals - final determination",
+            "value": "regulatory-references-and-appeals-final-determination"
+          }
+        ]
+      },
+      {
+        "key": "opened_date",
+        "name": "Opened",
+        "short_name": "Opened",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": false
+      },
+      {
+        "key": "closed_date",
+        "name": "Closed",
+        "short_name": "Closed",
+        "type": "date",
+        "preposition": "closed",
+        "display_as_result_metadata": true,
+        "filterable": true
+      }
+    ],
+    "default_documents_per_page": 50
+  }
+}

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -1,10 +1,96 @@
 {
+  "analytics_identifier": null,
   "base_path": "/cma-cases/email-signup",
   "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
   "document_type": "finder_email_signup",
+  "first_published_at": "2015-08-17T13:28:37.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-06-26T13:50:02.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
   "title": "Competition and Markets Authority cases",
+  "updated_at": "2019-07-19T11:59:45.822Z",
+  "withdrawn_notice": {
+
+  },
+  "publishing_request_id": "18907-1561557105.583-10.3.3.1-400",
+  "links": {
+    "organisations": [
+      {
+        "analytics_identifier": "D550",
+        "api_path": "/api/content/government/organisations/competition-and-markets-authority",
+        "base_path": "/government/organisations/competition-and-markets-authority",
+        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+        "description": "We work to promote competition for the benefit of consumers, both within and outside the UK. We have staff in London, Edinburgh, Belfast and Cardiff. CMA is a non-ministerial department.",
+        "document_type": "organisation",
+        "locale": "en",
+        "schema_name": "organisation",
+        "title": "Competition and Markets Authority",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "formatted_title": "Competition and <br/>Markets Authority",
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/550/CMA_Logo_01.png",
+              "alt_text": "Competition and Markets Authority"
+            }
+          },
+          "brand": "department-for-business-innovation-skills",
+          "default_news_image": null
+        },
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+        "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
+      }
+    ],
+    "related": [
+      {
+        "api_path": "/api/content/cma-cases",
+        "base_path": "/cma-cases",
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "description": "Find reports and updates on current and historical CMA investigations",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2019-06-26T13:50:02Z",
+        "schema_name": "finder",
+        "title": "Competition and Markets Authority cases",
+        "withdrawn": false,
+        "links": {
+
+        },
+        "api_url": "https://www.gov.uk/api/content/cma-cases",
+        "web_url": "https://www.gov.uk/cma-cases"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Competition and Markets Authority cases",
+        "public_updated_at": "2019-06-26T13:50:02Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/cma-cases/email-signup",
+        "description": "You'll get an email each time a case is updated or a new case is published.",
+        "api_path": "/api/content/cma-cases/email-signup",
+        "withdrawn": false,
+        "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
+        "web_url": "https://www.gov.uk/cma-cases/email-signup",
+        "links": {
+
+        }
+      }
+    ]
+  },
   "description": "You'll get an email each time a case is updated or a new case is published.",
   "details": {
+    "beta": false,
     "email_signup_choice": [
       {
         "key": "ca98-and-civil-cartels",
@@ -16,6 +102,42 @@
         "key": "competition-disqualification",
         "radio_button_name": "Competition disqualification",
         "topic_name": "competition disqualification",
+        "prechecked": false
+      },
+      {
+        "key": "criminal-cartels",
+        "radio_button_name": "Criminal cartels",
+        "topic_name": "criminal cartels",
+        "prechecked": false
+      },
+      {
+        "key": "markets",
+        "radio_button_name": "Markets",
+        "topic_name": "markets",
+        "prechecked": false
+      },
+      {
+        "key": "mergers",
+        "radio_button_name": "Mergers",
+        "topic_name": "mergers",
+        "prechecked": false
+      },
+      {
+        "key": "consumer-enforcement",
+        "radio_button_name": "Consumer enforcement",
+        "topic_name": "consumer enforcement",
+        "prechecked": false
+      },
+      {
+        "key": "regulatory-references-and-appeals",
+        "radio_button_name": "Regulatory references and appeals",
+        "topic_name": "regulatory references and appeals",
+        "prechecked": false
+      },
+      {
+        "key": "review-of-orders-and-undertakings",
+        "radio_button_name": "Reviews of orders and undertakings",
+        "topic_name": "reviews of orders and undertakings",
         "prechecked": false
       }
     ],

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1368,7 +1368,8 @@ module DocumentHelper
           "organisations": {
             "id": "https://www.gov.uk/api/world-locations/azkaban/organisations",
             "web_url": "https://www.gov.uk/world/azkaban#organisations"
-          }
+          },
+          "content_id": "azkaban-id"
         },
         {
           "id": "https://www.gov.uk/api/world-locations/tracy-island",
@@ -1384,7 +1385,8 @@ module DocumentHelper
           "organisations": {
             "id": "https://www.gov.uk/api/world-locations/tracy-island/organisations",
             "web_url": "https://www.gov.uk/world/tracy-island#organisations"
-          }
+          },
+          "content_id": "tracy-island-id"
         }
       ],
       "current_page": 1,

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -36,14 +36,49 @@ private
 
   def subscriber_list_options
     options = { "title" => subscriber_list_title }
-    if facet_groups?
+    if facet_groups? #business readiness legacy
       options["links"] = facet_groups
-    elsif facet_values?
+    elsif facet_values? #business readiness
       options["links"] = facet_values
+    elsif link_based_subscriber_list?
+      options["links"] = links
     else
       options["tags"] = tags
     end
     options
+  end
+
+  def link_based_subscriber_list?
+    content_types = %w[organisations people world_locations part_of_taxonomy_tree]
+    keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, '') }
+    (keys & content_types).present?
+  end
+
+  def links
+    selected_keys = applied_filters.keys.map(&:to_s) & facet_filter_keys
+    selected_keys.each_with_object({}) do |full_key, result|
+      operator, key = split_key(full_key)
+      values = applied_filters[full_key.to_sym]
+      result[key] ||= {}
+      result[key][operator] = to_content_ids(key, values)
+    end
+  end
+
+  def split_key(full_key)
+    matches = full_key.match(/^((?<operator>any|all)_)?(?<key>.*)$/)
+    operator = matches[:operator] || 'any'
+    [operator, matches[:key]]
+  end
+
+  def to_content_ids(key, values)
+    return values if key == 'part_of_taxonomy_tree'
+
+    registry = Registries::BaseRegistries.new.all[key]
+    values.map { |value| registry[value]['content_id'] }
+  end
+
+  def facet_filter_keys
+    @facet_filter_keys ||= facets.map { |f| f['filter_key'] || f['facet_id'] }
   end
 
   def facet_groups?

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -56,12 +56,17 @@ private
 
   def links
     selected_keys = applied_filters.keys.map(&:to_s) & facet_filter_keys
-    selected_keys.each_with_object({}) do |full_key, result|
+    filter_links = selected_keys.each_with_object({}) do |full_key, result|
       operator, key = split_key(full_key)
       values = applied_filters[full_key.to_sym]
       result[key] ||= {}
       result[key][operator] = to_content_ids(key, values)
     end
+    filter_links.merge(default_links)
+  end
+
+  def default_links
+    default_filters.transform_values { |value| { any: value } }
   end
 
   def split_key(full_key)

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -72,11 +72,12 @@ private
   def split_key(full_key)
     matches = full_key.match(/^((?<operator>any|all)_)?(?<key>.*)$/)
     operator = matches[:operator] || 'any'
-    [operator, matches[:key]]
+    key = matches[:key] == 'part_of_taxonomy_tree' ? 'taxon_tree' : matches[:key]
+    [operator, key]
   end
 
   def to_content_ids(key, values)
-    return values if key == 'part_of_taxonomy_tree'
+    return values if key == 'taxon_tree'
 
     registry = Registries::BaseRegistries.new.all[key]
     values.map { |value| registry[value]['content_id'] }

--- a/spec/helpers/registry_spec_helper.rb
+++ b/spec/helpers/registry_spec_helper.rb
@@ -14,35 +14,41 @@ module RegistrySpecHelper
                             value: {
                                 title: "Albus Dumbledore",
                                 slug: "albus-dumbledore",
-                                _id: "a field that we're not using"
+                                _id: "a field that we're not using",
+                                content_id: "content_id_for_albus-dumbledore"
                             }
                         },
                         {
                             value: {
                                 title: "Cornelius Fudge",
                                 slug: "cornelius-fudge",
-                                _id: "a field that we're not using"
+                                _id: "a field that we're not using",
+                                content_id: "content_id_for_cornelius-fudge"
+
                             }
                         },
                         {
                             value: {
                                 title: "Harry Potter",
                                 slug: "harry-potter",
-                                _id: "a field that we're not using"
+                                _id: "a field that we're not using",
+                                content_id: "content_id_for_harry-potter"
                             }
                         },
                         {
                             value: {
                                 title: "Ron Weasley",
                                 slug: "ron-weasley",
-                                _id: "a field that we're not using"
+                                _id: "a field that we're not using",
+                                content_id: "content_id_for_ron-weasley"
                             }
                         },
                         {
                             value: {
                                 title: "Rufus Scrimgeour",
                                 slug: "rufus-scrimgeour",
-                                _id: "/government/people/rufus-scrimgeour"
+                                _id: "/government/people/rufus-scrimgeour",
+                                content_id: "content_id_for_rufus-scrimgeour"
                             }
                         }
                     ]
@@ -55,7 +61,7 @@ module RegistrySpecHelper
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {
       count: 1500,
-      fields: %w(slug title acronym),
+      fields: %w(slug title acronym content_id),
       filter_format: %(organisation),
       order: 'title'
     })
@@ -63,24 +69,28 @@ module RegistrySpecHelper
       {
         "title": "Closed organisation: Death Eaters",
         "slug": "death-eaters",
-        "_id": "/government/organisations/death-eaters"
+        "_id": "/government/organisations/death-eaters",
+        "content_id": "content_id_for_death-eaters"
       },
       {
         "title": "Department of Mysteries",
         "slug": "department-of-mysteries",
-        "_id": "/government/organisations/department-of-mysteries"
+        "_id": "/government/organisations/department-of-mysteries",
+        "content_id": "content_id_for_department-of-mysteries"
       },
       {
         "title": "Gringots",
         "acronym": "GRI",
         "slug": "gringots",
-        "_id": "/government/organisations/gringots"
+        "_id": "/government/organisations/gringots",
+        "content_id": "content_id_for_gringots"
       },
       {
         "title": "Ministry of Magic",
         "slug": "ministry-of-magic",
         "acronym": "MOM",
-        "_id": "a field that we're not using"
+        "_id": "a field that we're not using",
+        "content_id": "content_id_for_ministry-of-magic"
       }
     ] }.to_json)
   end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -425,6 +425,11 @@ describe EmailAlertSignupAPI do
 
   context "Create link based subscriber lists" do
     let(:subscription_url) { "http://gov.uk/email/news-and-comms-subscription" }
+    let(:default_filters) {
+      {
+        "content_purpose_subgroup": %w[news speeches_and_statements]
+      }
+    }
     describe 'organisation facet' do
       let(:applied_filters) do
         { "organisations" => %w(death-eaters ministry-of-magic) }
@@ -444,6 +449,7 @@ describe EmailAlertSignupAPI do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             organisations: { any: %w(content_id_for_death-eaters content_id_for_ministry-of-magic) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] }
           },
           "subscription_url" => subscription_url
         )
@@ -490,6 +496,7 @@ describe EmailAlertSignupAPI do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             world_locations: { any: %w(location_id_1 location_id_2) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] }
           },
           "subscription_url" => subscription_url
         )
@@ -517,6 +524,7 @@ describe EmailAlertSignupAPI do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             people: { any: %w(content_id_for_albus-dumbledore content_id_for_ron-weasley) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] }
           },
           "subscription_url" => subscription_url
         )

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -430,6 +430,30 @@ describe EmailAlertSignupAPI do
         "content_purpose_subgroup": %w[news speeches_and_statements]
       }
     }
+    describe 'part_of_taxonomy_tree facet' do
+      let(:applied_filters) do
+        { "all_part_of_taxonomy_tree" => %w(content_id_1 content_id_2) }
+      end
+      let(:facets) do
+        [
+          {
+            "facet_id" => "all_part_of_taxonomy_tree",
+            "facet_name" => "Taxon"
+          }
+        ]
+      end
+      it 'translates all_part_of_taxonomy_tree to taxon_tree and does not convert values' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            taxon_tree: { all: %w(content_id_1 content_id_2) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+        assert_requested(req)
+      end
+    end
     describe 'organisation facet' do
       let(:applied_filters) do
         { "organisations" => %w(death-eaters ministry-of-magic) }

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Registries::OrganisationsRegistry do
   let(:rummager_params) {
     {
       "count" => 1500,
-      "fields" => %w(slug title acronym),
+      "fields" => %w(slug title acronym content_id),
       "filter_format" => "organisation",
-      "order" => 'title'
+      "order" => 'title',
     }
   }
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -26,7 +26,8 @@ RSpec.describe Registries::OrganisationsRegistry do
       expect(organisation).to eq(
         'title' => 'Ministry of Magic',
         'acronym' => 'MOM',
-        'slug' => slug
+        'slug' => slug,
+        'content_id' => 'content_id_for_ministry-of-magic'
       )
     end
 
@@ -57,26 +58,5 @@ RSpec.describe Registries::OrganisationsRegistry do
 
   def clear_cache
     Rails.cache.delete(described_class.new.cache_key)
-  end
-
-  def rummager_results
-    %|{
-      "results": [
-        {
-          "title": "Attorney General's Office",
-          "slug": "attorney-generals-office",
-          "_id": "/government/organisations/companies-house"
-        },
-        {
-          "title": "Ministry of Magic",
-          "slug": "ministry-of-magic",
-          "_id": "a field that we're not using"
-        }
-      ],
-      "total": 2,
-      "start": 0,
-      "aggregates": {},
-      "suggested_queries": []
-    }|
   end
 end

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Registries::WorldLocationsRegistry do
       fetched_document = registry[slug]
       expect(fetched_document).to eq(
         'title' => 'Privet Drive',
-        'slug' => slug
+        'slug' => slug,
+        'content_id' => 'content_id_for_privet-drive'
       )
     end
 

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -23,6 +23,10 @@ module FixturesHelper
     JSON.parse(File.read(fixtures_path + "/cma_cases_signup_content_item.json"))
   end
 
+  def news_and_communications_content_item
+    JSON.parse(File.read(fixtures_path + "/news_and_communications.json"))
+  end
+
   def news_and_communications_signup_content_item
     JSON.parse(File.read(fixtures_path + "/news_and_communications_signup_content_item.json"))
   end


### PR DESCRIPTION
Signing up to content linked to organisations, people and
world locations should result in a SubscriberList being created with
parameters included in the 'link' field of a SubscriberList.

Each of these parameters are given as slugs and should be converted to
a content_id, except for part_of_taxonomy_tree which is already a
content_id.

Trello: https://trello.com/c/JinK1IxW/868-fix-email-bug-in-new-finders

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
