### PR TITLE
Adds official-documents fixture

### DIFF
--- a/features/fixtures/official_documents.json
+++ b/features/fixtures/official_documents.json
@@ -1,0 +1,113 @@
+{
+"analytics_identifier": null,
+"base_path": "/search/official-documents",
+"content_id": "e96a1b16-a011-4dc6-9f6a-a54561c4db90",
+"content_purpose_document_supertype": "navigation",
+"document_type": "finder",
+"email_document_supertype": "other",
+"first_published_at": "2019-05-29 11:41:00 +0100",
+"government_document_supertype": "other",
+"locale": "en",
+"navigation_document_supertype": "other",
+"public_updated_at": "2019-05-29 11:41:00 +0100",
+"publishing_app": "finder-frontend",
+"rendering_app": "finder-frontend",
+"schema_name": "finder",
+"search_user_need_document_supertype": "government",
+"title": "Official Documents",
+"updated_at": "2019-05-29 11:41:00 +0100",
+"user_journey_document_supertype": "finding",
+"withdrawn_notice": {},
+"publishing_request_id": "",
+"links": {},
+"description": "Find official documents from government",
+"details": {
+  "document_noun": "result",
+  "filter": {
+    "has_official_document": true
+  },
+  "format_name": "Official documents",
+  "show_summaries": true,
+  "sort": [
+    {
+      "name": "Most viewed",
+      "key": "-popularity"
+    },
+    {
+      "name": "Relevance",
+      "key": "-relevance"
+    },
+    {
+      "name": "Updated (newest)",
+      "key": "-public_timestamp",
+      "default": true
+    },
+    {
+      "name": "Updated (oldest)",
+      "key": "public_timestamp"
+    }
+  ],
+  "facets": [
+    {
+      "key": "release_timestamp",
+      "name": "release_timestamp",
+      "short_name": "Release date",
+      "preposition": "from",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "key": "display_type",
+      "name": "content_store_document_type",
+      "short_name": "Document type",
+      "preposition": "from",
+      "type": "text",
+      "display_as_result_metadata": true,
+      "filterable": false
+    },
+    {
+      "filter_key": "all_part_of_taxonomy_tree",
+      "keys": [
+        "level_one_taxon",
+        "level_two_taxon"
+      ],
+      "name": "topic",
+      "short_name": "topic",
+      "type": "taxon",
+      "display_as_result_metadata": false,
+      "filterable": true,
+      "preposition": "about"
+    },
+    {
+      "key": "content_store_document_type",
+      "name": "official documents",
+      "type": "official_documents",
+      "preposition": "of type",
+      "display_as_result_metadata": true,
+      "filterable": true,
+      "hide_facet_tag": true
+    },
+    {
+      "key": "organisations",
+      "name": "Organisation",
+      "short_name": "Organisation",
+      "preposition": "from",
+      "type": "text",
+      "show_option_select_filter": true,
+      "display_as_result_metadata": true,
+      "filterable": true
+    },
+    {
+      "key": "public_timestamp",
+      "short_name": "Updated",
+      "name": "Updated",
+      "preposition": "Updated",
+      "type": "date",
+      "display_as_result_metadata": true,
+      "filterable": true
+    }
+  ],
+  "default_documents_per_page": 20
+  }
+}


### PR DESCRIPTION
This fixture was deleted in [a recent code clear up](https://github.com/alphagov/finder-frontend/pull/1199), but it's useful for local development so I've added it back.

