### PR TITLE
Allow content_store_document_type attribute as link based subscriberlist

### DIFF
--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -77,7 +77,7 @@ private
   end
 
   def to_content_ids(key, values)
-    return values if key == 'taxon_tree'
+    return values unless %w[organisations people world_locations].include?(key)
 
     registry = Registries::BaseRegistries.new.all[key]
     values.map { |value| registry[value]['content_id'] }

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -454,6 +454,34 @@ describe EmailAlertSignupAPI do
         assert_requested(req)
       end
     end
+    describe 'content_store_document_type' do
+      let(:applied_filters) do
+        { "content_store_document_type" => %w(document_type_1 document_type_2) }
+      end
+      let(:facets) do
+        [
+          {
+            "facet_id" => "content_store_document_type",
+            "facet_name" => "Document Type"
+          },
+          {
+            "facet_id" => "organisations",
+            "facet_name" => "Organisations"
+          }
+        ]
+      end
+      it 'It does not convert values' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            content_store_document_type: { any: %w(document_type_1 document_type_2) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+        assert_requested(req)
+      end
+    end
     describe 'organisation facet' do
       let(:applied_filters) do
         { "organisations" => %w(death-eaters ministry-of-magic) }


### PR DESCRIPTION
This is a requirement for amongst others the research and statistics
finder.

Make the code more robust by ensuring only valid registry keys are
used when converting values of link based subscriptions

Trello: https://trello.com/c/JinK1IxW/868-fix-email-bug-in-new-finders
https://trello.com/c/kNl6PISW/898-ensure-subscriptions-to-research-and-statistics-will-deliver-emails
---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
