### PR TITLE
Enforce link-based subscriber lists to have values that are arrays

### DIFF
--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -58,7 +58,7 @@ private
     selected_keys = applied_filters.keys.map(&:to_s) & facet_filter_keys
     filter_links = selected_keys.each_with_object({}) do |full_key, result|
       operator, key = split_key(full_key)
-      values = applied_filters[full_key.to_sym]
+      values = Array.wrap(applied_filters[full_key.to_sym])
       result[key] ||= {}
       result[key][operator] = to_content_ids(key, values)
     end
@@ -66,7 +66,7 @@ private
   end
 
   def default_links
-    default_filters.transform_values { |value| { any: value } }
+    default_filters.transform_values { |value| { any: Array.wrap(value) } }
   end
 
   def split_key(full_key)

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -481,6 +481,22 @@ describe EmailAlertSignupAPI do
         expect(subject.signup_url).to eql subscription_url
         assert_requested(req)
       end
+      describe 'handling default values' do
+        let(:default_filters) do
+          { "content_purpose_subgroup" => 'one_thing' }
+        end
+        it 'it converting scalar values to arrays' do
+          req = email_alert_api_has_subscriber_list(
+            "links" => {
+              content_store_document_type: { any: %w(document_type_1 document_type_2) },
+              content_purpose_subgroup: { any: %w[one_thing] }
+            },
+            "subscription_url" => subscription_url
+          )
+          expect(subject.signup_url).to eql subscription_url
+          assert_requested(req)
+        end
+      end
     end
     describe 'organisation facet' do
       let(:applied_filters) do


### PR DESCRIPTION
Link bases subscriber lists should have arrays as their values.
this commit converts values to arrays when necessary

Trello: https://trello.com/c/JinK1IxW/868-fix-email-bug-in-new-finders

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
