### PR TITLE
Hidden facets without allowed values now have to correct query params

### DIFF
--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -20,7 +20,8 @@ class HiddenFacet < FilterableFacet
   end
 
   def query_params
-    { key => selected_values.map { |value| value['value'] } }
+    values = allowed_values.empty? ? @value : selected_values.map { |value| value['value'] }
+    { key => values }
   end
 
 private

--- a/spec/models/hidden_facet_spec.rb
+++ b/spec/models/hidden_facet_spec.rb
@@ -21,10 +21,30 @@ describe HiddenFacet do
 
   describe "#query_params" do
     context "value selected" do
-      subject { HiddenFacet.new(facet_data, "hidden_value") }
-      specify {
-        expect(subject.query_params).to eql("test_facet" => %w[hidden_value])
+      it 'returns the value' do
+        facet = HiddenFacet.new(facet_data, "hidden_value")
+        expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
+      end
+    end
+    context "invalid value selected" do
+      it 'removes the invalid values' do
+        facet = HiddenFacet.new(facet_data, "not_allowed_value")
+        expect(facet.query_params).to eql("test_facet" => [])
+      end
+    end
+    context 'no allowed values specified' do
+      let(:facet_data) {
+        {
+          'key' => "test_facet",
+          'name' => "Test facet",
+          'preposition' => "of value",
+          'allowed_values' => []
+        }
       }
+      it 'returns the values without validation' do
+        facet = HiddenFacet.new(facet_data, "hidden_value")
+        expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
+      end
     end
   end
 end


### PR DESCRIPTION
From the topic pages, for instance www.gov.uk/transport, we can access the supergroup finders which will have their search results narrowed by the relevant topic. Subscribing to the email feeds of these finders do not take the hidden 'topic' parameter into account because hidden facets without any 'allowed values' are not passed on to the email subscription page.

This PR includes hidden facets with that have a value set.

trello: https://trello.com/c/0r8Pmg1k/897-ensure-hidden-topic-parameter-works-when-signing-up-to-finders
Also deploy and related: https://github.com/alphagov/search-api/pull/1639

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1277.herokuapp.com/search/all
- http://finder-frontend-pr-1277.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1277.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1277.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1277.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1277.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1277.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1277.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1277.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
