### PR TITLE
When there are no email signup choices, don't return any.

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -102,9 +102,13 @@ private
   end
 
   def single_facet_choice_data
+    facet_id = content_item.dig('details', "email_filter_by")
+
+    return [] if facet_id.nil?
+
     [
       {
-        "facet_id" => content_item['details']["email_filter_by"],
+        "facet_id" => facet_id,
         "facet_name" => single_facet_name,
         "facet_choices" => content_item['details']["email_signup_choice"]
       }

--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe SignupPresenter do
+  include FixturesHelper
+
+  describe '#choices' do
+    it 'returns an empty array when there are no facets to choose from' do
+      content_item = {
+        "details" => {
+          "email_signup_choice" => [],
+        }
+      }
+      expect(SignupPresenter.new(content_item, {}).choices).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug where EmailAlertSignupApi#link_based_subscriber_list? accesses bogus
data.
---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
