### PR TITLE
Fixes a bug signing up when there are no choices in the content item

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -53,7 +53,7 @@ class SignupPresenter
   end
 
   def choices?
-    multiple_facet_choice_data.present? || single_facet_choice_data[0]["facet_choices"].present?
+    multiple_facet_choice_data.present? || single_facet_choice_data.dig(0, "facet_choices").present?
   end
 
   def choices

--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -13,4 +13,15 @@ describe SignupPresenter do
       expect(SignupPresenter.new(content_item, {}).choices).to eq([])
     end
   end
+
+  describe '#choices?' do
+    it 'returns an empty array when there are no facets to choose from' do
+      content_item = {
+        "details" => {
+          "email_signup_choice" => [],
+        }
+      }
+      expect(SignupPresenter.new(content_item, {}).choices?).to be false
+    end
+  end
 end


### PR DESCRIPTION

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
