### PR TITLE
Add signup presenter specs

### DIFF
--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -3,25 +3,114 @@ require "spec_helper"
 describe SignupPresenter do
   include FixturesHelper
 
-  describe '#choices' do
-    it 'returns an empty array when there are no facets to choose from' do
-      content_item = {
-        "details" => {
-          "email_signup_choice" => [],
-        }
+  let(:params) {
+    ActionController::Parameters.new({})
+  }
+  describe 'single facet' do
+    let(:content_item) {
+      {
+        "details" =>
+          { "beta" => false,
+           "email_signup_choice" =>
+             [{ "key" => "devices",
+               "radio_button_name" => "Medical device alerts", },
+              { "key" => "drugs",
+                "radio_button_name" => "Drug alerts", }],
+           "email_filter_by" => "alert_type",
+           "email_filter_name" => "Alert Type", }
       }
-      expect(SignupPresenter.new(content_item, {}).choices).to eq([])
+    }
+    describe '#choices' do
+      it 'returns an array of signup facets' do
+        expect(SignupPresenter.new(content_item, params).choices).
+          to eq([
+                  { "facet_choices" => [{ "key" => "devices",
+                                         "radio_button_name" => "Medical device alerts", },
+                                        { "key" => "drugs",
+                                          "radio_button_name" => "Drug alerts", }],
+                   "facet_id" => "alert_type",
+                   "facet_name" => "Alert type" }
+                ])
+      end
+    end
+    describe '#choices?' do
+      it 'returns true' do
+        expect(SignupPresenter.new(content_item, params).choices?).to be true
+      end
+    end
+    describe '#can_modify_choices?' do
+      it 'returns false' do
+        expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be true
+      end
     end
   end
 
-  describe '#choices?' do
-    it 'returns an empty array when there are no facets to choose from' do
-      content_item = {
+  describe 'multiple facets' do
+    let(:content_item) {
+      {
+        "details" => {
+          "email_filter_facets" => [
+            {
+              "facet_id" => "people",
+              "facet_name" => "people"
+            },
+            {
+              "facet_id" => "organisations",
+              "facet_name" => "organisations"
+            }
+          ]
+        }
+      }
+    }
+    describe '#choices' do
+      it 'returns an array of signup facets' do
+        expect(SignupPresenter.new(content_item, params).choices).
+          to eq([
+                  {
+                    "facet_id" => "people",
+                    "facet_name" => "people"
+                  },
+                  {
+                    "facet_id" => "organisations",
+                    "facet_name" => "organisations"
+                  }
+])
+      end
+    end
+    describe '#choices?' do
+      it 'returns true' do
+        expect(SignupPresenter.new(content_item, params).choices?).to be true
+      end
+    end
+    describe '#can_modify_choices?' do
+      it 'returns false' do
+        expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be false
+      end
+    end
+  end
+
+  describe 'no facets in email signup' do
+    let(:content_item) {
+      {
         "details" => {
           "email_signup_choice" => [],
         }
       }
-      expect(SignupPresenter.new(content_item, {}).choices?).to be false
+    }
+    describe '#choices' do
+      it 'returns an empty array' do
+        expect(SignupPresenter.new(content_item, params).choices).to eq([])
+      end
+    end
+    describe '#choices?' do
+      it 'returns false' do
+        expect(SignupPresenter.new(content_item, params).choices?).to be false
+      end
+    end
+    describe '#can_modify_choices?' do
+      it 'returns an empty array' do
+        expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
We need some more tests for the SignupPresenter class.

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
