### PR TITLE
various renamings

### DIFF
--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,6 +1,6 @@
 module ResultSetParser
-  def self.parse(results, total, finder)
-    documents = results.map { |document| Document.new(document, finder) }
+  def self.parse(results, total, finder_presenter)
+    documents = results.map { |document| Document.new(document, finder_presenter) }
 
     ResultSet.new(
       documents,

--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -1,14 +1,14 @@
 class AtomPresenter
-  def initialize(finder, results, facet_tags)
-    @finder = finder
+  def initialize(finder_presenter, results, facet_tags)
+    @finder_presenter = finder_presenter
     @results = results
     @filter_descriptions = facet_tags.selected_filter_descriptions
   end
 
   def title
-    return "#{finder.name} #{filters_applied.join(' ')}" if filters_applied.present?
+    return "#{finder_presenter.name} #{filters_applied.join(' ')}" if filters_applied.present?
 
-    finder.name
+    finder_presenter.name
   end
 
   def filters_applied
@@ -18,7 +18,7 @@ class AtomPresenter
   end
 
   def entries
-    finder.results.documents
+    finder_presenter.results.documents
     .reject { |d| d.public_timestamp.blank? && d.release_timestamp.blank? }
     .map { |d| EntryPresenter.new(d) }
   end
@@ -29,5 +29,5 @@ class AtomPresenter
 
 private
 
-  attr_reader :finder, :results, :filter_descriptions
+  attr_reader :finder_presenter, :results, :filter_descriptions
 end

--- a/app/presenters/grouped_result_set_presenter.rb
+++ b/app/presenters/grouped_result_set_presenter.rb
@@ -1,7 +1,7 @@
 class GroupedResultSetPresenter < ResultSetPresenter
   def search_results_content
     super.merge(
-      grouped_documents: grouped_documents,
+      grouped_document_list_component_data: grouped_document_list_component_data,
       display_grouped_results: grouped_display?
     )
   end
@@ -11,10 +11,10 @@ class GroupedResultSetPresenter < ResultSetPresenter
     @filter_params[:order] == "topic" || (!@filter_params.has_key?(:order) && sorts_by_topic)
   end
 
-  def grouped_documents
+  def grouped_document_list_component_data
     return [] unless grouped_display?
 
-    documents_with_metadata = documents.select { |document| document[:metadata_raw].present? }
+    documents_with_metadata = document_list_component_data.select { |document| document[:metadata_raw].present? }
     sorted_documents = sort_by_alphabetical(documents_with_metadata)
 
     # Without facet filtering return all documents without grouping

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -8,19 +8,19 @@ class SearchResultPresenter
            :government_name,
            :format,
            :es_score,
-           to: :search_result
+           to: :document
 
-  def initialize(data = {})
-    @search_result = data[:search_result]
-    @metadata = data[:metadata]
-    @index = data[:doc_index] + 1
-    @count = data[:doc_count]
-    @finder_name = data[:finder_name]
-    @debug_score = data[:debug_score]
-    @highlight = data[:highlight]
+  def initialize(document:, metadata:, doc_index:, doc_count:, finder_name:, debug_score:, highlight:)
+    @document = document
+    @metadata = metadata
+    @index = doc_index + 1
+    @count = doc_count
+    @finder_name = finder_name
+    @debug_score = debug_score
+    @highlight = highlight
   end
 
-  def govuk_component_data
+  def document_list_component_data
     {
       link: {
         text: title,
@@ -45,7 +45,7 @@ class SearchResultPresenter
   end
 
   def link
-    search_result.path
+    document.path
   end
 
   def structure_metadata
@@ -71,7 +71,7 @@ class SearchResultPresenter
   end
 
   def summary_text
-    @highlight ? search_result.truncated_description : summary
+    @highlight ? document.truncated_description : summary
   end
 
   def highlight_text
@@ -80,5 +80,5 @@ class SearchResultPresenter
 
 private
 
-  attr_reader :search_result, :metadata
+  attr_reader :document, :metadata
 end

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -1,6 +1,6 @@
 <% if local_assigns[:display_grouped_results] %>
   <ul class="finder-results js-finder-results" data-module="track-click">
-    <% local_assigns[:grouped_documents].each do |group| %>
+    <% local_assigns[:grouped_document_list_component_data].each do |group| %>
       <li class="filtered-results__group">
         <% if group[:group_name] %>
           <h2 class="filtered-results__facet-heading"><%= group[:group_name] %></h2>
@@ -16,7 +16,7 @@
 <% else %>
   <div class="finder-results js-finder-results" data-module="track-click">
     <%= render "govuk_publishing_components/components/document_list", {
-      items: local_assigns[:documents],
+      items: local_assigns[:document_list_component_data],
       remove_underline: true
     } %>
   </div>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -7,7 +7,7 @@
   <%= auto_discovery_link_tag(:atom, result_set_presenter.signup_links[:feed_link]) %>
   <%= render 'finder_meta', finder_presenter: finder_presenter %>
 
-  <% if result_set_presenter.documents.present? && result_set_presenter.documents.first[:highlight] %>
+  <% if result_set_presenter.document_list_component_data.present? && result_set_presenter.document_list_component_data.first[:highlight] %>
     <meta name="govuk:relevant-result-shown" content="yes">
   <% end %>
 

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -195,15 +195,15 @@ RSpec.describe GroupedResultSetPresenter do
     }
 
     let(:primary_tagged_result) {
-      SearchResultPresenter.new(search_result: tagged_document, metadata: formatted_tagged_metadata, doc_index: 1, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).govuk_component_data
+      SearchResultPresenter.new(document: tagged_document, metadata: formatted_tagged_metadata, doc_index: 1, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     let(:primary_tagged_result_with_one_document) {
-      SearchResultPresenter.new(search_result: tagged_document, metadata: formatted_tagged_metadata, doc_index: 0, doc_count: 1, finder_name: finder_name, debug_score: false, highlight: false).govuk_component_data
+      SearchResultPresenter.new(document: tagged_document, metadata: formatted_tagged_metadata, doc_index: 0, doc_count: 1, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     let(:document_result) {
-      SearchResultPresenter.new(search_result: document, metadata: formatted_metadata, doc_index: 0, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).govuk_component_data
+      SearchResultPresenter.new(document: document, metadata: formatted_metadata, doc_index: 0, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     context "when not grouping results" do
@@ -211,7 +211,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document], total) }
 
       it "returns an empty array" do
-        expect(subject.grouped_documents).to eq([])
+        expect(subject.grouped_document_list_component_data).to eq([])
       end
     end
 
@@ -220,13 +220,13 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document], total) }
 
       it "groups all documents in the default group" do
-        expect(subject.grouped_documents).to eq([{
-          documents: subject.documents
+        expect(subject.grouped_document_list_component_data).to eq([{
+          documents: subject.document_list_component_data
         }])
       end
 
       it "does not populate the facet name for the group" do
-        expect(subject.grouped_documents.first).not_to have_key(:group_name)
+        expect(subject.grouped_document_list_component_data.first).not_to have_key(:group_name)
       end
     end
 
@@ -240,7 +240,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document, tagged_document], total) }
 
       it "groups the relevant documents by the primary facet" do
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'Aerospace',
             documents: [primary_tagged_result]
@@ -263,7 +263,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:facet_filters) { [sector_facet, a_facet, activity_facet] }
 
       it "orders the groups by facets in the other facets" do
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'Aerospace',
             documents: [primary_tagged_result]
@@ -292,7 +292,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document, tagged_document], total) }
 
       it "groups the relevant documents in the other facets" do
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'Organisation activity',
             documents: [document_result]
@@ -325,7 +325,7 @@ RSpec.describe GroupedResultSetPresenter do
       it "is grouped in the default set" do
         allow(a_facet_collection).to receive(:find).and_return(sector_facet)
 
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'All businesses',
             documents: [primary_tagged_result_with_one_document]
@@ -345,7 +345,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document, tagged_document], total) }
 
       it "groups the relevant documents in the primary facets" do
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'Aerospace',
             documents: [primary_tagged_result]
@@ -369,7 +369,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:results) { ResultSet.new([document, tagged_document], total) }
 
       it "groups the relevant documents in the other facets" do
-        expect(subject.grouped_documents).to eq([
+        expect(subject.grouped_document_list_component_data).to eq([
           {
             group_name: 'Case type',
             documents: [document_result]
@@ -425,7 +425,7 @@ RSpec.describe GroupedResultSetPresenter do
     let(:results) { ResultSet.new([document], total) }
 
     it "returns an empty array" do
-      expect(subject.grouped_documents).to eq([])
+      expect(subject.grouped_document_list_component_data).to eq([])
     end
   end
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'creates a new search_result_presenter hash for each result' do
-        search_result_objects = presenter.documents
+        search_result_objects = presenter.document_list_component_data
         expect(search_result_objects.count).to eql(1)
         expect(search_result_objects.first).to be_a(Hash)
       end
@@ -188,7 +188,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'creates a new document for each result' do
-        search_result_objects = presenter.documents
+        search_result_objects = presenter.document_list_component_data
         expect(search_result_objects.count).to eql(3)
       end
     end
@@ -202,7 +202,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'has the right data' do
-        search_result_objects = presenter.documents
+        search_result_objects = presenter.document_list_component_data
         expect(search_result_objects.first).to eql(expected_document_content)
       end
     end
@@ -215,7 +215,7 @@ RSpec.describe ResultSetPresenter do
       end
 
       it 'shows debug metadata' do
-        search_result_objects = presenter.documents
+        search_result_objects = presenter.document_list_component_data
         expect(search_result_objects.first[:subtext]).to eql(expected_document_content_with_debug)
       end
     end
@@ -268,7 +268,7 @@ RSpec.describe ResultSetPresenter do
         end
 
         it 'has top result true' do
-          search_result_objects = presenter.documents
+          search_result_objects = presenter.document_list_component_data
           expect(search_result_objects[0][:highlight]).to eql(true)
           expect(search_result_objects[0][:highlight_text]).to eql("Most relevant result")
           expect(search_result_objects[0][:link][:description]).to eql("A truncated description")
@@ -284,7 +284,7 @@ RSpec.describe ResultSetPresenter do
         end
 
         it 'has no top result' do
-          search_result_objects = presenter.documents
+          search_result_objects = presenter.document_list_component_data
           expect(search_result_objects[0][:highlight]).to_not eql(true)
         end
       end
@@ -293,7 +293,7 @@ RSpec.describe ResultSetPresenter do
         subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, metadata_presenter_class, false) }
 
         it 'has no top result' do
-          search_result_objects = presenter.documents
+          search_result_objects = presenter.document_list_component_data
           expect(search_result_objects[0][:highlight]).to_not eql(true)
         end
       end

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SearchResultPresenter do
   let(:highlight) { false }
 
   subject(:presenter) {
-    SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+    SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
   }
 
   let(:title) { 'Investigation into the distribution of road fuels in parts of Scotland' }
@@ -80,11 +80,11 @@ RSpec.describe SearchResultPresenter do
 
   describe "#govuk_component_data" do
     it "returns a hash" do
-      expect(subject.govuk_component_data.is_a?(Hash)).to be_truthy
+      expect(subject.document_list_component_data.is_a?(Hash)).to be_truthy
     end
 
     it "returns a hash of the data we need to show the document" do
-      hash = subject.govuk_component_data
+      hash = subject.document_list_component_data
 
       expect(hash).to eql(expected_document)
     end
@@ -96,7 +96,7 @@ RSpec.describe SearchResultPresenter do
     end
 
     it "returns structured data if show_metadata is true" do
-      with_metadata = SearchResultPresenter.new(search_result: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+      with_metadata = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
       expect(with_metadata.structure_metadata).to eql(
         "Case state" => "Case state: Open",
@@ -115,19 +115,19 @@ RSpec.describe SearchResultPresenter do
     end
 
     it "returns 'Published by' text if is_historic is true" do
-      with_historic = SearchResultPresenter.new(search_result: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+      with_historic = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
       expect(with_historic.subtext).to eql(historic_subtext)
     end
 
     it "returns debug metadata if debug_score" do
-      with_debug = SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
+      with_debug = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
       expect(with_debug.subtext).to eql(debug_subtext)
     end
 
     it "returns 'Published by' and debug metadata together" do
-      with_all = SearchResultPresenter.new(search_result: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
+      with_all = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
       expect(with_all.subtext).to eql("#{historic_subtext}#{debug_subtext}")
     end
@@ -135,13 +135,13 @@ RSpec.describe SearchResultPresenter do
 
   describe "summary_text" do
     it "returns summary if not highlighted" do
-      no_highlight = SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
+      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
       expect(no_highlight.summary_text).to eql(summary)
     end
 
     it "returns truncated summary if highlighted" do
-      with_highlight = SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
+      with_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
       expect(with_highlight.summary_text).to eql("I am a document.")
     end
@@ -149,13 +149,13 @@ RSpec.describe SearchResultPresenter do
 
   describe "highlight_text" do
     it "returns nothing if not highlight" do
-      no_highlight = SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
+      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
       expect(no_highlight.highlight_text).to eql(nil)
     end
 
     it "returns 'Most relevant result' if highlight" do
-      no_highlight = SearchResultPresenter.new(search_result: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
+      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
       expect(no_highlight.highlight_text).to eql("Most relevant result")
     end


### PR DESCRIPTION
Some variable names do not have very descriptive or sometimes misleading names. This
PR addresses and renames a few

## Search page examples to sanity check:

- http://finder-frontend-pr-1282.herokuapp.com/search/all
- http://finder-frontend-pr-1282.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1282.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1282.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1282.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1282.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1282.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1282.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1282.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
