### PR TITLE
Use select component full width option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'gds-api-adapters', '~> 59.6'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 1.20.1'
 gem 'govuk_document_types', '~> 0.9.2'
-gem 'govuk_publishing_components', '~> 17.19.1'
+gem 'govuk_publishing_components', '~> 17.20.0'
 gem 'rails', '~> 5.2.3'
 gem 'slimmer', '~> 13.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.19.1)
+    govuk_publishing_components (17.20.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -396,7 +396,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.20.1)
   govuk_document_types (~> 0.9.2)
   govuk_frontend_toolkit (~> 8.2)
-  govuk_publishing_components (~> 17.19.1)
+  govuk_publishing_components (~> 17.20.0)
   govuk_schemas (~> 4.0)
   govuk_test
   jasmine-rails

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -62,7 +62,7 @@
   }
 
   LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet () {
-    this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: $('.app-taxonomy-select') })
+    this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: $('.js-taxonomy-select') })
     return this.taxonomy
   }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -42,10 +42,6 @@
   .js-required {
     display: none;
   }
-
-  .govuk-select {
-    width: 100%;
-  }
 }
 
 .signup-choices {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,5 +1,5 @@
 <% unless i_am_a_topic_page_finder %>
-<div class="app-taxonomy-select">
+<div class="js-taxonomy-select">
   <%= render "govuk_publishing_components/components/select", {
     id: 'level_one_taxon',
     label: "Topic",

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -3,6 +3,7 @@
   <%= render "govuk_publishing_components/components/select", {
     id: 'level_one_taxon',
     label: "Topic",
+    full_width: true,
     options: taxon_facet.topics
   }
   %>
@@ -10,6 +11,7 @@
     <%= render "govuk_publishing_components/components/select", {
       id: 'level_two_taxon',
       label: "Sub-topic",
+      full_width: true,
       options: taxon_facet.sub_topics
     }
     %>


### PR DESCRIPTION
Updates the use of `select` components to use the `full_width` option, instead of having overriding CSS in `finder-frontend` to do that, which is against our component principles.

Also renames a CSS class to clarify that it is only used as a JS hook, not for styling (because I nearly removed it from a template because it wasn't in the Sass).

Trello card: https://trello.com/c/w34QlutZ/910-add-an-option-to-the-select-component-for-width-100

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1283.herokuapp.com/search/all
- http://finder-frontend-pr-1283.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1283.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1283.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1283.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1283.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1283.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1283.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1283.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
