### PR TITLE
Some refactoring

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -35,8 +35,7 @@ class ResultSetPresenter
   def document_list_component_data
     @document_list_component_data ||= begin
       documents.each_with_index.map do |document, index|
-        metadata = metadata_presenter_class.new(document.metadata).present
-        SearchResultPresenter.new(document: document, metadata: metadata, doc_index: index, doc_count: documents.count, finder_name: finder_presenter.name, debug_score: debug_score, highlight: highlight(index)).document_list_component_data
+        SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: index, doc_count: documents.count, finder_name: finder_presenter.name, debug_score: debug_score, highlight: highlight(index)).document_list_component_data
       end
     end
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -44,19 +44,18 @@ class SearchResultPresenter
     }
   end
 
+private
+
   def link
     document.path
   end
 
-  def structure_metadata
-    return {} unless show_metadata
+  def summary_text
+    @highlight ? document.truncated_description : summary
+  end
 
-    metadata.each_with_object({}) do |meta, component_metadata|
-      label = meta[:hide_label] ? "<span class='govuk-visually-hidden'>#{meta[:label]}:</span>" : "#{meta[:label]}:"
-      value = meta[:is_date] ? "<time datetime='#{meta[:machine_date]}'>#{meta[:human_date]}</time>" : meta[:value]
-
-      component_metadata[meta[:label]] = sanitize("#{label} #{value}", tags: %w(time span))
-    end
+  def highlight_text
+    I18n.t('finders.most_relevant') if @highlight
   end
 
   def subtext
@@ -70,15 +69,17 @@ class SearchResultPresenter
     sanitize("#{published_text}#{debug_text}") if published_text || debug_text
   end
 
-  def summary_text
-    @highlight ? document.truncated_description : summary
+  def structure_metadata
+    return {} unless show_metadata
+
+    metadata.each_with_object({}) do |meta, component_metadata|
+      label = meta[:hide_label] ? "<span class='govuk-visually-hidden'>#{meta[:label]}:</span>" : "#{meta[:label]}:"
+      value = meta[:is_date] ? "<time datetime='#{meta[:machine_date]}'>#{meta[:human_date]}</time>" : meta[:value]
+
+      component_metadata[meta[:label]] = sanitize("#{label} #{value}", tags: %w(time span))
+    end
   end
 
-  def highlight_text
-    I18n.t('finders.most_relevant') if @highlight
-  end
-
-private
 
   attr_reader :document, :metadata
 end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -10,9 +10,9 @@ class SearchResultPresenter
            :es_score,
            to: :document
 
-  def initialize(document:, metadata:, doc_index:, doc_count:, finder_name:, debug_score:, highlight:)
+  def initialize(document:, metadata_presenter_class:, doc_index:, doc_count:, finder_name:, debug_score:, highlight:)
     @document = document
-    @metadata = metadata
+    @metadata = metadata_presenter_class.new(document.metadata).present
     @index = doc_index + 1
     @count = doc_count
     @finder_name = finder_name

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -175,10 +175,6 @@ RSpec.describe GroupedResultSetPresenter do
       ]
     }
 
-    let(:formatted_tagged_metadata) {
-      metadata_presenter_class.new(tagging_metadata).present
-    }
-
     let(:tagged_document) {
       double(
         Document,
@@ -195,15 +191,15 @@ RSpec.describe GroupedResultSetPresenter do
     }
 
     let(:primary_tagged_result) {
-      SearchResultPresenter.new(document: tagged_document, metadata: formatted_tagged_metadata, doc_index: 1, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
+      SearchResultPresenter.new(document: tagged_document, metadata_presenter_class: metadata_presenter_class, doc_index: 1, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     let(:primary_tagged_result_with_one_document) {
-      SearchResultPresenter.new(document: tagged_document, metadata: formatted_tagged_metadata, doc_index: 0, doc_count: 1, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
+      SearchResultPresenter.new(document: tagged_document, metadata_presenter_class: metadata_presenter_class, doc_index: 0, doc_count: 1, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     let(:document_result) {
-      SearchResultPresenter.new(document: document, metadata: formatted_metadata, doc_index: 0, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
+      SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: 0, doc_count: 2, finder_name: finder_name, debug_score: false, highlight: false).document_list_component_data
     }
 
     context "when not grouping results" do

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe SearchResultPresenter do
 
   describe "structure_metadata" do
     it "returns nothing unless show_metadata" do
-      expect(subject.structure_metadata).to eql({})
+      expect(subject.document_list_component_data[:metadata]).to eql({})
     end
 
     it "returns structured data if show_metadata is true" do
       with_metadata = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
-      expect(with_metadata.structure_metadata).to eql(
+      expect(with_metadata.document_list_component_data[:metadata]).to eql(
         "Case state" => "Case state: Open",
         "Case type" => "<span class=\"govuk-visually-hidden\">Case type:</span> CA98 and civil cartels",
         "Opened date" => "Opened date: <time datetime=\"2006-07-14\">14 July 2006</time>"
@@ -111,25 +111,25 @@ RSpec.describe SearchResultPresenter do
     let(:debug_subtext) { "<span class=\"debug-results debug-results--link\">link-1</span><span class=\"debug-results debug-results--meta\">Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: cake</span>" }
 
     it "returns nothing unless is_historic or debug_score" do
-      expect(subject.subtext).to eql(nil)
+      expect(subject.document_list_component_data[:subtext]).to eql(nil)
     end
 
     it "returns 'Published by' text if is_historic is true" do
       with_historic = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
-      expect(with_historic.subtext).to eql(historic_subtext)
+      expect(with_historic.document_list_component_data[:subtext]).to eql(historic_subtext)
     end
 
     it "returns debug metadata if debug_score" do
       with_debug = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
-      expect(with_debug.subtext).to eql(debug_subtext)
+      expect(with_debug.document_list_component_data[:subtext]).to eql(debug_subtext)
     end
 
     it "returns 'Published by' and debug metadata together" do
       with_all = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
-      expect(with_all.subtext).to eql("#{historic_subtext}#{debug_subtext}")
+      expect(with_all.document_list_component_data[:subtext]).to eql("#{historic_subtext}#{debug_subtext}")
     end
   end
 
@@ -137,13 +137,13 @@ RSpec.describe SearchResultPresenter do
     it "returns summary if not highlighted" do
       no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
-      expect(no_highlight.summary_text).to eql(summary)
+      expect(no_highlight.document_list_component_data[:link][:description]).to eql(summary)
     end
 
     it "returns truncated summary if highlighted" do
       with_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
-      expect(with_highlight.summary_text).to eql("I am a document.")
+      expect(with_highlight.document_list_component_data[:link][:description]).to eql("I am a document.")
     end
   end
 
@@ -151,13 +151,13 @@ RSpec.describe SearchResultPresenter do
     it "returns nothing if not highlight" do
       no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
-      expect(no_highlight.highlight_text).to eql(nil)
+      expect(no_highlight.document_list_component_data[:highlight_text]).to eql(nil)
     end
 
     it "returns 'Most relevant result' if highlight" do
       no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
-      expect(no_highlight.highlight_text).to eql("Most relevant result")
+      expect(no_highlight.document_list_component_data[:highlight_text]).to eql("Most relevant result")
     end
   end
 end

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -7,8 +7,21 @@ RSpec.describe SearchResultPresenter do
   let(:debug_score) { false }
   let(:highlight) { false }
 
+  let(:metadata_presenter_class) do
+    Class.new do
+      attr_reader :raw_metadata
+      def initialize(raw_metadata)
+        @raw_metadata = raw_metadata
+      end
+
+      def present
+        [{ presented: :metadata }]
+      end
+    end
+  end
+
   subject(:presenter) {
-    SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+    SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
   }
 
   let(:title) { 'Investigation into the distribution of road fuels in parts of Scotland' }
@@ -48,9 +61,9 @@ RSpec.describe SearchResultPresenter do
 
   let(:metadata) {
     [
-      { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil },
-      { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
-      { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil, hide_label: true },
+      { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil, type: 'text', name: 'Case state' },
+      { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006", type: 'date', name: 'Opened Date', value: "2006-07-14" },
+      { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil, hide_label: true, type: 'text', name: 'Case type' },
     ]
   }
 
@@ -71,7 +84,7 @@ RSpec.describe SearchResultPresenter do
         }
       },
       metadata: {},
-      metadata_raw: metadata,
+      metadata_raw: [{ presented: :metadata }],
       subtext: nil,
       highlight: false,
       highlight_text: nil
@@ -96,7 +109,17 @@ RSpec.describe SearchResultPresenter do
     end
 
     it "returns structured data if show_metadata is true" do
-      with_metadata = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+      metadata_presenter_class.class_eval do
+        def present
+          [
+            { label: "Case state", value: "Open" },
+            { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
+            { label: "Case type", hide_label: true, value: "CA98 and civil cartels" }
+          ]
+        end
+      end
+
+      with_metadata = SearchResultPresenter.new(document: document_with_metadata, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
       expect(with_metadata.document_list_component_data[:metadata]).to eql(
         "Case state" => "Case state: Open",
@@ -115,19 +138,19 @@ RSpec.describe SearchResultPresenter do
     end
 
     it "returns 'Published by' text if is_historic is true" do
-      with_historic = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
+      with_historic = SearchResultPresenter.new(document: document_with_metadata, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: highlight)
 
       expect(with_historic.document_list_component_data[:subtext]).to eql(historic_subtext)
     end
 
     it "returns debug metadata if debug_score" do
-      with_debug = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
+      with_debug = SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
       expect(with_debug.document_list_component_data[:subtext]).to eql(debug_subtext)
     end
 
     it "returns 'Published by' and debug metadata together" do
-      with_all = SearchResultPresenter.new(document: document_with_metadata, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
+      with_all = SearchResultPresenter.new(document: document_with_metadata, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: 1, highlight: highlight)
 
       expect(with_all.document_list_component_data[:subtext]).to eql("#{historic_subtext}#{debug_subtext}")
     end
@@ -135,13 +158,13 @@ RSpec.describe SearchResultPresenter do
 
   describe "summary_text" do
     it "returns summary if not highlighted" do
-      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
+      no_highlight = SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
       expect(no_highlight.document_list_component_data[:link][:description]).to eql(summary)
     end
 
     it "returns truncated summary if highlighted" do
-      with_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
+      with_highlight = SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
       expect(with_highlight.document_list_component_data[:link][:description]).to eql("I am a document.")
     end
@@ -149,13 +172,13 @@ RSpec.describe SearchResultPresenter do
 
   describe "highlight_text" do
     it "returns nothing if not highlight" do
-      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
+      no_highlight = SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: false)
 
       expect(no_highlight.document_list_component_data[:highlight_text]).to eql(nil)
     end
 
     it "returns 'Most relevant result' if highlight" do
-      no_highlight = SearchResultPresenter.new(document: document, metadata: metadata, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
+      no_highlight = SearchResultPresenter.new(document: document, metadata_presenter_class: metadata_presenter_class, doc_index: doc_index, doc_count: doc_count, finder_name: finder_name, debug_score: debug_score, highlight: true)
 
       expect(no_highlight.document_list_component_data[:highlight_text]).to eql("Most relevant result")
     end


### PR DESCRIPTION
- Present metadata in SearchResultPresenter instead of ResultSetPresenter
- Make more methods of SearchResultPresenter private

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
