### PR TITLE
Change A/B test name to SearchClusterQuery

### DIFF
--- a/app/controllers/concerns/search_cluster_ab_testable.rb
+++ b/app/controllers/concerns/search_cluster_ab_testable.rb
@@ -11,7 +11,7 @@ module SearchClusterABTestable
   # anything else = use default cluster
   def search_cluster_test
     @search_cluster_test ||= GovukAbTesting::AbTest.new(
-      'SearchClusterABTest',
+      'SearchClusterQueryABTest',
       dimension: CUSTOM_DIMENSION,
       allowed_variants: %w[Default A B],
       control_variant: 'Default',
@@ -26,7 +26,7 @@ module SearchClusterABTestable
     if use_default_cluster?
       {}
     else
-      { search_cluster: use_b_cluster? ? 'B' : 'A' }
+      { search_cluster_query: use_b_cluster? ? 'B' : 'A' }
     end
   end
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -269,7 +269,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant Default sets use_default_cluster? and not use_b_cluster?" do
-      with_variant SearchClusterABTest: 'Default' do
+      with_variant SearchClusterQueryABTest: 'Default' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(true)
         expect(subject.use_b_cluster?).to eq(false)
@@ -277,7 +277,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant A does not set use_default_cluster? or use_b_cluster?" do
-      with_variant SearchClusterABTest: 'A' do
+      with_variant SearchClusterQueryABTest: 'A' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(false)
@@ -285,7 +285,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant 'B' sets use_b_cluster? and not use_default_cluster?" do
-      with_variant SearchClusterABTest: 'B' do
+      with_variant SearchClusterQueryABTest: 'B' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(true)


### PR DESCRIPTION
The behavioural change in search-api has been changed, so this is
effectively a new A/B test.

---

[Trello card](https://trello.com/c/dvLAhldZ/929-figure-out-result-ordering-weirdness-with-es6)