### PR TITLE
Strip excess whitespace from parameters

### DIFF
--- a/app/lib/params_cleaner.rb
+++ b/app/lib/params_cleaner.rb
@@ -11,6 +11,10 @@
 #
 #   foo: ["bar", "baz"]
 #
+# We also sometimes get parameters with leading or trailing whitespace
+# in facet values (trailing whitespace in the last facet is common for
+# the business readiness finder), strip those so that searches work.
+#
 class ParamsCleaner
   def initialize(params)
     @params = params
@@ -18,9 +22,13 @@ class ParamsCleaner
 
   def cleaned
     @params.each do |k, v|
-      next unless v.is_a?(Hash) && v.keys.all? { |d| d.match(/\A\d+\Z/) }
-
-      @params[k] = v.values
+      if v.is_a?(String)
+        @params[k] = v.strip
+      elsif v.is_a?(Array)
+        @params[k] = v.map { |x| x.is_a?(String) ? x.strip : x }
+      elsif v.is_a?(Hash) && v.keys.all? { |d| d.match(/\A\d+\Z/) }
+        @params[k] = v.values
+      end
     end
 
     @params

--- a/spec/lib/params_cleaner_spec.rb
+++ b/spec/lib/params_cleaner_spec.rb
@@ -25,5 +25,17 @@ describe ParamsCleaner do
 
       expect(cleaned).to eql(params)
     end
+
+    it "strips leading and trailing whitespace from string parameters" do
+      params = { "foo" => "    bar    " }
+      cleaned = ParamsCleaner.new(params).cleaned
+      expect(cleaned).to eql("foo" => "bar")
+    end
+
+    it "strips leading and trailing whitespace from array-of-stringstring parameters" do
+      params = { "foo" => ["    bar    "] }
+      cleaned = ParamsCleaner.new(params).cleaned
+      expect(cleaned).to eql("foo" => %w(bar))
+    end
   end
 end


### PR DESCRIPTION
We see a lot of requests to the business readiness finder where the
last facet value in the URL has a trailing space.  There's probably a
widely circulated bad link, or page with the bad link.  Rather than
track down the origin, we can make finder-frontend gracefully handle
user errors like this.

Compare the number of results returned [in production](https://www.gov.uk/find-eu-exit-guidance-business?keywords=&employ_eu_citizens%5B%5D=yes%20) with [this branch](http://finder-frontend-pr-1291.herokuapp.com/find-eu-exit-guidance-business?keywords=&employ_eu_citizens%5B%5D=yes%20).

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1291.herokuapp.com/search/all
- http://finder-frontend-pr-1291.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1291.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1291.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1291.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1291.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1291.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1291.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1291.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
