### PR TITLE
Research and Stats Finder displays older stats announcements

### DIFF
--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -6,8 +6,11 @@ module Filters
           'value' => 'upcoming_statistics',
           'label' => 'Statistics (upcoming)',
           'filter' => {
-            'release_timestamp' => "from:#{Time.zone.today}",
+            'release_timestamp' => "from:#{Time.zone.today - 1.month}",
             'format' => %w(statistics_announcement)
+          },
+          'reject' => {
+            'statistics_announcement_state' => 'statistics_published'
           }
         },
         {

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -151,7 +151,7 @@ module DocumentHelper
     Timecop.freeze(Time.local("2019-01-01").utc)
     stub_request(:get, "#{Plek.current.find('search')}/search.json")
       .with(query: hash_including("filter_format" => %w(statistics_announcement),
-                                  "filter_release_timestamp" => "from:2019-01-01"))
+                                  "filter_release_timestamp" => "from:2018-12-01"))
       .to_return(body: upcoming_statistics_results_for_statistics_json)
   end
 


### PR DESCRIPTION
https://trello.com/c/TRKpC1SC/935-users-cant-find-cancelled-statistics-releases


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
