### PR TITLE
Add cancelled statistics to the research and stats finder

### DIFF
--- a/app/lib/search/order_query_builder.rb
+++ b/app/lib/search/order_query_builder.rb
@@ -31,7 +31,7 @@ module Search
     end
 
     def public_timestamp_unsupported
-      params['content_store_document_type'] == 'upcoming_statistics'
+      %w(upcoming_statistics cancelled_statistics).include?(params['content_store_document_type'])
     end
 
     def release_timestamp_unsupported

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -3,6 +3,14 @@ module Filters
     def call
       [
         {
+          'value' => 'published_statistics',
+          'label' => 'Statistics (published)',
+          'filter' => {
+            'content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics)
+          },
+          'default' => true
+        },
+        {
           'value' => 'upcoming_statistics',
           'label' => 'Statistics (upcoming)',
           'filter' => {
@@ -11,12 +19,11 @@ module Filters
           }
         },
         {
-          'value' => 'published_statistics',
-          'label' => 'Statistics (published)',
+          'value' => 'cancelled_statistics',
+          'label' => 'Statistics (cancelled)',
           'filter' => {
-            'content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics)
-          },
-          'default' => true
+              'statistics_announcement_state' => 'cancelled'
+            }
         },
         {
           'value' => 'research',

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -1,25 +1,25 @@
 class StatisticsSortPresenter < SortPresenter
   def initialize(content_item, filter_params)
-    @stats_grouping = filter_params['content_store_document_type']
+    @doc_type = filter_params['content_store_document_type']
     super(content_item, filter_params)
   end
 
 private
 
-  attr_reader :stats_grouping, :user_selected_order, :keywords, :content_item_sort_options
+  attr_reader :doc_type, :user_selected_order, :keywords, :content_item_sort_options
 
   RELEVANCE_OPTION_TYPES = %w(relevance -relevance).freeze
   EXCLUDED_OPTIONS = {
-    published: %w(-release_timestamp release_timestamp),
-    upcoming: %w(-public_timestamp public_timestamp),
+    public: %w(-release_timestamp release_timestamp),
+    release: %w(-public_timestamp public_timestamp)
   }.freeze
   DEFAULT_KEY = {
-    published: '-public_timestamp',
-    upcoming: '-release_timestamp',
+    public: '-public_timestamp',
+    release: '-release_timestamp'
   }.freeze
 
   def default_key
-    DEFAULT_KEY[group]
+    DEFAULT_KEY[sort_type]
   end
 
   def is_default?(option)
@@ -28,7 +28,7 @@ private
 
   def sort_options
     content_item_sort_options.reject { |option|
-      EXCLUDED_OPTIONS[group].include? option['key']
+      EXCLUDED_OPTIONS[sort_type].include? option['key']
     }
   end
 
@@ -36,7 +36,16 @@ private
     sort_options.find { |option| option['key'] == default_key }
   end
 
-  def group
-    stats_grouping == 'upcoming_statistics' ? :upcoming : :published
+  def sort_type
+    case doc_type
+    when 'upcoming_statistics'
+      :release
+    when 'published_statistics'
+      :public
+    when 'cancelled_statistics'
+      :release
+    else
+      :public
+    end
   end
 end

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -15,7 +15,7 @@ private
   }.freeze
   DEFAULT_KEY = {
     public: '-public_timestamp',
-    release: '-release_timestamp'
+    release: 'release_timestamp'
   }.freeze
 
   def default_key

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -377,7 +377,7 @@ Feature: Filtering documents
     And I select upcoming statistics
     And I click filter results
     Then I should see upcoming statistics
-    And I see Release date (latest) order selected
+    And I see Release date (oldest) order selected
     And I can sort by:
       | Most viewed           |
       | Relevance             |
@@ -398,7 +398,7 @@ Feature: Filtering documents
     When I view the research and statistics finder
     And I select upcoming statistics
     Then I should see upcoming statistics
-    And I see Release date (latest) order selected
+    And I see Release date (oldest) order selected
     And I can sort by:
       | Most viewed           |
       | Relevance             |

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe StatisticsSortPresenter do
     context "when upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (latest)', 'release-date-latest')
+        expect_default('Release date (oldest)', 'release-date-oldest')
       end
     end
 
     context "when cancelled_statistics is selected" do
       let(:query) { cancelled_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (latest)', 'release-date-latest')
+        expect_default('Release date (oldest)', 'release-date-oldest')
       end
     end
 
@@ -133,8 +133,8 @@ RSpec.describe StatisticsSortPresenter do
         let(:query) { order.merge(upcoming_statistics_query) }
         it "returns Release date (latest)" do
           returns_the_default_option(
-            "key" => "-release_timestamp",
-            "name" => "Release date (latest)",
+            "key" => "release_timestamp",
+            "name" => "Release date (oldest)",
           )
         end
       end
@@ -143,8 +143,8 @@ RSpec.describe StatisticsSortPresenter do
         let(:query) { order.merge(cancelled_statistics_query) }
         it "returns Release date (latest)" do
           returns_the_default_option(
-            "key" => "-release_timestamp",
-            "name" => "Release date (latest)",
+            "key" => "release_timestamp",
+            "name" => "Release date (oldest)",
           )
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe StatisticsSortPresenter do
 
       context "upcoming statistics is selected" do
         let(:query) { order.merge(upcoming_statistics_query) }
-        it "returns Release date (latest) as the default" do
+        it "returns Release date (latest)" do
           returns_the_default_option(
             "key" => "-release_timestamp",
             "name" => "Release date (latest)",
@@ -188,10 +188,10 @@ RSpec.describe StatisticsSortPresenter do
 
         context "upcoming statistics is selected" do
           let(:query) { order.merge(upcoming_statistics_query) }
-          it "returns Release date (latest) as the default" do
+          it "returns Release date (oldest) as the default" do
             returns_the_default_option(
-              "key" => "-release_timestamp",
-              "name" => "Release date (latest)",
+              "key" => "release_timestamp",
+              "name" => "Release date (oldest)",
             )
           end
         end
@@ -346,7 +346,7 @@ RSpec.describe StatisticsSortPresenter do
 
     context "upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
-      it "sets default_value" do default_value_is("release-date-latest"); end
+      it "sets default_value" do default_value_is("release-date-oldest"); end
       it "sets relevance_value" do relevance_value_is_set; end
       it "has 4 options" do has_four_options; end
 

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe StatisticsSortPresenter do
     { "content_store_document_type" => "research" }
   end
 
+  let(:cancelled_statistics_query) do
+    { "content_store_document_type" => "cancelled_statistics" }
+  end
+
   let(:default_option) {
     {
       "default" => true,
@@ -77,6 +81,13 @@ RSpec.describe StatisticsSortPresenter do
       end
     end
 
+    context "when cancelled_statistics is selected" do
+      let(:query) { cancelled_statistics_query }
+      it "returns release timestamp" do
+        expect_default('Release date (latest)', 'release-date-latest')
+      end
+    end
+
     context "when no value is selected" do
       it "returns updated newest as the default" do
         expect_default('Updated (newest)', 'updated-newest')
@@ -120,6 +131,16 @@ RSpec.describe StatisticsSortPresenter do
 
       context "upcoming statistics is selected" do
         let(:query) { order.merge(upcoming_statistics_query) }
+        it "returns Release date (latest)" do
+          returns_the_default_option(
+            "key" => "-release_timestamp",
+            "name" => "Release date (latest)",
+          )
+        end
+      end
+
+      context "cancelled statistics is selected" do
+        let(:query) { order.merge(cancelled_statistics_query) }
         it "returns Release date (latest)" do
           returns_the_default_option(
             "key" => "-release_timestamp",


### PR DESCRIPTION
Before:

If a stats announcement is cancelled, it is lost from the finder once its scheduled release date is passed. As it won't show up in the published statistics results, and its outside of the time period of the scoped upcoming statistics search (results are from today onwards)

After:

<img width="969" alt="Screen Shot 2019-08-07 at 18 42 04" src="https://user-images.githubusercontent.com/17908089/62644891-16eba480-b943-11e9-8148-0ca6615828ca.png">



https://trello.com/c/TRKpC1SC/935-users-cant-find-cancelled-statistics-releases

---

## Search page example to sanity check:

- http://finder-frontend-pr-1294.herokuapp.com/search/research-and-statistics
