### PR TITLE
Hide 'Show only Brexit results' if filtering on the Brexit Topic.

### DIFF
--- a/app/lib/facets_builder.rb
+++ b/app/lib/facets_builder.rb
@@ -16,8 +16,21 @@ private
 
   attr_reader :content_item, :search_results, :value_hash
 
+  def filters_on_brexit_topic?
+    @value_hash['topic'] == ContentItem::BREXIT_CONTENT_ID
+  end
+
+  def is_related_to_brexit_checkbox?(facet_hash)
+    facet_hash['key'] == "related_to_brexit" && facet_hash['filter_value'] == ContentItem::BREXIT_CONTENT_ID
+  end
+
   def facet_hashes
-    FacetExtractor.new(content_item).extract
+    all_facet_hashes = FacetExtractor.new(content_item).extract
+    if filters_on_brexit_topic?
+      all_facet_hashes.reject { |facet_hash| is_related_to_brexit_checkbox?(facet_hash) }
+    else
+      all_facet_hashes
+    end
   end
 
   def build_facet(facet_hash)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,4 +1,6 @@
 class ContentItem
+  BREXIT_CONTENT_ID = 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'.freeze
+
   def initialize(content_item_hash)
     @content_item_hash = content_item_hash.freeze
   end

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -352,6 +352,14 @@ Feature: Filtering documents
     Then the page has a landmark to the search results
     And the page has a landmark to the search filters
 
+  Scenario: "Show only Brexit results" checkbox is removed if the topic parameter is set to the Brexit Topic.
+    When I view the news and communications finder filtered on the brexit topic
+    Then I cannot see the "show only brexit results" checkbox
+
+  Scenario: "Show only Brexit results" checkbox is shown if no topic parameter is set
+    When I view the news and communications finder
+    Then I can see the "show only brexit results" checkbox
+
   Scenario: Email links
     When I view the news and communications finder
     Then I see email and feed sign up links

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -108,6 +108,25 @@ When(/^I view the news and communications finder$/) do
   visit finder_path('search/news-and-communications')
 end
 
+When(/^I view the news and communications finder filtered on the brexit topic$/) do
+  stub_taxonomy_api_request
+  content_store_has_news_and_communications_finder
+  stub_whitehall_api_world_location_request
+  stub_all_rummager_api_requests_with_news_and_communication_results
+  stub_people_registry_request
+  stub_organisations_registry_request
+  visit finder_path('search/news-and-communications', topic: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea')
+end
+
+Then(/^I (can|cannot) see the "show only brexit results" checkbox$/) do |can_or_cannot|
+  have_clause = have_css(".govuk-checkboxes__label", text: "Show only Brexit results")
+  if can_or_cannot == 'can'
+    expect(page).to have_clause
+  else
+    expect(page).to_not have_clause
+  end
+end
+
 Given(/^I am in the variant B control group$/) do
   ab_test_variant = double(:variant, variant_name: "B", analytics_meta_tag: "")
   allow(ab_test_variant).to receive(:variant?).with("B").and_return(true)

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -70,8 +70,18 @@ describe FacetsBuilder do
       "allowed_values": [{ "value" => "my_manual" }]
     }
   }
+  let(:related_to_brexit_facet_hash) {
+    {
+      "key": "related_to_brexit",
+      "filter_key": "all_part_of_taxonomy_tree",
+      "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      "name": "Show only Brexit results",
+      "type": "checkbox",
+      "filterable": true
+    }
+  }
 
-  let(:detail_hashes) {
+  let(:detail_hash) {
     {
       "details" => {
         "facets" => [
@@ -95,6 +105,44 @@ describe FacetsBuilder do
   let(:content_item) {
     ContentItem.new(content_item_hash)
   }
+
+  describe 'Remove brexit checkbox filter' do
+    subject(:facets) do
+      FacetsBuilder.new(content_item: content_item, search_results: {}, value_hash: value_hash).facets
+    end
+    let(:detail_hash) {
+      {
+        "details" => {
+          "facets" => [
+            taxon_facet_hash,
+            checkbox_facet_hash,
+            radio_facet_hash,
+            related_to_brexit_facet_hash
+          ]
+        }
+      }
+    }
+    context 'The page is filtered on the brexit topic' do
+      let(:value_hash) {
+        {
+          'topic' => ContentItem::BREXIT_CONTENT_ID
+        }
+      }
+      it 'contains no related to brexit taxon' do
+        expect(facets).to_not include(an_object_satisfying { |facet| facet.key == 'related_to_brexit' })
+      end
+    end
+    context 'The page is not filtered on the brexit topic' do
+      let(:value_hash) {
+        {
+          related_to_brexit: ContentItem::BREXIT_CONTENT_ID
+        }
+      }
+      it 'contains a related to brexit taxon' do
+        expect(facets).to include(an_object_satisfying { |facet| facet.key == 'related_to_brexit' })
+      end
+    end
+  end
 
   describe 'facets' do
     subject(:facet) do


### PR DESCRIPTION
When we navigate from the Brexit Topic Page, we set the 'topic'
parameter to the Brexit content_id which filters the results
accordingly.

This means that the checkbox 'Show only Brexit results' should
be removed because selecting or deselecting it will have no
effect and is likely to confuse users.

## **With topic parameter - does not show the checkbox**

![image](https://user-images.githubusercontent.com/6050162/62714265-2546c880-b9f6-11e9-955e-5c0592f6f671.png)

## **Without topic parameter - does show the checkbox**
![image](https://user-images.githubusercontent.com/6050162/62714300-3394e480-b9f6-11e9-9d92-fe61ac375712.png)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1295.herokuapp.com/search/all
- http://finder-frontend-pr-1295.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1295.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1295.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1295.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1295.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1295.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1295.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1295.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
