### PR TITLE
Revert "Change default sort order on the stats finder"

### DIFF
--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -15,7 +15,7 @@ private
   }.freeze
   DEFAULT_KEY = {
     public: '-public_timestamp',
-    release: 'release_timestamp'
+    release: '-release_timestamp'
   }.freeze
 
   def default_key

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -385,7 +385,7 @@ Feature: Filtering documents
     And I select upcoming statistics
     And I click filter results
     Then I should see upcoming statistics
-    And I see Release date (oldest) order selected
+    And I see Release date (latest) order selected
     And I can sort by:
       | Most viewed           |
       | Relevance             |
@@ -406,7 +406,7 @@ Feature: Filtering documents
     When I view the research and statistics finder
     And I select upcoming statistics
     Then I should see upcoming statistics
-    And I see Release date (oldest) order selected
+    And I see Release date (latest) order selected
     And I can sort by:
       | Most viewed           |
       | Relevance             |

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe StatisticsSortPresenter do
     context "when upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (oldest)', 'release-date-oldest')
+        expect_default('Release date (latest)', 'release-date-latest')
       end
     end
 
     context "when cancelled_statistics is selected" do
       let(:query) { cancelled_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (oldest)', 'release-date-oldest')
+        expect_default('Release date (latest)', 'release-date-latest')
       end
     end
 
@@ -133,8 +133,8 @@ RSpec.describe StatisticsSortPresenter do
         let(:query) { order.merge(upcoming_statistics_query) }
         it "returns Release date (latest)" do
           returns_the_default_option(
-            "key" => "release_timestamp",
-            "name" => "Release date (oldest)",
+            "key" => "-release_timestamp",
+            "name" => "Release date (latest)",
           )
         end
       end
@@ -143,8 +143,8 @@ RSpec.describe StatisticsSortPresenter do
         let(:query) { order.merge(cancelled_statistics_query) }
         it "returns Release date (latest)" do
           returns_the_default_option(
-            "key" => "release_timestamp",
-            "name" => "Release date (oldest)",
+            "key" => "-release_timestamp",
+            "name" => "Release date (latest)",
           )
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe StatisticsSortPresenter do
 
       context "upcoming statistics is selected" do
         let(:query) { order.merge(upcoming_statistics_query) }
-        it "returns Release date (latest)" do
+        it "returns Release date (latest) as the default" do
           returns_the_default_option(
             "key" => "-release_timestamp",
             "name" => "Release date (latest)",
@@ -188,10 +188,10 @@ RSpec.describe StatisticsSortPresenter do
 
         context "upcoming statistics is selected" do
           let(:query) { order.merge(upcoming_statistics_query) }
-          it "returns Release date (oldest) as the default" do
+          it "returns Release date (latest) as the default" do
             returns_the_default_option(
-              "key" => "release_timestamp",
-              "name" => "Release date (oldest)",
+              "key" => "-release_timestamp",
+              "name" => "Release date (latest)",
             )
           end
         end
@@ -346,7 +346,7 @@ RSpec.describe StatisticsSortPresenter do
 
     context "upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
-      it "sets default_value" do default_value_is("release-date-oldest"); end
+      it "sets default_value" do default_value_is("release-date-latest"); end
       it "sets relevance_value" do relevance_value_is_set; end
       it "has 4 options" do has_four_options; end
 


### PR DESCRIPTION
This reverts commit 05d3d13e7a2809aed64060fdd7e6f8cc6ed4bff7.

There's a little oddness about what happens to the sort order when
switching between published, announced and cancelled statistics. I'm
going to spend a little time working it out, and don't want to block
other deploys.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1296.herokuapp.com/search/all
- http://finder-frontend-pr-1296.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1296.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1296.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1296.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1296.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1296.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1296.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1296.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
