### PR TITLE
Allow all sorting options for cancelled statistics

### DIFF
--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -10,10 +10,12 @@ private
 
   RELEVANCE_OPTION_TYPES = %w(relevance -relevance).freeze
   EXCLUDED_OPTIONS = {
+    any: [],
     public: %w(-release_timestamp release_timestamp),
     release: %w(-public_timestamp public_timestamp)
   }.freeze
   DEFAULT_KEY = {
+    any: '-public_timestamp',
     public: '-public_timestamp',
     release: '-release_timestamp'
   }.freeze
@@ -43,7 +45,7 @@ private
     when 'published_statistics'
       :public
     when 'cancelled_statistics'
-      :release
+      :any
     else
       :public
     end

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe StatisticsSortPresenter do
 
     context "when cancelled_statistics is selected" do
       let(:query) { cancelled_statistics_query }
-      it "returns release timestamp" do
-        expect_default('Release date (latest)', 'release-date-latest')
+      it "returns public timestamp" do
+        expect_default('Updated (newest)', 'updated-newest')
       end
     end
 
@@ -141,10 +141,11 @@ RSpec.describe StatisticsSortPresenter do
 
       context "cancelled statistics is selected" do
         let(:query) { order.merge(cancelled_statistics_query) }
-        it "returns Release date (latest)" do
+        it "returns Updated (newest)" do
           returns_the_default_option(
-            "key" => "-release_timestamp",
-            "name" => "Release date (latest)",
+            "default" => true,
+            "key" => "-public_timestamp",
+            "name" => "Updated (newest)",
           )
         end
       end


### PR DESCRIPTION
Cancelled stats release dates range from 2014 to 2020, but it's likely
that people will be most interested in contemporary changes (whatever they
are).  Because of this we'll allow (and default to) using "updated-newest"
as the default sort option for these.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1297.herokuapp.com/search/all
- http://finder-frontend-pr-1297.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1297.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1297.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1297.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1297.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1297.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1297.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1297.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
