### PR TITLE
Use "Release date (soonest)" for upcoming stats announcements

### DIFF
--- a/app/presenters/sort_option_presenter.rb
+++ b/app/presenters/sort_option_presenter.rb
@@ -1,9 +1,9 @@
 class SortOptionPresenter
   attr_reader :value, :key, :label
 
-  def initialize(label:, key:, default: false, disabled: false, selected: false)
+  def initialize(label:, value: nil, key:, default: false, disabled: false, selected: false)
     @label = label
-    @value = label.parameterize
+    @value = value || label.parameterize
     @key = key
     @default = default
     @disabled = disabled

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -41,6 +41,7 @@ private
     @presented_sort_options ||= sort_options.map do |option|
       SortOptionPresenter.new(
         label: option['name'],
+        value: option_value(option),
         key: option['key'],
         default: is_default?(option),
         selected: option_value(option) == option_value(selected_option),
@@ -80,6 +81,6 @@ private
   def option_value(option)
     return if option.nil?
 
-    option.fetch('name', '').parameterize
+    option.fetch('value', option.fetch('name', '').parameterize)
   end
 end

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -17,6 +17,11 @@ private
     public: '-public_timestamp',
     release: '-release_timestamp'
   }.freeze
+  RENAMED_OPTIONS = {
+    'upcoming_statistics' => {
+      'release_timestamp' => 'Release date (soonest)'
+    }
+  }.freeze
 
   def default_key
     DEFAULT_KEY[sort_type]
@@ -27,13 +32,27 @@ private
   end
 
   def sort_options
-    content_item_sort_options.reject { |option|
-      EXCLUDED_OPTIONS[sort_type].include? option['key']
-    }
+    content_item_sort_options.reject { |o| excluded? o }.map { |o| rename o }
   end
 
   def raw_default_option
     sort_options.find { |option| option['key'] == default_key }
+  end
+
+  def excluded?(option)
+    EXCLUDED_OPTIONS[sort_type].include? option['key']
+  end
+
+  def rename(option)
+    name = RENAMED_OPTIONS.dig(doc_type, option['key'])
+    if name
+      option.merge(
+        'name' => name,
+        'value' => option['name'].parameterize,
+      )
+    else
+      option
+    end
   end
 
   def sort_type

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -387,10 +387,10 @@ Feature: Filtering documents
     Then I should see upcoming statistics
     And I see Release date (latest) order selected
     And I can sort by:
-      | Most viewed           |
-      | Relevance             |
-      | Release date (latest) |
-      | Release date (oldest) |
+      | Most viewed            |
+      | Relevance              |
+      | Release date (latest)  |
+      | Release date (soonest) |
     And I should not see an upcoming statistics facet tag
     Then I select published statistics
     And I click filter results
@@ -408,10 +408,10 @@ Feature: Filtering documents
     Then I should see upcoming statistics
     And I see Release date (latest) order selected
     And I can sort by:
-      | Most viewed           |
-      | Relevance             |
-      | Release date (latest) |
-      | Release date (oldest) |
+      | Most viewed            |
+      | Relevance              |
+      | Release date (latest)  |
+      | Release date (soonest) |
     And I should not see an upcoming statistics facet tag
     Then I select published statistics
     Then I see Updated (newest) order selected

--- a/spec/presenters/sort_option_presenter_spec.rb
+++ b/spec/presenters/sort_option_presenter_spec.rb
@@ -3,12 +3,20 @@ require "helpers/taxonomy_spec_helper"
 
 RSpec.describe SortOptionPresenter do
   subject(:sort_option) { described_class.new(label: "Updated (newest)", key: "-public_timestamp") }
+  subject(:sort_option_with_value) { described_class.new(label: "Updated (newest)", value: "frogs-frogs-frogs", key: "-public_timestamp") }
   subject(:default_sort_option) { described_class.new(label: "Most viewed", key: "most-viewed", default: true) }
   subject(:relevance_sort_option) { described_class.new(label: "Show least relevant", key: "-relevance",) }
 
   describe "#value" do
-    it "returns label parameterized" do
-      expect(sort_option.value).to eq("updated-newest")
+    context "a value is provided" do
+      it "returns the given value" do
+        expect(sort_option_with_value.value).to eq("frogs-frogs-frogs")
+      end
+    end
+    context "a value is not provided" do
+      it "returns label parameterized" do
+        expect(sort_option.value).to eq("updated-newest")
+      end
     end
   end
 

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -197,6 +197,31 @@ RSpec.describe StatisticsSortPresenter do
         end
       end
     end
+
+    context "Sort option release-date-oldest is selected by the user" do
+      let(:order) { { 'order' => 'release-date-oldest' } }
+
+      context "upcoming statistics is selected" do
+        let(:query) { order.merge(upcoming_statistics_query) }
+        it "returns Release date (soonest) as the default" do
+          returns_the_default_option(
+            "key" => "release_timestamp",
+            "name" => "Release date (soonest)",
+            "value" => "release-date-oldest",
+          )
+        end
+      end
+
+      context "cancelled statistics statistics is selected" do
+        let(:query) { order.merge(cancelled_statistics_query) }
+        it "returns Release date (oldest) as the default" do
+          returns_the_default_option(
+            "key" => "release_timestamp",
+            "name" => "Release date (oldest)",
+          )
+        end
+      end
+    end
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
All stats announcements are in the future, so "Release date (oldest)" actually means the statistics which have the oldest date in the future.  English already has a perfectly cromulent word for that: "soonest".

I think "Release date (latest)" is still confusing, but "Release date (furthest in the future)" is a bit wordy.  That's a problem for... later.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1299.herokuapp.com/search/all
- http://finder-frontend-pr-1299.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1299.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1299.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1299.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1299.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1299.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1299.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1299.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/wVdsvb8m/951-change-oldest-to-soonest-on-sort-by-labels-for-upcoming-statistics)
