### PR TITLE
Add a development page for finder-frontend

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,7 @@
+class DevelopmentController < ApplicationController
+  layout "development_layout"
+
+  def index
+    @rendered_pages = Services.rummager.search(filter_rendering_app: "finder-frontend", count: 1000, order: "title")["results"]
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Finder Frontend" %>
+
+<%= render "govuk_publishing_components/components/title", title: "Finder Frontend" %>
+
+<%= render "govuk_publishing_components/components/govspeak" do %>
+  <p>This page is only visible in development and Heroku.</p>
+
+  <p>The following pages are rendered by this application:</p>
+
+  <ul>
+  <% @rendered_pages.each do |page| %>
+    <li><%= link_to page.fetch("title"), page.fetch("link") %></li>
+  <% end %>
+  </ul>
+<% end %>

--- a/app/views/layouts/development_layout.html.erb
+++ b/app/views/layouts/development_layout.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= yield :title %> - GOV.UK</title>
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+    <%= javascript_include_tag "application", integrity: true, crossorigin: "anonymous" %>
+    <meta name="robots" content="noindex">
+  </head>
+
+  <body>
+    <div id="wrapper">
+      <div class="govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= yield %>
+         </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ FinderFrontend::Application.routes.draw do
   )
   get '/healthcheck', to: proc { [200, {}, %w[OK]] }
 
+  root to: redirect('/development') unless Rails.env.test?
+  get '/development' => 'development#index'
+
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"
 


### PR DESCRIPTION
Currently this app doesn't have anything on the root, which sometimes causes problems (the dreaded "no such method `.to_html` for nilClass").

This solves that by adding a simple homepage, which is only visible on Heroku and development (because in production nothing will route to it).

The page is currently a list of stuff that's rendered by the app, according to the search-api. This is useful to find things to test.

<img width="1260" alt="Screen Shot 2019-08-15 at 11 41 59" src="https://user-images.githubusercontent.com/233676/63090402-0e065e80-bf53-11e9-8e2e-d628258efdb0.png">

Trello: https://trello.com/c/nKAnfZKE