### PR TITLE
Add development page for checklists

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,7 +1,19 @@
 class DevelopmentController < ApplicationController
   layout "development_layout"
 
+  # https://github.com/alphagov/content-tagger/blob/f917f70f33b97e8fc04b3ae953f4631f285f1c37/lib/data/find-eu-exit-guidance-dynamic-lists.yml#L2
+  CHECKLIST_FACET_GROUP = "e6dc1c00-453a-4fac-96ec-66a2f11ae327".freeze
+
   def index
     @rendered_pages = Services.rummager.search(filter_rendering_app: "finder-frontend", count: 1000, order: "title")["results"]
+  end
+
+  def checklists
+    @all_possible_checklist_items = Services.rummager.search(
+      filter_facet_groups: [CHECKLIST_FACET_GROUP],
+      count: 1000,
+      order: "title",
+      fields: %w[title link content_id],
+    )["results"]
   end
 end

--- a/app/views/development/checklists.html.erb
+++ b/app/views/development/checklists.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Brexit checklist development" %>
+
+<%= render "govuk_publishing_components/components/back_link", href: "/development" %>
+
+<%= render "govuk_publishing_components/components/title", title: "Brexit checklist development" %>
+
+<%= render "govuk_publishing_components/components/heading", level: 2, text: "All things tagged to checklist facets" %>
+
+<%= render "govuk_publishing_components/components/govspeak" do %>
+  <ul>
+  <% @all_possible_checklist_items.each do |page| %>
+    <li>
+      <%= link_to page.fetch("title"), page.fetch("link") %><br/>
+      facets:
+      <% Services.content_store.content_item(page.fetch("link"))["links"]["facet_values"].each do |f| %>
+        <%= tag.span f["details"]["value"], class: "govuk-tag" %>
+      <% end %>
+      | <%= link_to "update facets", "https://content-tagger.publishing.service.gov.uk/facet_groups/#{DevelopmentController::CHECKLIST_FACET_GROUP}/facet_taggings/#{page.fetch("content_id")}" %>
+    </li>
+  <% end %>
+  </ul>
+<% end %>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -5,6 +5,8 @@
 <%= render "govuk_publishing_components/components/govspeak" do %>
   <p>This page is only visible in development and Heroku.</p>
 
+  <p>There's a <%= link_to "special test page for the Brexit checklists", "/development/checklists" %></p>
+
   <p>The following pages are rendered by this application:</p>
 
   <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ FinderFrontend::Application.routes.draw do
 
   root to: redirect('/development') unless Rails.env.test?
   get '/development' => 'development#index'
+  get '/development/checklists' => 'development#checklists'
 
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"


### PR DESCRIPTION
We have [built a facet group into content-tagger](https://github.com/alphagov/content-tagger/blob/f917f70f33b97e8fc04b3ae953f4631f285f1c37/lib/data/find-eu-exit-guidance-dynamic-lists.yml) to allow us to tag content so that it will appear on checklists.

Currently we have no way to see all of the things that are tagged, and how they're tagged.

This page contains a list of anything that *could* show up on a checklist page, with the tags/facets that they've been given and a link to content-tagger.

## Screenie

(There's only one thing tagged at the moment)

<img width="1218" alt="Screen Shot 2019-08-15 at 13 52 50" src="https://user-images.githubusercontent.com/233676/63095816-1a46e780-bf64-11e9-8bda-a09d6bb5adb1.png">

https://trello.com/c/nKAnfZKE