### PR TITLE
Change default sort for upcoming statistics to release_date

### DIFF
--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -12,12 +12,12 @@ private
   EXCLUDED_OPTIONS = {
     any: [],
     public: %w(-release_timestamp release_timestamp),
-    release: %w(-public_timestamp public_timestamp)
+    upcoming: %w(-public_timestamp public_timestamp)
   }.freeze
   DEFAULT_KEY = {
     any: '-public_timestamp',
     public: '-public_timestamp',
-    release: '-release_timestamp'
+    upcoming: 'release_timestamp'
   }.freeze
   RENAMED_OPTIONS = {
     'upcoming_statistics' => {
@@ -60,7 +60,7 @@ private
   def sort_type
     case doc_type
     when 'upcoming_statistics'
-      :release
+      :upcoming
     when 'published_statistics'
       :public
     when 'cancelled_statistics'

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -385,7 +385,7 @@ Feature: Filtering documents
     And I select upcoming statistics
     And I click filter results
     Then I should see upcoming statistics
-    And I see Release date (latest) order selected
+    And I see Release date (soonest) order selected
     And I can sort by:
       | Most viewed            |
       | Relevance              |
@@ -406,7 +406,7 @@ Feature: Filtering documents
     When I view the research and statistics finder
     And I select upcoming statistics
     Then I should see upcoming statistics
-    And I see Release date (latest) order selected
+    And I see Release date (soonest) order selected
     And I can sort by:
       | Most viewed            |
       | Relevance              |

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe StatisticsSortPresenter do
     context "when upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (latest)', 'release-date-latest')
+        expect_default('Release date (soonest)', 'release-date-oldest')
       end
     end
 
@@ -131,10 +131,11 @@ RSpec.describe StatisticsSortPresenter do
 
       context "upcoming statistics is selected" do
         let(:query) { order.merge(upcoming_statistics_query) }
-        it "returns Release date (latest)" do
+        it "returns Release date (soonest)" do
           returns_the_default_option(
-            "key" => "-release_timestamp",
-            "name" => "Release date (latest)",
+            "key" => "release_timestamp",
+            "name" => "Release date (soonest)",
+            "value" => "release-date-oldest",
           )
         end
       end
@@ -189,10 +190,11 @@ RSpec.describe StatisticsSortPresenter do
 
         context "upcoming statistics is selected" do
           let(:query) { order.merge(upcoming_statistics_query) }
-          it "returns Release date (latest) as the default" do
+          it "returns Release date (soonest) as the default" do
             returns_the_default_option(
-              "key" => "-release_timestamp",
-              "name" => "Release date (latest)",
+              "key" => "release_timestamp",
+              "name" => "Release date (soonest)",
+              "value" => "release-date-oldest",
             )
           end
         end
@@ -372,7 +374,7 @@ RSpec.describe StatisticsSortPresenter do
 
     context "upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
-      it "sets default_value" do default_value_is("release-date-latest"); end
+      it "sets default_value" do default_value_is("release-date-oldest"); end
       it "sets relevance_value" do relevance_value_is_set; end
       it "has 4 options" do has_four_options; end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/UawC5z3z/965-make-soonest-the-default-sort-option-on-the-upcoming-statistics-finder)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1310.herokuapp.com/search/all
- http://finder-frontend-pr-1310.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1310.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1310.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1310.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1310.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1310.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1310.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1310.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
