### PR TITLE
Use sorter presenter to determine default sort order in query

### DIFF
--- a/app/lib/search/order_query_builder.rb
+++ b/app/lib/search/order_query_builder.rb
@@ -68,22 +68,22 @@ module Search
       { 'order' => sort_option['key'] }
     end
 
-    def sort_options
-      content_item.sort_options
+    def order_presenter
+      @order_presenter ||= content_item.sorter_class.new(content_item, params)
     end
 
     def sort_option
-      return if sort_options.blank?
+      return if order_presenter.sort_options.blank?
 
-      sort_option = if params['order']
-                      sort_options.detect { |option| option['name'].parameterize == params['order'] }
-                    end
-
-      sort_option || sort_options.detect { |option| option['default'] } || { 'key' => default_order }
+      order_presenter.selected_option
     end
 
     def default_order
-      content_item.default_order
+      if order_presenter.default_option
+        order_presenter.default_option['key']
+      else
+        content_item.default_order
+      end
     end
   end
 end

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -31,6 +31,10 @@ class SortPresenter
     user_selected_option || raw_default_option
   end
 
+  def sort_options
+    content_item_sort_options
+  end
+
 private
 
   attr_reader :user_selected_order, :keywords, :content_item_sort_options
@@ -52,10 +56,6 @@ private
 
   def is_default?(option)
     option['default']
-  end
-
-  def sort_options
-    content_item_sort_options
   end
 
   def options_as_hashes

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -4,6 +4,10 @@ class StatisticsSortPresenter < SortPresenter
     super(content_item, filter_params)
   end
 
+  def sort_options
+    content_item_sort_options.reject { |o| excluded? o }.map { |o| rename o }
+  end
+
 private
 
   attr_reader :doc_type, :user_selected_order, :keywords, :content_item_sort_options
@@ -31,10 +35,6 @@ private
 
   def is_default?(option)
     option['key'] == default_key
-  end
-
-  def sort_options
-    content_item_sort_options.reject { |o| excluded? o }.map { |o| rename o }
   end
 
   def raw_default_option


### PR DESCRIPTION
Referring to the content item directly doesn't work now that we have
special logic for the statistics finder.  Happily, re-using the
existing sorter presenter reduces code, as well as making the two sets
of behaviours consistent.

[Trello card](https://trello.com/c/UawC5z3z/965-make-soonest-the-default-sort-option-on-the-upcoming-statistics-finder)


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1327.herokuapp.com/search/all
- http://finder-frontend-pr-1327.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1327.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1327.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1327.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1327.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1327.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1327.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1327.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
