### PR TITLE
Update govuk-publishing-components gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'gds-api-adapters', '~> 59.6'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 1.20.2'
 gem 'govuk_document_types', '~> 0.9.2'
-gem 'govuk_publishing_components', '~> 18.1.2'
+gem 'govuk_publishing_components', '~> 18.2.0'
 gem 'rails', '~> 5.2.3'
 gem 'slimmer', '~> 13.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (18.1.2)
+    govuk_publishing_components (18.2.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -155,6 +155,7 @@ GEM
       selenium-webdriver (>= 3.142)
       webdrivers
     hashdiff (1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.6.0)
@@ -202,7 +203,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
-    oj (3.8.1)
+    oj (3.9.0)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -259,11 +260,12 @@ GEM
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.8.0)
+    rouge (3.9.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -307,9 +309,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -396,7 +397,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.20.2)
   govuk_document_types (~> 0.9.2)
   govuk_frontend_toolkit (~> 8.2)
-  govuk_publishing_components (~> 18.1.2)
+  govuk_publishing_components (~> 18.2.0)
   govuk_schemas (~> 4.0)
   govuk_test
   jasmine-rails


### PR DESCRIPTION
Update govuk-publishing-components to the latest version.
