### PR TITLE
Load checklist config via initializer

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -9,7 +9,6 @@ class Checklists::Action
   end
 
   def self.load_all
-    actions = YAML.load_file("lib/checklists/actions.yaml")
-    actions['actions'].map { |a| new(a) }
+    CHECKLISTS_ACTIONS.map { |a| new(a) }
   end
 end

--- a/app/lib/checklists/criterion.rb
+++ b/app/lib/checklists/criterion.rb
@@ -8,9 +8,7 @@ class Checklists::Criterion
   end
 
   def self.load_by(criteria_keys)
-    file = YAML.load_file("lib/checklists/criteria.yaml")
-
-    criteria = file['criteria'].map do |c|
+    criteria = CHECKLISTS_CRITERIA.map do |c|
       Checklists::Criterion.new(c) if criteria_keys.include?(c['key'])
     end
 

--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -33,8 +33,7 @@ class Checklists::Question
   end
 
   def self.load_all
-    file = YAML.load_file("lib/checklists/questions.yaml")
-    file["questions"].map do |question|
+    CHECKLISTS_QUESTIONS.map do |question|
       Checklists::Question.new(question)
     end
   end

--- a/config/initializers/checklists.rb
+++ b/config/initializers/checklists.rb
@@ -1,0 +1,5 @@
+CHECKLISTS_CONFIG_PATH = Rails.root.join('lib/checklists/')
+
+CHECKLISTS_QUESTIONS = YAML.load_file(CHECKLISTS_CONFIG_PATH + "questions.yaml")['questions']
+CHECKLISTS_CRITERIA = YAML.load_file(CHECKLISTS_CONFIG_PATH + "criteria.yaml")['criteria']
+CHECKLISTS_ACTIONS = YAML.load_file(CHECKLISTS_CONFIG_PATH + "actions.yaml")['actions']


### PR DESCRIPTION
This ensures the YAML config files are parsed only once and stored in memory for the lifetime of the application runtime. This prevents the overhead of re-parsing the YAML files for each request.