### PR TITLE
Add Document#summary method.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -38,6 +38,10 @@ class Document
     description.gsub(/\.\s[A-Z].*/, '.') if description.present?
   end
 
+  def summary
+    truncated_description if finder.show_summaries?
+  end
+
 private
 
   attr_reader :link, :document_hash, :finder


### PR DESCRIPTION
This method was recently removed as part of a refactor:
https://github.com/alphagov/finder-frontend/pull/1330/commits/e68f32542c0e23c6865a00c5af84d9030bfb2aa5

The Atomfeed still depends on this in show.atom.builder and so
this is temporarily added back

A future PR will add some tests to ensure this doesn't happen
again.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1334.herokuapp.com/search/all
- http://finder-frontend-pr-1334.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1334.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1334.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1334.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1334.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1334.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1334.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1334.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
