### PR TITLE
Add a feature test for Atom Feeds

### DIFF
--- a/features/finders.feature
+++ b/features/finders.feature
@@ -427,3 +427,8 @@ Feature: Filtering documents
     Then I can see results filtered by that manual
     And I click the Replacing bristles in your Nimbus 2000 remove control
     Then I see all content results
+
+  Scenario: Atom Feed
+    When I view the research and statistics finder
+    And I click on the atom feed link
+    Then I see the atom feed

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -331,6 +331,14 @@ Then(/^I can see documents which have government metadata$/) do
   end
 end
 
+Then(/^I see the atom feed$/) do
+  expect(page).to have_selector('id', text: 'tag:www.dev.gov.uk,2005:/restrictions-on-usage-of-spells-within-school-grounds')
+  expect(page).to have_selector('updated', text: '2017-12-30T10:00:00Z')
+  expect(page).to have_selector(:css, 'link[href="http://www.dev.gov.uk/restrictions-on-usage-of-spells-within-school-grounds"]')
+  expect(page).to have_selector('title', text: 'Restrictions on usage of spells within school grounds')
+  expect(page).to have_selector('summary', text: 'Restrictions on usage of spells within school grounds')
+end
+
 Given(/^a collection of documents with bad metadata exist$/) do
   stub_taxonomy_api_request
   content_store_has_mosw_reports_finder
@@ -429,6 +437,10 @@ Then(/^I browse to a huge page number and get an appropriate error$/) do
   visit finder_path('government/policies/benefits-reform', page: 999999)
 
   expect(page.status_code).to eq(422)
+end
+
+And("I click on the atom feed link") do
+  click_on 'Subscribe to feed'
 end
 
 And("there is machine readable information") do


### PR DESCRIPTION
Test if an atom feed displays when clicking on the atom feed link

Trello: https://trello.com/c/iEoFcAWG/983-add-feature-test-for-atom-feed-in-finder-frontend

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
