### PR TITLE
Show 'lead times' instead of 'due dates'

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,11 +1,11 @@
 class Checklists::Action
-  attr_accessor :title, :description, :path, :due_date, :applicable_criteria
+  attr_accessor :title, :description, :path, :lead_time, :applicable_criteria
 
   def initialize(params)
     @title = params['title']
     @description = params['description']
     @path = params['path']
-    @due_date = params['due_date']
+    @lead_time = params['lead_time']
     @applicable_criteria = params['applicable_criteria']
   end
 
@@ -13,6 +13,10 @@ class Checklists::Action
     applicable_criteria.any? do |key|
       criteria_keys.include?(key)
     end
+  end
+
+  def self.find_by_title(title)
+    load_all.find { |a| a.title.match(title) }
   end
 
   def self.load_all

--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -11,9 +11,9 @@
       <% end %>
     </div>
     <div class="govuk-grid-column-one-quarter">
-      <% if action.due_date.present? %>
+      <% if action.lead_time.present? %>
         <p class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold checklist-result__leadtime">
-          Due by <%= action.due_date %>
+          It takes up to <%= action.lead_time %>
         </p>
       <% end %>
     </div>

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -2,15 +2,14 @@ actions:
   - title: 'Get an EORI number that starts with GB to move goods in or out of the UK'
     description: |
       If you do not get one, you may have increased costs and delays. For example, if HM Revenue and Customs (HMRC) cannot clear your goods you may have to pay storage fees.
-    path: '/eori' 
-    due_date: 2019-10-31
+    path: '/eori'
+    lead_time: '3 months'
     applicable_criteria:
       - owns-business
   - title: 'Get a new passport'
     description: |
       If you do not get one, you will not be able to travel.
-    path: '/apply-renew-passport' 
-    due_date: 2019-10-31
+    path: '/apply-renew-passport'
+    lead_time: '2 weeks'
     applicable_criteria:
       - non-eu-national
-

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -1,47 +1,47 @@
 require "spec_helper"
 
 RSpec.feature "Questions workflow", type: :feature do
-  scenario "User answers questions" do
-    given_i_visit_the_checklist_question_and_answer_flow
-    and_i_have_a_business
-    and_i_say_that_i_sell_goods
-    and_i_say_that_i_am_a_eu_citizen
+  scenario "basic questions" do
+    when_i_visit_the_checklist_flow
+    and_i_answer_the_basic_questions
     then_i_should_see_the_results_page
+    and_i_should_see_a_passport_action
+    and_i_should_not_see_an_eori_action
   end
 
-  scenario "User answers conditional questions" do
-    given_i_visit_the_checklist_question_and_answer_flow
-    and_i_dont_have_a_business
-    and_i_say_that_i_am_a_eu_citizen
+  scenario "business activity question" do
+    when_i_visit_the_checklist_flow
+    and_i_also_answer_a_business_question
     then_i_should_see_the_results_page
-    and_i_should_not_see_unrelated_actions
+    and_i_should_see_a_passport_action
+    and_i_should_see_an_eori_action
   end
 
-  def given_i_visit_the_checklist_question_and_answer_flow
+  def when_i_visit_the_checklist_flow
     visit '/find-brexit-guidance'
   end
 
-  def and_i_have_a_business
+  def and_i_answer_the_basic_questions
     expect(page).to have_content "Do you own a business?"
-    choose "Yes"
+    choose "No"
     click_on "Next"
-  end
 
-  def and_i_dont_have_a_business
-    expect(page).to have_content "Do you own a business?"
+    expect(page).to have_content "Are you an EU national living in the UK?"
     choose "No"
     click_on "Next"
   end
 
-  def and_i_say_that_i_sell_goods
+  def and_i_also_answer_a_business_question
+    expect(page).to have_content "Do you own a business?"
+    choose "Yes"
+    click_on "Next"
+
     expect(page).to have_content "Does your business do any of the following activities?"
     check "Sell goods or provide services in the UK"
     click_on "Next"
-  end
 
-  def and_i_say_that_i_am_a_eu_citizen
     expect(page).to have_content "Are you an EU national living in the UK?"
-    choose "Yes"
+    choose "No"
     click_on "Next"
   end
 
@@ -49,11 +49,22 @@ RSpec.feature "Questions workflow", type: :feature do
     expect(page).to have_content "What you may need to know to prepare for Brexit"
   end
 
-  def and_i_should_see_the_related_actions
-    expect(page).to have_content "Get a new passport"
+  def and_i_should_see_a_passport_action
+    action = Checklists::Action.find_by_title("Get a new passport")
+    expect(page).to have_link(action.title, href: action.path)
+    expect(page).to have_content action.lead_time
+    expect(page).to have_content action.description
   end
 
-  def and_i_should_not_see_unrelated_actions
-    expect(page).not_to have_content "Get an EORI number that starts with GB to move goods in or out of the UK"
+  def and_i_should_not_see_an_eori_action
+    action = Checklists::Action.find_by_title("Get an EORI number")
+    expect(page).to_not have_link(action.title, href: action.path)
+  end
+
+  def and_i_should_see_an_eori_action
+    action = Checklists::Action.find_by_title("Get an EORI number")
+    expect(page).to have_link(action.title, href: action.path)
+    expect(page).to have_content action.lead_time
+    expect(page).to have_content action.description
   end
 end


### PR DESCRIPTION
https://trello.com/c/jNd5Qi4S/48-display-lead-time-for-actions

Previously we showed a specific due date for each action. This replaces
the dates with an textual lead time e.g. '3 months'.

This also fixes the feature spec to actually check which actions are
shown, as the associated method was not previously being called. In order
to mitigate the increasing number of feature steps, this combines the
question steps together, since the flow is custom for each scenario.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
