### PR TITLE
Change query parameter format for brexit checklists

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -24,9 +24,7 @@ class ChecklistController < ApplicationController
     render "checklist/results"
   end
 
-  def email_signup
-    @criteria = params.require(:c)
-  end
+  def email_signup; end
 
   def confirm_email_signup
     request = Services.email_alert_api.find_or_create_subscriber_list(subscriber_list_options)
@@ -42,18 +40,17 @@ private
   ###
 
   def subscriber_list_options
-    criteria = params.require(:c).reject(&:blank?)
-
     {
       "title" => "Your Get ready for Brexit results",
-      "slug" => "brexit-checklist-#{criteria.sort.join('-')}",
-      "tags" => { "brexit_checklist_criteria" => { "any" => criteria } },
-      "url" => checklist_results_path(c: criteria)
+      "slug" => "brexit-checklist-#{criteria_keys.sort.join('-')}",
+      "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
+      "url" => checklist_results_path(c: criteria_keys)
     }
   end
 
   ###
   # Redirect
+
   ###
   def redirect_to_results?
     @page_service.redirect_to_results?
@@ -73,7 +70,7 @@ private
   helper_method :filtered_params
 
   def criteria_keys
-    filtered_params.values.flatten
+    request.query_parameters.fetch(:c, [])
   end
   helper_method :criteria_keys
 

--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -19,4 +19,8 @@ module ChecklistHelper
       action.applies_to?(criteria_keys)
     end
   end
+
+  def persistent_criteria_keys(question_criteria_keys)
+    criteria_keys - question_criteria_keys
+  end
 end

--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -17,9 +17,13 @@ class Checklists::Question
     depends_on.blank? || (depends_on - criteria).empty?
   end
 
-  def formatted_options(filtered_params)
+  def possible_criteria
+    @possible_criteria ||= options.map { |o| o['value'] }
+  end
+
+  def formatted_options(criteria_keys)
     options.map do |option|
-      checked = filtered_params[key].present? && filtered_params[key].include?(option["value"])
+      checked = criteria_keys.include?(option["value"])
       { label: option["label"], text: option["label"], value: option["value"], checked: checked }
     end
   end

--- a/app/views/checklist/_form_data.html.erb
+++ b/app/views/checklist/_form_data.html.erb
@@ -1,10 +1,4 @@
-<% filtered_params.each_pair do |key, value| %>
-  <% if value.is_a?(Array) && key != current_question.key %>
-    <% value.each do |v| %>
-      <input type="hidden" name="<%= key %>[]" value="<%= v %>">
-    <% end %>
-  <% elsif key != current_question.key %>
-    <input type="hidden" name="<%= key %>" value="<%= value %>">
-  <% end %>
+<% criteria_keys.each do |key| %>
+  <input type="hidden" name="c[]" value="<%= key %>">
 <% end %>
 <input type="hidden" name="page" value="<%= next_page %>">

--- a/app/views/checklist/_question_multiple_choice.html.erb
+++ b/app/views/checklist/_question_multiple_choice.html.erb
@@ -1,8 +1,8 @@
 <%= render "govuk_publishing_components/components/checkboxes", {
-  name: "#{current_question.key}[]",
+  name: "c[]",
   heading: current_question.text,
   description: formatted_description,
   hint_text: current_question.hint_text,
   is_page_heading: true,
-  items: current_question.formatted_options(filtered_params)
+  items: current_question.formatted_options(criteria_keys)
 } %>

--- a/app/views/checklist/_question_single_choice.html.erb
+++ b/app/views/checklist/_question_single_choice.html.erb
@@ -1,8 +1,8 @@
 <%= render "govuk_publishing_components/components/radio", {
-  name: "#{current_question.key}[]",
+  name: "c[]",
   heading: current_question.text,
   description: formatted_description,
   hint_text: current_question.hint_title,
   is_page_heading: true,
-  items: current_question.formatted_options(filtered_params)
+  items: current_question.formatted_options(criteria_keys)
 } %>

--- a/app/views/checklist/email_signup.html.erb
+++ b/app/views/checklist/email_signup.html.erb
@@ -26,7 +26,7 @@
           This will include: Information about Brexit including what you and your business can do to prepare.
         </p>
 
-        <%= form_tag checklist_confirm_email_signup_path(c: @criteria) do %>
+        <%= form_tag checklist_confirm_email_signup_path(c: criteria_keys) do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('checklists_results.stay_updated.sign_up'),
             inline_layout: true

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -35,7 +35,10 @@
             } %>
           </div>
         <% end %>
-        <%= render 'form_data', current_question: @current_question, next_page: @page_service.next_page %>
+        <%= render 'form_data',
+          criteria_keys: persistent_criteria_keys(@current_question.possible_criteria),
+          next_page: @page_service.next_page
+        %>
         <%= render 'hint_text', current_question: @current_question %>
         <div class="govuk-form-footer">
           <%= render "govuk_publishing_components/components/button", {

--- a/spec/features/checklists/email_signup_spec.rb
+++ b/spec/features/checklists/email_signup_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Checklist email signup", type: :feature do
   end
 
   def given_im_on_the_results_page
-    visit "/get-ready-brexit-check/results?do_you_own_a_business%5B%5D=does-not-own-business&eu_national_in_uk%5B%5D=eu-national"
+    visit "/get-ready-brexit-check/results?c%5B%5D=does-not-own-business&c%5B%5D=eu-national"
   end
 
   def and_email_alert_api_has_subscriber_list

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -63,4 +63,15 @@ describe ChecklistHelper, type: :helper do
       end
     end
   end
+
+  describe "#persistent_criteria_keys" do
+    let(:criteria_keys) { %w[A B C D] }
+    let(:question_criteria_keys) { %w[C D] }
+
+    subject { persistent_criteria_keys(question_criteria_keys) }
+
+    it 'returns all but the questions criteria' do
+      expect(subject).to contain_exactly('A', 'B')
+    end
+  end
 end


### PR DESCRIPTION
This changes the way a user's criteria are stored within the URL. Instead of having <question_key>[]=<option_key>, the criteria are listed c[]-<criteria_key>.