### PR TITLE
Enable optional guidance links for actions

### DIFF
--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -26,4 +26,11 @@ module ChecklistHelper
       action.applies_to?(criteria_keys)
     end
   end
+
+  def action_guidance_link_text(action)
+    prompt = action.guidance_prompt.presence ||
+      t("checklists_results.actions.guidance_prompt")
+
+    "#{prompt}: #{action.guidance_text}"
+  end
 end

--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,5 +1,13 @@
 class Checklists::Action
-  attr_accessor :title, :description, :path, :lead_time, :applicable_criteria, :section
+  attr_accessor :title,
+                :description,
+                :path,
+                :lead_time,
+                :applicable_criteria,
+                :section,
+                :guidance_text,
+                :guidance_url,
+                :guidance_prompt
 
   def initialize(params)
     @title = params['title']
@@ -8,6 +16,9 @@ class Checklists::Action
     @lead_time = params['lead_time']
     @applicable_criteria = params['applicable_criteria']
     @section = params['section']
+    @guidance_text = params['guidance_text']
+    @guidance_url = params['guidance_url']
+    @guidance_prompt = params['guidance_prompt']
   end
 
   def applies_to?(criteria_keys)

--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -10,6 +10,7 @@
         </p>
       <% end %>
     </div>
+
     <div class="govuk-grid-column-one-quarter">
       <% if action.lead_time.present? %>
         <p class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold checklist-result__leadtime">
@@ -18,4 +19,8 @@
       <% end %>
     </div>
   </div>
+
+  <% if action.guidance_text.present? && action.guidance_url.present? %>
+    <a href="<%= action.guidance_url %>" class="govuk-link"><%= action_guidance_link_text(action) %></a>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     actions:
       no_results: "Based on your answers, we were not able to determine suitable actions for you."
       more_guidance: "View more guidance here"
+      guidance_prompt: Read the guidance
     sections:
       citizen:
         heading: 'You and your family'

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -15,3 +15,5 @@ actions:
     applicable_criteria:
       - non-eu-national
     section: citizen
+    guidance_url: 'http://guidance.com'
+    guidance_text: 'Guidance Central'

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -51,9 +51,11 @@ RSpec.feature "Questions workflow", type: :feature do
 
   def and_i_should_see_a_passport_action
     action = Checklists::Action.find_by_title("Get a new passport")
+    prompt = I18n.t!("checklists_results.actions.guidance_prompt")
     expect(page).to have_link(action.title, href: action.path)
     expect(page).to have_content action.lead_time
     expect(page).to have_content action.description
+    expect(page).to have_link("#{prompt}: #{action.guidance_text}", href: action.guidance_url)
   end
 
   def and_i_should_not_see_an_eori_action

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -105,4 +105,27 @@ describe ChecklistHelper, type: :helper do
       end
     end
   end
+
+  describe "#action_guidance_link_text" do
+    context "when no prompt is specified" do
+      let(:action) { Checklists::Action.new('guidance_text' => 'text') }
+
+      subject { action_guidance_link_text(action) }
+
+      it "returns link text with a default prompt" do
+        default_prompt = I18n.t!("checklists_results.actions.guidance_prompt")
+        expect(subject).to eq("#{default_prompt}: text")
+      end
+    end
+
+    context "when a prompt is specified" do
+      let(:action) { Checklists::Action.new('guidance_text' => 'text', 'guidance_prompt' => 'prompt') }
+
+      subject { action_guidance_link_text(action) }
+
+      it "returns link text with the prompt" do
+        expect(subject).to eq("prompt: text")
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/gmQNrkNN/45-display-guidance-link-for-actions

This enables optional 'guidance_text' and 'guidance_url' fields that are
shown as a link below each action. By default, the link is prefixed with
'Read the guidance', but this can be overridden if necessary.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
