### PR TITLE
Add some validations for checklist YAML files

### DIFF
--- a/app/lib/checklists/criterion.rb
+++ b/app/lib/checklists/criterion.rb
@@ -7,13 +7,15 @@ class Checklists::Criterion
     @depends_on = params.fetch('depends_on', [])
   end
 
-  def self.load_by(criteria_keys)
-    criteria = CHECKLISTS_CRITERIA.map do |c|
-      Checklists::Criterion.new(c) if criteria_keys.include?(c['key'])
+  def self.load_all
+    CHECKLISTS_CRITERIA.map do |criteria|
+      Checklists::Criterion.new(criteria)
     end
+  end
 
-    criteria.select do |c|
-      c.present? && (c.depends_on - criteria_keys).blank?
+  def self.load_by(criteria_keys)
+    load_all.select do |c|
+      criteria_keys.include?(c.key) && (c.depends_on - criteria_keys).blank?
     end
   end
 end

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -29,4 +29,25 @@ describe Checklists::Action do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe ".load_all" do
+    subject { described_class.load_all }
+
+    it "returns a list of actions with required keys" do
+      subject.each do |action|
+        expect(action.title).to be_present
+        expect(action.description).to be_present
+        expect(action.path).to be_present
+        expect(action.applicable_criteria).to be_a Array
+      end
+    end
+
+    it "returns actions that reference valid criteria" do
+      criteria = Checklists::Criterion.load_all.map(&:key)
+
+      subject.each do |action|
+        expect(criteria).to include(*action.applicable_criteria.to_a)
+      end
+    end
+  end
 end

--- a/spec/lib/checklists/criterion_spec.rb
+++ b/spec/lib/checklists/criterion_spec.rb
@@ -1,0 +1,20 @@
+describe Checklists::Criterion do
+  describe ".load_all" do
+    subject { described_class.load_all }
+
+    it "returns a list of criteria with valid keys" do
+      subject.each do |criteria|
+        expect(criteria.key).to be_present
+        expect(criteria.text).to be_present
+      end
+    end
+
+    it "returns criteria that reference valid criteria" do
+      keys = Checklists::Criterion.load_all.map(&:key)
+
+      subject.each do |criterion|
+        expect(keys).to include(*criterion.depends_on.to_a)
+      end
+    end
+  end
+end

--- a/spec/lib/checklists/question_spec.rb
+++ b/spec/lib/checklists/question_spec.rb
@@ -24,4 +24,29 @@ describe Checklists::Question do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe ".load_all" do
+    subject { described_class.load_all }
+
+    it "returns a list of questions with required keys" do
+      subject.each do |question|
+        expect(question.key).to be_present
+        expect(question.text).to be_present
+        expect(%w[single multiple]).to include(question.type)
+        expect(question.options).to be_a Array
+      end
+    end
+
+    it "returns question that reference valid criteria" do
+      criteria = Checklists::Criterion.load_all.map(&:key)
+
+      subject.each do |question|
+        question.options.each do |option|
+          expect(criteria).to include(option['value'])
+        end
+
+        expect(criteria).to include(*question.depends_on.to_a)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/uE8KljWU/84-validate-yaml-files-are-well-formed

This adds a few validations to check the content of the checklist YAML
files at the point of loading: required fields are present and
referenced criteria exist. Other optional fields could still be written
incorrectly, but that doesn't seem as critical to test. We should add
further validations as new fields are added to the checklist classes.

Follow-up work:

   - Add validation for `section` field when https://github.com/alphagov/finder-frontend/pull/1341 is merged
   - Add validation for `guidance_` fields when  https://github.com/alphagov/finder-frontend/pull/1346 is merged


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
