### PR TITLE
Allow lead time to be freeform

### DIFF
--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-one-quarter">
       <% if action.lead_time.present? %>
         <p class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold checklist-result__leadtime">
-          It takes up to <%= action.lead_time %>
+          <%= action.lead_time %>
         </p>
       <% end %>
     </div>

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -3,7 +3,7 @@ actions:
     description: |
       If you do not get one, you may have increased costs and delays. For example, if HM Revenue and Customs (HMRC) cannot clear your goods you may have to pay storage fees.
     path: '/eori'
-    lead_time: '3 months'
+    lead_time: 'It takes up to 3 months'
     applicable_criteria:
       - owns-business
     section: business
@@ -11,7 +11,7 @@ actions:
     description: |
       If you do not get one, you will not be able to travel.
     path: '/apply-renew-passport'
-    lead_time: '2 weeks'
+    lead_time: 'Do it as soon as possible'
     applicable_criteria:
       - non-eu-national
     section: citizen


### PR DESCRIPTION
https://trello.com/c/jNd5Qi4S/48-display-lead-time-for-actions

Previously we assumed the lead time would either be a duration or
nothing. This modifies the view to simply reproduce the text, as it
we now expect it to have a variety of forms.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
