### PR TITLE
Rename description field to consequence to better match purpose

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,6 +1,6 @@
 class Checklists::Action
   attr_accessor :title,
-                :description,
+                :consequence,
                 :path,
                 :lead_time,
                 :applicable_criteria,
@@ -11,7 +11,7 @@ class Checklists::Action
 
   def initialize(params)
     @title = params['title']
-    @description = params['description']
+    @consequence = params['consequence']
     @path = params['path']
     @lead_time = params['lead_time']
     @applicable_criteria = params['applicable_criteria']

--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -4,9 +4,9 @@
       <p class="govuk-body govuk-!-font-weight-bold">
         <a href="<%= action.path %>" class="govuk-link"><%= action.title %></a>
       </p>
-      <% if action.description.present? %>
+      <% if action.consequence.present? %>
         <p class="govuk-body govuk-!-font-size-16">
-          <%= action.description %>
+          <%= action.consequence %>
         </p>
       <% end %>
     </div>

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -1,6 +1,6 @@
 actions:
   - title: 'Get an EORI number that starts with GB to move goods in or out of the UK'
-    description: |
+    consequence: |
       If you do not get one, you may have increased costs and delays. For example, if HM Revenue and Customs (HMRC) cannot clear your goods you may have to pay storage fees.
     path: '/eori'
     lead_time: '3 months'
@@ -8,7 +8,7 @@ actions:
       - owns-business
     section: business
   - title: 'Get a new passport'
-    description: |
+    consequence: |
       If you do not get one, you will not be able to travel.
     path: '/apply-renew-passport'
     lead_time: '2 weeks'

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Questions workflow", type: :feature do
     prompt = I18n.t!("checklists_results.actions.guidance_prompt")
     expect(page).to have_link(action.title, href: action.path)
     expect(page).to have_content action.lead_time
-    expect(page).to have_content action.description
+    expect(page).to have_content action.consequence
     expect(page).to have_link("#{prompt}: #{action.guidance_text}", href: action.guidance_url)
   end
 
@@ -67,6 +67,6 @@ RSpec.feature "Questions workflow", type: :feature do
     action = Checklists::Action.find_by_title("Get an EORI number")
     expect(page).to have_link(action.title, href: action.path)
     expect(page).to have_content action.lead_time
-    expect(page).to have_content action.description
+    expect(page).to have_content action.consequence
   end
 end

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -36,9 +36,8 @@ describe Checklists::Action do
     it "returns a list of actions with required keys" do
       subject.each do |action|
         expect(action.title).to be_present
-        expect(action.description).to be_present
-        expect(action.path).to be_present
         expect(action.applicable_criteria).to be_a Array
+        expect(%w[business citizen]).to include(action.section)
       end
     end
 


### PR DESCRIPTION
This is part of a tidyup to ensure that our development terminology
matches the frontend and content design terminology. With this in
mind, "consequence" of an action is a better fitting description
of the field than "description". Main portion of this work was already 
complete, just needed the renaming

Trello https://trello.com/c/uozL8DGl/44-display-action-consequences-for-actions
