### PR TITLE
Update action YAML key references

### DIFF
--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -10,12 +10,12 @@ module ChecklistHelper
     criteria.map { |criterion| { readable_text: criterion.text } }
   end
 
-  def format_action_sections(actions)
-    action_groups = actions.group_by(&:section)
+  def format_action_audiences(actions)
+    action_groups = actions.group_by(&:audience)
 
     action_groups.map do |key, action_group|
       {
-        heading: I18n.t("checklists_results.sections.#{key}.heading"),
+        heading: I18n.t("checklists_results.audiences.#{key}.heading"),
         actions: action_group
       }
     end

--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,28 +1,28 @@
 class Checklists::Action
   attr_accessor :title,
                 :consequence,
-                :path,
+                :title_url,
                 :lead_time,
-                :applicable_criteria,
-                :section,
-                :guidance_text,
+                :criteria,
+                :audience,
+                :guidance_link_text,
                 :guidance_url,
                 :guidance_prompt
 
   def initialize(params)
     @title = params['title']
     @consequence = params['consequence']
-    @path = params['path']
+    @title_url = params['title_url']
     @lead_time = params['lead_time']
-    @applicable_criteria = params['applicable_criteria']
-    @section = params['section']
-    @guidance_text = params['guidance_text']
+    @criteria = params['criteria']
+    @audience = params['audience']
+    @guidance_link_text = params['guidance_link_text']
     @guidance_url = params['guidance_url']
     @guidance_prompt = params['guidance_prompt']
   end
 
   def applies_to?(criteria_keys)
-    applicable_criteria.any? do |key|
+    criteria.any? do |key|
       criteria_keys.include?(key)
     end
   end

--- a/app/views/checklist/_action_audiences.html.erb
+++ b/app/views/checklist/_action_audiences.html.erb
@@ -1,15 +1,15 @@
-<% if sections.any? %>
-  <% sections.each.with_index do |section, index| %>
+<% if audiences.any? %>
+  <% audiences.each.with_index do |audience, index| %>
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
       <div class="govuk-grid-column-full">
         <% if index != 0 %>
           <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
         <% end %>
-        <h2 class="govuk-heading-m"><%= section[:heading] %></h2>
+        <h2 class="govuk-heading-m"><%= audience[:heading] %></h2>
       </div>
       <div class="govuk-grid-column-full">
         <%= render "action_list", {
-          items: section[:actions]
+          items: audience[:actions]
         } %>
       </div>
     </div>

--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -2,8 +2,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <p class="govuk-body govuk-!-font-weight-bold">
-        <% if action.path.present? %>
-          <a href="<%= action.path %>" class="govuk-link"><%= action.title %></a>
+        <% if action.title_url.present? %>
+          <a href="<%= action.title_url %>" class="govuk-link"><%= action.title %></a>
         <% else %>
           <%= action.title %>
         <% end %>
@@ -24,8 +24,8 @@
     </div>
   </div>
 
-  <% if action.guidance_text.present? && action.guidance_url.present? %>
+  <% if action.guidance_link_text.present? && action.guidance_url.present? %>
     <% prompt = action.guidance_prompt || t("checklists_results.actions.guidance_prompt") %>
-    <%= prompt %>: <a href="<%= action.guidance_url %>" class="govuk-link"><%= action.guidance_text %></a>
+    <%= prompt %>: <a href="<%= action.guidance_url %>" class="govuk-link"><%= action.guidance_link_text %></a>
   <% end %>
 <% end %>

--- a/app/views/checklist/results.html.erb
+++ b/app/views/checklist/results.html.erb
@@ -40,7 +40,7 @@
       <%= render 'results_answers', answers: format_criteria_list(@criteria) %>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <%= render 'action_sections', sections: format_action_sections(@actions) %>
+      <%= render 'action_audiences', audiences: format_action_audiences(@actions) %>
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-section-break--bold">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
       no_results: "Based on your answers, we were not able to determine suitable actions for you."
       more_guidance: "View more guidance here"
       guidance_prompt: Read the guidance
-    sections:
+    audiences:
       citizen:
         heading: 'You and your family'
       business:

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -1,19 +1,21 @@
 actions:
   - title: 'Get an EORI number that starts with GB to move goods in or out of the UK'
+    title_url: '/eori'
     consequence: |
       If you do not get one, you may have increased costs and delays. For example, if HM Revenue and Customs (HMRC) cannot clear your goods you may have to pay storage fees.
-    path: '/eori'
     lead_time: 'It takes up to 3 months'
-    applicable_criteria:
+    criteria:
       - owns-business
-    section: business
+    audience: business
+    action_id: T001
   - title: 'Get a new passport'
+    title_url: '/apply-renew-passport'
     consequence: |
       If you do not get one, you will not be able to travel.
-    path: '/apply-renew-passport'
     lead_time: 'Do it as soon as possible'
-    applicable_criteria:
+    criteria:
       - non-eu-national
-    section: citizen
+    audience: citizen
     guidance_url: 'http://guidance.com'
-    guidance_text: 'Guidance Central'
+    guidance_link_text: 'Guidance Central'
+    action_id: T002

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -51,20 +51,20 @@ RSpec.feature "Questions workflow", type: :feature do
 
   def and_i_should_see_a_passport_action
     action = Checklists::Action.find_by_title("Get a new passport")
-    expect(page).to have_link(action.title, href: action.path)
+    expect(page).to have_link(action.title, href: action.title_url)
     expect(page).to have_content action.lead_time
     expect(page).to have_content action.consequence
-    expect(page).to have_link(action.guidance_text, href: action.guidance_url)
+    expect(page).to have_link(action.guidance_link_text, href: action.guidance_url)
   end
 
   def and_i_should_not_see_an_eori_action
     action = Checklists::Action.find_by_title("Get an EORI number")
-    expect(page).to_not have_link(action.title, href: action.path)
+    expect(page).to_not have_link(action.title, href: action.title_url)
   end
 
   def and_i_should_see_an_eori_action
     action = Checklists::Action.find_by_title("Get an EORI number")
-    expect(page).to have_link(action.title, href: action.path)
+    expect(page).to have_link(action.title, href: action.title_url)
     expect(page).to have_content action.lead_time
     expect(page).to have_content action.consequence
   end

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -44,9 +44,9 @@ describe ChecklistHelper, type: :helper do
   end
 
   describe "#filter_actions" do
-    let(:action1) { Checklists::Action.new('applicable_criteria' => []) }
-    let(:action2) { Checklists::Action.new('applicable_criteria' => %w[A]) }
-    let(:action3) { Checklists::Action.new('applicable_criteria' => %w[B C]) }
+    let(:action1) { Checklists::Action.new('criteria' => []) }
+    let(:action2) { Checklists::Action.new('criteria' => %w[A]) }
+    let(:action3) { Checklists::Action.new('criteria' => %w[B C]) }
     let(:actions) { [action1, action2, action3] }
 
     subject { filter_actions(actions, criteria_keys) }
@@ -76,22 +76,22 @@ describe ChecklistHelper, type: :helper do
     end
   end
 
-  describe "#format_action_sections" do
-    let(:citizen_action) { Checklists::Action.new('section' => 'citizen') }
-    let(:business_action) { Checklists::Action.new('section' => 'business') }
+  describe "#format_action_audiences" do
+    let(:citizen_action) { Checklists::Action.new('audience' => 'citizen') }
+    let(:business_action) { Checklists::Action.new('audience' => 'business') }
 
-    subject { format_action_sections(actions) }
+    subject { format_action_audiences(actions) }
 
     context "when there are actions for each section" do
       let(:actions) { [citizen_action, business_action] }
       it "return formatted sections" do
         expect(subject).to eq([
           {
-            heading: I18n.t("checklists_results.sections.citizen.heading"),
+            heading: I18n.t("checklists_results.audiences.citizen.heading"),
             actions: [citizen_action]
           },
           {
-            heading: I18n.t("checklists_results.sections.business.heading"),
+            heading: I18n.t("checklists_results.audiences.business.heading"),
             actions: [business_action]
           }
         ])

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -1,29 +1,29 @@
 require 'spec_helper'
 
 describe Checklists::Action do
-  describe '#applicable_criteria?' do
+  describe '#criteria?' do
     subject do
       described_class.new(
-        'applicable_criteria' => applicable_criteria
+        'criteria' => criteria
       ).applies_to?(selected_criteria)
     end
 
     context "no applicable criteria" do
-      let(:applicable_criteria) { [] }
+      let(:criteria) { [] }
       let(:selected_criteria) { %w[A] }
 
       it { is_expected.to eq(false) }
     end
 
     context "the selected criteria meets the applicable criteria" do
-      let(:applicable_criteria) { %w[A B C] }
+      let(:criteria) { %w[A B C] }
       let(:selected_criteria) { %w[A] }
 
       it { is_expected.to eq(true) }
     end
 
     context "no selected criteria" do
-      let(:applicable_criteria) { %w[A B C] }
+      let(:criteria) { %w[A B C] }
       let(:selected_criteria) { [] }
 
       it { is_expected.to eq(false) }
@@ -36,8 +36,10 @@ describe Checklists::Action do
     it "returns a list of actions with required fields" do
       subject.each do |action|
         expect(action.title).to be_present
-        expect(action.applicable_criteria).to be_a Array
-        expect(%w[business citizen]).to include(action.section)
+        expect(%w[business citizen]).to include(action.audience)
+        expect(action.consequence).to be_present
+        expect(action.title_url).to be_present
+        expect(action.criteria).to be_a Array
       end
     end
 
@@ -45,13 +47,13 @@ describe Checklists::Action do
       criteria = Checklists::Criterion.load_all.map(&:key)
 
       subject.each do |action|
-        expect(criteria).to include(*action.applicable_criteria.to_a)
+        expect(criteria).to include(*action.criteria.to_a)
       end
     end
 
     it "returns actions with guidance fields together" do
       subject.each do |action|
-        text = action.guidance_text.present?
+        text = action.guidance_link_text.present?
         url = action.guidance_url.present?
         expect(text ^ url).to be_falsey
       end


### PR DESCRIPTION
When we import the actions CSV and convert it to a YAML file, we take the field
headers in the CSV and format them to be compatible with YAML.  There are
instances where we have references to various fields in the output YAML file
and some of them now have different names as a result of importing the field
names from the actions CSV, so this updates these references.