### PR TITLE
PageService to calculate pages in Checklists to avoid redirects

### DIFF
--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -1,11 +1,4 @@
 module ChecklistHelper
-  def next_viewable_page(page, questions, criteria_keys)
-    next_page = (page..questions.length).find do |index|
-      questions[index - 1].show?(criteria_keys)
-    end
-    next_page || questions.length + 1
-  end
-
   def format_criteria_list(criteria)
     criteria.map { |criterion| { readable_text: criterion.text } }
   end

--- a/app/lib/checklists/page_service.rb
+++ b/app/lib/checklists/page_service.rb
@@ -1,0 +1,28 @@
+module Checklists
+  class PageService
+    attr_reader :current_page
+
+    def initialize(questions:, criteria_keys: [], current_page_from_params: 0)
+      @questions = questions
+      @criteria_keys = criteria_keys
+      @current_page_from_params = current_page_from_params
+      @current_page = fetch_page(current_page_from_params: @current_page_from_params, criteria_keys: @criteria_keys)
+    end
+
+    def next_page
+      current_page && current_page + 1
+    end
+
+    def redirect_to_results?
+      current_page.nil?
+    end
+
+  private
+
+    def fetch_page(current_page_from_params: 0, criteria_keys: [])
+      available_questions = @questions[current_page_from_params..] || []
+      relative_page_index = available_questions.find_index { |question| question.show?(criteria_keys) }
+      relative_page_index && (relative_page_index + current_page_from_params)
+    end
+  end
+end

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -35,7 +35,7 @@
             } %>
           </div>
         <% end %>
-        <%= render 'form_data', current_question: @current_question %>
+        <%= render 'form_data', current_question: @current_question, next_page: @page_service.next_page %>
         <%= render 'hint_text', current_question: @current_question %>
         <div class="govuk-form-footer">
           <%= render "govuk_publishing_components/components/button", {

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -1,48 +1,6 @@
 require 'spec_helper'
 
 describe ChecklistHelper, type: :helper do
-  describe "#next_viewable_page" do
-    let(:page) { 1 }
-    let(:criteria_keys) { [1, 2, 3] }
-    let(:questions) do
-      [
-        Checklists::Question.new('depends_on' => [1, 2, 3]),
-        Checklists::Question.new('depends_on' => [1, 2, 3]),
-        Checklists::Question.new('depends_on' => [1, 2, 3])
-      ]
-    end
-
-    subject { next_viewable_page(page, questions, criteria_keys) }
-
-    context "when its the first page and the question is not dependent" do
-      it { is_expected.to eq(1) }
-    end
-
-    context "when the question's criteria are not met" do
-      it 'returns the next page' do
-        questions[0] = Checklists::Question.new('depends_on' => [4])
-        expect(subject).to eq(2)
-      end
-    end
-
-    context "when consecutive questions' criteria are not met" do
-      it 'returns the page number of first applicable question' do
-        questions[0] = Checklists::Question.new('depends_on' => [4])
-        questions[1] = Checklists::Question.new('depends_on' => [4])
-        expect(subject).to eq(3)
-      end
-    end
-
-    context "when its the last page and question's criteria are not met" do
-      let(:page) { 3 }
-
-      it 'returns the next page' do
-        questions[2] = Checklists::Question.new('depends_on' => [4])
-        expect(subject).to eq(4)
-      end
-    end
-  end
-
   describe "#filter_actions" do
     let(:action1) { Checklists::Action.new('criteria' => []) }
     let(:action2) { Checklists::Action.new('criteria' => %w[A]) }

--- a/spec/lib/checklists/page_service_spec.rb
+++ b/spec/lib/checklists/page_service_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Checklists::PageService do
+  let(:questions) {
+    [
+      Checklists::Question.new(key: 'question_zero', 'depends_on' => []),
+      Checklists::Question.new(key: 'question_one', 'depends_on' => %i[a b]),
+      Checklists::Question.new(key: 'question_two', 'depends_on' => %i[c d]),
+      Checklists::Question.new(key: 'question_three', 'depends_on' => [:c])
+    ]
+  }
+  describe '#next_page' do
+    it 'returns nil if the last page has been reached' do
+      subject = Checklists::PageService.new(questions: questions,
+                                            current_page_from_params: questions.count,
+                                            criteria_keys: [])
+      expect(subject.next_page).to be nil
+    end
+    it 'returns the next viewable page + 1 if in range' do
+      subject = Checklists::PageService.new(questions: questions,
+                                            current_page_from_params: 0,
+                                            criteria_keys: [])
+      expect(subject.next_page).to be 1
+    end
+  end
+  describe '#redirect_to_results?' do
+    it 'return true  if the end of the questions has been reached' do
+      subject = Checklists::PageService.new(questions: questions,
+                                            current_page_from_params: questions.count,
+                                            criteria_keys: [])
+      expect(subject.redirect_to_results?).to be true
+    end
+    it 'returns false if the end of the questions has not been reached' do
+      subject = Checklists::PageService.new(questions: questions,
+                                            current_page_from_params: questions.count - 1,
+                                            criteria_keys: [:c])
+      expect(subject.redirect_to_results?).to be false
+    end
+  end
+  describe '#page' do
+    let(:subject) {
+      Checklists::PageService.new(questions: questions, current_page_from_params: current_page_from_params, criteria_keys: criteria_keys).current_page
+    }
+    let(:criteria_keys) { [] }
+    let(:current_page_from_params) { nil }
+
+    context 'the page on the form is 0' do
+      let(:current_page_from_params) { 0 }
+      it 'returns the page from the form ' do
+        expect(subject).to eq(0)
+      end
+    end
+    context 'the page on the form is 1 and the criteria_keys match question_two' do
+      let(:current_page_from_params) { 1 }
+      let(:criteria_keys) { %i[c d] }
+      it 'returns the page for question_two' do
+        expect(subject).to eq(2)
+      end
+    end
+    context 'the page on the form is 1 and the criteria_keys match question_three' do
+      let(:current_page_from_params) { 1 }
+      let(:criteria_keys) { [:c] }
+      it 'returns the page for question_three' do
+        expect(subject).to eq(3)
+      end
+    end
+    context 'the page on the form is 1 and the criteria_keys do not match anything' do
+      let(:current_page_from_params) { 1 }
+      let(:criteria_keys) { [:e] }
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+    context 'the page on the form is higher than the number of questions' do
+      let(:current_page_from_params) { questions.count + 1 }
+      it 'returns nil' do
+        expect(subject).to be nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Calculating which page to show next was done as a helper inline in the
controller. This functionality has been extracted to a separate model.

This also allows us to calculate the next viewable page directly
without having to redirect multiple times.

The Paging service also keeps track of the next page and whether
to redirect

Trello: https://trello.com/c/xZNMvlLk/88-remove-multiple-redirects
---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
