### PR TITLE
Add change notes

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,5 +1,6 @@
 class Checklists::Action
-  attr_accessor :title,
+  attr_accessor :id,
+                :title,
                 :consequence,
                 :title_url,
                 :lead_time,
@@ -10,6 +11,7 @@ class Checklists::Action
                 :guidance_prompt
 
   def initialize(params)
+    @id = params['action_id']
     @title = params['title']
     @consequence = params['consequence']
     @title_url = params['title_url']

--- a/app/lib/checklists/change_note.rb
+++ b/app/lib/checklists/change_note.rb
@@ -1,0 +1,18 @@
+class Checklists::ChangeNote
+  attr_reader :id, :title, :text, :action_id, :question_key
+
+  def initialize(params)
+    @id             = params['id']
+    @title          = params['title']
+    @text           = params['text']
+    @action_id      = params['action_id']
+    @question_key   = params['question_key']
+  end
+
+  def self.load_all
+    change_notes = YAML.load_file(Rails.root.join('lib/checklists/changenotes.yaml'))['change_notes']
+    change_notes.map do |change_note|
+      Checklists::ChangeNote.new(change_note)
+    end
+  end
+end

--- a/lib/checklists/changenotes.yaml
+++ b/lib/checklists/changenotes.yaml
@@ -1,0 +1,12 @@
+---
+change_notes:
+  - id: brexit_action_change_1
+    title: "Change to Get an EORI number that starts with GB to move goods in or out of the UK"
+    text: "EORI number description added"
+    action_id: 'T001'
+    question_key:
+  - id: brexit_action_change_2
+    title: "Change to question"
+    text: "The business activity question was changed"
+    action_id:
+    question_key: business_activity

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -35,6 +35,7 @@ describe Checklists::Action do
 
     it "returns a list of actions with required fields" do
       subject.each do |action|
+        expect(action.id).to be_present
         expect(action.title).to be_present
         expect(%w[business citizen]).to include(action.audience)
         expect(action.consequence).to be_present
@@ -57,6 +58,11 @@ describe Checklists::Action do
         url = action.guidance_url.present?
         expect(text ^ url).to be_falsey
       end
+    end
+
+    it "returns actions with unique ids" do
+      ids = subject.map(&:id)
+      expect(ids.uniq.count).to eq(ids.count)
     end
   end
 end

--- a/spec/lib/checklists/change_note_spec.rb
+++ b/spec/lib/checklists/change_note_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Checklists::ChangeNote do
+  describe ".load_all" do
+    subject { described_class.load_all }
+
+    it "returns a list of change notes with required fields" do
+      subject.each do |change_note|
+        expect(change_note.id).to be_present
+        expect(change_note.title).to be_present
+        expect(change_note.text).to be_present
+      end
+    end
+
+    it "requires an action_id or a question_key, but not both" do
+      subject.each do |change_note|
+        expect([change_note.action_id, change_note.question_key].compact.count).to eq(1)
+      end
+    end
+
+    it "returns change notes that reference actions or questions" do
+      action_changes = subject.map(&:action_id).compact
+      question_changes = subject.map(&:question_key).compact
+
+      action_ids = Checklists::Action.load_all.map(&:id)
+      action_changes.each { |action_id|
+        expect(action_ids).to include(action_id)
+      }
+
+      question_keys = Checklists::Question.load_all.map(&:key)
+      question_changes.each { |question_key|
+        expect(question_keys).to include(question_key)
+      }
+    end
+  end
+end


### PR DESCRIPTION
This is a backbone for the change notes which will be used to send emails.

Change notes will be created when content editors make major changes to actions or questions, which will lead to emails being sent to subscribers.

https://trello.com/c/MPEdEhsJ/69-capturing-content-changes