### PR TITLE
Tweak checklist routes to use new prefix

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -31,7 +31,7 @@ private
   end
 
   def redirect_to_next_question
-    redirect_to find_brexit_guidance_path(
+    redirect_to checklist_questions_path(
       filtered_params.merge(page: next_viewable_page(page, @questions, criteria_keys))
     )
   end
@@ -41,7 +41,7 @@ private
   end
 
   def redirect_to_result_page
-    redirect_to find_brexit_guidance_results_path(filtered_params)
+    redirect_to checklist_results_path(filtered_params)
   end
 
   ###
@@ -87,7 +87,7 @@ private
 
   def skip_link_url
     page_number = { page: next_page }
-    find_brexit_guidance_path(filtered_params.merge(page_number))
+    checklist_questions_path(filtered_params.merge(page_number))
   end
   helper_method :skip_link_url
 end

--- a/app/views/checklist/_results_answers.html.erb
+++ b/app/views/checklist/_results_answers.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-16">
-    <a href="<%= find_brexit_guidance_path(filtered_params) %>" class="govuk-link">
+    <a href="<%= checklist_questions_path(filtered_params) %>" class="govuk-link">
       <%= t('checklists_results.answers.change_answers') %>
     </a>
   </p>

--- a/app/views/checklist/results.html.erb
+++ b/app/views/checklist/results.html.erb
@@ -13,7 +13,7 @@
     },
     {
       title: t('checklists_results.breadcrumbs.q_and_a'),
-      url: find_brexit_guidance_path(filtered_params)
+      url: checklist_questions_path(filtered_params)
     }
   ] %>
   <div class="govuk-grid-row">

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -19,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="<%= find_brexit_guidance_path %>" method="get" id="finder-qa-facet-filter-selection" data-module="track-qa-choices">
+      <form action="<%= checklist_questions_path %>" method="get" id="finder-qa-facet-filter-selection" data-module="track-qa-choices">
         <% if @current_question.multiple? %>
           <div class="govuk-!-margin-top-8">
             <%= render 'question_multiple_choice', {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,8 +25,8 @@ FinderFrontend::Application.routes.draw do
   get '/prepare-business-uk-leaving-eu' => 'qa#show'
 
   # Q&A checklist frontend for brexit guidance
-  get '/find-brexit-guidance/results' => 'checklist#results'
-  get '/find-brexit-guidance' => 'checklist#show'
+  get '/get-ready-brexit-check/results' => 'checklist#results', as: :checklist_results
+  get '/get-ready-brexit-check/questions' => 'checklist#show', as: :checklist_questions
 
   # Q&A frontend for "UK Nationals in the EU" (www.gov.uk/uk-nationals-in-the-eu)
   get '/uk-nationals-living-eu' => 'qa_to_content#show'

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Questions workflow", type: :feature do
   end
 
   def when_i_visit_the_checklist_flow
-    visit '/find-brexit-guidance'
+    visit checklist_questions_path
   end
 
   def and_i_answer_the_basic_questions


### PR DESCRIPTION
https://trello.com/c/133tCceD/57-decide-url-paths

This changes the question and results checklist routes to use the new
'/get-ready-brexit-check/' prefix, introducing path aliases for both to
make any future changes easier. We can't use the the prefix route on its
own, since this is now reserved for the start page, which is going to be
published via Mainstream Publisher.

Depends on https://github.com/alphagov/special-route-publisher/pull/31

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
