### PR TITLE
Update results page content to match doc

### DIFF
--- a/app/views/checklist/_stay_updated.html.erb
+++ b/app/views/checklist/_stay_updated.html.erb
@@ -2,9 +2,11 @@
   text: t('checklists_results.stay_updated.heading')
 } %>
 
-<p class="govuk-body govuk-!-margin-top-4">
-  <%= sanitize( t('checklists_results.stay_updated.description') ) %>
-</p>
+<div class="govuk-!-margin-top-4">
+  <%= render "govuk_publishing_components/components/govspeak", {
+    content: t('checklists_results.stay_updated.description').html_safe
+  } %>
+</div>
 
 <%= render "govuk_publishing_components/components/button", {
   text: t('checklists_results.stay_updated.sign_up'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,17 +35,16 @@ en:
       more: "Show more search options"
       fewer: "Show fewer search options"
   checklists:
-    title: "Prepare yourself, your family and your business or organisation for the UK leaving the EU"
+    title: "Get ready for Brexit: check what you need to do"
   checklists_results:
     breadcrumbs:
       home: "Home"
       q_and_a: "Brexit Q&A"
-    title: "What you may need to know to prepare for Brexit"
+    title: "Your results: what you need to do to prepare for Brexit"
     description: |
-      The United Kingdom is leaving the European Union on the 31 October 2019.
-      The list may not be complete, and you might not need to take all actions.
+      You may not need to do everything on the list to prepare for Brexit, and your list of results may not be complete.
     email_sign_up_link: |
-      Sign up to recieve a copy of your results or to get email about alerts when your results are updated
+      Sign up to get email alerts about changes to Brexit information that may affect you or to get a copy of your results
     answers:
       list_context: "Based on your answers, we know:"
       change_answers: "Change your answers"
@@ -54,17 +53,20 @@ en:
         This is a safe and secure service. We don't store any of your personal information.
         To change your answers, follow the link below.
     actions:
-      no_results: "Based on your answers, we were not able to determine suitable actions for you."
+      no_results: "Based on your responses, you do not need to take any action to prepare for Brexit."
       more_guidance: "View more guidance here"
       guidance_prompt: Read the guidance
     audiences:
       citizen:
         heading: 'You and your family'
       business:
-        heading: 'Your business'
+        heading: 'Your business or organisation'
     stay_updated:
-      heading: "Stay up to date"
-      description: |
-        Sign up to receive a copy of your results or to get email alterts when your results are upadated.
-        To come back to your results page at anytime, just copy the url.
-      sign_up: "Sign up for emails"
+      heading: "Get updates"
+      description: >
+        <p>Sign up to receive:</p>
+        <ul>
+          <li>email alerts about changes to Brexit information that may affect you</li>
+          <li>a copy of your results</li>
+        </ul>
+      sign_up: "Subscribe"

--- a/spec/features/checklists/email_signup_spec.rb
+++ b/spec/features/checklists/email_signup_spec.rb
@@ -46,8 +46,8 @@ RSpec.feature "Checklist email signup", type: :feature do
   end
 
   def then_i_click_to_signup_to_emails
-    click_on "Sign up for emails" # on main results page
-    click_on "Sign up for emails" # on overview of subscription page
+    click_on "Subscribe" # on main results page
+    click_on "Subscribe" # on overview of subscription page
   end
 
   def and_i_am_taken_to_email_alert_frontend

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Questions workflow", type: :feature do
   end
 
   def then_i_should_see_the_results_page
-    expect(page).to have_content "What you may need to know to prepare for Brexit"
+    expect(page).to have_content I18n.t!("checklists_results.title")
   end
 
   def and_i_should_see_a_passport_action


### PR DESCRIPTION
https://trello.com/c/TRgvP0kn/75-update-page-furniture-content-title-etc

Since finder-frontend doesn't currently include the govspeak gem, it
seemed easier to manually write the HTML for the email signup bullets,
noting that the govspeak component assumes the input content is HTML.

## Before
<img width="791" alt="Screen Shot 2019-08-28 at 15 53 01" src="https://user-images.githubusercontent.com/9029009/63867304-930a6280-c9ac-11e9-81bf-2fdd5db11d75.png">

## After
<img width="805" alt="Screen Shot 2019-08-28 at 15 52 46" src="https://user-images.githubusercontent.com/9029009/63867335-9b629d80-c9ac-11e9-8307-8b83baf31209.png">

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
