### PR TITLE
Add back the single wrapped question type

### DIFF
--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -24,6 +24,10 @@ class Checklists::Question
     end
   end
 
+  def single_wrapped?
+    type == "single_wrapped"
+  end
+
   def multiple?
     type == "multiple"
   end

--- a/app/views/checklist/_question_single_wrapped_choice.html.erb
+++ b/app/views/checklist/_question_single_wrapped_choice.html.erb
@@ -1,0 +1,24 @@
+<% checkboxes = render "govuk_publishing_components/components/checkboxes", {
+  name: "#{current_question.key}[]",
+  heading: current_question.question,
+  visually_hide_heading: true,
+  items: current_question.formatted_options(filtered_params)
+} %>
+<%= render "govuk_publishing_components/components/radio", {
+  name: "#{current_question.key}-yesno",
+  heading: current_question.question,
+  description: formatted_description,
+  hint_text: current_question.hint_title,
+  is_page_heading: true,
+  items: [
+    {
+      value: "yes",
+      text: "Yes",
+      conditional: checkboxes
+    },
+    {
+      value: "no",
+      text: "No"
+    }
+  ]
+} %>

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -27,6 +27,13 @@
               formatted_description: formatted_description
             } %>
           </div>
+        <% elsif @current_question.single_wrapped? %>
+          <div class="govuk-!-margin-top-8">
+            <%= render 'question_single_wrapped_choice', {
+              current_question: @current_question,
+              formatted_description: formatted_description
+            } %>
+          </div>
         <% else %>
           <div class="govuk-!-margin-top-8">
             <%= render 'question_single_choice', {


### PR DESCRIPTION
This was initially removed on:
https://github.com/alphagov/finder-frontend/pull/1344

https://trello.com/c/KREWQlLE/90-add-single-wrapped-question-type