### PR TITLE
Update breadcrumb routing for checklists

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -75,15 +75,6 @@ private
   helper_method :criteria_keys
 
   ###
-  # Breadcrumbs
-  ###
-
-  def breadcrumbs
-    [{ title: "Home", url: "/" }]
-  end
-  helper_method :breadcrumbs
-
-  ###
   # Current page
   ###
 

--- a/app/views/checklist/email_signup.html.erb
+++ b/app/views/checklist/email_signup.html.erb
@@ -12,8 +12,16 @@
       url: "/"
     },
     {
-      title: t('checklists_results.breadcrumbs.q_and_a'),
-      url: checklist_questions_path(filtered_params)
+      title: t('checklists_results.breadcrumbs.brexit-home'),
+      url: "/brexit"
+    },
+    {
+      title: t('checklists_results.breadcrumbs.brexit-check'),
+      url: "/get-ready-brexit-check"
+    },
+    {
+      title: t('checklists_results.breadcrumbs.results'),
+      url: checklist_results_path(filtered_params)
     }
   ] %>
 

--- a/app/views/checklist/results.html.erb
+++ b/app/views/checklist/results.html.erb
@@ -12,8 +12,12 @@
       url: "/"
     },
     {
-      title: t('checklists_results.breadcrumbs.q_and_a'),
-      url: checklist_questions_path(filtered_params)
+      title: t('checklists_results.breadcrumbs.brexit-home'),
+      url: "/brexit"
+    },
+    {
+      title: t('checklists_results.breadcrumbs.brexit-check'),
+      url: "/get-ready-brexit-check"
     }
   ] %>
   <div class="govuk-grid-row">

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -15,7 +15,20 @@
 %>
 
 <div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [
+    {
+      title: t('checklists_results.breadcrumbs.home'),
+      url: "/"
+    },
+    {
+      title: t('checklists_results.breadcrumbs.brexit-home'),
+      url: "/brexit"
+    },
+    {
+      title: t('checklists_results.breadcrumbs.brexit-check'),
+      url: "/get-ready-brexit-check"
+    }
+  ] %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,10 @@ en:
   checklists_results:
     breadcrumbs:
       home: "Home"
-      q_and_a: "Brexit Q&A"
+      brexit-home: "Brexit"
+      brexit-check: "How to get ready"
+      questions: "Questions"
+      results: "Results"
     title: "Your results: what you need to do to prepare for Brexit"
     description: |
       You may not need to do everything on the list to prepare for Brexit, and your list of results may not be complete.


### PR DESCRIPTION
To ensure everything moves smoothly for the user we're ensuring there
are active breadcrumbs at every step of the quiz, allowing full
navigation when needed.

This is a draft PR for now until it has been overseen by a content designer. I don't like how I've structured the breadcrumbs as it's very much CPD, so I'll be breaking that out as much as I can.

Trello: https://trello.com/c/huyHusa7/23-link-back-to-landing-page
