### PR TITLE
Remove skip question link

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -93,10 +93,4 @@ private
   def current_page_from_params
     params[:page].to_i
   end
-
-  def skip_link_url
-    page_number = { page: @page_service.next_page }
-    checklist_questions_path(filtered_params.merge(page_number))
-  end
-  helper_method :skip_link_url
 end

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -41,7 +41,6 @@
           <%= render "govuk_publishing_components/components/button", {
             text: "Next"
           } %>
-          <a class="govuk-form-footer__alt-cta-link" href="<%= skip_link_url %>">Skip this question</a>
         </div>
       </form>
     </div>


### PR DESCRIPTION
This was a decision made by the content team
as skipping questions does not help us give users useful information.