### PR TITLE
Allow soft delete of actions

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -33,7 +33,7 @@ class Checklists::Action
     load_all.find { |a| a.title.match(title) }
   end
 
-  def self.load_all
-    CHECKLISTS_ACTIONS.map { |a| new(a) }
+  def self.load_all(exclude_deleted: true)
+    CHECKLISTS_ACTIONS.reject { |a| a['soft_deleted'] && exclude_deleted }.map { |a| new(a) }
   end
 end

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -19,3 +19,15 @@ actions:
     guidance_url: 'http://guidance.com'
     guidance_link_text: 'Guidance Central'
     action_id: T002
+  - title: 'Removed action'
+    soft_deleted: true
+    title_url: '/removed-action'
+    consequence: |
+      This action has been deleted.
+    lead_time: 'This action is not required'
+    criteria:
+      - non-eu-national
+    audience: citizen
+    guidance_url: 'https://gov.uk'
+    guidance_link_text: 'REMOVED'
+    action_id: SOFT_DELETED_TEST

--- a/lib/checklists/changenotes.yaml
+++ b/lib/checklists/changenotes.yaml
@@ -1,12 +1,16 @@
 ---
-change_notes:
-  - id: brexit_action_change_1
-    title: "Change to Get an EORI number that starts with GB to move goods in or out of the UK"
-    text: "EORI number description added"
-    action_id: 'T001'
-    question_key:
-  - id: brexit_action_change_2
-    title: "Change to question"
-    text: "The business activity question was changed"
-    action_id:
-    question_key: business_activity
+change_notes: []
+  # - id: brexit_action_change_1
+  #   title: "Change to Get an EORI number that starts with GB to move goods in or out of the UK"
+  #   text: "EORI number description added"
+  #   action_id: 'T001'
+  #   question_key:
+  # - id: brexit_action_change_2
+  #   title: "Change to question"
+  #   text: "The business activity question was changed"
+  #   action_id:
+  #   question_key: business_activity
+  # - id: brexit_action_change_3
+  #   title: "Removed action"
+  #   text: "This action was removed"
+  #   action_id: SOFT_DELETED_TEST

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -64,5 +64,10 @@ describe Checklists::Action do
       ids = subject.map(&:id)
       expect(ids.uniq.count).to eq(ids.count)
     end
+
+    it "does not return soft deleted actions by default" do
+      all_actions = described_class.load_all(exclude_deleted: false)
+      expect(subject.count).to be < all_actions.count
+    end
   end
 end

--- a/spec/lib/checklists/change_note_spec.rb
+++ b/spec/lib/checklists/change_note_spec.rb
@@ -22,7 +22,7 @@ describe Checklists::ChangeNote do
       action_changes = subject.map(&:action_id).compact
       question_changes = subject.map(&:question_key).compact
 
-      action_ids = Checklists::Action.load_all.map(&:id)
+      action_ids = Checklists::Action.load_all(exclude_deleted: false).map(&:id)
       action_changes.each { |action_id|
         expect(action_ids).to include(action_id)
       }


### PR DESCRIPTION
This enables us to to keep deleted actions but not display it to users.

We want to keep a record of deleted actions so we can refer to them in change notes.