### PR TITLE
Add description to checklist subscriber list

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -40,18 +40,21 @@ private
   ###
 
   def subscriber_list_options
+    path = checklist_results_path(c: criteria_keys)
+
     {
       "title" => "Your Get ready for Brexit results",
       "slug" => "brexit-checklist-#{criteria_keys.sort.join('-')}",
+      "description" => "[You can view a copy of your Brexit tool results](#{Plek.new.website_root}#{path}) on GOV.UK.",
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
-      "url" => checklist_results_path(c: criteria_keys)
+      "url" => path,
     }
   end
 
   ###
   # Redirect
-
   ###
+
   def redirect_to_results?
     @page_service.redirect_to_results?
   end

--- a/spec/features/checklists/email_signup_spec.rb
+++ b/spec/features/checklists/email_signup_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Checklist email signup", type: :feature do
     {
       "title" => "the Get ready for Brexit tool",
       "slug" => "brexit-checklist-does-not-own-business-eu-national",
+      "description" => "[You can view a copy of your Brexit tool results](http://www.test.gov.uk/results?c[]=does-not-own-business&c[]=eu-national) on GOV.UK.",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[does-not-own-business eu-national] } },
       "url" => "/results?c[]=does-not-own-business&c[]=eu-national"
     }


### PR DESCRIPTION
This description will appear in the subscription confirmation email making it clearer to users where they can access their results again.

Depends on https://github.com/alphagov/email-alert-api/pull/950.

[Trello Card](https://trello.com/c/IMPnQYnj/61-add-dynamic-lists-specific-content-to-subscription-confirmation-email)