### PR TITLE
Set a 5 minute Cache-Control on checklists

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -4,6 +4,10 @@ class ChecklistController < ApplicationController
 
   protect_from_forgery except: :confirm_email_signup
 
+  before_action do
+    expires_in(5.minutes, public: true)
+  end
+
   def show
     @questions = Checklists::Question.load_all
     @page_service = Checklists::PageService.new(questions: @questions,


### PR DESCRIPTION
This will set a 5 minute expiry on the checklist pages.

https://trello.com/c/gJhzTb9t/87-add-caching


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1375.herokuapp.com/search/all
- http://finder-frontend-pr-1375.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1375.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1375.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1375].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1375.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1375.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1375.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1375.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
