### PR TITLE
Add specific details for no actions required result page

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -90,4 +90,26 @@ private
   def current_page_from_params
     params[:page].to_i
   end
+
+  ###
+  # Results page
+  ###
+
+  def action_based_description
+    if @actions.any?
+      t('checklists_results.description')
+    else
+      t('checklists_results.description_no_actions')
+    end
+  end
+  helper_method :action_based_description
+
+  def action_based_email_link_label
+    if @actions.any?
+      t('checklists_results.email_sign_up_link')
+    else
+      t('checklists_results.email_sign_up_link_no_actions')
+    end
+  end
+  helper_method :action_based_email_link_label
 end

--- a/app/views/checklist/results.html.erb
+++ b/app/views/checklist/results.html.erb
@@ -22,7 +22,7 @@
         title: t('checklists_results.title')
       } %>
       <p class="govuk-body-l">
-        <%= t('checklists_results.description') %>
+        <%= action_based_description %>
       </p>
     </div>
   </div>
@@ -33,11 +33,11 @@
         <%= render './components/email_link', {
           data_attributes: {
             "module": "track-click",
-            "track-action": t('checklists_results.email_sign_up_link'),
+            "track-action": action_based_email_link_label,
             "track-category": "StayUpdated",
             "track-label": checklist_email_signup_path(c: criteria_keys)
           },
-          link_text: t('checklists_results.email_sign_up_link'),
+          link_text: action_based_email_link_label,
           link_href: checklist_email_signup_path(c: criteria_keys),
         } %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,8 +43,12 @@ en:
     title: "Your results: what you need to do to prepare for Brexit"
     description: |
       You may not need to do everything on the list to prepare for Brexit, and your list of results may not be complete.
+    description_no_actions: |
+      Based on your responses, you do not need to take any action to prepare for Brexit.
     email_sign_up_link: |
-      Sign up to get email alerts about changes to Brexit information that may affect you or to get a copy of your results
+      Sign up to get email alerts about changes to Brexit information that may affect you or to get a copy of your results.
+    email_sign_up_link_no_actions: |
+      This may change. Subscribe to email alerts about changes to Brexit information that may affect you.
     answers:
       list_context: "Based on your answers, we know:"
       change_answers: "Change your answers"


### PR DESCRIPTION
When the user has answered questions that have resulted in no
actions required from them, we need slightly different wording
on the results page. This PR:
- Implements conditional logic to allow these results to appear
- Adds the required strings to the front end yaml

Trello: https://trello.com/c/ujdneYjd/96-add-specific-details-for-no-actions-required-result-page


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
