### PR TITLE
Guidance text now wrapped around a paragraph

### DIFF
--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -15,9 +15,17 @@
           <%= action.title %>
         <% end %>
       </p>
+
       <% if action.consequence.present? %>
         <p class="govuk-body govuk-!-font-size-16">
           <%= action.consequence %>
+        </p>
+      <% end %>
+
+      <% if action.guidance_link_text.present? && action.guidance_url.present? %>
+        <p class="govuk-body govuk-!-font-size-16">
+          <% prompt = action.guidance_prompt || t("checklists_results.actions.guidance_prompt") %>
+          <%= prompt %>: <a href="<%= action.guidance_url %>" class="govuk-link"><%= action.guidance_link_text %></a>
         </p>
       <% end %>
     </div>
@@ -30,9 +38,4 @@
       <% end %>
     </div>
   </div>
-
-  <% if action.guidance_link_text.present? && action.guidance_url.present? %>
-    <% prompt = action.guidance_prompt || t("checklists_results.actions.guidance_prompt") %>
-    <%= prompt %>: <a href="<%= action.guidance_url %>" class="govuk-link"><%= action.guidance_link_text %></a>
-  <% end %>
 <% end %>


### PR DESCRIPTION
This also moves the guidance within the responsive body.

![Screen Shot 2019-08-29 at 11 06 23](https://user-images.githubusercontent.com/4599889/63931533-5d698600-ca4d-11e9-8396-ca1bbd195690.png)
![Screen Shot 2019-08-29 at 11 06 36](https://user-images.githubusercontent.com/4599889/63931534-5d698600-ca4d-11e9-8bdf-0e16bb9a3282.png)
