### PR TITLE
Improves text wrapping for checklist answers

### DIFF
--- a/app/assets/stylesheets/views/_checklist_results_page.scss
+++ b/app/assets/stylesheets/views/_checklist_results_page.scss
@@ -1,23 +1,28 @@
 .checklist-results-page {
-  .govuk-list--checked {
-    list-style: none;
-  }
-
-  .govuk-list--checked li:before {
-    width: 1em;
-    height: 1em;
-    content: '';
-    display: inline-block;
-    margin-right: govuk-spacing(2);
-    background-image: image-url('check.svg');
-  }
-
-  .govuk-tag--muted {
-    background-color: govuk-colour('grey-4');
-    color: govuk-colour('black');
-  }
-
   .govuk-section-break--bold {
     border-bottom: 3px solid govuk-colour('blue');
+  }
+
+  .checklist-results-answers__check {
+    width: 1em;
+    height: 1em;
+  }
+
+  .govuk-grid-column-one-tenth {
+    box-sizing: border-box;
+    padding: 0 $govuk-gutter-half;
+    @include govuk-media-query($from: mobile) {
+      width: 10%;
+      float: left;
+    }
+  }
+
+  .govuk-grid-column-nine-tenths {
+    box-sizing: border-box;
+    padding: 0 $govuk-gutter-half;
+    @include govuk-media-query($from: mobile) {
+      width: 85%;
+      float: left;
+    }
   }
 }

--- a/app/views/checklist/_results_answers.html.erb
+++ b/app/views/checklist/_results_answers.html.erb
@@ -1,9 +1,18 @@
 <div class="checklist-results-answers">
   <% if answers.present? %>
     <p class="govuk-body govuk-!-font-weight-bold"><%= t('checklists_results.answers.list_context') %></p>
-    <ul class="govuk-list govuk-!-margin-top-3 govuk-!-font-size-16 govuk-list--checked">
+    <ul class="govuk-list govuk-!-margin-top-3 govuk-!-font-size-16">
       <% answers.each do |answer| %>
-        <li><%= answer[:readable_text] %></li>
+        <li>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-tenth">
+              <%= image_tag 'check', class: "checklist-results-answers__check" %>
+            </div>
+            <div class="govuk-grid-column-nine-tenths">
+              <%= answer[:readable_text] %>
+            </div>
+          </div>
+        </li>
       <% end %>
     </ul>
   <% else %>


### PR DESCRIPTION
Adds in new grid column option to allow support for 1 tenth and 9 tenths.

Also removed unused CSS.

![Aug-29-2019 11-52-53](https://user-images.githubusercontent.com/4599889/63935007-7fb2d200-ca54-11e9-8caf-b0461ac068c5.gif)
