### PR TITLE
Adds role presentation to check icon

### DIFF
--- a/app/views/checklist/_results_answers.html.erb
+++ b/app/views/checklist/_results_answers.html.erb
@@ -6,7 +6,7 @@
         <li>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-tenth">
-              <%= image_tag 'check', class: "checklist-results-answers__check" %>
+              <%= image_tag 'check', class: "checklist-results-answers__check", role: "presentation" %>
             </div>
             <div class="govuk-grid-column-nine-tenths">
               <%= answer[:readable_text] %>


### PR DESCRIPTION
This is done to stop screen readers from reading out the name of the file or any other description.
As this is purely presentational, the check icon doesn't need to be described to the user.

https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/presentation/PresentationRoleExamples.html