### PR TITLE
Use yes/no questions instead of none/neither

### DIFF
--- a/lib/checklists/criteria.yaml
+++ b/lib/checklists/criteria.yaml
@@ -133,8 +133,6 @@ criteria:
     text: "Your business provides services in the EU"
   - key: haulage-goods-across-eu-borders
     text: "Your business transports goods across EU borders"
-  - key: export-to-eu-none-of-these
-    text: "Your business does not sell goods or services in the UK"
 
   # employ_eu_citizens
   - text: You employ EU citizens
@@ -209,8 +207,6 @@ criteria:
     text: "You are employed"
   - key: employment-study
     text: "You are studying"
-  - key: employment-neither
-    text: "You are not employed or studying"
 
   - key: travelling-to-eu-yes
     text: "You intend to travel to the EU"
@@ -226,8 +222,6 @@ criteria:
     text: "You intend to bring your pet"
   - key: pet-or-driving-drive
     text: "You intend to drive"
-  - key: pet-or-driving-other
-    text: "You do not intend to drive or bring your pet"
 
   - key: property-yes
     text: "You are planning to buy or already own property in the EU"

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -185,8 +185,6 @@ questions:
         value: provide-services-do-business-in-eu
       - label: "Transporting goods across EU borders"
         value: haulage-goods-across-eu-borders
-      - label: "None of these"
-        value: export-to-eu-none-of-these
 
   - key: employ_eu_citizens
     depends_on:
@@ -314,7 +312,7 @@ questions:
 
   # TIER 3
   #UK NATIONAL -> LIVE IN EU
-  - key: employment-1
+  - key: employment
     depends_on:
       - does-not-own-business
       - nationality-uk
@@ -326,8 +324,6 @@ questions:
         value: employment-work
       - label: Study
         value: employment-study
-      - label: Neither
-        value: employment-neither
 
   # UK NATIONAL -> LIVE IN UK
   - key: travelling-to-eu-1
@@ -335,11 +331,16 @@ questions:
       - does-not-own-business
       - nationality-uk
       - living-uk
-    question_type: single
+    question_type: single_wrapped
     question: 'Are you planning to travel to the EU after 31 October 2019?'
     options:
       - label: "Yes"
         value: travelling-to-eu-yes
+        options:
+          - label: You plan to bring your pet
+            value: pet-or-driving-pet
+          - label: You plan to drive
+            value: pet-or-driving-drive
       - label: "No"
         value: travelling-to-eu-no
 
@@ -349,11 +350,16 @@ questions:
       - does-not-own-business
       - nationality-uk
       - living-other
-    question_type: single
+    question_type: single_wrapped
     question: 'Are you planning to travel to the EU after 31 October 2019?'
     options:
       - label: "Yes"
         value: travelling-to-eu-yes
+        options:
+          - label: You plan to bring your pet
+            value: pet-or-driving-pet
+          - label: You plan to drive
+            value: pet-or-driving-drive
       - label: "No"
         value: travelling-to-eu-no
 
@@ -370,11 +376,9 @@ questions:
         value: employment-work
       - label: Study
         value: employment-study
-      - label: Neither
-        value: employment-neither
 
   # ROW NATIONAL -> LIVE IN EU
-  - key: travelling-to-uk-3
+  - key: travelling-to-uk-1
     depends_on:
       - does-not-own-business
       - nationality-row
@@ -388,7 +392,7 @@ questions:
         value: travelling-to-uk-no
 
   # ROW NATIONAL -> LIVE OTHER
-  - key: travelling-to-uk-4
+  - key: travelling-to-uk-2
     depends_on:
       - does-not-own-business
       - nationality-row
@@ -414,11 +418,9 @@ questions:
         value: employment-work
       - label: Study
         value: employment-study
-      - label: Neither
-        value: employment-neither
 
   # EU NATIONAL -> LIVE IN EU
-  - key: travelling-to-uk-5
+  - key: travelling-to-uk-3
     depends_on:
       - does-not-own-business
       - nationality-eu
@@ -432,39 +434,6 @@ questions:
         value: travelling-to-uk-no
 
   # TIER 4
-  # UK NATIONAL -> LIVE IN UK
-  - key: pet-or-driving-1
-    depends_on:
-      - does-not-own-business
-      - nationality-uk
-      - living-uk
-    question_type: "multiple"
-    question: 'Are you planning to do the following? (Select all that apply)'
-    options:
-      - label: Bring your pet
-        value: pet-or-driving-pet
-      - label: Drive
-        value: pet-or-driving-drive
-      - label: Other
-        value: pet-or-driving-other
-
-  # UK NATIONAL -> LIVE IN OTHER
-  - key: pet-or-driving-2
-    depends_on:
-      - does-not-own-business
-      - nationality-uk
-      - living-other
-    question_type: "multiple"
-    question: 'Are you planning to do the following? (Select all that apply)'
-    options:
-      - label: Bring your pet
-        value: pet-or-driving-pet
-      - label: Drive
-        value: pet-or-driving-drive
-      - label: Other
-        value: pet-or-driving-other
-
-  # TIER 5
   # UK NATIONAL
   - key: property
     depends_on:

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Questions workflow", type: :feature do
   def and_i_answer_business_questions
     answer_question("do_you_own_a_business", "Yes")
     answer_question("sector_business_area", "Tourism")
-    answer_question("business_activity", "No")
+    answer_question("business_activity")
     answer_question("employ_eu_citizens", "No")
     answer_question("personal_data", "No")
     answer_question("intellectual_property", "No")
@@ -36,8 +36,7 @@ RSpec.feature "Questions workflow", type: :feature do
     answer_question("do_you_own_a_business", "No")
     answer_question("nationality", "UK")
     answer_question("living", "Rest of world")
-    answer_question("travelling-to-eu-2", "No")
-    answer_question("pet-or-driving-1", "Bring your pet")
+    answer_question("travelling-to-eu-2", "Yes", "You plan to bring your pet")
     answer_question("property", "Yes")
   end
 


### PR DESCRIPTION
https://trello.com/c/AAQQmYqv/91-build-question-yaml-file

Previously we had a couple of multiple choice questions with a 'none',
'other' or 'neither' option, which is confusing because the user can
also check other options that logically conflict with this. This changes
the approach for such questions to remove such options, so the user just
doesn't make any selection. In the case of pets/driving, it also makes
sense to merge this question using the 'single wrapped' question type.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
