### PR TITLE
Use eval to capture action criteria logic

### DIFF
--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -4,8 +4,7 @@ actions:
     consequence: |
       If you do not get one, you may have increased costs and delays. For example, if HM Revenue and Customs (HMRC) cannot clear your goods you may have to pay storage fees.
     lead_time: 'It takes up to 3 months'
-    criteria:
-      - owns-business
+    criteria: owns-business
     audience: business
     action_id: T001
     priority: 5
@@ -14,8 +13,7 @@ actions:
     consequence: |
       If you do not get one, you will not be able to travel.
     lead_time: 'Do it as soon as possible'
-    criteria:
-      - sector-tourism
+    criteria: sector-tourism
     audience: citizen
     guidance_url: 'http://guidance.com'
     guidance_link_text: 'Guidance Central'
@@ -27,11 +25,9 @@ actions:
     consequence: |
       This action has been deleted.
     lead_time: 'This action is not required'
-    criteria:
-      - non-eu-national
+    criteria: non-eu-national
     audience: citizen
     guidance_url: 'https://gov.uk'
     guidance_link_text: 'REMOVED'
     action_id: SOFT_DELETED_TEST
     priority: 2
-

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 describe ChecklistHelper, type: :helper do
   describe "#filter_actions" do
-    let(:action1) { Checklists::Action.new('criteria' => []) }
-    let(:action2) { Checklists::Action.new('criteria' => %w[A]) }
-    let(:action3) { Checklists::Action.new('criteria' => %w[B C]) }
+    let(:action1) { Checklists::Action.new('criteria' => "") }
+    let(:action2) { Checklists::Action.new('criteria' => "a") }
+    let(:action3) { Checklists::Action.new('criteria' => "b || c") }
     let(:actions) { [action1, action2, action3] }
+
+    before do
+      allow(Checklists::Criterion).to receive(:load_all).and_return([
+        double(key: 'a'), double(key: 'b'), double(key: 'c')
+      ])
+    end
 
     subject { filter_actions(actions, criteria_keys) }
 
@@ -18,7 +24,7 @@ describe ChecklistHelper, type: :helper do
     end
 
     context "when there is a criteria" do
-      let(:criteria_keys) { %w[A] }
+      let(:criteria_keys) { %w[a] }
 
       it "returns some actions" do
         expect(subject).to eq([action2])
@@ -26,7 +32,7 @@ describe ChecklistHelper, type: :helper do
     end
 
     context "when there is multiple criteria" do
-      let(:criteria_keys) { %w[A B] }
+      let(:criteria_keys) { %w[a b] }
 
       it "returns some actions" do
         expect(subject).to eq([action2, action3])


### PR DESCRIPTION
The logic for capturing which actions to appear on each criteria is more complicated than we initially thought. This is designed as a semi-temporary measure until we're sure what all the criteria will be and we can design a better solution using a YAML structure.