### PR TITLE
Simplify travelling questions

### DIFF
--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -361,27 +361,9 @@ questions:
       - label: Study
         value: employment-study
 
-  - key: travelling-to-eu-1
+  - key: travelling-to-eu
     depends_on:
       - nationality-uk
-      - living-uk
-    question_type: single_wrapped
-    question: 'Are you planning to travel to the EU after 31 October 2019?'
-    options:
-      - label: "Yes"
-        value: travelling-to-eu-yes
-        options:
-          - label: You plan to bring your pet
-            value: pet-or-driving-pet
-          - label: You plan to drive
-            value: pet-or-driving-drive
-      - label: "No"
-        value: travelling-to-eu-no
-
-  - key: travelling-to-eu-2
-    depends_on:
-      - nationality-uk
-      - living-other
     question_type: single_wrapped
     question: 'Are you planning to travel to the EU after 31 October 2019?'
     options:
@@ -398,7 +380,6 @@ questions:
   - key: travelling-to-uk-1
     depends_on:
       - nationality-row
-      - living-eu
     question_type: single
     question: 'Are you planning to travel to the UK after 31 October 2019?'
     options:
@@ -409,20 +390,7 @@ questions:
 
   - key: travelling-to-uk-2
     depends_on:
-      - nationality-row
-      - living-other
-    question_type: single
-    question: 'Are you planning to travel to the UK after 31 October 2019?'
-    options:
-      - label: "Yes"
-        value: travelling-to-uk-yes
-      - label: "No"
-        value: travelling-to-uk-no
-
-  - key: travelling-to-uk-3
-    depends_on:
       - nationality-eu
-      - living-eu
     question_type: single
     question: 'Are you planning to travel to the UK after 31 October 2019?'
     options:
@@ -442,8 +410,6 @@ questions:
       - label: "No"
         value: property-no
 
-  # TIER 5
-  # UK NATIONAL -> LIVE IN EU
   - key: returning-1
     depends_on:
       - nationality-uk
@@ -456,7 +422,6 @@ questions:
       - label: "No"
         value: returning-no
 
-  # UK NATIONAL -> LIVE OUTSIDE EU
   - key: returning-2
     depends_on:
       - nationality-uk

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Questions workflow", type: :feature do
   def and_i_answer_citizen_questions
     answer_question("nationality", "UK")
     answer_question("living", "Rest of world")
-    answer_question("travelling-to-eu-2", "Yes", "You plan to bring your pet")
+    answer_question("travelling-to-eu", "Yes", "You plan to bring your pet")
     answer_question("property", "Yes")
     answer_question("returning-2", "Yes")
   end


### PR DESCRIPTION
https://trello.com/c/AAQQmYqv/91-build-question-yaml-file

Previously the questions about travelling to the UK/EU depended on a
combination of nationality and where the user lives. This changes the
dependencies to be purely based on nationality to support actions that
are relevant to travelling but not where the user lives.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
