### PR TITLE
Remove reference to EEA (assume 'EU' is ambiguous)

### DIFF
--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -294,7 +294,7 @@ questions:
 
   - key: join-family-uk-1
     question_type: single
-    question: Do you plan to join an EU or EEA family member in the UK?
+    question: Do you plan to join an EU family member in the UK?
     depends_on:
       - nationality-eu
     options:
@@ -305,7 +305,7 @@ questions:
 
   - key: join-family-uk-2
     question_type: single
-    question: Do you plan to join an EU or EEA family member in the UK?
+    question: Do you plan to join an EU family member in the UK?
     depends_on:
       - nationality-row
     options:


### PR DESCRIPTION
https://trello.com/c/AAQQmYqv/91-build-question-yaml-file

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
