### PR TITLE
Re-use criteria logic for questions

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -25,9 +25,8 @@ class Checklists::Action
     @priority = params['priority']
   end
 
-  def applies_to?(criteria_keys)
-    all_criteria = Checklists::Criterion.load_all.map(&:key)
-    CriteriaLogic.new(criteria, criteria_keys, all_criteria).applies?
+  def applies_to?(selected_criteria)
+    Checklists::CriteriaLogic.new(criteria, selected_criteria).applies?
   end
 
   def self.find_by_id(id)
@@ -36,47 +35,5 @@ class Checklists::Action
 
   def self.load_all(exclude_deleted: true)
     CHECKLISTS_ACTIONS.reject { |a| a['soft_deleted'] && exclude_deleted }.map { |a| new(a) }
-  end
-end
-
-class CriteriaLogic
-  def initialize(string, selected_options, all_options)
-    @string = string&.underscore
-    @selected_options = selected_options.map(&:underscore)
-    @all_options = all_options.map(&:underscore)
-  end
-
-  def applies?
-    return false if string.blank?
-
-    eval(string, context) # rubocop:disable Security/Eval
-  end
-
-private
-
-  attr_reader :string, :selected_options, :all_options
-
-  def context
-    all_options_hash = all_options.each_with_object({}) do |key, hash|
-      hash[key] = false
-    end
-
-    options_hash = selected_options.each_with_object(all_options_hash) do |key, hash|
-      hash[key] = true
-    end
-
-    HashBinding.new(options_hash).context
-  end
-end
-
-class HashBinding
-  def initialize(hash)
-    hash.each do |key, value|
-      singleton_class.send(:define_method, key) { value }
-    end
-  end
-
-  def context
-    binding
   end
 end

--- a/app/lib/checklists/criteria_logic.rb
+++ b/app/lib/checklists/criteria_logic.rb
@@ -1,0 +1,44 @@
+class Checklists::CriteriaLogic
+  def initialize(string, selected_options)
+    @string = string.to_s.underscore
+    @selected_options = selected_options.map(&:underscore)
+  end
+
+  def applies?
+    return true if string.blank?
+
+    eval(string, context) # rubocop:disable Security/Eval
+  end
+
+private
+
+  attr_reader :string, :selected_options
+
+  def all_options
+    @all_options ||= Checklists::Criterion.load_all.map(&:key).map(&:underscore)
+  end
+
+  def context
+    all_options_hash = all_options.each_with_object({}) do |key, hash|
+      hash[key] = false
+    end
+
+    options_hash = selected_options.each_with_object(all_options_hash) do |key, hash|
+      hash[key] = true
+    end
+
+    HashBinding.new(options_hash).context
+  end
+
+  class HashBinding
+    def initialize(hash)
+      hash.each do |key, value|
+        singleton_class.send(:define_method, key) { value }
+      end
+    end
+
+    def context
+      binding
+    end
+  end
+end

--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -1,6 +1,6 @@
 class Checklists::Question
   attr_reader :key, :text, :description, :hint_title, :hint_text,
-              :options, :type, :depends_on
+              :options, :type, :criteria
 
   def initialize(params)
     @key            = params['key']
@@ -10,15 +10,15 @@ class Checklists::Question
     @hint_text      = params['hint_text']
     @options        = params['options']
     @type           = params['question_type']
-    @depends_on     = params['depends_on']
+    @criteria       = params['criteria']
   end
 
   def self.find_by_key(key)
     load_all.find { |q| q.key == key }
   end
 
-  def show?(criteria)
-    depends_on.blank? || (depends_on - criteria).empty?
+  def show?(selected_criteria)
+    Checklists::CriteriaLogic.new(criteria, selected_criteria).applies?
   end
 
   def possible_criteria

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -10,8 +10,7 @@ questions:
         value: does-not-own-business
 
   - key: sector_business_area
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "multiple"
     question: "What does your business or organisation do?"
     description: |
@@ -169,8 +168,7 @@ questions:
             value: sector-warehouses-services-pipelines
 
   - key: business_activity
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "multiple"
     question: "Does your business do any of the following activities?"
     description: <p>Importing and exporting includes temporarily taking goods across the EU border, for example to a trade fair.</p>
@@ -187,8 +185,7 @@ questions:
         value: haulage-goods-across-eu-borders
 
   - key: employ_eu_citizens
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "single"
     question: "Do you employ anyone from another European country?"
     description: |
@@ -200,8 +197,7 @@ questions:
         value: do-not-employ-eu-citizens
 
   - key: personal_data
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "single_wrapped"
     question: "Do you exchange personal data with another organisation in Europe?"
     description: |
@@ -222,8 +218,7 @@ questions:
         value: do-not-exchange-personal-data-with-eu-org
 
   - key: intellectual_property
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "single_wrapped"
     question: "Do you use or rely on intellectual property (IP) protection?"
     description: |
@@ -246,8 +241,7 @@ questions:
         value: do-not-use-rely-ip
 
   - key: eu_uk_government_funding
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "single_wrapped"
     question: "Do you get EU or UK government funding?"
     description: |
@@ -264,8 +258,7 @@ questions:
         value: do-not-get-eu-uk-funding
 
   - key: public_sector_procurement
-    depends_on:
-      - owns-business
+    criteria: owns-business
     question_type: "single_wrapped"
     question: "Do you sell your products or services to the public sector?"
     description: |
@@ -292,22 +285,10 @@ questions:
       - label: Rest of world
         value: nationality-row
 
-  - key: join-family-uk-1
+  - key: join-family-uk
     question_type: single
     question: Do you plan to join an EU family member in the UK?
-    depends_on:
-      - nationality-eu
-    options:
-      - label: "Yes"
-        value: join-family-uk-yes
-      - label: "No"
-        value: join-family-uk-no
-
-  - key: join-family-uk-2
-    question_type: single
-    question: Do you plan to join an EU family member in the UK?
-    depends_on:
-      - nationality-row
+    criteria: "nationality-eu || nationality-row"
     options:
       - label: "Yes"
         value: join-family-uk-yes
@@ -325,24 +306,10 @@ questions:
       - label: Rest of world
         value: living-other
 
-  - key: drive-in-eu-1
+  - key: drive-in-eu
     question_type: single
     question: Do you need to drive in the EU?
-    depends_on:
-      - nationality-uk
-      - living-eu
-    options:
-      - label: "Yes"
-        value: drive-eu-yes
-      - label: "No"
-        value: drive-eu-no
-
-  - key: drive-in-eu-2
-    question_type: single
-    question: Do you need to drive in the EU?
-    depends_on:
-      - nationality-uk
-      - living-other
+    criteria: "nationality-uk && (living-eu || living-other)"
     options:
       - label: "Yes"
         value: drive-eu-yes
@@ -350,9 +317,7 @@ questions:
         value: drive-eu-no
 
   - key: employment-1
-    depends_on:
-      - nationality-uk
-      - living-eu
+    criteria: "nationality-uk && living-eu"
     question_type: multiple
     question: 'What do you do?'
     options:
@@ -362,9 +327,7 @@ questions:
         value: employment-study
 
   - key: employment-2
-    depends_on:
-      - nationality-row
-      - living-uk
+    criteria: "nationality-row && living-uk"
     question_type: multiple
     question: 'What do you do?'
     options:
@@ -374,9 +337,7 @@ questions:
         value: employment-study
 
   - key: employment-3
-    depends_on:
-      - nationality-eu
-      - living-uk
+    criteria: "nationality-eu && living-uk"
     question_type: multiple
     question: 'What do you do?'
     options:
@@ -386,8 +347,7 @@ questions:
         value: employment-study
 
   - key: travelling-to-eu
-    depends_on:
-      - nationality-uk
+    criteria: "nationality-uk"
     question_type: single_wrapped
     question: 'Are you planning to travel to the EU after 31 October 2019?'
     options:
@@ -401,20 +361,8 @@ questions:
       - label: "No"
         value: travelling-to-eu-no
 
-  - key: travelling-to-uk-1
-    depends_on:
-      - nationality-row
-    question_type: single
-    question: 'Are you planning to travel to the UK after 31 October 2019?'
-    options:
-      - label: "Yes"
-        value: travelling-to-uk-yes
-      - label: "No"
-        value: travelling-to-uk-no
-
-  - key: travelling-to-uk-2
-    depends_on:
-      - nationality-eu
+  - key: travelling-to-uk
+    criteria: "nationality-row || nationality-eu"
     question_type: single
     question: 'Are you planning to travel to the UK after 31 October 2019?'
     options:
@@ -424,8 +372,7 @@ questions:
         value: travelling-to-uk-no
 
   - key: property
-    depends_on:
-      - nationality-uk
+    criteria: "nationality-uk"
     question_type: "single"
     question: 'Are you planning to buy or do you already own property in the EU?'
     options:
@@ -434,22 +381,8 @@ questions:
       - label: "No"
         value: property-no
 
-  - key: returning-1
-    depends_on:
-      - nationality-uk
-      - living-eu
-    question_type: single
-    question: 'Are you planning to move back to the UK?'
-    options:
-      - label: "Yes"
-        value: returning-yes
-      - label: "No"
-        value: returning-no
-
-  - key: returning-2
-    depends_on:
-      - nationality-uk
-      - living-other
+  - key: returning
+    criteria: "nationality-uk && (living-eu || living-other)"
     question_type: single
     question: 'Are you planning to move back to the UK?'
     options:

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -41,10 +41,10 @@ RSpec.feature "Questions workflow", type: :feature do
   def and_i_answer_citizen_questions
     answer_question("nationality", "UK")
     answer_question("living", "Rest of world")
-    answer_question("drive-in-eu-2", "No")
+    answer_question("drive-in-eu", "No")
     answer_question("travelling-to-eu", "Yes", "You plan to bring your pet")
     answer_question("property", "Yes")
-    answer_question("returning-2", "Yes")
+    answer_question("returning", "Yes")
   end
 
   def then_i_should_see_the_results_page

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 describe ChecklistHelper, type: :helper do
   describe "#filter_actions" do
-    let(:action1) { Checklists::Action.new('criteria' => "") }
-    let(:action2) { Checklists::Action.new('criteria' => "a") }
-    let(:action3) { Checklists::Action.new('criteria' => "b || c") }
-    let(:actions) { [action1, action2, action3] }
+    let(:action1) { Checklists::Action.new('criteria' => "a") }
+    let(:action2) { Checklists::Action.new('criteria' => "b || c") }
+    let(:actions) { [action1, action2] }
 
     before do
       allow(Checklists::Criterion).to receive(:load_all).and_return([
@@ -27,7 +26,7 @@ describe ChecklistHelper, type: :helper do
       let(:criteria_keys) { %w[a] }
 
       it "returns some actions" do
-        expect(subject).to eq([action2])
+        expect(subject).to eq([action1])
       end
     end
 
@@ -35,7 +34,7 @@ describe ChecklistHelper, type: :helper do
       let(:criteria_keys) { %w[a b] }
 
       it "returns some actions" do
-        expect(subject).to eq([action2, action3])
+        expect(subject).to eq([action1, action2])
       end
     end
   end

--- a/spec/lib/checklists/criteria_logic_spec.rb
+++ b/spec/lib/checklists/criteria_logic_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Checklists::CriteriaLogic do
+  describe '#applies?' do
+    before do
+      allow(Checklists::Criterion).to receive(:load_all).and_return([
+        double(key: 'a'), double(key: 'b'), double(key: 'c')
+      ])
+    end
+
+    subject do
+      described_class.new(criteria, selected_criteria).applies?
+    end
+
+    context "a nil criteria" do
+      let(:criteria) { nil }
+      let(:selected_criteria) { %w[a] }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "an empty criteria" do
+      let(:criteria) { "" }
+      let(:selected_criteria) { %w[a] }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "the selected criteria meets the applicable criteria" do
+      let(:criteria) { "a || b || c" }
+      let(:selected_criteria) { %w[a] }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "the selected criteria meets the applicable criteria with an AND" do
+      let(:criteria) { "a && b || c" }
+      let(:selected_criteria) { %w[a b] }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "the selected criteria doesn't meet the applicable criteria with an AND" do
+      let(:criteria) { "a && (b || c)" }
+      let(:selected_criteria) { %w[c] }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "no selected criteria" do
+      let(:criteria) { "a || b || c" }
+      let(:selected_criteria) { [] }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/lib/checklists/question_spec.rb
+++ b/spec/lib/checklists/question_spec.rb
@@ -2,26 +2,16 @@ require 'spec_helper'
 
 describe Checklists::Question do
   describe '#show?' do
-    let(:criteria) { [] }
-    subject { described_class.new('depends_on' => dependencies).show?(criteria) }
-
-    context "when the question has no dependencies" do
-      let(:dependencies) { [] }
-
-      it { is_expected.to eq(true) }
+    let(:criteria_logic) do
+      instance_double Checklists::CriteriaLogic, applies?: :result
     end
 
-    context "when the question has unmet dependencies" do
-      let(:dependencies) { %w[A] }
+    it "delegates to the CriteriaLogic" do
+      allow(Checklists::CriteriaLogic).to receive(:new)
+        .with('criteria', 'selected_criteria') { criteria_logic }
 
-      it { is_expected.to eq(false) }
-    end
-
-    context "when the question has met dependencies" do
-      let(:criteria) { %w[A B] }
-      let(:dependencies) { %w[A B] }
-
-      it { is_expected.to eq(true) }
+      action = described_class.new('criteria' => 'criteria')
+      expect(action.show?('selected_criteria')).to eq :result
     end
   end
 
@@ -50,7 +40,7 @@ describe Checklists::Question do
           expect(criteria).to include(option['value'])
         end
 
-        expect(criteria).to include(*question.depends_on.to_a)
+        expect { question.show?([]) }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/AAQQmYqv/91-build-question-yaml-file

This replaces the current 'AND' logic for question dependencies with the
same logic we use for actions. In order to support that a question
without any dependencies will be shown, this changes the default return
value for criteria logic to be truthy, while changing the validation for
actions to force them to have criteria, which seems to be the intention
of the original return value.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
