### PR TITLE
Stop caching checklist YAML in dev

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -1,4 +1,6 @@
 class Checklists::Action
+  CONFIG_PATH = Rails.root.join('lib', 'checklists', 'actions.yaml')
+
   attr_accessor :id,
                 :title,
                 :consequence,
@@ -33,7 +35,8 @@ class Checklists::Action
     load_all.find { |a| a.id == id }
   end
 
-  def self.load_all(exclude_deleted: true)
-    CHECKLISTS_ACTIONS.reject { |a| a['soft_deleted'] && exclude_deleted }.map { |a| new(a) }
+  def self.load_all
+    @load_all = nil if Rails.env.development?
+    @load_all ||= YAML.load_file(CONFIG_PATH)['actions'].map { |a| new(a) }
   end
 end

--- a/app/lib/checklists/criterion.rb
+++ b/app/lib/checklists/criterion.rb
@@ -1,4 +1,6 @@
 class Checklists::Criterion
+  CONFIG_PATH = Rails.root.join('lib', 'checklists', 'criteria.yaml')
+
   attr_reader :key, :text, :depends_on
 
   def initialize(params)
@@ -8,9 +10,10 @@ class Checklists::Criterion
   end
 
   def self.load_all
-    CHECKLISTS_CRITERIA.map do |criteria|
-      Checklists::Criterion.new(criteria)
-    end
+    @load_all = nil if Rails.env.development?
+
+    @load_all ||= YAML.load_file(CONFIG_PATH)['criteria']
+      .map { |c| new(c) }
   end
 
   def self.load_by(criteria_keys)

--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -1,4 +1,6 @@
 class Checklists::Question
+  CONFIG_PATH = Rails.root.join('lib', 'checklists', 'questions.yaml')
+
   attr_reader :key, :text, :description, :hint_title, :hint_text,
               :options, :type, :criteria
 
@@ -35,8 +37,9 @@ class Checklists::Question
   end
 
   def self.load_all
-    CHECKLISTS_QUESTIONS.map do |question|
-      Checklists::Question.new(question)
-    end
+    @load_all = nil if Rails.env.development?
+
+    @load_all ||= YAML.load_file(CONFIG_PATH)['questions']
+      .map { |q| new(q) }
   end
 end

--- a/config/initializers/checklists.rb
+++ b/config/initializers/checklists.rb
@@ -1,5 +1,0 @@
-CHECKLISTS_CONFIG_PATH = Rails.root.join('lib/checklists/')
-
-CHECKLISTS_QUESTIONS = YAML.load_file(CHECKLISTS_CONFIG_PATH + "questions.yaml")['questions']
-CHECKLISTS_CRITERIA = YAML.load_file(CHECKLISTS_CONFIG_PATH + "criteria.yaml")['criteria']
-CHECKLISTS_ACTIONS = YAML.load_file(CHECKLISTS_CONFIG_PATH + "actions.yaml")['actions']

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -48,10 +48,5 @@ describe Checklists::Action do
       ids = subject.map(&:id)
       expect(ids.uniq.count).to eq(ids.count)
     end
-
-    # it "does not return soft deleted actions by default" do
-    #   all_actions = described_class.load_all(exclude_deleted: false)
-    #   expect(subject.count).to be < all_actions.count
-    # end
   end
 end

--- a/spec/lib/checklists/change_note_spec.rb
+++ b/spec/lib/checklists/change_note_spec.rb
@@ -22,7 +22,7 @@ describe Checklists::ChangeNote do
       action_changes = subject.map(&:action_id).compact
       question_changes = subject.map(&:question_key).compact
 
-      action_ids = Checklists::Action.load_all(exclude_deleted: false).map(&:id)
+      action_ids = Checklists::Action.load_all.map(&:id)
       action_changes.each { |action_id|
         expect(action_ids).to include(action_id)
       }


### PR DESCRIPTION
This moves the memoisation of questions/criteria into the associated
model classes, which gives us the opportunity to auto-reload them in
development and quicken the debug/test cycle when changing them.

Previously we switched the behaviour of loading actions to potentially
include ones that are soft deleted. This temporarily removes the soft
deletion behaviour, which isn't currently used, in order to get the same
(lack of) memoisation benefits for actions in development.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
