### PR TITLE
Remove IE6, 7, 8 specific stylesheets

### DIFF
--- a/app/assets/stylesheets/_not-ie-conditional.scss
+++ b/app/assets/stylesheets/_not-ie-conditional.scss
@@ -1,7 +1,0 @@
-$is-ie: false !default;
-
-@mixin not-ie-lte($version){
-  @if $is-ie == false or $ie-version > $version {
-    @content;
-  }
-}

--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,8 +1,0 @@
-// BASE STYLESHEET FOR IE 6 COMPILER
-
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "application";
-

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 7 COMPILER
-
-$is-ie: true;
-$ie-version: 7;
-
-@import "application";
-

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 8 COMPILER
-
-$is-ie: true;
-$ie-version: 8;
-
-@import "application";
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,6 @@
 $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 
-@import 'not-ie-conditional';
 @import 'reset';
 @import 'govuk_publishing_components/all_components';
 @import 'components/*';

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -2,10 +2,7 @@
 <html>
   <head>
     <title><%= yield :title %> - GOV.UK</title>
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
-    <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
+    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
     <%= stylesheet_link_tag "print", media: "print" %>
     <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
     <%= csrf_meta_tags %>

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -3,10 +3,7 @@
   <head>
     <title><%= yield :title %> - GOV.UK</title>
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><![endif]-->
-    <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
+    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
     <%= stylesheet_link_tag "print", media: "print" %>
     <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
     <% if @content_item %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,4 @@
 Rails.application.config.assets.precompile += [
-  "application-ie6.css",
-  "application-ie7.css",
-  "application-ie8.css",
   "application.js",
   "print.css"
 ]


### PR DESCRIPTION
- we don't support IE6 and 7 anymore, and these files impact compile time
- can find no specific styles for these browsers anyway

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1413.herokuapp.com/search/all
- http://finder-frontend-pr-1413.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1413.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1413.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1413.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1413.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1413.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1413.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1413.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
