### PR TITLE
Get the feature specs working again

### DIFF
--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -86,9 +86,7 @@ actions:
     to take it with you.
   lead_time: It takes at least 4 months
   guidance_prompt: Read the guidance
-  guidance_link_text: 'Pet travel to Europe after Brexit
-
-    '
+  guidance_link_text: 'Pet travel to Europe after Brexit'
   guidance_url: https://www.gov.uk/guidance/pet-travel-to-europe-after-brexit
   criteria: nationality-uk && visiting-eu && bring-pet-eu
   audience: citizen
@@ -734,7 +732,7 @@ actions:
     Europe
   title_url:
   consequence: 'You may not be able to run unscheduled services in Europe without
-    the right documents. '
+    the right documents.'
   lead_time: Do it as soon as possible
   guidance_prompt: Read the guidance
   guidance_link_text: Run international bus or coach services and tours after Brexit

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -5,17 +5,23 @@ RSpec.feature "Questions workflow", type: :feature do
     when_i_visit_the_checklist_flow
     and_i_answer_business_questions
     then_i_should_see_the_results_page
-#    and_i_should_see_a_passport_action
-#    and_i_should_see_an_eori_action
+    and_i_should_see_a_pet_action
+    and_i_should_see_a_tourism_action
   end
 
   scenario "citizen questions" do
     when_i_visit_the_checklist_flow
     and_i_do_not_answer_business_questions
     and_i_answer_citizen_questions
-#    then_i_should_see_the_no_results_page # we have no results here
-#    and_i_should_not_see_a_passport_action
-#    and_i_should_not_see_an_eori_action
+    then_i_should_see_the_results_page
+    and_i_should_see_a_pet_action
+    and_i_should_not_see_a_tourism_action
+  end
+
+  scenario "skip all questions" do
+    when_i_visit_the_checklist_flow
+    and_i_dont_answer_enough_questions
+    then_i_should_see_the_no_results_page
   end
 
   def when_i_visit_the_checklist_flow
@@ -24,6 +30,12 @@ RSpec.feature "Questions workflow", type: :feature do
 
   def and_i_do_not_answer_business_questions
     answer_question("do_you_own_a_business", "No")
+  end
+
+  def and_i_dont_answer_enough_questions
+    answer_question("do_you_own_a_business")
+    answer_question("nationality")
+    answer_question("living", "Rest of world")
   end
 
   def and_i_answer_business_questions
@@ -41,7 +53,7 @@ RSpec.feature "Questions workflow", type: :feature do
   def and_i_answer_citizen_questions
     answer_question("nationality", "UK")
     answer_question("living", "Rest of world")
-    answer_question("drive-in-eu", "No")
+    answer_question("drive-in-eu", "Yes")
     answer_question("travelling-to-eu", "Yes", "You plan to bring your pet")
     answer_question("property", "Yes")
     answer_question("returning", "Yes")
@@ -55,20 +67,16 @@ RSpec.feature "Questions workflow", type: :feature do
     expect(page).to have_content I18n.t!("checklists_results.title_no_actions")
   end
 
-  def and_i_should_see_a_passport_action
-    action_is_shown("T002")
+  def and_i_should_see_a_pet_action
+    action_is_shown("S009")
   end
 
-  def and_i_should_not_see_a_passport_action
-    action_not_shown("T002")
+  def and_i_should_not_see_a_tourism_action
+    action_not_shown("T063")
   end
 
-  def and_i_should_not_see_an_eori_action
-    action_not_shown("T001")
-  end
-
-  def and_i_should_see_an_eori_action
-    action_is_shown("T001")
+  def and_i_should_see_a_tourism_action
+    action_is_shown("T063")
   end
 
   def action_not_shown(key)
@@ -78,7 +86,7 @@ RSpec.feature "Questions workflow", type: :feature do
 
   def action_is_shown(key)
     action = Checklists::Action.find_by_id(key)
-    expect(page).to have_link(action.title, href: action.title_url)
+    expect(page).to have_content action.title
     expect(page).to have_content action.lead_time
     expect(page).to have_content action.consequence
 


### PR DESCRIPTION
Some of the actions needed to be manually 'stripped' for the checks to
work. This should be fixed generally when we import next.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
