### PR TITLE
Add back the criteria dependencies

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -22,8 +22,11 @@ class ChecklistController < ApplicationController
 
   def results
     all_actions = Checklists::Action.load_all
-    @criteria = Checklists::Criterion.load_by(criteria_keys)
-    @actions = filter_actions(all_actions, criteria_keys)
+    all_questions = Checklists::Question.load_all
+    valid_criteria_keys = Checklists::CriteriaPathService.new(all_questions).used_criteria(criteria_keys)
+
+    @criteria = Checklists::Criterion.load_by(valid_criteria_keys)
+    @actions = filter_actions(all_actions, valid_criteria_keys)
 
     render "checklist/results"
   end

--- a/app/lib/checklists/criteria_path_service.rb
+++ b/app/lib/checklists/criteria_path_service.rb
@@ -1,0 +1,26 @@
+module Checklists
+  class CriteriaPathService
+    def initialize(questions)
+      @questions = questions
+    end
+
+    def used_criteria(criteria_keys)
+      used_questions(criteria_keys).inject([]) do |result, question|
+        result + (question.possible_criteria & criteria_keys)
+      end
+    end
+
+  private
+
+    attr_reader :questions
+
+    def used_questions(criteria_keys, start_page = 0)
+      page_service = Checklists::PageService.new(questions: questions,
+                                                 criteria_keys: criteria_keys,
+                                                 current_page_from_params: start_page)
+      return [] if page_service.redirect_to_results?
+
+      Array.wrap(questions[page_service.current_page]) + used_questions(criteria_keys, page_service.next_page)
+    end
+  end
+end

--- a/app/views/checklist/_change_answers_link.html.erb
+++ b/app/views/checklist/_change_answers_link.html.erb
@@ -3,8 +3,8 @@
   data-module="track-click"
   data-track-action="ChangeAnswers"
   data-track-category="ChangeAnswersClicked"
-  data-track-label="<%= checklist_questions_path %>"
-  href="<%= checklist_questions_path %>"
+  data-track-label="<%= checklist_questions_path(filtered_params) %>"
+  href="<%= checklist_questions_path(filtered_params) %>"
 >
   <%= t('checklists_results.answers.change_answers') %>
 </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
       This may change. Subscribe to email alerts about changes to Brexit information that may affect you.
     answers:
       list_context: "Based on your answers, we know:"
-      change_answers: "Start again"
+      change_answers: "Change your answers"
       no_answers: |
         You did not answer any of the questions.
         This is a safe and secure service. We don't store any of your personal information.

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -18,6 +18,18 @@ RSpec.feature "Questions workflow", type: :feature do
     and_i_should_not_see_a_tourism_action
   end
 
+  scenario "changing answers" do
+    when_i_visit_the_checklist_flow
+    and_i_answer_business_questions
+    then_i_should_see_the_results_page
+    and_i_click_the_change_answers_link
+    and_i_do_not_answer_business_questions
+    and_i_answer_citizen_questions
+    then_i_should_see_the_results_page
+    and_i_should_see_a_pet_action
+    and_i_should_not_see_a_tourism_action
+  end
+
   scenario "skip all questions" do
     when_i_visit_the_checklist_flow
     and_i_dont_answer_enough_questions
@@ -57,6 +69,10 @@ RSpec.feature "Questions workflow", type: :feature do
     answer_question("travelling-to-eu", "Yes", "You plan to bring your pet")
     answer_question("property", "Yes")
     answer_question("returning", "Yes")
+  end
+
+  def and_i_click_the_change_answers_link
+    click_on(I18n.t!("checklists_results.answers.change_answers"))
   end
 
   def then_i_should_see_the_results_page

--- a/spec/lib/checklists/criteria_path_service_spec.rb
+++ b/spec/lib/checklists/criteria_path_service_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Checklists::CriteriaPathService do
+  context 'there are questions' do
+    let(:questions) do
+      one = Checklists::Question.new('key' => 'question_one',
+                                     'options' => [{ 'value' => 'A' }, { 'value' => 'B' }])
+      two = Checklists::Question.new('key' => 'question_two',
+                                     'options' => [{ 'value' => 'C' }, { 'value' => 'D' }],
+                                     'criteria' => 'A')
+      three = Checklists::Question.new('key' => 'question_three',
+                                       'options' => [{ 'value' => 'E' }, { 'value' => 'F' }],
+                                       'criteria' => 'A && C')
+      [one, two, three]
+    end
+
+    subject(:subject) { Checklists::CriteriaPathService.new(questions) }
+
+    before :each do
+      allow(Checklists::Criterion).to receive(:load_all).and_return([Checklists::Criterion.new('key' => 'A'),
+                                                                     Checklists::Criterion.new('key' => 'B'),
+                                                                     Checklists::Criterion.new('key' => 'C'),
+                                                                     Checklists::Criterion.new('key' => 'D'),
+                                                                     Checklists::Criterion.new('key' => 'E'),
+                                                                     Checklists::Criterion.new('key' => 'F')])
+    end
+    it 'returns no used criteria' do
+      expect(subject.used_criteria([])).to eq([])
+    end
+    it 'returns one used criterion' do
+      expect(subject.used_criteria(%w[B])).to eq(%w[B])
+    end
+    it 'returns one criterion from the correct path, ignoring the one from a previously selected path' do
+      expect(subject.used_criteria(%w(B C))).to eq(%w[B])
+    end
+    it 'returns thee criteria from the correct path' do
+      expect(subject.used_criteria(%w(A C E))).to eq(%w(A C E))
+    end
+    it 'does not care about the order of criteria inputted' do
+      expect(subject.used_criteria(%w(C E F A))).to eq(%w(A C E F))
+    end
+    it 'handles unfinished paths' do
+      expect(subject.used_criteria(%w(C A))).to eq(%w(A C))
+    end
+  end
+end


### PR DESCRIPTION
Previously we removed the capability for a user to change
the parameters when completing a dynamic lists. Instead
when the user wants to update some selections they
would have to start again from scratch.

This was needed because we needed a way to disregard
previous selections. When displaying the results only
the new answers should be presented to the user and
not any possibe leftover selections that are no
longer valid.

This commit adds a way of filtering all criteria submitted
through the URL by selection only those criteria that
the user selected in their latest run

related: https://github.com/alphagov/finder-frontend/pull/1386

Trello: https://trello.com/c/aIsjxObF/107-reintroduce-change-your-answers-and-criteria-dependencies


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
