### PR TITLE
Rename 'possible_criteria' -> options

### DIFF
--- a/app/lib/checklists/question.rb
+++ b/app/lib/checklists/question.rb
@@ -22,7 +22,7 @@ class Checklists::Question
   def valid?
     return false unless Checklists::CriteriaLogic.new(criteria, []).valid?
 
-    possible_criteria.all? do |criterion|
+    possible_options.all? do |criterion|
       Checklists::CriteriaLogic.new(criterion, []).valid?
     end
   end
@@ -31,7 +31,7 @@ class Checklists::Question
     Checklists::CriteriaLogic.new(criteria, selected_criteria).applies?
   end
 
-  def possible_criteria
+  def possible_options
     sub_options = options.flat_map { |o| o['options'].to_a }
     (options + sub_options).map { |o| o['value'] }
   end

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -61,7 +61,7 @@
           </div>
         <% end %>
         <%= render 'form_data',
-          criteria_keys: persistent_criteria_keys(@current_question.possible_criteria),
+          criteria_keys: persistent_criteria_keys(@current_question.possible_options),
           next_page: @page_service.next_page
         %>
         <%= render 'hint_text', current_question: @current_question %>

--- a/spec/lib/checklists/criterion_spec.rb
+++ b/spec/lib/checklists/criterion_spec.rb
@@ -26,7 +26,7 @@ describe Checklists::Criterion do
 
     it "returns criteria that are covered by a question" do
       possible_criteria = Checklists::Question.load_all
-        .flat_map(&:possible_criteria)
+        .flat_map(&:possible_options)
 
       subject.each do |criterion|
         expect(possible_criteria).to include(criterion.key)


### PR DESCRIPTION
This makes the naming of this method consistent with the type of data
it's dealing with.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
