### PR TITLE
Add variance to the "registry" cache refresh period

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,7 +8,8 @@ set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
 bundler_prefix = ENV.fetch('BUNDLER_PREFIX', '/usr/local/bin/govuk_setenv finder-frontend')
 job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
 
-every 1.hour do
+cache_refresh_schedule = Random.new.rand(45..60)
+every cache_refresh_schedule.minutes do
   rake "registries:cache_refresh"
 end
 


### PR DESCRIPTION
At present this job refreshes hourly and queries elasticsearch and the content store.  If we greatly increase the number of machines this might present an unhelpful load all at once to a number of services.

By adding some semblance of variance, we're less likely to all be calling the same things at the same time except on deploy.

Cron tasks cannot be configured by the second, but this is probably sufficient for now.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1436.herokuapp.com/search/all

[Other finders](https://live-stuff.herokuapp.com/finders)
