### PR TITLE
Add job to populate registry caches if empty

### DIFF
--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -14,6 +14,14 @@ module Registries
       }
     end
 
+    def ensure_warm_cache
+      all.values.each { |registry|
+        if registry.can_refresh_cache?
+          registry.fetch_from_cache
+        end
+      }
+    end
+
     def refresh_cache
       all.values.each { |registry|
         if registry.can_refresh_cache?

--- a/lib/tasks/registries.rake
+++ b/lib/tasks/registries.rake
@@ -3,11 +3,23 @@ namespace :registries do
   Fetch data for registries and add to cache
   Fetching registry data takes a while. Rather than have a user
   experience a delay while we read-through an empty cache, we write ahead to
-  the cache with this job at regular intervals (and as part of the deploy).
+  the cache with this job at regular intervals.
   "
   task cache_refresh: :environment do
     puts "Refreshing registry cache..."
     Registries::BaseRegistries.new.refresh_cache
     puts "Finished refreshing registry cache."
+  end
+
+  desc "
+  Fetch data for registries and add to cache _if they are not already present_.
+  This job will be used as part of the deploy.  It should only affect servers with
+  empty caches (which are probably new).
+  Caches are properly refreshed on a schedule.
+  "
+  task cache_warm: :environment do
+    puts "Making sure registry cache is warm..."
+    Registries::BaseRegistries.new.ensure_warm_cache
+    puts "Finished making registry cache toasty."
   end
 end


### PR DESCRIPTION
At present we refresh all registry caches on deploy.  This is generally
OK, but if we increase the number servers dramatically then this might
cause load issues down the line.

It's mostly unnecessary anyway.  Mostly we just want to ensure that we
have _something_ in the cache, not that it's exactly up to date.

The new job will populate the caches if they're empty, but otherwise
leave well alone.  We'll swap the deployment task to use it if it fits the bill.

Related to https://github.com/alphagov/govuk-app-deployment/pull/323

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1437.herokuapp.com/search/all
[Other finders](https://live-stuff.herokuapp.com/finders)
