### PR TITLE
Cache email-alert-api subscriber list responses

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -31,7 +31,7 @@ class ChecklistController < ApplicationController
   def email_signup; end
 
   def confirm_email_signup
-    request = Services.email_alert_api.find_or_create_subscriber_list(subscriber_list_options)
+    request = Services.find_or_create_subscriber_list(subscriber_list_options)
     subscriber_list_slug = request.dig("subscriber_list", "slug")
 
     redirect_to email_alert_frontend_signup_path(topic_id: subscriber_list_slug)

--- a/app/lib/email_alert_subscriber_list_service.rb
+++ b/app/lib/email_alert_subscriber_list_service.rb
@@ -1,0 +1,21 @@
+require 'digest'
+
+class EmailAlertSubscriberListService
+  def initialize(options)
+    @options = options
+  end
+
+  def cacheable_subscriber_list
+    Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+      Services.email_alert_api.find_or_create_subscriber_list(options).to_h
+    end
+  end
+
+private
+
+  def cache_key
+    Digest::SHA256.hexdigest(options.to_s)
+  end
+
+  attr_reader :options
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,6 +1,7 @@
 require 'gds_api/content_store'
 require 'gds_api/rummager'
 require 'gds_api/email_alert_api'
+require 'email_alert_subscriber_list_service'
 
 module Services
   def self.content_store
@@ -24,6 +25,10 @@ module Services
       Plek.find("email-alert-api"),
       bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "wubbalubbadubdub")
     )
+  end
+
+  def self.find_or_create_subscriber_list(options)
+    EmailAlertSubscriberListService.new(options).cacheable_subscriber_list
   end
 
   def self.worldwide_api

--- a/spec/lib/email_alert_subscriber_list_service_spec.rb
+++ b/spec/lib/email_alert_subscriber_list_service_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/email_alert_api'
+require 'email_alert_subscriber_list_service'
+
+describe EmailAlertSubscriberListService do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  subject(:service) { described_class.new(subscriber_list_options) }
+
+  let(:subscriber_list_slug) { "brexit-checklist-does-not-own-business-eu-national" }
+
+  let(:subscriber_list_options) do
+    {
+      "title" => "Your Get ready for Brexit results",
+      "slug" => subscriber_list_slug,
+      "description" => "You can view a copy of your Brexit tool results on GOV.UK.",
+      "tags" => { "brexit_checklist_criteria" => { "any" => %w(does-not-own-business eu-national) } },
+      "url" => "/results?c[]=does-not-own-business&c[]=eu-national",
+    }
+  end
+
+  describe ".cacheable_subscriber_list" do
+    context "the subscriber list exists in email-alert-api" do
+      before do
+        @stub = stub_email_alert_api_has_subscriber_list(subscriber_list_options)
+      end
+
+      it "returns a subscriber list if one exists" do
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+      end
+
+      it "returns a cached subscriber list on subsequent requests" do
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(@stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "the subscriber list does not exist in email-alert-api" do
+      before do
+        @not_found_stub = stub_email_alert_api_does_not_have_subscriber_list(subscriber_list_options)
+        @creation_stub = stub_email_alert_api_creates_subscriber_list(subscriber_list_options)
+      end
+
+      it "returns a newly created subscriber list" do
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+      end
+
+      it "caches the subscriber list once created" do
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(service.cacheable_subscriber_list.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(@not_found_stub).to have_been_requested.times(1)
+        expect(@creation_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "email alert api refuses to create the subscriber list" do
+      before do
+        stub_email_alert_api_does_not_have_subscriber_list(subscriber_list_options)
+        email_alert_api_refuses_to_create_subscriber_list
+      end
+
+      it "bubbles up the 422 error" do
+        expect {
+          service.cacheable_subscriber_list
+        }.to raise_error(GdsApi::HTTPUnprocessableEntity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will cache subscriber lists returned by email-alert-api for the brexit checker for 1 hour.

This request happens when a user clicks 'subscribe' on this page https://www-origin.integration.publishing.service.gov.uk/get-ready-brexit-check/email-signup.

The email subscriber list lookup seems to be the slowest request the application makes. The intent is to reduce page load time by not needing to request the same subscriber list from email-alert-api more than once an hour. 

This will only affect the brexit subscriptions, if this works well we could migrate other parts of finder-frontend to use this.

From comparing this branch on integration to master on staging it appears to reduce the load time from +200ms to <50ms.

This is on integration at the moment to check it: https://www-origin.integration.publishing.service.gov.uk/get-ready-brexit-check/questions

- http://finder-frontend-pr-1439.herokuapp.com/get-ready-brexit-check/questions