### PR TITLE
Fix 500ing on unexpected query params

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -39,10 +39,6 @@ class ChecklistController < ApplicationController
 
 private
 
-  ###
-  # Email signup
-  ###
-
   def subscriber_list_options
     path = checklist_results_path(c: criteria_keys)
 
@@ -55,10 +51,6 @@ private
     }
   end
 
-  ###
-  # Redirect
-  ###
-
   def redirect_to_results?
     @page_service.redirect_to_results?
   end
@@ -67,23 +59,17 @@ private
     redirect_to checklist_results_path(filtered_params)
   end
 
-  ###
-  # Filtered params
-  ###
-
   def filtered_params
     request.query_parameters.except(:page)
   end
   helper_method :filtered_params
 
   def criteria_keys
-    request.query_parameters.fetch(:c, []).reject(&:blank?)
+    return [] unless params[:c].is_a? Array
+
+    params[:c].select { |k| k =~ /[a-z\-]+/ }
   end
   helper_method :criteria_keys
-
-  ###
-  # Current page
-  ###
 
   def current_page_from_params
     params[:page].to_i


### PR DESCRIPTION
Fixes some 500 errors we've been getting in prod...

Previously we assumed the c[] query param would be an array, but there's
nothing stopping the user manually entering '?c=foo' or '?c[0]=foo' or
injecting arbitrary strings instead of real criteria. This fixes that.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
