### PR TITLE
Cache all_options_hash

### DIFF
--- a/app/lib/checklists/criteria_logic.rb
+++ b/app/lib/checklists/criteria_logic.rb
@@ -11,7 +11,7 @@ class Checklists::CriteriaLogic
     return true if tokens.empty?
 
     allowed_values = {
-      on_ident: all_options,
+      on_ident: self.class.all_options,
       on_sp: [" "],
       on_op: %w(&& ||),
       on_lparen: ["("],
@@ -31,20 +31,22 @@ class Checklists::CriteriaLogic
     eval(string, context) # rubocop:disable Security/Eval
   end
 
+  def self.all_options
+    @all_options ||= Checklists::Criterion.load_all.map(&:key_underscored)
+  end
+
+  def self.all_options_hash
+    @all_options_hash ||= all_options.each_with_object({}) do |key, hash|
+      hash[key] = false
+    end
+  end
+
 private
 
   attr_reader :string, :selected_options
 
-  def all_options
-    @all_options ||= Checklists::Criterion.load_all.map(&:key_underscored)
-  end
-
   def context
-    all_options_hash = all_options.each_with_object({}) do |key, hash|
-      hash[key] = false
-    end
-
-    options_hash = selected_options.each_with_object(all_options_hash) do |key, hash|
+    options_hash = selected_options.each_with_object(self.class.all_options_hash.dup) do |key, hash|
       hash[key] = true
     end
 

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -7,9 +7,8 @@ describe ChecklistHelper, type: :helper do
     let(:actions) { [action1, action2] }
 
     before do
-      allow(Checklists::Criterion).to receive(:load_all).and_return([
-        double(key_underscored: 'a'), double(key_underscored: 'b'), double(key_underscored: 'c')
-      ])
+      allow(Checklists::CriteriaLogic).to receive(:all_options).and_return(%w(a b c))
+      allow(Checklists::CriteriaLogic).to receive(:all_options_hash).and_return("a" => false, "b" => false, "c" => false)
     end
 
     subject { filter_actions(actions, criteria_keys) }

--- a/spec/lib/checklists/criteria_logic_spec.rb
+++ b/spec/lib/checklists/criteria_logic_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Checklists::CriteriaLogic do
   before do
-    allow(Checklists::Criterion).to receive(:load_all).and_return([
-      double(key_underscored: 'a'), double(key_underscored: 'b'), double(key_underscored: 'c')
-    ])
+    allow(described_class).to receive(:all_options).and_return(%w(a b c))
+    allow(described_class).to receive(:all_options_hash).and_return("a" => false, "b" => false, "c" => false)
   end
 
   let(:selected_criteria) { [] }

--- a/spec/lib/checklists/page_service_spec.rb
+++ b/spec/lib/checklists/page_service_spec.rb
@@ -11,9 +11,8 @@ describe Checklists::PageService do
   }
 
   before do
-    allow(Checklists::Criterion).to receive(:load_all).and_return([
-      double(key_underscored: 'a'), double(key_underscored: 'b'), double(key_underscored: 'c'), double(key_underscored: 'd')
-    ])
+    allow(Checklists::CriteriaLogic).to receive(:all_options).and_return(%w(a b c d))
+    allow(Checklists::CriteriaLogic).to receive(:all_options_hash).and_return("a" => false, "b" => false, "c" => false, "d" => false)
   end
 
   describe '#next_page' do


### PR DESCRIPTION
We generate this hash for each request, it seems like we could cache it.

The tests are becoming a bit coupled to the implementation now, but I couldn't figure out a nice way to get around the memoization.