### PR TITLE
Add the ability to state exception for actions

### DIFF
--- a/app/lib/checklists/action.rb
+++ b/app/lib/checklists/action.rb
@@ -4,6 +4,7 @@ class Checklists::Action
   attr_accessor :id,
                 :title,
                 :consequence,
+                :exception,
                 :title_url,
                 :lead_time,
                 :criteria,
@@ -17,6 +18,7 @@ class Checklists::Action
     @id = params['action_id']
     @title = params['title']
     @consequence = params['consequence']
+    @exception = params['exception']
     @title_url = params['title_url']
     @lead_time = params['lead_time']
     @criteria = params['criteria']

--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -21,6 +21,11 @@
           <%= action.consequence %>
         </p>
       <% end %>
+      <% if action.exception.present? %>
+        <p class="govuk-body govuk-!-font-size-16">
+          <%= action.exception %>
+        </p>
+      <% end %>
 
       <% if action.guidance_link_text.present? && action.guidance_url.present? %>
         <p class="govuk-body govuk-!-font-size-16">

--- a/lib/checklists/actions.yaml
+++ b/lib/checklists/actions.yaml
@@ -7,6 +7,7 @@ actions:
   title_url: https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status
   consequence: If you do not apply to the Settlement Scheme, you may not be able to
     continue living or working in the UK as you do now.
+  exception: "You do not need to apply if you have: indefinite leave to enter the UK, indefinite leave to remain in the UK, British or Irish citizenship (including ‘dual citizenship’)."
   lead_time: Do it as soon as possible
   guidance_prompt: Read the guidance
   guidance_link_text: Apply to the EU Settlement Scheme (settled and pre-settled status)

--- a/lib/checklists/changenotes.yaml
+++ b/lib/checklists/changenotes.yaml
@@ -1,5 +1,10 @@
 ---
-change_notes: []
+change_notes:
+   - id: add_exception_to_settled_status
+     title: "Apply to the EU Settlement Scheme by 31 December 2020 to continue living in the UK"
+     text: "Added exceptions to settle status for those with indefinite leave to enter/remain and Irish citizenship"
+     action_id: 'S001'
+     question_key:
   # - id: brexit_action_change_1
   #   title: "Change to Get an EORI number that starts with GB to move goods in or out of the UK"
   #   text: "EORI number description added"


### PR DESCRIPTION
This is a temporary fix - needed because we need to display an exceptions for some actions and didn't support govspeak in action consequences to allow multiple paragraphs to be added.