### PR TITLE
Change criteria for showing the travel activities question

### DIFF
--- a/lib/checklists/changenotes.yaml
+++ b/lib/checklists/changenotes.yaml
@@ -30,6 +30,11 @@ change_notes:
      text: "Change criteria to only show those UK nationals traveling to the EU and EU nationals travelling to the UK"
      action_id: 'S025'
      question_key:
+   - id: change_criteria_for_activities_question
+     title: "Are you planning to do any of the following?"
+     text: "Change criteria to only show question to anyone travelling to the EU or the UK"
+     action_id:
+     question_key: activities
   # - id: brexit_action_change_1
   #   title: "Change to Get an EORI number that starts with GB to move goods in or out of the UK"
   #   text: "EORI number description added"

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -63,7 +63,7 @@ questions:
         value: travelling-no
 
   - key: activities
-    criteria: "(nationality-uk && visiting-eu) || visiting-uk"
+    criteria: "visiting-eu || visiting-uk"
     question_type: multiple
     question: 'Are you planning to do any of the following?'
     options:


### PR DESCRIPTION
This loosens the criteria for a showing the travel activities question. The question should be shown to anyone travelling to the EU, rather than just UK-nationals visiting to the EU.
