### PR TITLE
Iterate params cleaning to use existing class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,6 @@ private
     # TODO Use a whitelist based on the facets in the schema
     @filter_params ||= begin
       permitted_params = params
-                           .to_unsafe_hash
                            .except(
                              :controller,
                              :action,
@@ -68,10 +67,7 @@ private
         permitted_params["keywords"] = permitted_params.delete("q")
       end
 
-      ParamsCleaner
-        .new(permitted_params)
-        .cleaned
-        .delete_if { |_, value| value.blank? }
+      ParamsCleaner.new(permitted_params).cleaned
     end
   end
 end

--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -12,7 +12,7 @@ class ChecklistController < ApplicationController
     @questions = Checklists::Question.load_all
     @page_service = Checklists::PageService.new(questions: @questions,
                                                 criteria_keys: criteria_keys,
-                                                current_page_from_params: params[:page].to_i)
+                                                current_page_from_params: page)
 
     if @page_service.redirect_to_results?
       redirect_to checklist_results_path(c: criteria_keys)
@@ -51,9 +51,11 @@ private
   end
 
   def criteria_keys
-    return [] unless params[:c].is_a? Array
-
-    params[:c].select { |k| k =~ /[a-z\-]+/ }
+    @criteria_keys ||= ParamsCleaner.new(params).fetch(:c, [])
   end
   helper_method :criteria_keys
+
+  def page
+    @page ||= ParamsCleaner.new(params).fetch(:page, "0").to_i
+  end
 end

--- a/app/lib/params_cleaner.rb
+++ b/app/lib/params_cleaner.rb
@@ -16,21 +16,39 @@
 # the business readiness finder), strip those so that searches work.
 #
 class ParamsCleaner
+  attr_reader :cleaned
+
   def initialize(params)
-    @params = params
+    @cleaned = cleanup(params)
   end
 
-  def cleaned
-    @params.each do |k, v|
-      if v.is_a?(String)
-        @params[k] = v.strip
-      elsif v.is_a?(Array)
-        @params[k] = v.map { |x| x.is_a?(String) ? x.strip : x }
-      elsif v.is_a?(Hash) && v.keys.all? { |d| d.match(/\A\d+\Z/) }
-        @params[k] = v.values
-      end
+  def fetch(key, default)
+    value = cleaned[key]
+    value.is_a?(default.class) ? value : default
+  end
+
+private
+
+  def cleanup(params)
+    param_pairs = params.to_unsafe_hash
+      .map { |k, v| [k, cleanup_value(v)] }
+
+    Hash[param_pairs]
+      .delete_if { |_, value| value.blank? }
+      .with_indifferent_access
+  end
+
+  def cleanup_value(value)
+    return value.strip if value.is_a?(String)
+
+    if value.is_a? Array
+      return value.map { |x| x.is_a?(String) ? x.strip : x }
     end
 
-    @params
+    if value.respond_to?(:keys) && value.keys.all? { |d| d.match(/\A\d+\Z/) }
+      return value.values
+    end
+
+    value
   end
 end

--- a/spec/lib/params_cleaner_spec.rb
+++ b/spec/lib/params_cleaner_spec.rb
@@ -3,39 +3,53 @@ require "spec_helper"
 describe ParamsCleaner do
   describe "#cleaned" do
     it "makes an array of a array-like hash" do
-      params = { "foo" => { "0" => "bar", "1" => "baz" } }
-
+      params = ActionController::Parameters.new("foo" => { "0" => "bar", "1" => "baz" })
       cleaned = ParamsCleaner.new(params).cleaned
-
-      expect(cleaned).to eql("foo" => %w(bar baz))
+      expect(cleaned).to match("foo" => %w(bar baz))
     end
 
     it "leaves normal params alone" do
-      params = { "foo" => "bar" }
-
+      params = ActionController::Parameters.new("foo" => "bar")
       cleaned = ParamsCleaner.new(params).cleaned
-
-      expect(cleaned).to eql(params)
+      expect(cleaned).to match(params)
     end
 
     it "does not touch other types of hash-params " do
-      params = { "foo" => { "from" => "bar", "to" => "baz" } }
-
+      params = ActionController::Parameters.new("foo" => { "from" => "bar", "to" => "baz" })
       cleaned = ParamsCleaner.new(params).cleaned
-
-      expect(cleaned).to eql(params)
+      expect(cleaned).to match(params)
     end
 
     it "strips leading and trailing whitespace from string parameters" do
-      params = { "foo" => "    bar    " }
+      params = ActionController::Parameters.new("foo" => "    bar    ")
       cleaned = ParamsCleaner.new(params).cleaned
-      expect(cleaned).to eql("foo" => "bar")
+      expect(cleaned).to match("foo" => "bar")
     end
 
     it "strips leading and trailing whitespace from array-of-stringstring parameters" do
-      params = { "foo" => ["    bar    "] }
+      params = ActionController::Parameters.new("foo" => ["    bar    "])
       cleaned = ParamsCleaner.new(params).cleaned
-      expect(cleaned).to eql("foo" => %w(bar))
+      expect(cleaned).to match("foo" => %w(bar))
+    end
+
+    it "removes params with blank values" do
+      params = ActionController::Parameters.new("foo" => "  ")
+      cleaned = ParamsCleaner.new(params).cleaned
+      expect(cleaned).to be_empty
+    end
+  end
+
+  describe "#fetch" do
+    it "returns the param when the default class matches" do
+      params = ActionController::Parameters.new("foo" => { "0" => "bar", "1" => "baz" })
+      value = ParamsCleaner.new(params).fetch(:foo, [])
+      expect(value).to eq(%w(bar baz))
+    end
+
+    it "returns the default when the param class differs" do
+      params = ActionController::Parameters.new("foo" => { "a" => "bar", "b" => "baz" })
+      value = ParamsCleaner.new(params).fetch(:foo, [])
+      expect(value).to be_empty
     end
   end
 end


### PR DESCRIPTION
Previously we used a private controller method to cleanup checklist
params, but it turns out there's an existing, albeit somewhat broken,
class with the same aim. This fixes the ParamsCleaner class and changes
the ChecklistsController to use it.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
