### PR TITLE
Cache content items twice as long

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -8,7 +8,7 @@ module Services
   end
 
   def self.cached_content_item(base_path)
-    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 5.minutes) do
+    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 10.minutes) do
       GovukStatsd.time("content_store.fetch_request_time") do
         content_store.content_item(base_path).to_h
       end


### PR DESCRIPTION
We have a lot of calculators frontend machines now.  Until we scale up the content store machines, we might need to request content items a little less frequently because caching in a local memcached on each machine is less effective.  Content store appears to be getting a little warm.

The checker doesn't load content items, so will be unaffected by this.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1453.herokuapp.com/search/all
- http://finder-frontend-pr-1453.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
