### PR TITLE
Iterate conditional options

### DIFF
--- a/app/controllers/checklist_controller.rb
+++ b/app/controllers/checklist_controller.rb
@@ -24,7 +24,7 @@ class ChecklistController < ApplicationController
   def results
     all_actions = Checklists::Action.load_all
     @criteria = Checklists::Criterion.load_by(criteria_keys)
-    @actions = filter_actions(all_actions, criteria_keys)
+    @actions = filter_items(all_actions, criteria_keys)
   end
 
   def email_signup; end

--- a/app/helpers/checklist_helper.rb
+++ b/app/helpers/checklist_helper.rb
@@ -16,8 +16,8 @@ module ChecklistHelper
     end
   end
 
-  def filter_actions(actions, criteria_keys)
-    actions.select { |a| a.show?(criteria_keys) }
+  def filter_items(items, criteria_keys)
+    items.select { |i| i.show?(criteria_keys) }
   end
 
   def persistent_criteria_keys(question_criteria_keys)
@@ -25,8 +25,7 @@ module ChecklistHelper
   end
 
   def format_question_options(options, criteria_keys)
-    options.select { |o| o.show?(criteria_keys) }
-      .map { |o| format_question_option(o, criteria_keys) }
+    options.map { |o| format_question_option(o, criteria_keys) }
   end
 
   def format_question_option(option, criteria_keys)

--- a/app/views/checklist/_question_single_wrapped.html.erb
+++ b/app/views/checklist/_question_single_wrapped.html.erb
@@ -6,12 +6,14 @@
     hint_text: current_question.hint_title,
     is_page_heading: true,
     items: current_question.options.map do |option|
-      checkboxes = if option.sub_options.present?
+      sub_options = filter_items(option.sub_options, criteria_keys)
+
+      checkboxes = if sub_options.present?
                      render "govuk_publishing_components/components/checkboxes", {
                        name: "c[]",
                        heading: option.label,
                        visually_hide_heading: true,
-                       items: format_question_options(option.sub_options, criteria_keys)
+                       items: format_question_options(sub_options, criteria_keys)
                      }
                    end
 

--- a/spec/helpers/checklist_helper_spec.rb
+++ b/spec/helpers/checklist_helper_spec.rb
@@ -1,40 +1,23 @@
 require 'spec_helper'
 
 describe ChecklistHelper, type: :helper do
-  describe "#filter_actions" do
-    let(:action1) { Checklists::Action.new('criteria' => "a") }
-    let(:action2) { Checklists::Action.new('criteria' => "b || c") }
-    let(:actions) { [action1, action2] }
-
-    before do
-      allow(Checklists::CriteriaLogic).to receive(:all_options).and_return(%w(a b c))
-      allow(Checklists::CriteriaLogic).to receive(:all_options_hash).and_return("a" => false, "b" => false, "c" => false)
+  describe "#filter_items" do
+    it "filters actions that should be shown" do
+      action1 = instance_double Checklists::Action, show?: true
+      action2 = instance_double Checklists::Action, show?: false
+      expect(action1).to receive(:show?).with([])
+      expect(action2).to receive(:show?).with([])
+      results = filter_items([action1, action2], [])
+      expect(results).to eq([action1])
     end
 
-    subject { filter_actions(actions, criteria_keys) }
-
-    context "when there is no criteria" do
-      let(:criteria_keys) { [] }
-
-      it "returns no actions" do
-        expect(subject).to eq([])
-      end
-    end
-
-    context "when there is a criteria" do
-      let(:criteria_keys) { %w[a] }
-
-      it "returns some actions" do
-        expect(subject).to eq([action1])
-      end
-    end
-
-    context "when there is multiple criteria" do
-      let(:criteria_keys) { %w[a b] }
-
-      it "returns some actions" do
-        expect(subject).to eq([action1, action2])
-      end
+    it "filters options that should be shown" do
+      option1 = instance_double Checklists::Question::Option, show?: true
+      option2 = instance_double Checklists::Question::Option, show?: false
+      expect(option1).to receive(:show?).with([])
+      expect(option2).to receive(:show?).with([])
+      results = filter_items([option1, option2], [])
+      expect(results).to eq([option1])
     end
   end
 
@@ -72,37 +55,6 @@ describe ChecklistHelper, type: :helper do
 
     it 'returns all but the questions criteria' do
       expect(subject).to contain_exactly('A', 'B')
-    end
-  end
-
-  describe "#format_question_options" do
-    it "filters options which should not be shown" do
-      option = Checklists::Question::Option.new({})
-      allow(option).to receive(:show?).with([]) { false }
-      results = format_question_options([option], [])
-      expect(results).to be_empty
-    end
-
-    it "returns a hash of options for rendering" do
-      option = Checklists::Question::Option.new('label' => 'label',
-                                                'value' => 'value',
-                                                'hint_text' => 'hint_text')
-
-      allow(option).to receive(:show?) { true }
-      results = format_question_options([option], [])
-
-      expect(results[0]).to match(label: 'label',
-                                  text: 'label',
-                                  value: 'value',
-                                  hint_text: 'hint_text',
-                                  checked: false)
-    end
-
-    it "returns a hash of any checked options" do
-      option = Checklists::Question::Option.new('value' => 'value')
-      allow(option).to receive(:show?) { true }
-      results = format_question_options([option], %w(value))
-      expect(results[0][:checked]).to be_truthy
     end
   end
 end


### PR DESCRIPTION
    Previously we filtered question options as part as formatting them for
    rendering, which caused an issue when all available options were
    filtered out. This renames and re-uses the filter_actions helper to
    filter options before they are formatted.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
