### PR TITLE
Remove travel option criteria pending fix

### DIFF
--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -59,13 +59,10 @@ questions:
         options:
           - label: To the UK
             value: visiting-uk
-            criteria: "(living-eu || living-row || living-ie)"
           - label: To the EU
             value: visiting-eu
-            criteria: "(living-uk || living-row || living-ie)"
           - label: To the rest of the world
             value: visiting-row
-            criteria: "(living-eu || living-uk || living-ie)"
       - label: "No"
         value: travelling-no
 


### PR DESCRIPTION
This removes criteria for travel question options due to a potential
flaw where no sub-options are shown if a person skips the question
that identifies where they live.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
