### PR TITLE
Healthcheck to make sure Action URLs are not broken

### DIFF
--- a/lib/tasks/checklists/test_action_url_responses.sh
+++ b/lib/tasks/checklists/test_action_url_responses.sh
@@ -1,0 +1,27 @@
+#Basic BASH script that ensures that each URL linked to on the Actions page
+#from the Actions yaml is a valid link responding with 200
+link_list=($(awk 'BEGIN {OFS = ":"; ORS = "\n" } /http/ { print $2 }' ./lib/checklists/actions.yaml))
+
+echo $(realpath ../../)
+#Rejects duplicates so we don't end up pinging the same site multiple times
+uniq_link_list=($(printf "%s\n" "${link_list[@]}" | sort -u))
+
+echo '\nRunning check of all links found in actions.yaml for 200:OK status'
+echo 'This may take some time...'
+
+final_status="OK\n"
+for i in "${uniq_link_list[@]}"
+do
+   :
+  status=$(curl -s -o /dev/null -w '%{http_code}' $i)
+  if [ $status != '200' ]; then
+    echo $i ":" $status ": FAIL"
+    final_status='FAIL'
+  fi
+done
+
+echo $final_status
+if [ $final_status != 'FAIL' ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
This commit introduces a simple script that pings every url in the
actions yaml for a header response of 200:OK. If the URL does not
respond with 200:OK, it will report the failing URL and the
response code for manual checking.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
