### PR TITLE
Iterate CSV rake task test

### DIFF
--- a/lib/tasks/checklists/convert_csv_to_yaml.rake
+++ b/lib/tasks/checklists/convert_csv_to_yaml.rake
@@ -4,7 +4,7 @@ namespace :checklists do
   namespace :convert_csv_to_yaml do
     desc "Import actions CSV and convert to YAML file"
     task :actions, [:csv_path] => :environment do |_, args|
-      abort MISSING_CSV_MESSAGE unless args.csv_path
+      raise MISSING_CSV_MESSAGE unless args.csv_path
 
       processor = Checklists::ConvertCsvToYaml::ActionsProcessor.new
       converter = Checklists::ConvertCsvToYaml::Converter.new(processor)
@@ -18,7 +18,7 @@ namespace :checklists do
 
     desc "Import criteria CSV and convert to YAML file"
     task :criteria, [:csv_path] => :environment do |_, args|
-      abort MISSING_CSV_MESSAGE unless args.csv_path
+      raise MISSING_CSV_MESSAGE unless args.csv_path
 
       processor = Checklists::ConvertCsvToYaml::CriteriaProcessor.new
       converter = Checklists::ConvertCsvToYaml::Converter.new(processor)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
+Rails.application.load_tasks
 
 GovukAbTesting.configure do |config|
   config.acceptance_test_framework = :active_support

--- a/spec/tasks/checklists/convert_csv_to_yaml_spec.rb
+++ b/spec/tasks/checklists/convert_csv_to_yaml_spec.rb
@@ -1,17 +1,12 @@
 require "spec_helper"
-require "rake"
 
 RSpec.describe "Convert CSV to YAML tasks" do
   include FixturesHelper
 
-  before do
-    Rake.application.rake_require "tasks/checklists/convert_csv_to_yaml"
-    Rake::Task.define_task(:environment)
-  end
-
   describe "checklists:convert_csv_to_yaml:actions" do
     before do
       Rake::Task["checklists:convert_csv_to_yaml:actions"].reenable
+      allow($stdout).to receive(:puts)
     end
 
     let(:actions_yaml_file_path) { Tempfile.new("actions.yaml").path }
@@ -53,6 +48,7 @@ RSpec.describe "Convert CSV to YAML tasks" do
   describe "checklists:convert_csv_to_yaml:criteria" do
     before do
       Rake::Task["checklists:convert_csv_to_yaml:criteria"].reenable
+      allow($stdout).to receive(:puts)
     end
 
     let(:criteria_yaml_file_path) { Tempfile.new("criteria.yaml").path }


### PR DESCRIPTION
Previously we (repeatedly) loaded individual tasks as part of the spec.
This switches to loading all tasks once, which supports the further work
we will do to add more rake tasks/tests. This also modifies the rake task
to import questions, etc. to stop it leaking into the test output.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
