### PR TITLE
Move valid? method code into specs

### DIFF
--- a/lib/checklists/action.rb
+++ b/lib/checklists/action.rb
@@ -29,10 +29,6 @@ class Checklists::Action
     @priority = params['priority']
   end
 
-  def valid?
-    Checklists::CriteriaLogic::Validator.validate(criteria)
-  end
-
   def show?(selected_criteria)
     Checklists::CriteriaLogic::Evaluator.evaluate(criteria, selected_criteria)
   end

--- a/lib/checklists/question.rb
+++ b/lib/checklists/question.rb
@@ -25,14 +25,6 @@ class Checklists::Question
     load_all.find { |q| q.key == key }
   end
 
-  def valid?
-    return false unless Checklists::CriteriaLogic::Validator.validate(criteria)
-
-    possible_values.all? do |criterion|
-      Checklists::CriteriaLogic::Validator.validate([criterion])
-    end
-  end
-
   def show?(selected_criteria)
     Checklists::CriteriaLogic::Evaluator.evaluate(criteria, selected_criteria)
   end

--- a/spec/lib/checklists/action_spec.rb
+++ b/spec/lib/checklists/action_spec.rb
@@ -28,8 +28,10 @@ describe Checklists::Action do
     end
 
     it "returns actions that reference valid criteria" do
+      validator = Checklists::CriteriaLogic::Validator
+
       subject.each do |action|
-        expect(action.valid?).to be true
+        expect(validator.validate(action.criteria)).to be_truthy
       end
     end
 

--- a/spec/lib/checklists/question_spec.rb
+++ b/spec/lib/checklists/question_spec.rb
@@ -30,8 +30,14 @@ describe Checklists::Question do
     end
 
     it "returns questions that reference valid criteria" do
+      validator = Checklists::CriteriaLogic::Validator
+
       subject.each do |question|
-        expect(question.valid?).to be true
+        expect(validator.validate(question.criteria)).to be_truthy
+
+        question.possible_values.each do |value|
+          expect(validator.validate([value])).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
Previously we did had validations in both the specs and the models for
questions and actions, which is confusing since e.g. 'Question#valid?'
only validates the question criteria. This moves the 'valid?' code into
the specs for questions and actions, but leaves the actual validation of
criteria cohesively together with other CriteriaLogic classes.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
