### PR TITLE
Fix Google API gem not being available in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby File.read(".ruby-version").strip
 gem 'chronic', '~> 0.10.2'
 gem 'dalli'
 gem 'gds-api-adapters', '~> 60.0'
+gem "google-api-client"
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 2.0.0'
 gem 'govuk_document_types', '~> 0.9.2'
@@ -30,7 +31,6 @@ end
 group :development, :test do
   gem 'awesome_print'
   gem "dotenv-rails"
-  gem "google-api-client"
   gem 'govuk-lint', '~> 3.11.5'
   gem 'govuk_schemas', '~> 4.0'
   gem 'jasmine-rails'


### PR DESCRIPTION
This is currently causing an issue where the app cannot start due to the
a failing 'require' statement for this gem.

```
I, [2019-09-06T09:56:57.666428 #19754]  INFO -- : Refreshing Gem list
/data/vhost/finder-frontend/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require': No such file to load -- google/apis/drive_v3.rb (LoadError)
	from /data/vhost/finder-frontend/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	from /data/vhost/finder-frontend/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
```


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
