### PR TITLE
Fix not reenabling dependent 'actions' task

### DIFF
--- a/spec/tasks/checklists/convert_csv_to_yaml_spec.rb
+++ b/spec/tasks/checklists/convert_csv_to_yaml_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Convert CSV to YAML tasks" do
   let(:actions_yaml_file) { Tempfile.new("actions.yaml") }
   let(:actions_csv_file_path) { actions_csv_to_convert_to_yaml }
 
-  describe "checklists:convert_csv_to_yaml:actions" do
-    before do
-      Rake::Task["checklists:convert_csv_to_yaml:actions"].reenable
-      allow($stdout).to receive(:puts)
-    end
+  before do
+    Rake::Task["checklists:convert_csv_to_yaml:actions"].reenable
+    allow($stdout).to receive(:puts)
+  end
 
+  describe "checklists:convert_csv_to_yaml:actions" do
     it "converts the actions CSV to YAML and writes to the actions.yml file" do
       # Override the YAML file path that is sent to the Converter with a tempfile
       # so that "lib/checklists/actions.yaml" isn't overwritten by the test.


### PR DESCRIPTION
Previously we only reenabled the Google API task under test, but this
delegates to the 'action' task. It's not clear why not reenabling (i.e.
skipping invocation) of the 'action' task results in a leaking
exception, but this ought to fix the test issue we're seeing.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
