### PR TITLE
Fix 'the' -> 'that' typo

### DIFF
--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -56,7 +56,7 @@ questions:
   - key: travelling
     question_type: single_wrapped
     question: 'Do you plan to travel after 31 October 2019?'
-    hint_text: "This includes travel the may have started on or before 31 October 2019"
+    hint_text: "This includes travel that may have started on or before 31 October 2019"
     options:
       - label: "Yes"
         value: travelling


### PR DESCRIPTION
---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
