### PR TITLE
Add new module to track brexit questions

### DIFF
--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -1,0 +1,43 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  var $ = global.jQuery
+
+  GOVUK.Modules.TrackBrexitQaChoices = function () {
+    this.start = function (element) {
+      track(element)
+    }
+
+    function track (element) {
+      element.on('submit', function (event) {
+        var $checkedOption, eventLabel, options
+        var $submittedForm = $(event.target)
+        var $checkedOptions = $submittedForm.find('input:checked')
+        var questionKey = $submittedForm.data('question-key')
+
+        if ($checkedOptions.length) {
+          $checkedOptions.each(function (index) {
+            $checkedOption = $(this)
+            var checkedOptionId = $checkedOption.attr('id')
+            var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
+            eventLabel = checkedOptionLabel.length
+              ? checkedOptionLabel
+              : $checkedOption.val()
+
+            options = { transport: 'beacon', label: eventLabel }
+
+            GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
+          })
+        } else {
+          // Skipped questions
+          options = { transport: 'beacon', label: 'no choice' }
+
+          GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
+        }
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/views/checklist/show.html.erb
+++ b/app/views/checklist/show.html.erb
@@ -30,7 +30,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="<%= checklist_questions_path %>" method="get" id="finder-qa-facet-filter-selection" data-module="track-qa-choices">
+      <form
+        action="<%= checklist_questions_path %>"
+        method="get"
+        id="finder-qa-facet-filter-selection"
+        data-module="track-brexit-qa-choices"
+        data-question-key="<%= @current_question.key %>"
+      >
         <% if @current_question.multiple? %>
           <div class="govuk-!-margin-top-8">
             <%= render 'question_multiple_choice', {

--- a/spec/javascripts/modules/track-brexit-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-brexit-qa-choices.spec.js
@@ -1,0 +1,69 @@
+/* eslint-env jasmine, jquery */
+
+var $ = window.jQuery
+
+describe('Brexit QA choices tracker', function () {
+  var GOVUK = window.GOVUK || {}
+  var tracker
+  var $element
+
+  beforeEach(function () {
+    spyOn(GOVUK.SearchAnalytics, 'trackEvent')
+
+    $element = $(
+      '<div>' +
+        '<form onsubmit="event.preventDefault()" data-question-key="question-key">' +
+          '<div>' +
+            '<input name="sector_business_area[]" id="construction" type="checkbox" value="construction">' +
+            '<label for="construction">Construction label</label>' +
+          '</div>' +
+          '<div>' +
+            '<input name="sector_business_area[]" id="accommodation" type="checkbox" value="accommodation">' +
+            '<label for="accommodation">Accommodation label</label>' +
+          '</div>' +
+          '<div>' +
+            '<input name="sector_business_area[]" type="checkbox" value="furniture">' +
+          '</div>' +
+          '<button type="submit">Next</button>' +
+        '</form>' +
+      '</div>'
+    )
+
+    tracker = new GOVUK.Modules.TrackBrexitQaChoices()
+    tracker.start($element)
+  })
+
+  afterEach(function () {
+    GOVUK.SearchAnalytics.trackEvent.calls.reset()
+  })
+
+  it('tracks checked checkboxes when clicking submit', function () {
+    $element.find('input[value="accommodation"]').trigger('click')
+    $element.find('input[value="construction"]').trigger('click')
+    $element.find('form').trigger('submit')
+
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
+      'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+    )
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
+      'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'Construction label' }
+    )
+  })
+
+  it('track events sends value of checkbox when no label is set', function () {
+    $element.find('input[value="furniture"]').trigger('click')
+    $element.find('form').trigger('submit')
+
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
+      'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'furniture' }
+    )
+  })
+
+  it('track event triggered when no choice is made', function () {
+    $element.find('form').trigger('submit')
+
+    expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
+      'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'no choice' }
+    )
+  })
+})


### PR DESCRIPTION
## What
Look into the current analytics that is being tracked and suggest improvements that can be made

## Why
Good analytics allow us to have a better understanding of how the product is being used.

## Changes
`Question Key` should be `event action` and `values label` should be `event label`.

Two new event categories - `brexit-checker-qa` and `brexit-checker-results`

https://trello.com/c/QTt0pDDW/211-change-question-event-tracking