### PR TITLE
Add id to checklist email signup form

### DIFF
--- a/app/views/checklist/email_signup.html.erb
+++ b/app/views/checklist/email_signup.html.erb
@@ -34,7 +34,7 @@
           This will include: Information about Brexit including what you and your business can do to prepare.
         </p>
 
-        <%= form_tag checklist_confirm_email_signup_path(c: criteria_keys) do %>
+        <%= form_tag checklist_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('checklists_results.stay_updated.sign_up'),
             inline_layout: true


### PR DESCRIPTION
This will make this form much easier to target via css selectors.


http://finder-frontend-pr-1499.herokuapp.com/get-ready-brexit-check/email-signup

<img width="920" alt="Screen Shot 2019-09-06 at 13 55 04" src="https://user-images.githubusercontent.com/14851208/64429491-106d5b80-d0ae-11e9-9216-22e1b96593df.png">
