### PR TITLE
Update facet remove button focus state

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -197,6 +197,12 @@
 
   .js-enabled & {
     display: inline-block;
+    border: 1px solid transparent;
+    &:focus {
+      -webkit-box-shadow: inset 0 0 0 2px;
+      box-shadow: inset 0 0 0 2px;
+      border: solid 1px govuk-colour("black");
+    }
   }
 }
 


### PR DESCRIPTION
Follow-on from https://github.com/alphagov/finder-frontend/pull/1478

We are not likely to redesign the facet tags anytime soon, so best to update their focus state to match newer style.

This borrows the look from input focus styles

Example search
- http://finder-frontend-pr-1502.herokuapp.com/search/?keywords=pet+micro+pig+requirement&order=relevance

Before:
<img width="640" alt="Screen Shot 2019-09-06 at 14 44 12" src="https://user-images.githubusercontent.com/3758555/64432638-d3589780-d0b4-11e9-9be3-b84fb27089ec.png">

After: 
<img width="655" alt="Screen Shot 2019-09-06 at 14 43 51" src="https://user-images.githubusercontent.com/3758555/64432646-d81d4b80-d0b4-11e9-90b4-9cfe496668a6.png">



