### PR TITLE
Tweak notification copy to match new content

### DIFF
--- a/app/views/checklist_mailer/change_notification.text.erb
+++ b/app/views/checklist_mailer/change_notification.text.erb
@@ -1,5 +1,3 @@
-<% if @action.title_url.present? %><%= @action.title_url %><% end %>
-
 <% if @action.consequence.present? %><%= @action.consequence %><% end %>
 
 <% if @action.exception.present? %><%= @action.exception %><% end %>
@@ -9,10 +7,8 @@
 [<%= @action.guidance_link_text %>](<%= @action.guidance_url %>)
 <% end %>
 
-<% if @change_note.note.present? %>
-What's changed
-<%= @change_note.note %>
-<% end %>
+Updated
+<%= DateTime.parse(@change_note.time).strftime("%-d %B, %Y") %>
 
-Time updated
-<%= DateTime.parse(@change_note.time).strftime("%l.%M%P, %-d %B") %>
+Changes made
+<%= @change_note.note.presence || t("checklists_mailer.change_notification.added") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
       fewer: "Show fewer search options"
   checklists:
     title: "Get ready for Brexit: check what you need to do"
+  checklists_mailer:
+    change_notification:
+      added: This action has been added to your list of results.
   checklists_results:
     social_media_meta:
       title: "Get ready for Brexit"

--- a/lib/tasks/checklists/change_notifications.rake
+++ b/lib/tasks/checklists/change_notifications.rake
@@ -9,6 +9,7 @@ namespace :checklists do
 
     GdsApi.email_alert_api.create_message(
       title: mail.subject,
+      url: change_note.action.title_url,
       body: mail.body.raw_source,
       sender_message_id: change_note.id,
       criteria_rules: criteria_rules(change_note.action.criteria)

--- a/spec/lib/checklists/change_note_spec.rb
+++ b/spec/lib/checklists/change_note_spec.rb
@@ -7,7 +7,7 @@ describe Checklists::ChangeNote do
     it "returns a list of change notes with required fields" do
       subject.each do |change_note|
         expect(change_note.id.length).to eq SecureRandom.uuid.length
-        expect(change_note.time).to match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/)
+        expect(change_note.time).to match(/\d{4}-\d{2}-\d{2}/)
         expect(%w(content_change addition)).to include(change_note.type)
 
         if change_note.type == "content_change"

--- a/spec/tasks/checklists/change_notifications_spec.rb
+++ b/spec/tasks/checklists/change_notifications_spec.rb
@@ -64,12 +64,15 @@ RSpec.describe "Change notifications" do
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
         expect(payload["title"]).to eq "Added: #{action.title}"
+        expect(payload["url"]).to eq action.title_url
         expect(payload["sender_message_id"]).to eq action.id
         expect(payload["body"]).to match(action.consequence)
-        expect(payload["body"]).to match(action.title_url)
 
         date = DateTime.parse(change_note.time)
-        expect(payload["body"]).to match(date.strftime("%l.%M%P, %-d %B"))
+        expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
+
+        note = I18n.t!("checklists_mailer.change_notification.added")
+        expect(payload["body"]).to match(note)
 
         expect(payload["criteria_rules"]).to eq([
           {
@@ -98,12 +101,12 @@ RSpec.describe "Change notifications" do
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
         expect(payload["title"]).to eq "Changed: #{action.title}"
+        expect(payload["url"]).to eq action.title_url
         expect(payload["sender_message_id"]).to eq action.id
-        expect(payload["body"]).to match(change_note.note)
-        expect(payload["body"]).to match(action.title_url)
 
         date = DateTime.parse(change_note.time)
-        expect(payload["body"]).to match(date.strftime("%l.%M%P, %-d %B"))
+        expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
+        expect(payload["body"]).to match(change_note.note)
 
         expect(payload["criteria_rules"]).to eq([
           {


### PR DESCRIPTION
https://trello.com/c/o9XgkCxT/126-send-email-updates-for-actions

This updates the way notifications are presented to match the copy (see attachment on card).

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
