### PR TITLE
Bump components gem for input fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "google-api-client"
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 2.0.0'
 gem 'govuk_document_types', '~> 0.9.2'
-gem 'govuk_publishing_components', '~> 20.2.0'
+gem 'govuk_publishing_components', '~> 20.2.1'
 gem 'rails', '~> 5.2.3'
 gem 'slimmer', '~> 13.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (20.2.0)
+    govuk_publishing_components (20.2.1)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -431,7 +431,7 @@ DEPENDENCIES
   govuk_app_config (~> 2.0.0)
   govuk_document_types (~> 0.9.2)
   govuk_frontend_toolkit (~> 8.2)
-  govuk_publishing_components (~> 20.2.0)
+  govuk_publishing_components (~> 20.2.1)
   govuk_schemas (~> 4.0)
   govuk_test
   jasmine-rails


### PR DESCRIPTION
Fixes this:

<img width="815" alt="Screen Shot 2019-09-06 at 14 12 15" src="https://user-images.githubusercontent.com/861310/64437232-d906ab00-d0bd-11e9-86c6-d16f0ca52b61.png">


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1505.herokuapp.com/search/all
- http://finder-frontend-pr-1505.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1505.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1505.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1505.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1505.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1505.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1505.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1505.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
