### PR TITLE
Add tracking for action and guidance links

### DIFF
--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -1,4 +1,5 @@
 <% items.each.with_index do | action, index | %>
+  <% action_index = "#{audience_index}.#{'%02d' % (index + 1)}"%>
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
     <div class="govuk-grid-column-three-quarters">
       <p class="govuk-body govuk-!-font-weight-bold">
@@ -7,8 +8,8 @@
             class="govuk-link"
             href="<%= action.title_url %>"
             data-module="track-click"
-            data-track-action="<%= audience_heading %> <%= audience_index %>.<%= index + 1 %>"
-            data-track-category="ContentItemClicked"
+            data-track-action="<%= audience_heading %> <%= action_index %> - Action"
+            data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
           ><%= action.title %></a>
         <% else %>
@@ -30,7 +31,15 @@
       <% if action.guidance_url.present? %>
         <p class="govuk-body govuk-!-font-size-16">
           <% prompt = action.guidance_prompt || t("checklists_results.actions.guidance_prompt") %>
-          <%= prompt %>: <a href="<%= action.guidance_url %>" class="govuk-link"><%= action.guidance_link_text %></a>
+          <%= prompt %>: 
+            <a 
+              href="<%= action.guidance_url %>"
+              class="govuk-link"
+              data-module="track-click"
+              data-track-action="<%= audience_heading %> <%= action_index %> - Guidance"
+              data-track-category="brexit-checker-results"
+              data-track-label="<%= action.guidance_link_text %>"
+            ><%= action.guidance_link_text %></a>
         </p>
       <% end %>
     </div>


### PR DESCRIPTION
## What
Look into the current analytics that is being tracked and suggest improvements that can be made

## Why
Good analytics allow us to have a better understanding of how the product is being used.

### Why do we track position of links?

The current reasoning for tracking the position of links is to understand where users are clicking on links. This information will be used to make informed decisions about the ordering of links and understand how far down the list users scroll and click. This is also something that is done in other finders across GOV.UK.

This is something that will need to be reviewed in the future and understand the user need more clearly.

## Tracking that needs to be added

### Action link
- Event Category: `brexit-checker-results`
- Event Action: `You or your family 1.02 - Action`
- Event Label: `[URL]`

### Guidance link
- Event Category: `brexit-checker-results`
- Event Action: `You or your family 1.02 - Guidance`
- Event Label: `[URL]`

Change `1.1` to `1.01` on action link tracking so that ordering in GA is done correctly

https://trello.com/c/Jg2VKa98/210-update-event-tracking-for-action-and-guidance-links