### PR TITLE
Change travel question to multiple checkboxes

### DIFF
--- a/lib/checklists/criteria.yaml
+++ b/lib/checklists/criteria.yaml
@@ -206,16 +206,12 @@ criteria:
   text: You plan to travel to the EU
 - key: visiting-row
   text: You plan to travel to the rest of the world
-- key: travelling
-  text: You plan to travel after 31 October 2019
 - key: visiting-uk
   text: You plan to travel to the UK
 - key: visiting-bring-pet
   text: You are travelling with a pet
 - key: visiting-driving
   text: You need to drive abroad
-- key: travelling-no
-  text: You do not plan to travel after 31 October 2019
 - key: return-to-uk
   text: You are planning to live in UK
 - key: return-to-uk-no

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -54,23 +54,18 @@ questions:
         value: living-driving-eu-no
 
   - key: travelling
-    question_type: single_wrapped
-    question: 'Do you plan to travel after 31 October 2019?'
-    hint_text: "This includes travel that may have started on or before 31 October 2019"
+    question_type: multiple
+    question: 'Where do you plan to travel after 31 October 2019?'
+    hint_text: "This includes travel that may have started on or before 31 October 2019. Select all that apply. If you do not plan to travel, select next."
     options:
-      - label: "Yes"
-        value: travelling
-        options:
-          - label: To the UK
-            value: visiting-uk
-          - label: To Ireland
-            value: visiting-ie
-          - label: To another EU country, Iceland, Liechtenstein, Norway or Switzerland
-            value: visiting-eu
-          - label: To the rest of the world
-            value: visiting-row
-      - label: "No"
-        value: travelling-no
+      - label: To the UK
+        value: visiting-uk
+      - label: To Ireland
+        value: visiting-ie
+      - label: To another EU country, Iceland, Liechtenstein, Norway or Switzerland
+        value: visiting-eu
+      - label: To the rest of the world
+        value: visiting-row
 
   - key: activities
     criteria:

--- a/spec/features/checklists/question_results_spec.rb
+++ b/spec/features/checklists/question_results_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Questions workflow", type: :feature do
     answer_question("nationality", "British")
     answer_question("living", "UK")
     answer_question("employment")
-    answer_question("travelling", "Yes", "To another EU country, Iceland, Liechtenstein, Norway or Switzerland")
+    answer_question("travelling", "To another EU country, Iceland, Liechtenstein, Norway or Switzerland")
     answer_question("activities", "Bring your pet")
   end
 


### PR DESCRIPTION
This refactors the travel question in the Brexit checklists to be a multiple choice question with checkboxes. 
