### PR TITLE
Tweak notifications titles to remove categories

### DIFF
--- a/app/mailers/checklist_mailer.rb
+++ b/app/mailers/checklist_mailer.rb
@@ -2,13 +2,6 @@ class ChecklistMailer < ApplicationMailer
   def change_notification(change_note)
     @change_note = change_note
     @action = @change_note.action
-    mail(subject: subject)
-  end
-
-private
-
-  def subject
-    prefix = @change_note.type == "addition" ? "Added" : "Changed"
-    "#{prefix}: #{@action.title}"
+    mail(subject: @action.title)
   end
 end

--- a/spec/lib/tasks/checklists/change_notifications_spec.rb
+++ b/spec/lib/tasks/checklists/change_notifications_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Change notifications" do
 
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
-        expect(payload["title"]).to eq "Added: #{action.title}"
+        expect(payload["title"]).to eq action.title
         expect(payload["url"]).to eq action.title_url
         expect(payload["sender_message_id"]).to eq action.id
         expect(payload["body"]).to match(action.consequence)
@@ -100,7 +100,7 @@ RSpec.describe "Change notifications" do
 
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
-        expect(payload["title"]).to eq "Changed: #{action.title}"
+        expect(payload["title"]).to eq action.title
         expect(payload["url"]).to eq action.title_url
         expect(payload["sender_message_id"]).to eq action.id
 


### PR DESCRIPTION
https://trello.com/c/o9XgkCxT/126-send-email-updates-for-actions

This got missed in the main copy updates.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
