### PR TITLE
Add email alerts to Research and Statistics Finder

### DIFF
--- a/features/fixtures/statistics_email_signup.json
+++ b/features/fixtures/statistics_email_signup.json
@@ -1,0 +1,43 @@
+{
+  "base_path": "/search/research-and-statistics/email-signup",
+  "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+  "document_type": "finder_email_signup",
+  "title": "Research and statistics",
+  "description": "You'll get an email each time news or communications are published.",
+  "details": {
+    "filter": {
+      "content_purpose_subgroup": ["news", "research_and_statistics"]
+    },
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Research and statistics ",
+    "email_filter_facets": [
+      {
+        "facet_id": "content_store_document_type",
+        "facet_name": "Research and Statistics"
+      },
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -600,4 +600,97 @@ describe EmailAlertSignupAPI do
       end
     end
   end
+
+  context "Create research and statistics subscriber lists" do
+    let(:subscription_url) { "http://gov.uk/email/research-and-statistics-subscription" }
+
+    let(:facets) {
+      [
+        {
+        "facet_id" => "content_store_document_type",
+        "facet_name" => "Document type"
+        }
+      ]
+    }
+
+    describe 'cancelled statistics' do
+      let(:applied_filters) {
+        {
+          "content_store_document_type" => %w[cancelled_statistics]
+        }
+      }
+
+      it 'asks email-alert-api to find or create the subscriber list' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            statistics_announcement_state: { any: "cancelled" }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
+
+    describe 'upcoming statistics' do
+      let(:applied_filters) {
+        {
+          "content_store_document_type" => %w[upcoming_statistics]
+        }
+      }
+
+      it 'asks email-alert-api to find or create the subscriber list' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            document_type: { any: %w(national_statistics_announcement official_statistics_announcement statistics_announcement national official) }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
+
+    describe 'published statistics' do
+      let(:applied_filters) {
+        {
+          "content_store_document_type" => %w[published_statistics]
+        }
+      }
+
+      it 'asks email-alert-api to find or create the subscriber list' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            content_store_document_type: { any:  %w(statistics national_statistics statistical_data_set official_statistics) }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
+
+    describe 'research' do
+      let(:applied_filters) {
+        {
+          "content_store_document_type" => %w[research]
+        }
+      }
+
+      it 'asks email-alert-api to find or create the subscriber list' do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            content_store_document_type: { any:  %w(dfid_research_output independent_report research) }
+          },
+          "subscription_url" => subscription_url
+        )
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/jh8yogol/955-add-more-email-alerts-to-the-research-and-statistics-finder