### PR TITLE
Stub stdout in GoogleDriveCsvDownloader spec

### DIFF
--- a/spec/lib/checklists/convert_csv_to_yaml/google_drive_csv_downloader_spec.rb
+++ b/spec/lib/checklists/convert_csv_to_yaml/google_drive_csv_downloader_spec.rb
@@ -15,6 +15,7 @@ describe Checklists::ConvertCsvToYaml::GoogleDriveCsvDownloader do
 
   describe "#download" do
     before do
+      allow($stdout).to receive(:puts)
       api_url = "https://www.googleapis.com/drive/v3/files/#{sheet_id}/export?alt=media&mimeType=text/csv"
       stub_request(:get, api_url).to_return(body: File.open(csv_to_download))
     end


### PR DESCRIPTION
This prevents `puts` from printing out when the test file is run.