### PR TITLE
Change change note time -> date

### DIFF
--- a/app/views/checklist_mailer/change_notification.text.erb
+++ b/app/views/checklist_mailer/change_notification.text.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 Updated
-<%= DateTime.parse(@change_note.time).strftime("%-d %B, %Y") %>
+<%= Date.parse(@change_note.date).strftime("%-d %B, %Y") %>
 
 Changes made
 <%= @change_note.note.presence || t("checklists_mailer.change_notification.added") %>

--- a/lib/checklists/change_note.rb
+++ b/lib/checklists/change_note.rb
@@ -5,11 +5,11 @@ class Checklists::ChangeNote
 
   validates_presence_of :action_id
   validates_inclusion_of :type, in: %w(addition content_change)
-  validates_format_of :time, with: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}/
+  validates_format_of :date, with: /\d{4}-\d{2}-\d{2}/
   validates_presence_of :note, if: -> { type == "content_change" }
   validates_length_of :id, is: SecureRandom.uuid.length, message: "ID not a UUID"
 
-  attr_reader :id, :action_id, :type, :note, :time
+  attr_reader :id, :action_id, :type, :note, :date
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
@@ -23,6 +23,7 @@ class Checklists::ChangeNote
   def self.load(params)
     parsed_params = params.dup
     parsed_params['id'] = params['uuid']
+    parsed_params['date'] = params['date'].to_s
     new(parsed_params)
   end
 

--- a/lib/checklists/change_notes.yaml
+++ b/lib/checklists/change_notes.yaml
@@ -4,44 +4,44 @@ change_notes:
      #note: "Added exceptions to settle status for those with indefinite leave to enter/remain and Irish citizenship"
      #type: content_change
      #action_id: 'S001'
-     #time: "2019-09-08 10:20"
+     #date: "2019-09-08"
    #- uuid: "047d877f-9034-4845-b19d-02b3e413aa94"
      #type: addition
      #action_id: S011
-     #time: TODO
+     #date: TODO
    #- uuid: "72e4f470-f60f-42df-8724-7bb5d6055ff5"
      #type: addition
      #action_id: T078
-     #time: TODO
+     #date: TODO
    #- uuid: "b64e80e1-332d-4893-873a-94c13423a0b3"
      #type: addition
      #action_id: T079
-     #time: TODO
+     #date: TODO
    #- uuid: "871e7fe2-395e-4b65-a6e5-453031082a43"
      #type: addition
      #action_id: S006
-     #time: TODO
+     #date: TODO
    #- uuid: "921cd309-c1ef-4902-9154-4f2299240a20"
      #type: addition
      #action_id: T025
-     #time: TODO
+     #date: TODO
    #- uuid: "64c565bc-cc88-417a-90b9-618f5de6134c"
      #type: addition
      #action_id: T026
-     #time: TODO
+     #date: TODO
    #- uuid: "553fa1b6-30f8-405e-95dd-0bb1a9ea7111"
      #type: content_change
      #action_id: S029
-     #time: TODO
+     #date: TODO
    #- uuid: "89a7c363-f4b4-4b7c-90fb-baa315092415"
      #type: addition
      #action_id: S014
-     #time: 2019-09-06 07:51
+     #date: 2019-09-06
    #- uuid: "5fe018d7-edb1-4d7a-858e-065e46d0917e"
      #type: addition
      #action_id: T092
-     #time: 2019-09-09 08:18
+     #date: 2019-09-09
    #- uuid: "24b21f22-5f2c-4f11-9a08-25fe84919b67"
      #type: addition
      #action_id: T023
-     #time: 2019-09-09 08:29
+     #date: 2019-09-09

--- a/spec/factories/checklists/change_note.rb
+++ b/spec/factories/checklists/change_note.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     action_id { SecureRandom.uuid }
     type { "addition" }
-    time { "2019-08-07 10:10" }
+    date { "2019-08-07" }
 
     initialize_with { Checklists::ChangeNote.new(attributes) }
   end

--- a/spec/lib/tasks/checklists/change_notifications_spec.rb
+++ b/spec/lib/tasks/checklists/change_notifications_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Change notifications" do
         expect(payload["sender_message_id"]).to eq addition.id
         expect(payload["body"]).to match(addition.action.consequence)
 
-        date = DateTime.parse(addition.time)
+        date = DateTime.parse(addition.date)
         expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
 
         note = I18n.t!("checklists_mailer.change_notification.added")
@@ -96,7 +96,7 @@ RSpec.describe "Change notifications" do
         expect(payload["title"]).to eq content_change.action.title
         expect(payload["url"]).to eq content_change.action.title_url
 
-        date = DateTime.parse(content_change.time)
+        date = DateTime.parse(content_change.date)
         expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
         expect(payload["body"]).to match(content_change.note)
 


### PR DESCRIPTION
https://trello.com/c/o9XgkCxT/126-send-email-updates-for-actions

Previously each change note had a 'time' field, which was confusing
because, while the date is intuitive, it's unclear what the exact time
of a given change note is referring to. This renames and reformats the
'time' field to simply store the date of the change, which is consistent
with the latest copy for the emails we're intending to send.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
