### PR TITLE
Add 'What do you do?' options

### DIFF
--- a/lib/checklists/criteria.yaml
+++ b/lib/checklists/criteria.yaml
@@ -190,10 +190,14 @@ criteria:
   text: You live in the EU
 - key: working-eu
   text: You are employed in the EU
+- key: working-ie
+  text: You are employed in Ireland
 - key: working-uk
   text: You are employed in the UK
 - key: studying-eu
   text: You are studying in the EU
+- key: studying-ie
+  text: You are studying in Ireland
 - key: studying-uk
   text: You are studying in the UK
 - key: living-driving-eu

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -27,18 +27,24 @@ questions:
         value: living-row
 
   - key: employment
-    question_type: multiple
-    question: 'What do you do?'
-    hint_text: 'Select all that apply. If you do something else, select next.'
+    question_type: multiple_grouped
     options:
-      - label: "Work in the UK"
-        value: working-uk
-      - label: "Study in the UK"
-        value: studying-uk
-      - label: "Work in the EU"
-        value: working-eu
-      - label: "Study in the EU"
-        value: studying-eu
+      - label: Work
+        options:
+          - label: "Work in the UK"
+            value: working-uk
+          - label: "Work in Ireland"
+            value: working-ie
+          - label: "Work in another EU country, Iceland, Liechtenstein, Norway or Switzerland"
+            value: working-eu
+      - label: Study
+        options:
+          - label: "Study in the UK"
+            value: studying-uk
+          - label: "Study in Ireland"
+            value: studying-ie
+          - label: "Study in another EU country, Iceland, Liechtenstein, Norway or Switzerland"
+            value: studying-eu
 
   - key: drive-in-eu
     question_type: single

--- a/lib/checklists/questions.yaml
+++ b/lib/checklists/questions.yaml
@@ -28,6 +28,8 @@ questions:
 
   - key: employment
     question_type: multiple_grouped
+    question: 'Do you work or study?'
+    hint_text: 'Select all that apply. If you do not work or study, select next.'
     options:
       - label: Work
         options:


### PR DESCRIPTION
For https://trello.com/c/kzCkkToG/136-add-options-for-what-do-you-do

This PR:
- Changes the 'What do you do?' question type to `multiple_grouped`
- Adds options for studying and working in Ireland to the question
- Updates the question text and hint text
- Updates the text for other EU country options

This PR does not:
- Add `studying-ie` or `working-ie` criteria to any questions

<img width="736" alt="Screen Shot 2019-09-09 at 14 15 24" src="https://user-images.githubusercontent.com/13434452/64539098-c090cd80-d315-11e9-86c5-cf96b7c929b3.png">
