### PR TITLE
Add "Get ready for Brexit questions" to development index

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,6 +8,7 @@
   <p>The following pages are rendered by this application:</p>
 
   <ul>
+    <li><%= link_to "Get ready for Brexit questions", checklist_questions_path %></li>
   <% @rendered_pages.each do |page| %>
     <li><%= link_to page.fetch("title"), page.fetch("link") %></li>
   <% end %>

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -6,6 +6,7 @@
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
+- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
 - http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance


### PR DESCRIPTION
This page was previously not showing as it is a special route and not on
the whitelist [1] for search-api.

As this page is likely the most frequently reviewed page of Finder
Frontend I've put it to the top of the list for convenience.

[1]: https://github.com/alphagov/search-api/blob/a58e8e6f4325494ec88e4244f785f6b83228b5cd/config/govuk_index/migrated_formats.yaml#L283-L284


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
