### PR TITLE
Iterate notification emails again

### DIFF
--- a/app/mailers/checklist_mailer.rb
+++ b/app/mailers/checklist_mailer.rb
@@ -2,6 +2,12 @@ class ChecklistMailer < ApplicationMailer
   def change_notification(change_note)
     @change_note = change_note
     @action = @change_note.action
-    mail(subject: @action.title)
+    mail(subject: subject)
+  end
+
+private
+
+  def subject
+    I18n.t!("checklists_mailer.change_notification.title")
   end
 end

--- a/app/views/checklist_mailer/change_notification.text.erb
+++ b/app/views/checklist_mailer/change_notification.text.erb
@@ -1,3 +1,11 @@
+<%= t("checklists_mailer.change_notification.#{@change_note.type}") %>
+
+<% if @action.title_url.present? %>
+[<%= @action.title %>](<%= @action.title_url %>)
+<% else %>
+<%= @action.title %>
+<% end %>
+
 <% if @action.consequence.present? %><%= @action.consequence %><% end %>
 
 <% if @action.exception.present? %><%= @action.exception %><% end %>
@@ -10,5 +18,7 @@
 Updated
 <%= Date.parse(@change_note.date).strftime("%-d %B, %Y") %>
 
+<% if @change_note.note.present? %>
 Changes made
-<%= @change_note.note.presence || t("checklists_mailer.change_notification.added") %>
+<%= @change_note.note %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,9 @@ en:
     title: "Get ready for Brexit: check what you need to do"
   checklists_mailer:
     change_notification:
-      added: This action has been added to your list of results.
+      title: Your Get ready for Brexit results
+      addition: A new action has been added
+      content_change: An action has been updated
   checklists_results:
     social_media_meta:
       title: "Get ready for Brexit"

--- a/spec/lib/tasks/checklists/change_notifications_spec.rb
+++ b/spec/lib/tasks/checklists/change_notifications_spec.rb
@@ -58,16 +58,18 @@ RSpec.describe "Change notifications" do
 
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
-        expect(payload["title"]).to eq addition.action.title
-        expect(payload["url"]).to eq addition.action.title_url
         expect(payload["sender_message_id"]).to eq addition.id
+        expect(payload["body"]).to match(addition.action.title)
         expect(payload["body"]).to match(addition.action.consequence)
+
+        title = I18n.t!("checklists_mailer.change_notification.title")
+        expect(payload["title"]).to eq title
+
+        change_text = I18n.t!("checklists_mailer.change_notification.addition")
+        expect(payload["body"]).to match(change_text)
 
         date = DateTime.parse(addition.date)
         expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
-
-        note = I18n.t!("checklists_mailer.change_notification.added")
-        expect(payload["body"]).to match(note)
 
         expect(payload["criteria_rules"]).to eq([
           {
@@ -93,8 +95,17 @@ RSpec.describe "Change notifications" do
 
       assert_requested(:post, "#{endpoint}/messages") do |request|
         payload = JSON.parse(request.body)
-        expect(payload["title"]).to eq content_change.action.title
-        expect(payload["url"]).to eq content_change.action.title_url
+        expect(payload["sender_message_id"]).to eq content_change.id
+        expect(payload["body"]).to match(content_change.action.title)
+
+        title = I18n.t!("checklists_mailer.change_notification.title")
+        expect(payload["title"]).to eq title
+
+        change_text = I18n.t!("checklists_mailer.change_notification.content_change")
+        expect(payload["body"]).to match(change_text)
+
+        date = DateTime.parse(addition.date)
+        expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))
 
         date = DateTime.parse(content_change.date)
         expect(payload["body"]).to match(date.strftime("%-d %B, %Y"))


### PR DESCRIPTION
https://trello.com/c/o9XgkCxT/126-send-email-updates-for-actions

This updates the Brexit checker emails to reflect the latest design
iteration. We decided to use a static title/subject for all emails to
better reflect the checklist results page as a single 'content item' on
GOV.UK, rather than trying to hack-in action-specific messaging.

Part of the new design is to have a static piece of copy after the (now
static) title, which introduces the type of change, so that the final
('Changed') section is now exclusively for showing a change note.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
