### PR TITLE
Change event label to be guidance url

### DIFF
--- a/app/views/checklist/_action_list.html.erb
+++ b/app/views/checklist/_action_list.html.erb
@@ -38,7 +38,7 @@
               data-module="track-click"
               data-track-action="<%= audience_heading %> <%= action_index %> - Guidance"
               data-track-category="brexit-checker-results"
-              data-track-label="<%= action.guidance_link_text %>"
+              data-track-label="<%= action.guidance_url %>"
             ><%= action.guidance_link_text %></a>
         </p>
       <% end %>


### PR DESCRIPTION
This fixes an issue introduced in #1506 where it was using the label as the event label rather than the URL (which is what the requested value was).

https://trello.com/c/xwBjteBk/229-fix-guidance-event-tracking