### PR TITLE
Stop sending slug to Email Alert API and change 

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -43,7 +43,6 @@ private
 
     {
       "title" => "Your Get ready for Brexit results",
-      "slug" => "brexit-checklist-#{criteria_keys.sort.join('-')}",
       "description" => "[You can view a copy of your Brexit tool results](#{Plek.new.website_root}#{path}) on GOV.UK.",
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -7,8 +7,8 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
 
   let(:subscriber_list) do
     {
-      "title" => "the Get ready for Brexit tool",
-      "slug" => "brexit-checklist-does-not-own-business-eu-national",
+      "title" => "Your Get ready for Brexit results",
+      "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
       "description" => "[You can view a copy of your Brexit tool results](http://www.test.gov.uk/results?c[]=does-not-own-business&c[]=eu-national) on GOV.UK.",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[does-not-own-business eu-national] } },
       "url" => "/results?c[]=does-not-own-business&c[]=eu-national"
@@ -52,6 +52,6 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   def and_i_am_taken_to_email_alert_frontend
-    expect(page).to have_current_path("/email/subscriptions/new?topic_id=brexit-checklist-does-not-own-business-eu-national")
+    expect(page).to have_current_path("/email/subscriptions/new?topic_id=your-get-ready-for-brexit-results-a1a2a3a4a5")
   end
 end

--- a/spec/lib/services/email_alert_api_spec.rb
+++ b/spec/lib/services/email_alert_api_spec.rb
@@ -9,7 +9,7 @@ describe Services::EmailAlertApi do
       described_class.new.find_or_create_subscriber_list_cached(subscriber_list_options)
     end
 
-    let(:subscriber_list_slug) { "brexit-checklist-does-not-own-business-eu-national" }
+    let(:subscriber_list_slug) { "your-get-ready-for-brexit-results-a1a2a3a4a5" }
 
     let(:subscriber_list_options) do
       {


### PR DESCRIPTION
Trello: https://trello.com/c/XBuIOfXj/86-reduce-slug-lengths-used-by-brexit-checklist

This parameter is to be removed, slugs will be automatically be created
based on the title of the list.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1537.herokuapp.com/search/all
- http://finder-frontend-pr-1537.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1537.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1537.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1537.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1537.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1537.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1537.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1537.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1537.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
