### PR TITLE
Update copy of Brexit checker descriptions

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -43,7 +43,7 @@ private
 
     {
       "title" => "Your Get ready for Brexit results",
-      "description" => "[You can view a copy of your Brexit tool results](#{Plek.new.website_root}#{path}) on GOV.UK.",
+      "description" => "[You can view a copy of your results on GOV.UK.](#{Plek.new.website_root}#{path})",
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,
     }

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     {
       "title" => "Your Get ready for Brexit results",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your Brexit tool results](http://www.test.gov.uk/results?c[]=does-not-own-business&c[]=eu-national) on GOV.UK.",
+      "description" => "[You can view a copy of your results on GOV.UK.](http://www.test.gov.uk/results?c[]=does-not-own-business&c[]=eu-national)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[does-not-own-business eu-national] } },
       "url" => "/results?c[]=does-not-own-business&c[]=eu-national"
     }

--- a/spec/lib/services/email_alert_api_spec.rb
+++ b/spec/lib/services/email_alert_api_spec.rb
@@ -15,7 +15,7 @@ describe Services::EmailAlertApi do
       {
         "title" => "Your Get ready for Brexit results",
         "slug" => subscriber_list_slug,
-        "description" => "You can view a copy of your Brexit tool results on GOV.UK.",
+        "description" => "You can view a copy of your results on GOV.UK.",
         "tags" => { "brexit_checklist_criteria" => { "any" => %w(does-not-own-business eu-national) } },
         "url" => "/results?c[]=does-not-own-business&c[]=eu-national",
       }


### PR DESCRIPTION
Trello: https://trello.com/c/FGYU4NlN/92-differentiate-between-your-get-ready-for-brexit-results-in-subscription-management

The terminology of "Brexit tool" was considered a potential point of
confusion given this isn't the name of the tool. This has been removed
so the sentence is entirely contextual.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1538.herokuapp.com/search/all
- http://finder-frontend-pr-1538.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1538.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1538.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1538.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1538.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1538.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1538.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1538.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1538.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
