### PR TITLE
Update element on toggle search options functionality

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -305,3 +305,25 @@
     color: govuk-colour("white");
   }
 }
+
+.app-c-button-as-link {
+  padding: 0;
+  border-width: 0;
+  color: $govuk-link-colour;
+  background: none;
+  cursor: pointer;
+  -webkit-appearance: none;
+  text-decoration: underline;
+
+  // we need consistent font-size across breakpoints
+  // so we cannot use govuk-font mixin
+  font-size: 16px;
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+
+  // Remove default button focus outline in Firefox
+  &::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+  }
+}

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -27,9 +27,9 @@
 
   <% if finder_presenter.filters.any? %>
     <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hide" <%= "class=facet-toggle--only-on-mobile" unless finder_presenter.hide_facets_by_default %>>
-      <a href="#" class="facet-toggle govuk-link" data-controls="facet-wrapper" data-expanded="false" data-track-category="filterClicked" data-track-action="accordion" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
+      <button type="button" class="facet-toggle app-c-button-as-link" data-controls="facet-wrapper" data-expanded="false" data-track-category="filterClicked" data-track-action="accordion" data-toggled-text="- <%= t("finders.facet_disclosure.fewer", default: "Show fewer search options") %>">
         + <%= t("finders.facet_disclosure.more", default: "Show more search options") %>
-      </a>
+      </button>
 
       <div id="facet-wrapper" class="facet-toggle__content facet-toggle__content--hide">
         <%= render finder_presenter.filters %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -327,9 +327,9 @@ Feature: Filtering documents
   @javascript
   Scenario: Facets should not be hidden by default on finders except all content
     When I view the research and statistics finder
-    And I should not see a "Show more search options" link
+    And I should not see a "Show more search options" button
     Then I view the all content finder
-    And I should see a "Show more search options" link
+    And I should see a "Show more search options" button
 
   @javascript
   Scenario: A Blue Banner should be displayed when navigating from a topic page
@@ -337,14 +337,14 @@ Feature: Filtering documents
     Then I should see a blue banner
 
   @javascript
-  Scenario: Facets should expand when clicking on the "Show more search options" link on all content
+  Scenario: Facets should expand when clicking on the "Show more search options" button on all content
     When I view the all content finder
-    And I should see a "Show more search options" link
-    And I should not see a "Show fewer search options" link
+    And I should see a "Show more search options" button
+    And I should not see a "Show fewer search options" button
     And Facets should be hidden
     Then I click "Show more search options" to expand all facets
-    And I should see a "Show fewer search options" link
-    And I should not see a "Show more search options" link
+    And I should see a "Show fewer search options" button
+    And I should not see a "Show more search options" button
     And Facets should be visible
 
   Scenario: Results should be a landmark to allow screenreaders to jump to it quickly

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -880,7 +880,7 @@ And(/^I press (tab) key to navigate$/) do |key|
 end
 
 Then(/^I click "(.*)" to expand|collapse all facets/) do |link_text|
-  click_link(link_text)
+  click_button(link_text)
 end
 
 And(/^I visit the benefits-reform page$/) do
@@ -904,14 +904,14 @@ Then(/^I should (see|not see) a "Skip to results" link$/) do |can_be_seen|
   expect(page).to have_css('[href="#js-results"]', visible: visibility)
 end
 
-Then(/^I should see a "(Show .* search options)" link$/) do |link_text|
+Then(/^I should see a "(Show .* search options)" button$/) do |link_text|
   expect(page).to have_css('.facet-toggle', visible: true)
-  expect(page).to have_link(link_text)
+  expect(page).to have_selector(:link_or_button, link_text)
 end
 
-Then(/^I should not see a "(Show .* search options)" link$/) do |link_text|
+Then(/^I should not see a "(Show .* search options)" button$/) do |link_text|
   expect(page).to have_css('.facet-toggle', visible: false)
-  expect(page).to_not have_link(link_text)
+  expect(page).to_not have_selector(:link_or_button, link_text)
 end
 
 Then(/^Facets should be visible$/) do


### PR DESCRIPTION
Use `button` instead of `a` for search options toggle
- Use a semantically correct HTMl element
- Add custom app styles to make it look like a link (retain previous visual)

Fixes: #1323

Visual check: 
- http://finder-frontend-pr-1542.herokuapp.com/search/all

