### PR TITLE
Enforce consistent quote style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'lib/tasks/cucumber.rake' # Automatically generated
+    - tmp/**/*
 
 Lint/AmbiguousRegexpLiteral:
   Exclude:
@@ -11,3 +12,6 @@ Metrics/BlockLength:
     - 'features/**/*.rb'
     - 'spec/**/*'
     - 'config/routes.rb'
+
+Style/StringLiterals:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,26 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby File.read(".ruby-version").strip
 
-gem 'chronic', '~> 0.10.2'
-gem 'dalli'
-gem 'gds-api-adapters', '~> 60.0'
+gem "chronic", "~> 0.10.2"
+gem "dalli"
+gem "gds-api-adapters", "~> 60.0"
 gem "google-api-client"
-gem 'govuk_ab_testing', '~> 2.4.1'
-gem 'govuk_app_config', '~> 2.0.0'
-gem 'govuk_document_types', '~> 0.9.2'
-gem 'govuk_publishing_components', '~> 20.5.0'
-gem 'rails', '~> 5.2.3'
-gem 'slimmer', '~> 13.1.0'
+gem "govuk_ab_testing", "~> 2.4.1"
+gem "govuk_app_config", "~> 2.0.0"
+gem "govuk_document_types", "~> 0.9.2"
+gem "govuk_publishing_components", "~> 20.5.0"
+gem "rails", "~> 5.2.3"
+gem "slimmer", "~> 13.1.0"
 
-gem 'govuk_frontend_toolkit', '~> 8.2'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '~> 4.1'
-gem 'whenever', "~> 1.0.0"
+gem "govuk_frontend_toolkit", "~> 8.2"
+gem "sass-rails", "~> 5.0"
+gem "uglifier", "~> 4.1"
+gem "whenever", "~> 1.0.0"
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
-  gem 'sdoc', require: false
+  gem "sdoc", require: false
 end
 
 group :development do
@@ -29,23 +29,23 @@ group :development do
 end
 
 group :development, :test do
-  gem 'awesome_print'
+  gem "awesome_print"
   gem "dotenv-rails"
-  gem 'govuk-lint', '~> 3.11.5'
-  gem 'govuk_schemas', '~> 4.0'
-  gem 'jasmine-rails'
-  gem 'pry-byebug'
-  gem 'rspec-rails', '~> 3.8.2'
+  gem "govuk-lint", "~> 3.11.5"
+  gem "govuk_schemas", "~> 4.0"
+  gem "jasmine-rails"
+  gem "pry-byebug"
+  gem "rspec-rails", "~> 3.8.2"
 end
 
 group :test do
-  gem 'cucumber-rails', '~> 1.8.0', require: false
-  gem 'factory_bot'
-  gem 'govuk-content-schema-test-helpers', '~> 1.6'
-  gem 'govuk_test'
-  gem 'launchy', '~> 2.4.2'
-  gem 'rails-controller-testing'
-  gem 'simplecov', '~> 0.17.0'
+  gem "cucumber-rails", "~> 1.8.0", require: false
+  gem "factory_bot"
+  gem "govuk-content-schema-test-helpers", "~> 1.6"
+  gem "govuk_test"
+  gem "launchy", "~> 2.4.2"
+  gem "rails-controller-testing"
+  gem "simplecov", "~> 0.17.0"
   gem "timecop"
-  gem 'webmock', '~> 3.7.2'
+  gem "webmock", "~> 3.7.2"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,16 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
-if Rails.env.development? && ENV['LIVE']
-  puts 'Pointing application at live dependencies...'
-  ENV['GOVUK_APP_DOMAIN'] = 'www.gov.uk'
-  ENV['GOVUK_WEBSITE_ROOT'] = 'https://www.gov.uk'
-  ENV['PLEK_SERVICE_SEARCH_URI'] = 'https://www.gov.uk/api'
-  ENV['PLEK_SERVICE_CONTENT_STORE_URI'] = 'https://www.gov.uk/api'
-  ENV['PLEK_SERVICE_STATIC_URI'] = 'assets.publishing.service.gov.uk'
-  ENV['PLEK_SERVICE_WHITEHALL_ADMIN_URI'] = 'https://www.gov.uk'
+if Rails.env.development? && ENV["LIVE"]
+  puts "Pointing application at live dependencies..."
+  ENV["GOVUK_APP_DOMAIN"] = "www.gov.uk"
+  ENV["GOVUK_WEBSITE_ROOT"] = "https://www.gov.uk"
+  ENV["PLEK_SERVICE_SEARCH_URI"] = "https://www.gov.uk/api"
+  ENV["PLEK_SERVICE_CONTENT_STORE_URI"] = "https://www.gov.uk/api"
+  ENV["PLEK_SERVICE_STATIC_URI"] = "assets.publishing.service.gov.uk"
+  ENV["PLEK_SERVICE_WHITEHALL_ADMIN_URI"] = "https://www.gov.uk"
 end
 
 FinderFrontend::Application.load_tasks

--- a/app/controllers/concerns/search_cluster_ab_testable.rb
+++ b/app/controllers/concerns/search_cluster_ab_testable.rb
@@ -11,10 +11,10 @@ module SearchClusterABTestable
   # anything else = use default cluster
   def search_cluster_test
     @search_cluster_test ||= GovukAbTesting::AbTest.new(
-      'SearchClusterQueryABTest',
+      "SearchClusterQueryABTest",
       dimension: CUSTOM_DIMENSION,
       allowed_variants: %w[Default A B],
-      control_variant: 'Default',
+      control_variant: "Default",
     )
   end
 
@@ -26,7 +26,7 @@ module SearchClusterABTestable
     if use_default_cluster?
       {}
     else
-      { search_cluster_query: use_b_cluster? ? 'B' : 'A' }
+      { search_cluster_query: use_b_cluster? ? "B" : "A" }
     end
   end
 
@@ -35,11 +35,11 @@ module SearchClusterABTestable
   end
 
   def use_default_cluster?
-    !(search_cluster_variant.variant?('A') || search_cluster_variant.variant?('B'))
+    !(search_cluster_variant.variant?("A") || search_cluster_variant.variant?("B"))
   end
 
   def use_b_cluster?
-    search_cluster_variant.variant? 'B'
+    search_cluster_variant.variant? "B"
   end
 
   def search_cluster_test_in_scope?

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -46,10 +46,10 @@ private
   def applied_filters
     params
       .permit("filter" => {})
-      .dig('filter')
+      .dig("filter")
       .to_h
       .merge(
-        filter_params.fetch('subscriber_list_params', {})
+        filter_params.fetch("subscriber_list_params", {})
       )
   end
 
@@ -73,16 +73,16 @@ private
     title_builder = signup_presenter.email_filter_by == "facet_values" ? EmailAlertListTitleBuilder : EmailAlertTitleBuilder
     title_builder.call(
       filter: applied_filters,
-      subscription_list_title_prefix: content.dig('details', 'subscription_list_title_prefix'),
+      subscription_list_title_prefix: content.dig("details", "subscription_list_title_prefix"),
       facets: signup_presenter.choices
     )
   end
 
   def default_filters
-    content['details'].fetch('filter', {})
+    content["details"].fetch("filter", {})
   end
 
   def finder_format
-    finder_content_item.dig('details', 'filter', 'document_type')
+    finder_content_item.dig("details", "filter", "document_type")
   end
 end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -39,7 +39,7 @@ class FindersController < ApplicationController
       end
     end
   rescue ActionController::UnknownFormat
-    render plain: 'Not acceptable', status: :not_acceptable
+    render plain: "Not acceptable", status: :not_acceptable
   end
 
 private
@@ -51,7 +51,7 @@ private
   def redirect_to_destination
     @redirect = content_item.redirect
     @finder_slug = finder_slug
-    render 'finders/show-redirect'
+    render "finders/show-redirect"
   end
 
   def json_response
@@ -129,8 +129,8 @@ private
   def pagination_presenter
     PaginationPresenter.new(
       per_page: content_item.default_documents_per_page,
-      start_offset: search_results.dig('start'),
-      total_results: search_results.dig('total'),
+      start_offset: search_results.dig("start"),
+      total_results: search_results.dig("total"),
       url_builder: finder_url_builder,
     )
   end
@@ -140,7 +140,7 @@ private
   end
 
   def suggestions
-    search_results.fetch('suggested_queries', []).map do |keywords|
+    search_results.fetch("suggested_queries", []).map do |keywords|
       {
         keywords: keywords,
         link: finder_url_builder.url(keywords: keywords),
@@ -153,7 +153,7 @@ private
   end
 
   def parent
-    params.fetch(:parent, '')
+    params.fetch(:parent, "")
   end
 
   def facet_tags
@@ -169,7 +169,7 @@ private
   end
 
   def remove_search_box
-    hide_site_serch = params['slug'] == 'search/all'
+    hide_site_serch = params["slug"] == "search/all"
     set_slimmer_headers(remove_search: hide_site_serch)
   end
 
@@ -178,11 +178,11 @@ private
   end
 
   def taxonomy_registry
-    Services.registries.all['full_topic_taxonomy']
+    Services.registries.all["full_topic_taxonomy"]
   end
 
   def organisation_registry
-    Services.registries.all['organisations']
+    Services.registries.all["organisations"]
   end
 
   def debug_score?

--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -97,7 +97,7 @@ private
   end
 
   def custom_options?
-    question_type == "single" && current_facet['custom_options'].present?
+    question_type == "single" && current_facet["custom_options"].present?
   end
 
   def options
@@ -143,7 +143,7 @@ private
   helper_method :next_page_url
 
   def redirect_to_finder
-    redirect_to qa_config["finder_base_path"] + '?' + filtered_params.to_query
+    redirect_to qa_config["finder_base_path"] + "?" + filtered_params.to_query
   end
 
   def skip_link_url
@@ -166,7 +166,7 @@ private
   helper_method :filtered_params
 
   def permitted_params
-    permitted_yesnos = facets.map { |facet| :"#{facet['key']}-yesno" }
+    permitted_yesnos = facets.map { |facet| :"#{facet["key"]}-yesno" }
 
     permitted_keys = facets.each_with_object({}) do |facet, keys|
       keys[facet["key"]] = []

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -1,11 +1,11 @@
 class RedirectionController < ApplicationController
   include PublicationsRoutes
-  DEFAULT_PUBLICATIONS_PATH = 'search/all'.freeze
+  DEFAULT_PUBLICATIONS_PATH = "search/all".freeze
 
   def announcements
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/news-and-communications', params: convert_common_parameters)) }
-      format.atom { redirect_to(finder_path('search/news-and-communications', params: convert_common_parameters, format: :atom)) }
+      format.html { redirect_to(finder_path("search/news-and-communications", params: convert_common_parameters)) }
+      format.atom { redirect_to(finder_path("search/news-and-communications", params: convert_common_parameters, format: :atom)) }
     end
   end
 
@@ -18,34 +18,34 @@ class RedirectionController < ApplicationController
 
   def published_statistics
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/statistics', params: convert_common_parameters)) }
-      format.atom { redirect_to(finder_path('search/statistics', params: convert_common_parameters, format: :atom)) }
+      format.html { redirect_to(finder_path("search/statistics", params: convert_common_parameters)) }
+      format.atom { redirect_to(finder_path("search/statistics", params: convert_common_parameters, format: :atom)) }
     end
   end
 
   def upcoming_statistics
     respond_to do |format|
-      format.html { redirect_to(finder_path('search/statistics', params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming))) }
-      format.atom { redirect_to(finder_path('search/statistics', params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming), format: :atom)) }
+      format.html { redirect_to(finder_path("search/statistics", params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming))) }
+      format.atom { redirect_to(finder_path("search/statistics", params: convert_common_parameters.merge(content_store_document_type: :statistics_upcoming), format: :atom)) }
     end
   end
 
   def advanced_search
     conversion_hash =
       {
-          'services' => 'services',
-          'guidance_and_regulation' => 'guidance-and-regulation',
-          'news_and_communications' => 'news-and-communications',
-          'research_and_statistics' => 'research-and-statistics',
-          'policy_and_engagement' => 'policy-papers-and-consultations',
-          'transparency' => 'transparency-and-freedom-of-information-releases'
+          "services" => "services",
+          "guidance_and_regulation" => "guidance-and-regulation",
+          "news_and_communications" => "news-and-communications",
+          "research_and_statistics" => "research-and-statistics",
+          "policy_and_engagement" => "policy-papers-and-consultations",
+          "transparency" => "transparency-and-freedom-of-information-releases"
       }
-    group = conversion_hash[params['group']]
+    group = conversion_hash[params["group"]]
     error_not_found && return if group.nil?
 
-    topic = params['topic']
+    topic = params["topic"]
     url_params = if topic.present?
-                   registry = Services.registries.all['full_topic_taxonomy']
+                   registry = Services.registries.all["full_topic_taxonomy"]
                    content_id, = registry.taxonomy.find { |_, hash| hash["base_path"] == topic }
                    { topic: content_id }
                  else
@@ -66,12 +66,12 @@ private
   end
 
   def convert_common_parameters
-    { keywords: params['keywords'],
-      level_one_taxon: params['taxons'].try(:first) || params['topics'].try(:first),
-      level_two_taxon: params['subtaxons'].try(:first),
-      organisations: params['departments'] || params['organisations'],
-      people: params['people'],
-      world_locations: params['world_locations'],
-      public_timestamp: { from: params['from_date'], to: params['to_date'] }.compact.presence }.compact
+    { keywords: params["keywords"],
+      level_one_taxon: params["taxons"].try(:first) || params["topics"].try(:first),
+      level_two_taxon: params["subtaxons"].try(:first),
+      organisations: params["departments"] || params["organisations"],
+      people: params["people"],
+      world_locations: params["world_locations"],
+      public_timestamp: { from: params["from_date"], to: params["to_date"] }.compact.presence }.compact
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -14,7 +14,7 @@ class SearchController < ApplicationController
       redirect_to_all_content_finder(search_params) && return
     end
 
-    render(action: 'no_search_term') && return
+    render(action: "no_search_term") && return
   end
 
 protected
@@ -39,12 +39,12 @@ protected
   def redirect_to_all_content_finder(search_params)
     all_content_params = {
       keywords: search_params.search_term,
-      organisations: params['filter_organisations'],
-      manual: params['filter_manual'],
-      format: params['format'],
-      order: 'relevance'
+      organisations: params["filter_organisations"],
+      manual: params["filter_manual"],
+      format: params["format"],
+      order: "relevance"
     }.compact
 
-    redirect_to(finder_path('search/all', params: all_content_params), status: :moved_permanently)
+    redirect_to(finder_path("search/all", params: all_content_params), status: :moved_permanently)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
 
   def arr_to_links(arr)
     arr.map { |link|
-      link_to(link['title'], link['web_url'])
+      link_to(link["title"], link["web_url"])
     }
   end
 end

--- a/app/models/checkbox_facet.rb
+++ b/app/models/checkbox_facet.rb
@@ -8,14 +8,14 @@ class CheckboxFacet < FilterableFacet
     return nil unless is_checked?
 
     {
-      'key' => key,
-      'preposition' => preposition,
-      'values' => [{
-        'label' => short_name,
-        'parameter_key' => key,
-        'value' => value
+      "key" => key,
+      "preposition" => preposition,
+      "values" => [{
+        "label" => short_name,
+        "parameter_key" => key,
+        "value" => value
       }],
-      'word_connectors' => and_word_connectors
+      "word_connectors" => and_word_connectors
     }
   end
 
@@ -24,7 +24,7 @@ class CheckboxFacet < FilterableFacet
   end
 
   def value
-    facet['filter_value'] || true
+    facet["filter_value"] || true
   end
 
   def is_checked?

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,5 @@
 class ContentItem
-  BREXIT_CONTENT_ID = 'd6c2de5d-ef90-45d1-82d4-5f2438369eea'.freeze
+  BREXIT_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
 
   def initialize(content_item_hash)
     @content_item_hash = content_item_hash.freeze
@@ -15,55 +15,55 @@ class ContentItem
   end
 
   def is_search?
-    document_type == 'search'
+    document_type == "search"
   end
 
   def is_finder?
-    document_type == 'finder'
+    document_type == "finder"
   end
 
   def is_redirect?
-    document_type == 'redirect'
+    document_type == "redirect"
   end
 
   def description
-    content_item_hash['description']
+    content_item_hash["description"]
   end
 
   def links
-    content_item_hash['links']
+    content_item_hash["links"]
   end
 
   def title
-    content_item_hash['title']
+    content_item_hash["title"]
   end
 
   def logo_path
-    content_item_hash['details']['logo_path']
+    content_item_hash["details"]["logo_path"]
   end
 
   def filter
-    content_item_hash.dig('details', 'filter') || {}
+    content_item_hash.dig("details", "filter") || {}
   end
 
   def reject
-    content_item_hash.dig('details', 'reject') || {}
+    content_item_hash.dig("details", "reject") || {}
   end
 
   def sort_options
-    content_item_hash.dig('details', 'sort') || []
+    content_item_hash.dig("details", "sort") || []
   end
 
   def default_order
-    content_item_hash['details']['default_order'] || "-public_timestamp"
+    content_item_hash["details"]["default_order"] || "-public_timestamp"
   end
 
   def phase_message
-    content_item_hash['details']['beta_message'] || content_item_hash['details']['alpha_message'] || ""
+    content_item_hash["details"]["beta_message"] || content_item_hash["details"]["alpha_message"] || ""
   end
 
   def phase
-    content_item_hash['phase']
+    content_item_hash["phase"]
   end
 
   def no_index?
@@ -71,50 +71,50 @@ class ContentItem
   end
 
   def canonical_link?
-    content_item_hash['details']['canonical_link']
+    content_item_hash["details"]["canonical_link"]
   end
 
   def all_content_finder?
-    content_item_hash['content_id'] == 'dd395436-9b40-41f3-8157-740a453ac972'
+    content_item_hash["content_id"] == "dd395436-9b40-41f3-8157-740a453ac972"
   end
 
   # FIXME: This should be removed once we have a way to determine
   # whether to display metadata in the finder definition
   def eu_exit_finder?
-    EuExitFinderHelper.eu_exit_finder? content_item_hash['content_id']
+    EuExitFinderHelper.eu_exit_finder? content_item_hash["content_id"]
   end
 
   def related
-    related = content_item_hash['links']['related'] || []
-    related.sort_by { |link| link['title'] }
+    related = content_item_hash["links"]["related"] || []
+    related.sort_by { |link| link["title"] }
   end
 
   def show_phase_banner?
-    content_item_hash['phase'].in?(%w[alpha beta])
+    content_item_hash["phase"].in?(%w[alpha beta])
   end
 
   def document_noun
-    content_item_hash['details']['document_noun'] || ""
+    content_item_hash["details"]["document_noun"] || ""
   end
 
   def show_summaries?
-    content_item_hash['details']['show_summaries']
+    content_item_hash["details"]["show_summaries"]
   end
 
   def summary
-    content_item_hash['details']['summary']
+    content_item_hash["details"]["summary"]
   end
 
   def email_alert_signup
-    content_item_hash.dig('links', 'email_alert_signup', 0)
+    content_item_hash.dig("links", "email_alert_signup", 0)
   end
 
   def hide_facets_by_default
-    content_item_hash['details']['hide_facets_by_default'] || false
+    content_item_hash["details"]["hide_facets_by_default"] || false
   end
 
   def signup_link
-    content_item_hash['details']['signup_link']
+    content_item_hash["details"]["signup_link"]
   end
 
   def sorter_class
@@ -130,11 +130,11 @@ class ContentItem
   end
 
   def default_documents_per_page
-    content_item_hash.dig('details', 'default_documents_per_page') || 1500
+    content_item_hash.dig("details", "default_documents_per_page") || 1500
   end
 
   def base_path
-    content_item_hash.dig('base_path')
+    content_item_hash.dig("base_path")
   end
 
   def raw_facets
@@ -142,7 +142,7 @@ class ContentItem
   end
 
   def redirect
-    content_item_hash.dig('redirects', 0, 'destination')
+    content_item_hash.dig("redirects", 0, "destination")
   end
 
 private
@@ -150,10 +150,10 @@ private
   attr_reader :content_item_hash
 
   def is_research_and_statistics?
-    base_path == '/search/research-and-statistics'
+    base_path == "/search/research-and-statistics"
   end
 
   def document_type
-    content_item_hash['document_type']
+    content_item_hash["document_type"]
   end
 end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -10,10 +10,10 @@ class DateFacet < FilterableFacet
     return nil unless has_filters?
 
     {
-      'key' => key,
-      'preposition' => [preposition, additional_preposition].compact.join(' '),
-      'values' => value_fragments,
-      'word_connectors' => and_word_connectors
+      "key" => key,
+      "preposition" => [preposition, additional_preposition].compact.join(" "),
+      "values" => value_fragments,
+      "word_connectors" => and_word_connectors
     }
   end
 
@@ -32,10 +32,10 @@ private
   def value_fragments
     present_values.map { |name, date|
       {
-        'label' => date.date.strftime("%e %B %Y"),
-        'parameter_key' => key,
-        'value' => date.original_input,
-        'name' => "#{key}[#{name}]"
+        "label" => date.date.strftime("%e %B %Y"),
+        "parameter_key" => key,
+        "value" => date.original_input,
+        "name" => "#{key}[#{name}]"
       }
     }
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,7 +35,7 @@ class Document
 
   def truncated_description
     # This truncates the description at the end of the first sentence
-    description.gsub(/\.\s[A-Z].*/, '.') if description.present?
+    description.gsub(/\.\s[A-Z].*/, ".") if description.present?
   end
 
   def summary
@@ -71,7 +71,7 @@ private
   def tag_metadata_keys
     keys = finder.text_metadata_keys
     keys.reject do |key|
-      key == 'organisations' && is_mainstream_content?
+      key == "organisations" && is_mainstream_content?
     end
   end
 
@@ -80,7 +80,7 @@ private
   end
 
   def date_metadata
-    return [] if @content_purpose_supergroup == 'services'
+    return [] if @content_purpose_supergroup == "services"
 
     date_metadata_keys
       .map(&method(:build_date_metadata))
@@ -140,14 +140,14 @@ private
 
   def get_metadata_label(key, tag)
     if tag.respond_to? :fetch
-      tag.fetch(finder.display_key_for_metadata_key(key), '')
+      tag.fetch(finder.display_key_for_metadata_key(key), "")
     else
       tag
     end
   rescue StandardError => e
     GovukError.notify(
       e,
-      level: 'debug',
+      level: "debug",
       extra: { url: finder.slug, document: link }
     )
     nil

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -4,35 +4,35 @@ class Facet
   end
 
   def key
-    facet['key']
+    facet["key"]
   end
 
   def keys
-    facet['keys']
+    facet["keys"]
   end
 
   def name
-    facet['name']
+    facet["name"]
   end
 
   def type
-    facet['type']
+    facet["type"]
   end
 
   def show_option_select_filter
-    facet['show_option_select_filter']
+    facet["show_option_select_filter"]
   end
 
   def short_name
-    facet['short_name']
+    facet["short_name"]
   end
 
   def hide_facet_tag?
-    facet['hide_facet_tag'] || false
+    facet["hide_facet_tag"] || false
   end
 
   def filterable?
-    facet['filterable'] || false
+    facet["filterable"] || false
   end
 
   def has_filters?
@@ -40,11 +40,11 @@ class Facet
   end
 
   def metadata?
-    facet['display_as_result_metadata'] || false
+    facet["display_as_result_metadata"] || false
   end
 
   def allowed_values
-    facet['allowed_values'] || []
+    facet["allowed_values"] || []
   end
 
   def query_params
@@ -54,11 +54,11 @@ class Facet
 private
 
   def and_word_connectors
-    { words_connector: ' and ', two_words_connector: ' and ' }
+    { words_connector: " and ", two_words_connector: " and " }
   end
 
   def or_word_connectors
-    { words_connector: ' or ', last_word_connector: ' or ' }
+    { words_connector: " or ", last_word_connector: " or " }
   end
 
   def value_fragments

--- a/app/models/filterable_facet.rb
+++ b/app/models/filterable_facet.rb
@@ -1,8 +1,8 @@
 class FilterableFacet < Facet
-  DEFAULT_PREPOSITION = 'related to'.freeze
+  DEFAULT_PREPOSITION = "related to".freeze
 
   def preposition
-    facet['preposition'] || DEFAULT_PREPOSITION
+    facet["preposition"] || DEFAULT_PREPOSITION
   end
 
   def to_partial_path

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -3,33 +3,33 @@ module Filters
     def call
       [
         {
-          'value' => 'published_statistics',
-          'label' => 'Statistics (published)',
-          'filter' => {
-            'content_store_document_type' => %w(statistics national_statistics statistical_data_set official_statistics)
+          "value" => "published_statistics",
+          "label" => "Statistics (published)",
+          "filter" => {
+            "content_store_document_type" => %w(statistics national_statistics statistical_data_set official_statistics)
           },
-          'default' => true
+          "default" => true
         },
         {
-          'value' => 'upcoming_statistics',
-          'label' => 'Statistics (upcoming)',
-          'filter' => {
-            'release_timestamp' => "from:#{Time.zone.today}",
-            'format' => %w(statistics_announcement)
+          "value" => "upcoming_statistics",
+          "label" => "Statistics (upcoming)",
+          "filter" => {
+            "release_timestamp" => "from:#{Time.zone.today}",
+            "format" => %w(statistics_announcement)
           }
         },
         {
-          'value' => 'cancelled_statistics',
-          'label' => 'Statistics (cancelled)',
-          'filter' => {
-              'statistics_announcement_state' => 'cancelled'
+          "value" => "cancelled_statistics",
+          "label" => "Statistics (cancelled)",
+          "filter" => {
+              "statistics_announcement_state" => "cancelled"
             }
         },
         {
-          'value' => 'research',
-          'label' => 'Research',
-          'filter' => {
-            'content_store_document_type' => %w(dfid_research_output independent_report research)
+          "value" => "research",
+          "label" => "Research",
+          "filter" => {
+            "content_store_document_type" => %w(dfid_research_output independent_report research)
           }
         }
       ]
@@ -40,27 +40,27 @@ module Filters
     def call
       [
         {
-          'value' => 'command_or_act_papers',
-          'label' => 'Command or act papers',
-          'filter' => {
-            'has_official_document' => true
+          "value" => "command_or_act_papers",
+          "label" => "Command or act papers",
+          "filter" => {
+            "has_official_document" => true
           },
-            'default' => true
+            "default" => true
         },
         {
-          'value' => 'command_papers',
-          'label' => 'Command papers only',
-          'filter' => {
-            'has_command_paper' => true,
-            'has_act_paper' => false
+          "value" => "command_papers",
+          "label" => "Command papers only",
+          "filter" => {
+            "has_command_paper" => true,
+            "has_act_paper" => false
           }
         },
         {
-          'value' => 'act_papers',
-          'label' => 'Act papers only',
-          'filter' => {
-            'has_act_paper' => true,
-            'has_command_paper' => false
+          "value" => "act_papers",
+          "label" => "Act papers only",
+          "filter" => {
+            "has_act_paper" => true,
+            "has_command_paper" => false
           }
         }
       ]

--- a/app/models/hidden_clearable_facet.rb
+++ b/app/models/hidden_clearable_facet.rb
@@ -8,10 +8,10 @@ class HiddenClearableFacet < FilterableFacet
     return nil unless selected_values.any?
 
     {
-        'key' => key,
-        'preposition' => preposition,
-        'values' => value_fragments,
-        'word_connectors' => or_word_connectors
+        "key" => key,
+        "preposition" => preposition,
+        "values" => value_fragments,
+        "word_connectors" => or_word_connectors
     }
   end
 
@@ -20,7 +20,7 @@ class HiddenClearableFacet < FilterableFacet
   end
 
   def query_params
-    { key => selected_values.map { |value| value['value'] } }
+    { key => selected_values.map { |value| value["value"] } }
   end
 
 private
@@ -28,9 +28,9 @@ private
   def value_fragments
     selected_values.map { |value|
       {
-          'label' => value['label'],
-          'value' => value['value'],
-          'parameter_key' => key
+          "label" => value["label"],
+          "value" => value["value"],
+          "parameter_key" => key
       }
     }
   end
@@ -40,7 +40,7 @@ private
       return [] if @value.nil?
 
       allowed_values.select { |option|
-        @value.include?(option['value'])
+        @value.include?(option["value"])
       }
     end
   end

--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -8,10 +8,10 @@ class HiddenFacet < FilterableFacet
     return nil unless has_filters?
 
     {
-      'key' => key,
-      'preposition' => preposition,
-      'values' => value_fragments,
-      'word_connectors' => or_word_connectors
+      "key" => key,
+      "preposition" => preposition,
+      "values" => value_fragments,
+      "word_connectors" => or_word_connectors
     }
   end
 
@@ -20,7 +20,7 @@ class HiddenFacet < FilterableFacet
   end
 
   def query_params
-    values = allowed_values.empty? ? @value : selected_values.map { |value| value['value'] }
+    values = allowed_values.empty? ? @value : selected_values.map { |value| value["value"] }
     { key => values }
   end
 
@@ -29,8 +29,8 @@ private
   def value_fragments
     selected_values.map { |value|
       {
-          'label' => value['label'],
-          'parameter_key' => key,
+          "label" => value["label"],
+          "parameter_key" => key,
       }
     }
   end
@@ -39,7 +39,7 @@ private
     return [] if @value.nil?
 
     allowed_values.select { |option|
-      @value.include?(option['value'])
+      @value.include?(option["value"])
     }
   end
 end

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -7,11 +7,11 @@ class KeywordFacet
     return nil unless has_filters?
 
     {
-      'key' => key,
-      'preposition' => 'containing',
-      'values' => value_fragments,
-      'word_connectors' => {
-        words_connector: ''
+      "key" => key,
+      "preposition" => "containing",
+      "values" => value_fragments,
+      "word_connectors" => {
+        words_connector: ""
       }
     }
   end
@@ -21,7 +21,7 @@ class KeywordFacet
   end
 
   def key
-    'keywords'
+    "keywords"
   end
 
   def value
@@ -49,10 +49,10 @@ private
     keyword_array.each do |keyword|
       unless keyword.empty?
         keyword_fragments << {
-          'label' => keyword,
-          'parameter_key' => key,
-          'name' => 'keywords',
-          'value' => keyword.gsub('"', "&quot;")
+          "label" => keyword,
+          "parameter_key" => key,
+          "name" => "keywords",
+          "value" => keyword.gsub('"', "&quot;")
         }
       end
     end

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -12,14 +12,14 @@ class OptionSelectFacet < FilterableFacet
     # that expects symbol keys, not strings
     @options ||= allowed_values.map do |allowed_value|
       {
-        value: allowed_value['value'],
-        label: allowed_value['label'],
+        value: allowed_value["value"],
+        label: allowed_value["label"],
         id: "#{key}-#{allowed_value['value']}",
         data_attributes: {
           track_category: "filterClicked",
           uncheck_track_category: "filterRemoved",
           track_action: name,
-          track_label: allowed_value['label'],
+          track_label: allowed_value["label"],
         },
         checked: selected_values.include?(allowed_value),
         controls: controls || nil
@@ -31,10 +31,10 @@ class OptionSelectFacet < FilterableFacet
     return nil unless selected_values.any?
 
     {
-      'key' => key,
-      'preposition' => preposition,
-      'values' => value_fragments,
-      'word_connectors' => or_word_connectors
+      "key" => key,
+      "preposition" => preposition,
+      "values" => value_fragments,
+      "word_connectors" => or_word_connectors
     }
   end
 
@@ -55,7 +55,7 @@ class OptionSelectFacet < FilterableFacet
   end
 
   def query_params
-    { key => selected_values.map { |value| value['value'] } }
+    { key => selected_values.map { |value| value["value"] } }
   end
 
 private
@@ -63,9 +63,9 @@ private
   def value_fragments
     @value_fragments ||= selected_values.map { |value|
       {
-        'label' => value['label'],
-        'value' => value['value'],
-        'parameter_key' => key
+        "label" => value["label"],
+        "value" => value["value"],
+        "parameter_key" => key
       }
     }
   end
@@ -75,7 +75,7 @@ private
       return [] if @value.nil?
 
       allowed_values.select { |option|
-        @value.include?(option['value'])
+        @value.include?(option["value"])
       }
     end
   end

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -5,14 +5,14 @@ class RadioFacet < FilterableFacet
   end
 
   def value
-    @value || default_value['value']
+    @value || default_value["value"]
   end
 
   def options
     allowed_values.map do |allowed_value|
       {
-        value: allowed_value['value'],
-        text: allowed_value['label'],
+        value: allowed_value["value"],
+        text: allowed_value["label"],
         checked: selected_value == allowed_value,
       }
     end
@@ -27,16 +27,16 @@ class RadioFacet < FilterableFacet
   end
 
   def query_params
-    { key => selected_value['value'] }
+    { key => selected_value["value"] }
   end
 
 private
 
   def selected_value
-    allowed_values.find { |option| @value == option['value'] } || default_value
+    allowed_values.find { |option| @value == option["value"] } || default_value
   end
 
   def default_value
-    @default_value ||= allowed_values.find { |option| option['default'] } || {}
+    @default_value ||= allowed_values.find { |option| option["default"] } || {}
   end
 end

--- a/app/models/radio_facet_for_multiple_filters.rb
+++ b/app/models/radio_facet_for_multiple_filters.rb
@@ -9,9 +9,9 @@ class RadioFacetForMultipleFilters < FilterableFacet
   def options
     @filter_hashes.map do |filter_hash|
       {
-        value: filter_hash['value'],
-        text: filter_hash['label'],
-        checked: @value == filter_hash['value'],
+        value: filter_hash["value"],
+        text: filter_hash["label"],
+        checked: @value == filter_hash["value"],
       }
     end
   end
@@ -41,10 +41,10 @@ private
   attr_reader :filter_hashes
 
   def validated_value(value, filter_hashes)
-    filter_hashes.map { |f| f['value'] }.include?(value) ? value : default_value
+    filter_hashes.map { |f| f["value"] }.include?(value) ? value : default_value
   end
 
   def default_value
-    @filter_hashes.find { |hash_hash| hash_hash['default'] }.fetch('value')
+    @filter_hashes.find { |hash_hash| hash_hash["default"] }.fetch("value")
   end
 end

--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -24,7 +24,7 @@ class SearchParameters
   end
 
   def search_term
-    full_term = params[:q]&.strip&.gsub(/\s{2,}/, ' ')
+    full_term = params[:q]&.strip&.gsub(/\s{2,}/, " ")
     unless full_term.nil?
       full_term[0, Search::QueryBuilder::MAX_QUERY_LENGTH]
     end

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -1,6 +1,6 @@
 class TaxonFacet < FilterableFacet
-  LEVEL_ONE_TAXON_KEY = 'level_one_taxon'.freeze
-  LEVEL_TWO_TAXON_KEY = 'level_two_taxon'.freeze
+  LEVEL_ONE_TAXON_KEY = "level_one_taxon".freeze
+  LEVEL_TWO_TAXON_KEY = "level_two_taxon".freeze
 
   def initialize(facet, value_hash)
     @value_hash = value_hash
@@ -8,7 +8,7 @@ class TaxonFacet < FilterableFacet
   end
 
   def name
-    facet['name']
+    facet["name"]
   end
 
   def topics
@@ -25,10 +25,10 @@ class TaxonFacet < FilterableFacet
     return nil if selected_level_one_value.nil?
 
     {
-      'type' => "taxon",
-      'preposition' => preposition,
-      'values' => value_fragments,
-      'word_connectors' => and_word_connectors
+      "type" => "taxon",
+      "preposition" => preposition,
+      "values" => value_fragments,
+      "word_connectors" => and_word_connectors
     }
   end
 
@@ -56,24 +56,24 @@ private
     return nil if value.nil?
 
     {
-      'label' => value[:text],
-      'parameter_key' => key,
-      'value' => value[:value]
+      "label" => value[:text],
+      "parameter_key" => key,
+      "value" => value[:value]
     }
   end
 
   def level_one_taxons
     @level_one_taxons ||= registry.taxonomy_tree.values.map { |v|
       {
-        value: v['content_id'],
-        text: v['title'],
-        sub_topics: v['children'],
+        value: v["content_id"],
+        text: v["title"],
+        sub_topics: v["children"],
         data_attributes: {
           track_category: "filterClicked",
           track_action: "level_one_taxon",
-          track_label: v['title'],
+          track_label: v["title"],
         },
-        selected: v['content_id'] == @value_hash[LEVEL_ONE_TAXON_KEY]
+        selected: v["content_id"] == @value_hash[LEVEL_ONE_TAXON_KEY]
       }
     }
   end
@@ -85,15 +85,15 @@ private
       .flatten
       .map { |v|
         {
-          text: v['title'],
-          value: v['content_id'],
+          text: v["title"],
+          value: v["content_id"],
           data_attributes: {
             track_category: "filterClicked",
             track_action: "level_two_taxon",
-            track_label: v['title'],
-            topic_parent: v['parent'],
+            track_label: v["title"],
+            topic_parent: v["parent"],
           },
-          selected: v['content_id'] == @value_hash[LEVEL_TWO_TAXON_KEY]
+          selected: v["content_id"] == @value_hash[LEVEL_TWO_TAXON_KEY]
         }
       }
   end
@@ -111,14 +111,14 @@ private
   end
 
   def default_sub_topic_value
-    { text: 'All sub-topics', value: '', parent: '' }
+    { text: "All sub-topics", value: "", parent: "" }
   end
 
   def default_topic_value
-    { text: 'All topics', value: '' }
+    { text: "All topics", value: "" }
   end
 
   def registry
-    @registry ||= Registries::BaseRegistries.new.all['part_of_taxonomy_tree']
+    @registry ||= Registries::BaseRegistries.new.all["part_of_taxonomy_tree"]
   end
 end

--- a/app/models/topical_facet.rb
+++ b/app/models/topical_facet.rb
@@ -1,6 +1,6 @@
 class TopicalFacet < OptionSelectFacet
   def allowed_values
-    [facet['open_value'], facet['closed_value']]
+    [facet["open_value"], facet["closed_value"]]
   end
 
   def to_partial_path

--- a/app/parsers/facet_parser.rb
+++ b/app/parsers/facet_parser.rb
@@ -1,27 +1,27 @@
 module FacetParser
   def self.parse(facet, value_hash)
-    if facet['filterable']
-      case facet['type']
-      when 'text', 'content_id'
-        OptionSelectFacet.new(facet, value_hash[facet['key']])
-      when 'topical'
-        TopicalFacet.new(facet, value_hash[facet['key']])
-      when 'taxon'
-        TaxonFacet.new(facet, value_hash.slice(*facet['keys']))
-      when 'date'
-        DateFacet.new(facet, value_hash[facet['key']])
-      when 'hidden'
-        HiddenFacet.new(facet, value_hash[facet['key']])
-      when 'checkbox'
-        CheckboxFacet.new(facet, value_hash[facet['key']])
-      when 'radio'
-        RadioFacet.new(facet, value_hash[facet['key']])
-      when 'hidden_clearable'
-        HiddenClearableFacet.new(facet, value_hash[facet['key']])
-      when 'research_and_statistics'
-        RadioFacetForMultipleFilters.new(facet, value_hash[facet['key']], ::Filters::ResearchAndStatsHashes.new.call)
-      when 'official_documents'
-        RadioFacetForMultipleFilters.new(facet, value_hash[facet['key']], ::Filters::OfficialDocumentsHashes.new.call)
+    if facet["filterable"]
+      case facet["type"]
+      when "text", "content_id"
+        OptionSelectFacet.new(facet, value_hash[facet["key"]])
+      when "topical"
+        TopicalFacet.new(facet, value_hash[facet["key"]])
+      when "taxon"
+        TaxonFacet.new(facet, value_hash.slice(*facet["keys"]))
+      when "date"
+        DateFacet.new(facet, value_hash[facet["key"]])
+      when "hidden"
+        HiddenFacet.new(facet, value_hash[facet["key"]])
+      when "checkbox"
+        CheckboxFacet.new(facet, value_hash[facet["key"]])
+      when "radio"
+        RadioFacet.new(facet, value_hash[facet["key"]])
+      when "hidden_clearable"
+        HiddenClearableFacet.new(facet, value_hash[facet["key"]])
+      when "research_and_statistics"
+        RadioFacetForMultipleFilters.new(facet, value_hash[facet["key"]], ::Filters::ResearchAndStatsHashes.new.call)
+      when "official_documents"
+        RadioFacetForMultipleFilters.new(facet, value_hash[facet["key"]], ::Filters::OfficialDocumentsHashes.new.call)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet['type']}")
       end

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -4,7 +4,7 @@ class EntryPresenter
            :path,
            to: :entry
 
-  WEBSITE_ROOT = Plek.current.website_root.gsub(/https?:\/\//, '')
+  WEBSITE_ROOT = Plek.current.website_root.gsub(/https?:\/\//, "")
 
   def initialize(entry)
     @entry = entry

--- a/app/presenters/facet_tag_presenter.rb
+++ b/app/presenters/facet_tag_presenter.rb
@@ -10,14 +10,14 @@ class FacetTagPresenter
   def present
     return {} if @fragment.nil? || @hide_facet_tag
 
-    @fragment['values'].map.with_index do |value, i|
+    @fragment["values"].map.with_index do |value, i|
       {
-        preposition: i.zero? ? @fragment['preposition'].titlecase : @fragment['word_connectors'][:words_connector],
-        text: html_escape(value['label']),
-        data_facet: value['parameter_key'],
-        data_name: value['name'],
-        data_value: value['value'],
-        data_track_label: value['label'],
+        preposition: i.zero? ? @fragment["preposition"].titlecase : @fragment["word_connectors"][:words_connector],
+        text: html_escape(value["label"]),
+        data_facet: value["parameter_key"],
+        data_name: value["name"],
+        data_value: value["value"],
+        data_track_label: value["label"],
       }
     end
   end
@@ -25,13 +25,13 @@ class FacetTagPresenter
 private
 
   def remove_taxonomy_facets(fragment)
-    return nil if fragment.nil? || fragment['values'].nil?
+    return nil if fragment.nil? || fragment["values"].nil?
     return fragment unless @i_am_a_topic_page_finder
 
-    fragment['values'] = fragment['values'].reject do |value|
-      %w[level_one_taxon level_two_taxon].include? value['parameter_key']
+    fragment["values"] = fragment["values"].reject do |value|
+      %w[level_one_taxon level_two_taxon].include? value["parameter_key"]
     end
 
-    fragment['values'].count.zero? ? nil : fragment
+    fragment["values"].count.zero? ? nil : fragment
   end
 end

--- a/app/presenters/finder_breadcrumbs_presenter.rb
+++ b/app/presenters/finder_breadcrumbs_presenter.rb
@@ -10,7 +10,7 @@ class FinderBreadcrumbsPresenter
     return nil if organisation.blank?
 
     crumbs = [{ title: "Home", url: "/" }]
-    crumbs << { title: 'Organisations', url: '/government/organisations' }
+    crumbs << { title: "Organisations", url: "/government/organisations" }
 
     if organisation_is_valid?
       crumbs << { title: organisation["title"], url: "/government/organisations/#{organisation['slug']}" }

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -27,7 +27,7 @@ class FinderPresenter
   def initialize(content_item, facets, search_results, values = {})
     @content_item = content_item
     @search_results = search_results
-    @organisations = content_item.links.fetch('organisations', [])
+    @organisations = content_item.links.fetch("organisations", [])
     @values = values
     @facets = facets
     @keywords = values["keywords"].presence
@@ -50,7 +50,7 @@ class FinderPresenter
   end
 
   def government_content_section
-    slug.split('/')[2]
+    slug.split("/")[2]
   end
 
   def display_metadata?
@@ -91,7 +91,7 @@ class FinderPresenter
   end
 
   def start_offset
-    search_results.fetch('start', 0) + 1
+    search_results.fetch("start", 0) + 1
   end
 
   def label_for_metadata_key(key)
@@ -102,9 +102,9 @@ class FinderPresenter
 
   def display_key_for_metadata_key(key)
     if %w[organisations document_collections].include?(key)
-      'title'
+      "title"
     else
-      'label'
+      "label"
     end
   end
 
@@ -120,11 +120,11 @@ class FinderPresenter
   end
 
   def topic_finder?
-    values.include?('topic') && topic_finder_parent.present?
+    values.include?("topic") && topic_finder_parent.present?
   end
 
   def topic_finder_parent
-    Services.registries.all['full_topic_taxonomy'][values['topic']]
+    Services.registries.all["full_topic_taxonomy"][values["topic"]]
   end
 
 private

--- a/app/presenters/grouped_result_set_presenter.rb
+++ b/app/presenters/grouped_result_set_presenter.rb
@@ -22,7 +22,7 @@ private
 
   def grouped_display?
     @grouped_display ||= begin
-      sorts_by_topic = sort_option.dig('key') == 'topic'
+      sorts_by_topic = sort_option.dig("key") == "topic"
       @filter_params[:order] == "topic" || (!@filter_params.has_key?(:order) && sorts_by_topic)
     end
   end
@@ -48,7 +48,7 @@ private
     @facet_by_allowed_value_lookup_hash ||= begin
       finder_presenter.facets.each_with_object({}) do |facet, result|
         facet.allowed_values.each do |allowed_value|
-          result[allowed_value['content_id']] = facet
+          result[allowed_value["content_id"]] = facet
         end
       end
     end
@@ -62,7 +62,7 @@ private
     @facet_value_lookup_hash ||= begin
       all_allowed_values = finder_presenter.facets.flat_map(&:allowed_values)
       all_allowed_values.to_h do |val|
-        [val['content_id'], val['value']]
+        [val["content_id"], val["value"]]
       end
     end
   end
@@ -146,14 +146,14 @@ private
     facet_datum = document_facet_data.find { |m| m[:key] == primary_facet_key }
     return false unless primary_facet && facet_datum
 
-    allowed_values = primary_facet.allowed_values.map { |v| v['value'] }
+    allowed_values = primary_facet.allowed_values.map { |v| v["value"] }
     facet_datum[:labels].to_set.superset? allowed_values.to_set
   end
 
   def label_for_facet_value(key)
     allowed_values = finder_presenter.facets.flat_map(&:allowed_values)
     allowed_value = allowed_values.find(-> { {} }) { |v| v["value"] == key }
-    allowed_value.fetch("label", '')
+    allowed_value.fetch("label", "")
   end
 
   def sort_by_alphabetical(documents)

--- a/app/presenters/metadata_presenter.rb
+++ b/app/presenters/metadata_presenter.rb
@@ -6,9 +6,9 @@ class MetadataPresenter
   def present
     raw_metadata.map { |datum|
       case datum.fetch(:type)
-      when 'date'
+      when "date"
         build_date_metadata(datum)
-      when 'text', 'content_id'
+      when "text", "content_id"
         build_text_metadata(datum)
       end
     }

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -37,7 +37,7 @@ class ResultSetPresenter
     @show_top_result &&
       finder_presenter.eu_exit_finder? &&
       documents.length >= 2 &&
-      sort_option.dig('key').eql?("-relevance") &&
+      sort_option.dig("key").eql?("-relevance") &&
       best_bet?
   end
 
@@ -46,7 +46,7 @@ class ResultSetPresenter
   end
 
   def user_supplied_keywords
-    @filter_params.fetch('keywords', '')
+    @filter_params.fetch("keywords", "")
   end
 
   def signup_links

--- a/app/presenters/screen_reader_filter_description_presenter.rb
+++ b/app/presenters/screen_reader_filter_description_presenter.rb
@@ -22,11 +22,11 @@ private
   end
 
   def filter_label(filter)
-    selected_option = filter.allowed_values.find { |option| option['value'] == filter.value }
-    return selected_option['label'] unless selected_option.nil?
+    selected_option = filter.allowed_values.find { |option| option["value"] == filter.value }
+    return selected_option["label"] unless selected_option.nil?
 
-    default_option = filter.allowed_values.find { |option| option['default'] }
-    return default_option['label'] unless default_option.nil?
+    default_option = filter.allowed_values.find { |option| option["default"] }
+    return default_option["label"] unless default_option.nil?
 
     nil
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -55,7 +55,7 @@ private
   end
 
   def highlight_text
-    I18n.t('finders.most_relevant') if @highlight
+    I18n.t("finders.most_relevant") if @highlight
   end
 
   def subtext

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -13,25 +13,25 @@ class SignupPresenter
   end
 
   def name
-    content_item['title']
+    content_item["title"]
   end
 
   def default_frequency
     # return 'nil' if NOT the business finder email signup page to avoid `default_frequency` appearing in other URLs
     # as this may not be expected and could have some side-effects
-    EuExitFinderHelper.eu_exit_finder_email_signup?(@content_item['content_id']) ? 'daily' : nil
+    EuExitFinderHelper.eu_exit_finder_email_signup?(@content_item["content_id"]) ? "daily" : nil
   end
 
   def body
-    content_item['description']
+    content_item["description"]
   end
 
   def beta?
-    content_item['details']['beta']
+    content_item["details"]["beta"]
   end
 
   def email_filter_by
-    content_item['details'].fetch('email_filter_by', nil)
+    content_item["details"].fetch("email_filter_by", nil)
   end
 
   def can_modify_choices?
@@ -41,7 +41,7 @@ class SignupPresenter
   def hidden_choices
     hidden_choices = choices.map do |choice|
       if ignore_facet?(choice["facet_id"])
-        choice['facet_choices'].map do |facet_choice|
+        choice["facet_choices"].map do |facet_choice|
           {
             name: "filter[#{choice['facet_id']}][]",
             value: facet_choice["key"],
@@ -67,15 +67,15 @@ class SignupPresenter
   def choices_formatted
     @choices_formatted ||= facets_with_choices.map { |choice|
       {
-        label: choice['facet_name'],
-        value: choice['facet_id'],
-        checked: choice['prechecked'],
-        items: choice['facet_choices'].map do |facet_choice|
+        label: choice["facet_name"],
+        value: choice["facet_id"],
+        checked: choice["prechecked"],
+        items: choice["facet_choices"].map do |facet_choice|
           {
             name: "filter[#{choice['facet_id']}][]",
-            label: facet_choice['radio_button_name'],
-            value: facet_choice.fetch('content_id', nil) || facet_choice['key'],
-            checked: facet_choice['prechecked'] || selected_choices.fetch(choice['facet_id'], []).include?(facet_choice['key'])
+            label: facet_choice["radio_button_name"],
+            value: facet_choice.fetch("content_id", nil) || facet_choice["key"],
+            checked: facet_choice["prechecked"] || selected_choices.fetch(choice["facet_id"], []).include?(facet_choice["key"])
           }
         end
       }
@@ -90,19 +90,19 @@ private
 
   def facets_with_choices
     choices.select { |choice|
-      choice['facet_choices'] && choice["facet_choices"].any? && !ignore_facet?(choice["facet_id"])
+      choice["facet_choices"] && choice["facet_choices"].any? && !ignore_facet?(choice["facet_id"])
     }
   end
 
   def selected_choices
     facets_ids = choices.each_with_object({}) do |choice, hash|
-      hash[choice['facet_id'].to_sym] = []
+      hash[choice["facet_id"].to_sym] = []
     end
     params.permit(facets_ids).to_h
   end
 
   def single_facet_choice_data
-    facet_id = content_item.dig('details', "email_filter_by")
+    facet_id = content_item.dig("details", "email_filter_by")
 
     return [] if facet_id.nil?
 
@@ -110,13 +110,13 @@ private
       {
         "facet_id" => facet_id,
         "facet_name" => single_facet_name,
-        "facet_choices" => content_item['details']["email_signup_choice"]
+        "facet_choices" => content_item["details"]["email_signup_choice"]
       }
     ]
   end
 
   def multiple_facet_choice_data
-    content_item['details']["email_filter_facets"]
+    content_item["details"]["email_filter_facets"]
   end
 
   def single_facet_name

--- a/app/presenters/sort_option_presenter.rb
+++ b/app/presenters/sort_option_presenter.rb
@@ -18,8 +18,8 @@ class SortOptionPresenter
     {
       label: label,
       value: value,
-      data_track_category: 'dropDownClicked',
-      data_track_action: 'clicked',
+      data_track_category: "dropDownClicked",
+      data_track_action: "clicked",
       data_track_label: label,
       selected: selected,
       disabled: disabled,
@@ -32,9 +32,9 @@ private
 
   def tracking_attributes
     {
-      'data-track-category' => 'dropDownClicked',
-      'data-track-action' => 'clicked',
-      'data-track-label' => label
+      "data-track-category" => "dropDownClicked",
+      "data-track-action" => "clicked",
+      "data-track-label" => label
     }
   end
 end

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -1,6 +1,6 @@
 class SortPresenter
   def initialize(content_item, filter_params)
-    @user_selected_order = filter_params['order']
+    @user_selected_order = filter_params["order"]
     @keywords = filter_params["keywords"]
     @content_item_sort_options = content_item.sort_options
   end
@@ -44,9 +44,9 @@ private
   def presented_sort_options
     @presented_sort_options ||= sort_options.map do |option|
       SortOptionPresenter.new(
-        label: option['name'],
+        label: option["name"],
         value: option_value(option),
-        key: option['key'],
+        key: option["key"],
         default: is_default?(option),
         selected: option_value(option) == option_value(selected_option),
         disabled: option_value(option) == disabled_option_value,
@@ -55,7 +55,7 @@ private
   end
 
   def is_default?(option)
-    option['default']
+    option["default"]
   end
 
   def options_as_hashes
@@ -67,20 +67,20 @@ private
   end
 
   def disabled_option_value
-    keywords.blank? && relevance_option.present? ? option_value(relevance_option) : ''
+    keywords.blank? && relevance_option.present? ? option_value(relevance_option) : ""
   end
 
   def raw_default_option
-    sort_options.find { |option| option['default'] }
+    sort_options.find { |option| option["default"] }
   end
 
   def relevance_option
-    sort_options.find { |option| RELEVANCE_OPTION_TYPES.include?(option['key']) }
+    sort_options.find { |option| RELEVANCE_OPTION_TYPES.include?(option["key"]) }
   end
 
   def option_value(option)
     return if option.nil?
 
-    option.fetch('value', option.fetch('name', '').parameterize)
+    option.fetch("value", option.fetch("name", "").parameterize)
   end
 end

--- a/app/presenters/statistics_metadata_presenter.rb
+++ b/app/presenters/statistics_metadata_presenter.rb
@@ -3,9 +3,9 @@ class StatisticsMetadataPresenter < MetadataPresenter
     formatted_metadata =
       raw_metadata.map { |datum|
         case datum.fetch(:type)
-        when 'date'
+        when "date"
           build_date_metadata(datum)
-        when 'text', 'content_id'
+        when "text", "content_id"
           build_text_metadata(datum)
         end
       }

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -1,6 +1,6 @@
 class StatisticsSortPresenter < SortPresenter
   def initialize(content_item, filter_params)
-    @doc_type = filter_params['content_store_document_type']
+    @doc_type = filter_params["content_store_document_type"]
     super(content_item, filter_params)
   end
 
@@ -19,13 +19,13 @@ private
     upcoming: %w(-public_timestamp public_timestamp)
   }.freeze
   DEFAULT_KEY = {
-    any: '-public_timestamp',
-    public: '-public_timestamp',
-    upcoming: 'release_timestamp'
+    any: "-public_timestamp",
+    public: "-public_timestamp",
+    upcoming: "release_timestamp"
   }.freeze
   RENAMED_OPTIONS = {
-    'upcoming_statistics' => {
-      'release_timestamp' => 'Release date (soonest)'
+    "upcoming_statistics" => {
+      "release_timestamp" => "Release date (soonest)"
     }
   }.freeze
 
@@ -34,23 +34,23 @@ private
   end
 
   def is_default?(option)
-    option['key'] == default_key
+    option["key"] == default_key
   end
 
   def raw_default_option
-    sort_options.find { |option| option['key'] == default_key }
+    sort_options.find { |option| option["key"] == default_key }
   end
 
   def excluded?(option)
-    EXCLUDED_OPTIONS[sort_type].include? option['key']
+    EXCLUDED_OPTIONS[sort_type].include? option["key"]
   end
 
   def rename(option)
-    name = RENAMED_OPTIONS.dig(doc_type, option['key'])
+    name = RENAMED_OPTIONS.dig(doc_type, option["key"])
     if name
       option.merge(
-        'name' => name,
-        'value' => option['name'].parameterize,
+        "name" => name,
+        "value" => option["name"].parameterize,
       )
     else
       option
@@ -59,11 +59,11 @@ private
 
   def sort_type
     case doc_type
-    when 'upcoming_statistics'
+    when "upcoming_statistics"
       :upcoming
-    when 'published_statistics'
+    when "published_statistics"
       :public
-    when 'cancelled_statistics'
+    when "cancelled_statistics"
       :any
     else
       :public

--- a/app/presenters/subscriber_list_params_presenter.rb
+++ b/app/presenters/subscriber_list_params_presenter.rb
@@ -23,16 +23,16 @@ private
 
   def used_facets
     facets.select { |facet|
-      params[facet['facet_id']].present?
+      params[facet["facet_id"]].present?
     }
   end
 
   def facets
-    allowed_facets.reject { |facet| facet.key?('facet_choices') }
+    allowed_facets.reject { |facet| facet.key?("facet_choices") }
   end
 
   def allowed_facets
-    content_item['details'].fetch('email_filter_facets', [])
+    content_item["details"].fetch("email_filter_facets", [])
   end
 
   def hash_with_default_as_array
@@ -40,20 +40,20 @@ private
   end
 
   def facet_filter_key(facet)
-    facet['filter_key'] || facet['facet_id']
+    facet["filter_key"] || facet["facet_id"]
   end
 
   def facet_filter_value(facet)
-    return facet['filter_value'] if facet['filter_value'].present?
+    return facet["filter_value"] if facet["filter_value"].present?
 
-    values = Array(params[facet['facet_id']])
+    values = Array(params[facet["facet_id"]])
 
-    return facet_option_lookup_values(values, facet) if facet['option_lookup'].present?
+    return facet_option_lookup_values(values, facet) if facet["option_lookup"].present?
 
     values
   end
 
   def facet_option_lookup_values(values, facet)
-    facet['option_lookup'].select { |key, _| values.include? key }.values.flatten
+    facet["option_lookup"].select { |key, _| values.include? key }.values.flatten
   end
 end

--- a/app/views/finders/show-redirect.atom.builder
+++ b/app/views/finders/show-redirect.atom.builder
@@ -44,12 +44,12 @@ atom_feed do |feed|
   ) do |entry|
     entry.title("This feed has ended")
 
-    summary = if @finder_slug.starts_with? 'government/policies/'
+    summary = if @finder_slug.starts_with? "government/policies/"
                 policy_summary
               else
                 generic_summary
               end
 
-    entry.summary(summary, type: 'html')
+    entry.summary(summary, type: "html")
   end
 end

--- a/app/views/finders/show.atom.builder
+++ b/app/views/finders/show.atom.builder
@@ -4,13 +4,13 @@ atom_feed do |feed|
   feed.updated(@feed.updated_at) if @feed.entries.present?
 
   feed.author do |author|
-    author.name 'HM Government'
+    author.name "HM Government"
   end
 
   @feed.entries.each do |result|
     feed.entry(result, id: result.tag(feed), url: absolute_url_for(result.path), updated: result.updated_at) do |entry|
       entry.title(result.title)
-      entry.summary(result.summary, type: 'html')
+      entry.summary(result.summary, type: "html")
     end
   end
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
 # Pick the frameworks you want:
 # require "active_record/railtie"
@@ -12,8 +12,8 @@ require "active_model/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
-  require 'govuk_publishing_components'
+if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
+  require "govuk_publishing_components"
 end
 
 module FinderFrontend
@@ -32,11 +32,11 @@ module FinderFrontend
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'ALLOWALL'
+      "X-Frame-Options" => "ALLOWALL"
     }
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = '/finder-frontend'
+    config.assets.prefix = "/finder-frontend"
 
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 FinderFrontend::Application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ FinderFrontend::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  if ENV['GOVUK_ASSET_ROOT'].present?
-    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  if ENV["GOVUK_ASSET_ROOT"].present?
+    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,23 +1,23 @@
 FinderFrontend::Application.configure do
   # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
   # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?('GOVUK_ASSET_ROOT') && ENV['HEROKU_APP_NAME']
-    ENV['GOVUK_ASSET_ROOT'] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
+    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
   end
 
   config.cache_classes = true
-  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true } unless ENV['HEROKU_APP_NAME']
+  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true } unless ENV["HEROKU_APP_NAME"]
   config.eager_load = true
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true
-  config.assets.version = '1.0'
-  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
-  config.slimmer.asset_host = Plek.current.find('static')
+  config.assets.version = "1.0"
+  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
+  config.slimmer.asset_host = Plek.current.find("static")
   config.log_level = :info
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ FinderFrontend::Application.configure do
 
   config.cache_classes = true
   config.eager_load = false
-  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  config.public_file_server.headers = { "Cache-Control" => "public, max-age=3600" }
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.action_dispatch.show_exceptions = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,48 +1,48 @@
 FinderFrontend::Application.routes.draw do
-  mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
+  mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get '/healthcheck.json', to: GovukHealthcheck.rack_response(
+  get "/healthcheck.json", to: GovukHealthcheck.rack_response(
     Healthchecks::RegistriesCache,
   )
-  get '/healthcheck', to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
-  root to: redirect('/development') unless Rails.env.test?
-  get '/development' => 'development#index'
+  root to: redirect("/development") unless Rails.env.test?
+  get "/development" => "development#index"
 
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"
 
-  if ENV['GOVUK_WEBSITE_ROOT'] =~ /integration/ || ENV['GOVUK_WEBSITE_ROOT'] =~ /staging/
+  if ENV["GOVUK_WEBSITE_ROOT"] =~ /integration/ || ENV["GOVUK_WEBSITE_ROOT"] =~ /staging/
     get "/test-search/search" => "search#index"
     get "/test-search/search/opensearch" => "search#opensearch"
   end
 
   # Routes for the for Brexit Checker
-  get '/get-ready-brexit-check/results' => 'brexit_checker#results', as: :brexit_checker_results
-  get '/get-ready-brexit-check/questions' => 'brexit_checker#show', as: :brexit_checker_questions
-  get '/get-ready-brexit-check/email-signup' => 'brexit_checker#email_signup', as: :brexit_checker_email_signup
-  post '/get-ready-brexit-check/email-signup' => 'brexit_checker#confirm_email_signup', as: :brexit_checker_confirm_email_signup
-  get '/email/subscriptions/new', to: proc { [200, {}, ['']] }, as: :email_alert_frontend_signup
+  get "/get-ready-brexit-check/results" => "brexit_checker#results", as: :brexit_checker_results
+  get "/get-ready-brexit-check/questions" => "brexit_checker#show", as: :brexit_checker_questions
+  get "/get-ready-brexit-check/email-signup" => "brexit_checker#email_signup", as: :brexit_checker_email_signup
+  post "/get-ready-brexit-check/email-signup" => "brexit_checker#confirm_email_signup", as: :brexit_checker_confirm_email_signup
+  get "/email/subscriptions/new", to: proc { [200, {}, [""]] }, as: :email_alert_frontend_signup
 
-  get '/*slug/email-signup' => 'email_alert_subscriptions#new', as: :new_email_alert_subscriptions
-  post '/*slug/email-signup' => 'email_alert_subscriptions#create', as: :email_alert_subscriptions
+  get "/*slug/email-signup" => "email_alert_subscriptions#new", as: :new_email_alert_subscriptions
+  post "/*slug/email-signup" => "email_alert_subscriptions#create", as: :email_alert_subscriptions
 
   # Q&A frontend for "Find EU Exit guidance for your business" (www.gov.uk/find-eu-exit-guidance-business)
-  get '/prepare-business-uk-leaving-eu' => 'qa#show'
+  get "/prepare-business-uk-leaving-eu" => "qa#show"
 
   # Q&A frontend for "UK Nationals in the EU" (www.gov.uk/uk-nationals-in-the-eu)
-  get '/uk-nationals-living-eu' => 'qa_to_content#show'
+  get "/uk-nationals-living-eu" => "qa_to_content#show"
 
-  get '/search/advanced' => 'redirection#advanced_search'
+  get "/search/advanced" => "redirection#advanced_search"
 
-  get '/redirect/announcements' => 'redirection#announcements'
+  get "/redirect/announcements" => "redirection#announcements"
 
-  get '/redirect/publications' => 'redirection#publications'
+  get "/redirect/publications" => "redirection#publications"
 
-  get '/redirect/statistics' => 'redirection#published_statistics'
+  get "/redirect/statistics" => "redirection#published_statistics"
 
-  get '/redirect/statistics/announcements' => 'redirection#upcoming_statistics'
+  get "/redirect/statistics/announcements" => "redirection#upcoming_statistics"
 
-  get '/*slug' => 'finders#show', as: :finder
+  get "/*slug" => "finders#show", as: :finder
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,9 +3,9 @@
 # It's helpful, but not entirely necessary to understand cron before proceeding.
 # http://en.wikipedia.org/wiki/Cron
 
-set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
+set :output, error: "log/cron.error.log", standard: "log/cron.log"
 
-bundler_prefix = ENV.fetch('BUNDLER_PREFIX', '/usr/local/bin/govuk_setenv finder-frontend')
+bundler_prefix = ENV.fetch("BUNDLER_PREFIX", "/usr/local/bin/govuk_setenv finder-frontend")
 job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
 
 cache_refresh_schedule = Random.new.rand(45..60)

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,49 +1,49 @@
 Then(/^the links on the page have tracking attributes$/) do
-  visit finder_path('government/policies/benefits-reform')
+  visit finder_path("government/policies/benefits-reform")
 
   expect(page).to have_selector('.finder-results[data-module="track-click"]')
 
-  document_links = page.all('.gem-c-document-list__item-title')
+  document_links = page.all(".gem-c-document-list__item-title")
   expect(document_links.count).to be_positive
 
   first_link = document_links.first
 
-  expect(first_link['data-track-category']).to eq('navFinderLinkClicked')
-  expect(first_link['data-track-action']).to eq('Ministry of Silly Walks reports.1')
-  expect(first_link['data-track-label']).to eq(first_link['href'])
+  expect(first_link["data-track-category"]).to eq("navFinderLinkClicked")
+  expect(first_link["data-track-action"]).to eq("Ministry of Silly Walks reports.1")
+  expect(first_link["data-track-label"]).to eq(first_link["href"])
 
-  options = JSON.parse(first_link['data-track-options'])
+  options = JSON.parse(first_link["data-track-options"])
 
-  expect(options['dimension28']).to eq(document_links.count)
-  expect(options['dimension29']).to eq(first_link.text)
+  expect(options["dimension28"]).to eq(document_links.count)
+  expect(options["dimension29"]).to eq(first_link.text)
 end
 
 Then(/^the ecommerce tracking tags are present$/) do
-  visit finder_path('search/all', q: 'breakfast')
+  visit finder_path("search/all", q: "breakfast")
 
-  expect(page).to have_selector('form[data-analytics-ecommerce]')
+  expect(page).to have_selector("form[data-analytics-ecommerce]")
 
-  form = page.find('form[data-analytics-ecommerce]')
-  expect(form['data-ecommerce-start-index']).to eq("1")
-  expect(form['data-list-title']).to eq('Search')
-  expect(form['data-search-query']).to eq('breakfast')
+  form = page.find("form[data-analytics-ecommerce]")
+  expect(form["data-ecommerce-start-index"]).to eq("1")
+  expect(form["data-list-title"]).to eq("Search")
+  expect(form["data-search-query"]).to eq("breakfast")
 
-  results = page.all('a[data-ecommerce-row]')
+  results = page.all("a[data-ecommerce-row]")
   expect(results.count).to be_positive
 
   first_link = results.first
 
-  expect(first_link['data-ecommerce-path']).to eq('/restrictions-on-usage-of-spells-within-school-grounds')
-  expect(first_link['data-ecommerce-content-id']).to eq('1234')
+  expect(first_link["data-ecommerce-path"]).to eq("/restrictions-on-usage-of-spells-within-school-grounds")
+  expect(first_link["data-ecommerce-content-id"]).to eq("1234")
 end
 
 And(/^I search for lunch$/) do
-  stub_rummager_api_request_with_query_param_no_results('lunch')
+  stub_rummager_api_request_with_query_param_no_results("lunch")
 
-  fill_in 'Search', with: "lunch"
+  fill_in "Search", with: "lunch"
 end
 
 Then(/^the data-search-query has been updated to (.*)$/) do |query|
-  form = page.find('form[data-analytics-ecommerce]')
-  expect(form['data-search-query']).to eq(query)
+  form = page.find("form[data-analytics-ecommerce]")
+  expect(form["data-search-query"]).to eq(query)
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -15,24 +15,24 @@ Given /^the business finder QA exists/ do
 end
 
 When(/^I view the finder with no keywords and no facets$/) do
-  visit finder_path('mosw-reports')
+  visit finder_path("mosw-reports")
 end
 
 Then(/I see no results$/) do
-  expect(page).to have_content('0 reports')
-  expect(page).to have_css('.filtered-results .gem-c-document-list__item', count: 0)
+  expect(page).to have_content("0 reports")
+  expect(page).to have_css(".filtered-results .gem-c-document-list__item", count: 0)
 end
 
 And(/there is no keyword search box$/) do
-  expect(page).to_not have_css('#finder-keyword-search')
+  expect(page).to_not have_css("#finder-keyword-search")
 end
 
 And(/there is a zero results message$/) do
-  expect(page).to have_content('no matching results')
+  expect(page).to have_content("no matching results")
 end
 
 And(/there is not a zero results message$/) do
-  expect(page).to_not have_content('no matching results')
+  expect(page).to_not have_content("no matching results")
 end
 
 And(/the page title contains both keywords$/) do
@@ -52,25 +52,25 @@ And(/the page title is updated$/) do
 end
 
 Then(/^I can get a list of all documents with matching metadata$/) do
-  visit finder_path('mosw-reports')
+  visit finder_path("mosw-reports")
 
-  expect(page).to have_content('2 reports')
-  expect(page).to have_css('.finder-results .gem-c-document-list__item', count: 2)
-  expect(page).to have_css('.gem-c-metadata')
+  expect(page).to have_content("2 reports")
+  expect(page).to have_css(".finder-results .gem-c-document-list__item", count: 2)
+  expect(page).to have_css(".gem-c-metadata")
 
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
     expect(page).to have_link(
-      'West London wobbley walk',
-      href: '/mosw-reports/west-london-wobbley-walk',
+      "West London wobbley walk",
+      href: "/mosw-reports/west-london-wobbley-walk",
     )
-    expect(page).to have_content('30 December 2003')
-    expect(page).to have_content('Backward')
+    expect(page).to have_content("30 December 2003")
+    expect(page).to have_content("Backward")
   end
 
-  visit_filtered_finder('walk_type' => 'hopscotch')
+  visit_filtered_finder("walk_type" => "hopscotch")
 
-  expect(page).to have_content('1 report')
-  expect(page).to have_css('.finder-results .gem-c-document-list__item', count: 1)
+  expect(page).to have_content("1 report")
+  expect(page).to have_css(".finder-results .gem-c-document-list__item", count: 1)
 end
 
 And("I see email and feed sign up links") do
@@ -95,7 +95,7 @@ When(/^I view a list of news and communications$/) do
   stub_people_registry_request
   stub_organisations_registry_request
   stub_rummager_api_request_with_news_and_communication_results
-  visit finder_path('search/news-and-communications')
+  visit finder_path("search/news-and-communications")
 end
 
 When(/^I view the news and communications finder$/) do
@@ -105,7 +105,7 @@ When(/^I view the news and communications finder$/) do
   stub_all_rummager_api_requests_with_news_and_communication_results
   stub_people_registry_request
   stub_organisations_registry_request
-  visit finder_path('search/news-and-communications')
+  visit finder_path("search/news-and-communications")
 end
 
 When(/^I view the news and communications finder filtered on the brexit topic$/) do
@@ -115,12 +115,12 @@ When(/^I view the news and communications finder filtered on the brexit topic$/)
   stub_all_rummager_api_requests_with_news_and_communication_results
   stub_people_registry_request
   stub_organisations_registry_request
-  visit finder_path('search/news-and-communications', topic: 'd6c2de5d-ef90-45d1-82d4-5f2438369eea')
+  visit finder_path("search/news-and-communications", topic: "d6c2de5d-ef90-45d1-82d4-5f2438369eea")
 end
 
 Then(/^I (can|cannot) see the "show only brexit results" checkbox$/) do |can_or_cannot|
   have_clause = have_css(".govuk-checkboxes__label", text: "Show only Brexit results")
-  if can_or_cannot == 'can'
+  if can_or_cannot == "can"
     expect(page).to have_clause
   else
     expect(page).to_not have_clause
@@ -141,20 +141,20 @@ When(/^I view the business readiness finder$/) do
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_business_readiness_results
   stub_rummager_api_request_with_filtered_business_readiness_results(
-    'q' => 'Keyword2'
+    "q" => "Keyword2"
   )
   stub_rummager_api_request_with_filtered_business_readiness_results(
-    'q' => 'Keyword1 Keyword2'
+    "q" => "Keyword1 Keyword2"
   )
   stub_rummager_api_request_with_filtered_business_readiness_results(
-    'filter_any_facet_values[0]' => '24fd50fa-6619-46ca-96cd-8ce90fa076ce'
+    "filter_any_facet_values[0]" => "24fd50fa-6619-46ca-96cd-8ce90fa076ce"
   )
   stub_rummager_api_request_with_filtered_business_readiness_results(
-    'filter_any_facet_values[0]' => '24fd50fa-6619-46ca-96cd-8ce90fa076ce',
-    'q' => 'Keyword1 Keyword2'
+    "filter_any_facet_values[0]" => "24fd50fa-6619-46ca-96cd-8ce90fa076ce",
+    "q" => "Keyword1 Keyword2"
   )
 
-  visit finder_path('find-eu-exit-guidance-business')
+  visit finder_path("find-eu-exit-guidance-business")
 end
 
 When(/^I view the policy papers and consultations finder$/) do
@@ -165,7 +165,7 @@ When(/^I view the policy papers and consultations finder$/) do
   stub_rummager_api_request_with_policy_papers_results
   stub_rummager_api_request_with_filtered_policy_papers_results
 
-  visit finder_path('search/policy-papers-and-consultations')
+  visit finder_path("search/policy-papers-and-consultations")
 end
 
 When(/^I view the research and statistics finder$/) do
@@ -176,7 +176,7 @@ When(/^I view the research and statistics finder$/) do
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_research_and_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
-  visit finder_path('search/research-and-statistics')
+  visit finder_path("search/research-and-statistics")
 end
 
 When(/^I view the research and statistics finder with a topic param set$/) do
@@ -193,7 +193,7 @@ When(/^I view the research and statistics finder with a topic param set$/) do
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_research_and_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
-  visit finder_path('search/research-and-statistics', topic: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0')
+  visit finder_path("search/research-and-statistics", topic: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0")
 end
 
 When(/^I view the aaib reports finder with a topic param set$/) do
@@ -209,7 +209,7 @@ When(/^I view the aaib reports finder with a topic param set$/) do
   stub_manuals_registry_request
   stub_whitehall_api_world_location_request
   stub_rummager_api_request_with_aaib_reports_results
-  visit finder_path('aaib-reports', topic: 'c58fdadd-7743-46d6-9629-90bb3ccc4ef0')
+  visit finder_path("aaib-reports", topic: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0")
 end
 
 When(/^I view the all content finder with a manual filter$/) do
@@ -221,17 +221,17 @@ When(/^I view the all content finder with a manual filter$/) do
   stub_manuals_registry_request
 
   stub_request(:get, DocumentHelper::SEARCH_ENDPOINT).
-    with(query: hash_including(q: 'Replacing bristles', order: '-public_timestamp')).
+    with(query: hash_including(q: "Replacing bristles", order: "-public_timestamp")).
     to_return(body: all_content_results_json)
 
   stub_request(:get, DocumentHelper::SEARCH_ENDPOINT).
     with(query: hash_including(
-      filter_manual: '/guidance/care-and-use-of-a-nimbus-2000',
-      q: 'Replacing bristles',
-      order: '-public_timestamp'
+      filter_manual: "/guidance/care-and-use-of-a-nimbus-2000",
+      q: "Replacing bristles",
+      order: "-public_timestamp"
     )).to_return(body: all_content_manuals_results_json)
 
-  visit finder_path('search/all', manual: '/guidance/care-and-use-of-a-nimbus-2000', q: 'Replacing bristles')
+  visit finder_path("search/all", manual: "/guidance/care-and-use-of-a-nimbus-2000", q: "Replacing bristles")
 end
 
 When(/^I view the all content finder$/) do
@@ -243,7 +243,7 @@ When(/^I view the all content finder$/) do
   stub_manuals_registry_request
   stub_rummager_api_request_with_all_content_results
 
-  visit finder_path('search/all')
+  visit finder_path("search/all")
 end
 
 When(/^I view a list of services$/) do
@@ -253,17 +253,17 @@ When(/^I view a list of services$/) do
   stub_people_registry_request
   stub_organisations_registry_request
 
-  visit finder_path('search/services')
+  visit finder_path("search/services")
 end
 
 When(/^I search documents by keyword$/) do
   stub_keyword_search_api_request
 
-  visit finder_path('mosw-reports')
+  visit finder_path("mosw-reports")
 
   @keyword_search = "keyword searchable"
 
-  within '.filter-form' do
+  within ".filter-form" do
     fill_in("Search", with: @keyword_search)
   end
 
@@ -274,11 +274,11 @@ When(/^I search documents by keyword for business finder$/) do
   content_store_has_business_readiness_finder
   stub_keyword_business_readiness_search_api_request
 
-  visit finder_path('find-eu-exit-guidance-business')
+  visit finder_path("find-eu-exit-guidance-business")
 
   @keyword_search = "keyword searchable"
 
-  within '.filter-form' do
+  within ".filter-form" do
     fill_in("Search", with: @keyword_search)
   end
 
@@ -294,7 +294,7 @@ end
 When(/^I visit a finder by keyword with q parameter$/) do
   stub_keyword_search_api_request
 
-  visit finder_path('mosw-reports', q: @keyword_search)
+  visit finder_path("mosw-reports", q: @keyword_search)
 end
 
 Given(/^a government finder exists$/) do
@@ -305,38 +305,38 @@ Given(/^a government finder exists$/) do
 end
 
 Then(/^I can see the government header$/) do
-  visit finder_path('government/policies/benefits-reform')
-  expect(page).to have_css('#proposition-menu')
+  visit finder_path("government/policies/benefits-reform")
+  expect(page).to have_css("#proposition-menu")
 end
 
 Then(/^I should see a blue banner$/) do
-  expect(page).to have_css('.gem-c-inverse-header')
-  expect(page).to have_content('Education, training and skills')
-  expect(page).to_not have_css('.app-taxonomy-select')
+  expect(page).to have_css(".gem-c-inverse-header")
+  expect(page).to have_content("Education, training and skills")
+  expect(page).to_not have_css(".app-taxonomy-select")
 end
 
 Then(/^I can see documents which are marked as being in history mode$/) do
-  expect(page).to have_css('.published-by', count: 5)
+  expect(page).to have_css(".published-by", count: 5)
   expect(page).to have_content("2005 to 2010 Labour government")
 end
 
 Then(/^I can see documents which have government metadata$/) do
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to have_content('Updated:')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to have_content("Updated:")
     expect(page).to have_css('dl time[datetime="2007-02-14"]')
 
-    expect(page).to have_content('News Story')
+    expect(page).to have_content("News Story")
 
-    expect(page).to have_content('Ministry of Justice')
+    expect(page).to have_content("Ministry of Justice")
   end
 end
 
 Then(/^I see the atom feed$/) do
-  expect(page).to have_selector('id', text: 'tag:www.dev.gov.uk,2005:/restrictions-on-usage-of-spells-within-school-grounds')
-  expect(page).to have_selector('updated', text: '2017-12-30T10:00:00Z')
+  expect(page).to have_selector("id", text: "tag:www.dev.gov.uk,2005:/restrictions-on-usage-of-spells-within-school-grounds")
+  expect(page).to have_selector("updated", text: "2017-12-30T10:00:00Z")
   expect(page).to have_selector(:css, 'link[href="http://www.dev.gov.uk/restrictions-on-usage-of-spells-within-school-grounds"]')
-  expect(page).to have_selector('title', text: 'Restrictions on usage of spells within school grounds')
-  expect(page).to have_selector('summary', text: 'Restrictions on usage of spells within school grounds')
+  expect(page).to have_selector("title", text: "Restrictions on usage of spells within school grounds")
+  expect(page).to have_selector("summary", text: "Restrictions on usage of spells within school grounds")
 end
 
 Given(/^a collection of documents with bad metadata exist$/) do
@@ -346,17 +346,17 @@ Given(/^a collection of documents with bad metadata exist$/) do
 end
 
 Then(/^I can get a list of all documents with good metadata$/) do
-  visit finder_path('mosw-reports')
-  expect(page).to have_css('.finder-results .gem-c-document-list__item', count: 2)
+  visit finder_path("mosw-reports")
+  expect(page).to have_css(".finder-results .gem-c-document-list__item", count: 2)
 
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to have_content('Backward')
-    expect(page).not_to have_content('England')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to have_content("Backward")
+    expect(page).not_to have_content("England")
   end
 
-  within '.finder-results .gem-c-document-list__item:nth-child(2)' do
-    expect(page).to have_content('Northern Ireland')
-    expect(page).not_to have_content('Hopscotch')
+  within ".finder-results .gem-c-document-list__item:nth-child(2)" do
+    expect(page).to have_content("Northern Ireland")
+    expect(page).not_to have_content("Hopscotch")
   end
 end
 
@@ -393,54 +393,54 @@ Given(/^a finder with a dynamic filter exists$/) do
 end
 
 Then(/^I can see filters based on the results$/) do
-  visit finder_path('mosw-reports')
+  visit finder_path("mosw-reports")
 
-  within first('.app-c-option-select') do
-    expect(page).to have_selector('input#walk_type-backward')
-    expect(page).to have_content('Hopscotch')
-    expect(page).to_not have_selector('input#organisations-ministry-of-silly-walks')
+  within first(".app-c-option-select") do
+    expect(page).to have_selector("input#walk_type-backward")
+    expect(page).to have_content("Hopscotch")
+    expect(page).to_not have_selector("input#organisations-ministry-of-silly-walks")
   end
 end
 
 And(/^filters are wrapped in a progressive disclosure element$/) do
-  expect(page).to have_selector('#facet-wrapper')
+  expect(page).to have_selector("#facet-wrapper")
 end
 
 And(/^filters are not wrapped in a progressive disclosure element$/) do
-  expect(page).not_to have_selector('#facet-wrapper')
+  expect(page).not_to have_selector("#facet-wrapper")
 end
 
 Given(/^a finder with paginated results exists$/) do
   stub_taxonomy_api_request
   content_store_has_government_finder_with_10_items
   stub_rummager_api_request_with_10_government_results
-  stub_rummager_api_request_with_query_param_no_results('xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx')
+  stub_rummager_api_request_with_query_param_no_results("xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx")
 end
 
 Then(/^I can see pagination$/) do
-  visit finder_path('government/policies/benefits-reform')
+  visit finder_path("government/policies/benefits-reform")
 
-  expect(page).not_to have_content('Previous page')
-  expect(page).to have_content('Next page')
+  expect(page).not_to have_content("Previous page")
+  expect(page).to have_content("Next page")
 end
 
 Then(/^I can browse to the next page$/) do
   stub_rummager_api_request_with_10_government_results_page_2
-  visit finder_path('government/policies/benefits-reform', page: 2)
+  visit finder_path("government/policies/benefits-reform", page: 2)
 
-  expect(page).to have_content('Previous page')
-  expect(page).not_to have_content('Next page')
+  expect(page).to have_content("Previous page")
+  expect(page).not_to have_content("Next page")
 end
 
 Then(/^I browse to a huge page number and get an appropriate error$/) do
   stub_rummager_api_request_with_422_response(999999)
-  visit finder_path('government/policies/benefits-reform', page: 999999)
+  visit finder_path("government/policies/benefits-reform", page: 999999)
 
   expect(page.status_code).to eq(422)
 end
 
 And("I click on the atom feed link") do
-  click_on 'Subscribe to feed'
+  click_on "Subscribe to feed"
 end
 
 And("there is machine readable information") do
@@ -523,7 +523,7 @@ Given(/^an organisation finder exists$/) do
   stub_people_registry_request
   stub_taxonomy_api_request
 
-  visit finder_path('government/policies/benefits-reform', parent: 'ministry-of-magic')
+  visit finder_path("government/policies/benefits-reform", parent: "ministry-of-magic")
 end
 
 Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
@@ -534,7 +534,7 @@ Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   stub_people_registry_request
   stub_taxonomy_api_request
 
-  visit finder_path('government/policies/benefits-reform', parent: 'bernard-cribbins')
+  visit finder_path("government/policies/benefits-reform", parent: "bernard-cribbins")
 end
 
 Then(/^I can see a breadcrumb for home$/) do
@@ -570,7 +570,7 @@ Then(/^I can see a breadcrumb that not a link for the finder$/) do
 end
 
 Then(/^I can see taxonomy breadcrumbs$/) do
-  visit finder_path('cma-cases')
+  visit finder_path("cma-cases")
   expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Competition Act and cartels")
   expect(page.find_all(".govuk-breadcrumbs__list-item").count).to eql(2)
 end
@@ -597,8 +597,8 @@ end
 
 Then(/^I only see documents that match the checkbox filter$/) do
   expect(page).to have_content("1 case")
-  expect(page).to have_css('.facet-tags__preposition', text: "That Is")
-  expect(page).to have_css('.facet-tag__text', text: "Open")
+  expect(page).to have_css(".facet-tags__preposition", text: "That Is")
+  expect(page).to have_css(".facet-tag__text", text: "Open")
 
   within ".finder-results .gem-c-document-list__item:nth-child(1)" do
     expect(page).to have_content("Big Beer Co / Salty Snacks Ltd merger inquiry")
@@ -614,35 +614,35 @@ Then(/^The checkbox has the correct tracking data$/) do
 end
 
 Then(/^I can sort by:$/) do |table|
-  expect(find_all('.js-order-results option').collect(&:text)).to eq(table.raw.flatten)
+  expect(find_all(".js-order-results option").collect(&:text)).to eq(table.raw.flatten)
 end
 
 When(/^I sort by most viewed$/) do
-  select 'Most viewed', from: 'order'
+  select "Most viewed", from: "order"
 end
 
 When(/^I sort by A-Z$/) do
-  select 'A-Z', from: 'order'
+  select "A-Z", from: "order"
 end
 
 When(/^I sort by most relevant$/) do
-  select 'Relevance', from: 'Sort by'
+  select "Relevance", from: "Sort by"
 end
 
 
 
 When(/^I filter the results$/) do
-  click_on 'Filter results'
+  click_on "Filter results"
 end
 
 Then(/^I see the most viewed articles first$/) do
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to have_content('Press release from Hogwarts')
-    expect(page).to have_content('25 December 2017')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to have_content("Press release from Hogwarts")
+    expect(page).to have_content("25 December 2017")
   end
 
-  within '.finder-results .gem-c-document-list__item:nth-child(2)' do
-    expect(page).to have_content('16 November 2018')
+  within ".finder-results .gem-c-document-list__item:nth-child(2)" do
+    expect(page).to have_content("16 November 2018")
   end
 
   expect(page).to have_css("a[data-track-category='navFinderLinkClicked']")
@@ -650,12 +650,12 @@ Then(/^I see the most viewed articles first$/) do
 end
 
 Then(/^I see services in alphabetical order$/) do
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to have_content('Apply for your full broomstick licence')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to have_content("Apply for your full broomstick licence")
   end
 
-  within '.finder-results .gem-c-document-list__item:nth-child(2)' do
-    expect(page).to have_content('Register a magical spell')
+  within ".finder-results .gem-c-document-list__item:nth-child(2)" do
+    expect(page).to have_content("Register a magical spell")
   end
 
   expect(page).to have_css("a[data-track-category='navFinderLinkClicked']")
@@ -663,15 +663,15 @@ Then(/^I see services in alphabetical order$/) do
 end
 
 Then(/^I see most relevant order selected$/) do
-  expect(page).to have_select('order', selected: "Relevance")
+  expect(page).to have_select("order", selected: "Relevance")
 end
 
 Then(/^I see (.*) order selected$/) do |label|
-  expect(page).to have_select('order', selected: label)
+  expect(page).to have_select("order", selected: label)
 end
 
 And(/^I see the facet tag$/) do
-  within '.facet-tags' do
+  within ".facet-tags" do
     expect(page).to have_button("✕")
     expect(page).to have_content("Open")
     expect(page).to have_css("[data-module='remove-filter-link']")
@@ -680,25 +680,25 @@ And(/^I see the facet tag$/) do
 end
 
 And(/^I select a taxon$/) do
-  select('Taxon_1', from: 'Topic')
+  select("Taxon_1", from: "Topic")
 end
 
 And(/^I select a Person$/) do
-  check('Rufus Scrimgeour')
+  check("Rufus Scrimgeour")
 end
 
 And(/^I select some document types$/) do
-  click_on('Document type')
-  find('.govuk-checkboxes__item .govuk-label', text: 'Policy papers').click
-  find('.govuk-checkboxes__item .govuk-label', text: 'Consultations (closed)').click
+  click_on("Document type")
+  find(".govuk-checkboxes__item .govuk-label", text: "Policy papers").click
+  find(".govuk-checkboxes__item .govuk-label", text: "Consultations (closed)").click
 end
 
 And(/^I select upcoming statistics$/) do
-  find('.govuk-label', text: 'Statistics (upcoming)').click
+  find(".govuk-label", text: "Statistics (upcoming)").click
 end
 
 And(/^I select published statistics$/) do
-  find('.govuk-label', text: 'Statistics (published)').click
+  find(".govuk-label", text: "Statistics (published)").click
 end
 
 And(/^I click filter results$/) do
@@ -706,44 +706,44 @@ And(/^I click filter results$/) do
 end
 
 And(/^I reload the page$/) do
-  visit [current_path, page.driver.request.env['QUERY_STRING']].reject(&:blank?).join('?')
+  visit [current_path, page.driver.request.env["QUERY_STRING"]].reject(&:blank?).join("?")
 end
 
 Then(/^I should see all people in the people facet$/) do
   expect(page).to have_css('input[id^="people-"]', count: 5)
-  find('label', text: 'Albus Dumbledore')
-  find('label', text: 'Cornelius Fudge')
-  find('label', text: 'Harry Potter')
-  find('label', text: 'Ron Weasley')
-  find('label', text: 'Rufus Scrimgeour')
+  find("label", text: "Albus Dumbledore")
+  find("label", text: "Cornelius Fudge")
+  find("label", text: "Harry Potter")
+  find("label", text: "Ron Weasley")
+  find("label", text: "Rufus Scrimgeour")
 end
 
 And(/^I should see all organisations in the organisation facet$/) do
   expect(page).to have_css('input[id^="organisations-"]', count: 4)
-  find('label', text: 'Department of Mysteries')
-  find('label', text: 'Gringots')
-  find('label', text: 'Ministry of Magic')
-  find('label', text: 'Closed organisation: Death Eaters')
+  find("label", text: "Department of Mysteries")
+  find("label", text: "Gringots")
+  find("label", text: "Ministry of Magic")
+  find("label", text: "Closed organisation: Death Eaters")
 end
 
 Then(/^I should see all world locations in the world location facet$/) do
   expect(page).to have_css('input[id^="world_locations-"]', count: 2)
-  find('label', text: 'Azkaban')
-  find('label', text: 'Tracy Island')
+  find("label", text: "Azkaban")
+  find("label", text: "Tracy Island")
 end
 
 And(/^I select a World Location$/) do
-  click_on('World location')
-  check('Azkaban')
+  click_on("World location")
+  check("Azkaban")
 end
 
 And(/^I click button \"([^\"]*)\" and select facet (.*)$/) do |button, facet|
   click_on(button)
-  find('label', text: facet).click
+  find("label", text: facet).click
 end
 
 And(/^I select facet (.*) in the already expanded \"([^\"]*)\" section$/) do |facet, _button|
-  find('label', text: facet).click
+  find("label", text: facet).click
 end
 
 When(/^I click the (.*) remove control$/) do |filter|
@@ -760,11 +760,11 @@ Then(/^The (.*) checkbox in deselected$/) do |checkbox|
 end
 
 And(/^I fill in some keywords$/) do
-  fill_in 'Search', with: "Keyword1 Keyword2\n"
+  fill_in "Search", with: "Keyword1 Keyword2\n"
 end
 
 When(/^I fill in a keyword that should match no results$/) do
-  fill_in 'Search', with: "xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx\n"
+  fill_in "Search", with: "xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx\n"
 end
 
 And(/^I submit the form$/) do
@@ -772,11 +772,11 @@ And(/^I submit the form$/) do
 end
 
 Then(/^The keyword textbox is empty$/) do
-  expect(page).to have_field('Search', with: '')
+  expect(page).to have_field("Search", with: "")
 end
 
 Then(/^The keyword textbox only contains (.*)$/) do |filter|
-  expect(page).to have_field('Search', with: filter)
+  expect(page).to have_field("Search", with: filter)
 end
 
 When(/^I use a checkbox filter and another disallowed filter$/) do
@@ -789,30 +789,30 @@ end
 Then(/^I can sign up to email alerts for allowed filters$/) do
   email_alert_api_has_subscriber_list(
     "tags" => { "case_state" => { any: { "0" => "open" } }, "format" => { any: { "0" => "cma_case" } } },
-    'subscription_url' => 'http://www.rathergood.com'
+    "subscription_url" => "http://www.rathergood.com"
   )
 
   signup_content_item = cma_cases_with_multi_facets_signup_content_item
-  signup_content_item['details']['email_filter_facets'] = [{ 'facet_id' => 'case_state', 'facet_name' => 'case_state' }]
+  signup_content_item["details"]["email_filter_facets"] = [{ "facet_id" => "case_state", "facet_name" => "case_state" }]
 
-  content_store_has_item('/cma-cases/email-signup', signup_content_item)
+  content_store_has_item("/cma-cases/email-signup", signup_content_item)
 
-  click_link('Get email alerts')
+  click_link("Get email alerts")
 
   begin
-    click_on('Create subscription')
+    click_on("Create subscription")
   rescue ActionController::RoutingError
     expect(page.status_code).to eq(302)
-    expect(page.response_headers['Location']).to eql('http://www.rathergood.com')
+    expect(page.response_headers["Location"]).to eql("http://www.rathergood.com")
   end
 end
 
 When("I create an email subscription") do
-  click_link('Get email alerts')
+  click_link("Get email alerts")
 end
 
 Then("I see the email subscription page") do
-  visit finder_path('find-eu-exit-guidance-business/email-signup')
+  visit finder_path("find-eu-exit-guidance-business/email-signup")
   expect(page).to have_button("Create subscription")
 end
 
@@ -833,14 +833,14 @@ Then("I should see results in the default group") do
 end
 
 Then("I should see results for scoped by the selected document type") do
-  expect(page).to have_text('3 results')
+  expect(page).to have_text("3 results")
   within("#js-results") do
     expect(page.all(".gem-c-document-list__item").size).to eq(3) # 3 results in fixture
-    expect(page).to have_link('Restrictions on usage of spells within school grounds')
-    expect(page).to have_link('New platform at Hogwarts for the express train')
-    expect(page).to have_link('Installation of double glazing at Hogwarts')
+    expect(page).to have_link("Restrictions on usage of spells within school grounds")
+    expect(page).to have_link("New platform at Hogwarts for the express train")
+    expect(page).to have_link("Installation of double glazing at Hogwarts")
 
-    expect(page).to have_no_link('Proposed changes to magic tournaments')
+    expect(page).to have_no_link("Proposed changes to magic tournaments")
   end
 end
 
@@ -865,18 +865,18 @@ Then("I see results with top result") do
 end
 
 Then("I should see upcoming statistics") do
-  expect(page).to have_text('1 result')
+  expect(page).to have_text("1 result")
   within("#js-results") do
     expect(page.all(".gem-c-document-list__item").size).to eq(1)
-    expect(page).to have_link('Restrictions on usage of spells within school grounds')
-    expect(page).to have_no_link('New platform at Hogwarts for the express train')
-    expect(page).to have_no_link('Installation of double glazing at Hogwarts')
-    expect(page).to have_no_link('Proposed changes to magic tournaments')
+    expect(page).to have_link("Restrictions on usage of spells within school grounds")
+    expect(page).to have_no_link("New platform at Hogwarts for the express train")
+    expect(page).to have_no_link("Installation of double glazing at Hogwarts")
+    expect(page).to have_no_link("Proposed changes to magic tournaments")
   end
 end
 
 And(/^I press (tab) key to navigate$/) do |key|
-  find_field('Search').send_keys key.to_sym
+  find_field("Search").send_keys key.to_sym
 end
 
 Then(/^I click "(.*)" to expand|collapse all facets/) do |link_text|
@@ -884,42 +884,42 @@ Then(/^I click "(.*)" to expand|collapse all facets/) do |link_text|
 end
 
 And(/^I visit the benefits-reform page$/) do
-  visit finder_path('government/policies/benefits-reform')
+  visit finder_path("government/policies/benefits-reform")
 end
 
 Then(/^I should see results and pagination$/) do
-  expect(page).to have_text('20 reports')
-  expect(page).to have_css('.finder-results', visible: true)
-  expect(page).to have_css('.gem-c-pagination')
+  expect(page).to have_text("20 reports")
+  expect(page).to have_css(".finder-results", visible: true)
+  expect(page).to have_css(".gem-c-pagination")
 end
 
 Then(/^the results and pagination should be removed$/) do
-  expect(page).not_to have_text('20 reports')
-  expect(page).to have_css('.finder-results', visible: false)
-  expect(page).to_not have_css('.gem-c-pagination')
+  expect(page).not_to have_text("20 reports")
+  expect(page).to have_css(".finder-results", visible: false)
+  expect(page).to_not have_css(".gem-c-pagination")
 end
 
 Then(/^I should (see|not see) a "Skip to results" link$/) do |can_be_seen|
-  visibility = can_be_seen == 'see'
+  visibility = can_be_seen == "see"
   expect(page).to have_css('[href="#js-results"]', visible: visibility)
 end
 
 Then(/^I should see a "(Show .* search options)" link$/) do |link_text|
-  expect(page).to have_css('.facet-toggle', visible: true)
+  expect(page).to have_css(".facet-toggle", visible: true)
   expect(page).to have_link(link_text)
 end
 
 Then(/^I should not see a "(Show .* search options)" link$/) do |link_text|
-  expect(page).to have_css('.facet-toggle', visible: false)
+  expect(page).to have_css(".facet-toggle", visible: false)
   expect(page).to_not have_link(link_text)
 end
 
 Then(/^Facets should be visible$/) do
-  expect(page).to_not have_css('.facet-toggle__content--hide')
+  expect(page).to_not have_css(".facet-toggle__content--hide")
 end
 
 Then(/^Facets should be hidden/) do
-  expect(page).to have_css('.facet-toggle__content--hide', visible: false)
+  expect(page).to have_css(".facet-toggle__content--hide", visible: false)
 end
 
 Then(/^the page has results region$/) do
@@ -943,19 +943,19 @@ And(/^The top result has the correct tracking data$/) do
 end
 
 Then(/^I can see results filtered by that manual$/) do
-  expect(page).to have_css('.finder-results .gem-c-document-list__item', count: 1)
+  expect(page).to have_css(".finder-results .gem-c-document-list__item", count: 1)
 
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to_not have_content('Restrictions on usage of spells within school grounds')
-    expect(page).to have_content('Replacing bristles in your Nimbus 2000')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to_not have_content("Restrictions on usage of spells within school grounds")
+    expect(page).to have_content("Replacing bristles in your Nimbus 2000")
   end
 end
 
 Then(/^I see all content results$/) do
-  expect(page).to have_css('.finder-results .gem-c-document-list__item', count: 1)
+  expect(page).to have_css(".finder-results .gem-c-document-list__item", count: 1)
 
-  within '.finder-results .gem-c-document-list__item:nth-child(1)' do
-    expect(page).to have_content('Restrictions on usage of spells within school grounds')
-    expect(page).to_not have_content('Replacing bristles in your Nimbus 2000')
+  within ".finder-results .gem-c-document-list__item:nth-child(1)" do
+    expect(page).to have_content("Restrictions on usage of spells within school grounds")
+    expect(page).to_not have_content("Replacing bristles in your Nimbus 2000")
   end
 end

--- a/features/step_definitions/qa_steps.rb
+++ b/features/step_definitions/qa_steps.rb
@@ -27,7 +27,7 @@ Given /^I am answering a (.*?) answer question/ do |type|
 end
 
 Then /^I should see a collection of radio buttons/ do
-  expect(page).to have_css('.govuk-radios')
+  expect(page).to have_css(".govuk-radios")
 end
 
 When /^I select (.*?) radio button/ do |_amount|
@@ -37,7 +37,7 @@ When /^I select (.*?) radio button/ do |_amount|
 end
 
 Then /^I should see a collection of checkboxes/ do
-  expect(page).to have_css('.govuk-checkboxes')
+  expect(page).to have_css(".govuk-checkboxes")
 end
 
 When /^I select multiple checkboxes/ do
@@ -58,12 +58,12 @@ When /^I submit my answer/ do
 end
 
 Then /^no options are persisted/ do
-  params = current_url.split('?')[1]
-  expect(params).to eq('page=2')
+  params = current_url.split("?")[1]
+  expect(params).to eq("page=2")
 end
 
 Then /^my options are persisted as url params/ do
-  params = Array(@radio_params&.split('&')) + Array(@checkbox_params&.split('&'))
+  params = Array(@radio_params&.split("&")) + Array(@checkbox_params&.split("&"))
   params.each { |param| expect(current_url).to include(param) }
 end
 
@@ -75,7 +75,7 @@ Given /^I am answering the final question/ do
 end
 
 Then /^I am redirected to the finder results page/ do
-  finder_url = mock_qa_config['finder_base_path'] + '?'
+  finder_url = mock_qa_config["finder_base_path"] + "?"
   expect(current_url).to match(finder_url)
 end
 
@@ -87,7 +87,7 @@ When /^I visit the business finder Q&A/ do
     "filter_any_facet_values[0]" => "24fd50fa-6619-46ca-96cd-8ce90fa076ce",
     "filter_any_facet_values[1]" => "a55f04df-3877-4c73-bbfe-ad7339cdfccf"
   )
-  qa_url = business_readiness_qa_config['base_path']
+  qa_url = business_readiness_qa_config["base_path"]
   visit qa_url
 end
 
@@ -96,18 +96,18 @@ When /^I select choice "(.+)"/ do |label|
 end
 
 When /^I choose 'Yes' and select choice "(.+)"/ do |label|
-  choose 'Yes', allow_label_click: true
+  choose "Yes", allow_label_click: true
   find("label", text: label).click
 end
 
 When /^I skip the rest of the questions/ do
   5.times do
-    click_on 'Skip this question'
+    click_on "Skip this question"
   end
 end
 
 Then /^I should be on the business finder page/ do
-  expect(page.current_path).to eq '/find-eu-exit-guidance-business'
+  expect(page.current_path).to eq "/find-eu-exit-guidance-business"
 end
 
 Then /^the correct facets have been pre-selected/ do

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,9 +1,9 @@
 Given /^the search page exists$/ do
-  content_store_has_item("/search", schema: 'special_route')
+  content_store_has_item("/search", schema: "special_route")
 end
 
 When(/^I search for an empty string$/) do
-  visit '/search?q='
+  visit "/search?q="
 end
 
 When(/^I search for "([^"]*)" from "([^"]*)"$/) do |search_term, organisation|
@@ -19,7 +19,7 @@ When(/^I search for "([^"]*)" from "(.*)" on the json endpoint$/) do |search_ter
 end
 
 Then /^I am able to set search terms$/ do
-  expect(page).to have_field('Search GOV.UK', with: '')
+  expect(page).to have_field("Search GOV.UK", with: "")
 end
 
 Given(/^the all content finder exists$/) do
@@ -35,8 +35,8 @@ Given(/^the all content finder exists$/) do
 end
 
 Then(/^I am redirected to the (html|json) all content finder results page$/) do |format|
-  expect(page).to have_current_path(finder_path('search/all'), ignore_query: true)
-  expect(page.response_headers['Content-Type']).to include(format)
+  expect(page).to have_current_path(finder_path("search/all"), ignore_query: true)
+  expect(page.response_headers["Content-Type"]).to include(format)
 end
 
 Then(/^results are filtered with a facet tag of (.*)/) do |text|

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,9 +1,9 @@
-require_relative '../../spec/support/content_helper'
+require_relative "../../spec/support/content_helper"
 require_relative "../../spec/support/taxonomy_helper"
 require_relative "../../spec/support/registry_helper"
-require_relative '../../spec/support/fixtures_helper'
-require 'gds_api/test_helpers/email_alert_api'
-require 'gds_api/test_helpers/content_store'
+require_relative "../../spec/support/fixtures_helper"
+require "gds_api/test_helpers/email_alert_api"
+require "gds_api/test_helpers/content_store"
 
 module DocumentHelper
   include FixturesHelper
@@ -55,7 +55,7 @@ module DocumentHelper
 
   def stub_rummager_api_request_with_query_param_no_results(query)
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: hash_including('q' => query))
+      .with(query: hash_including("q" => query))
       .to_return(
         body: no_results_json,
       )
@@ -109,7 +109,7 @@ module DocumentHelper
 
   def stub_rummager_api_request_with_all_content_results
     stub_request(:get, SEARCH_ENDPOINT).
-      with(query: hash_including(all_content_params.merge(order: '-public_timestamp'))).
+      with(query: hash_including(all_content_params.merge(order: "-public_timestamp"))).
       to_return(body: all_content_results_json)
   end
 
@@ -205,29 +205,29 @@ module DocumentHelper
   end
 
   def content_store_has_mosw_reports_finder
-    content_store_has_item('/mosw-reports', govuk_content_schema_example('finder').to_json)
+    content_store_has_item("/mosw-reports", govuk_content_schema_example("finder").to_json)
   end
 
   def content_store_has_mosw_reports_finder_with_no_facets
-    finder = govuk_content_schema_example('finder')
+    finder = govuk_content_schema_example("finder")
     finder["details"]["facets"] = []
-    content_store_has_item('/mosw-reports', finder.to_json)
+    content_store_has_item("/mosw-reports", finder.to_json)
   end
 
   def content_store_has_qa_finder
-    content_store_has_item('/aaib-reports', aaib_reports_content_item.to_json)
+    content_store_has_item("/aaib-reports", aaib_reports_content_item.to_json)
   end
 
   def content_store_has_news_and_communications_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'news_and_communications_with_checkboxes.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "news_and_communications_with_checkboxes.json"))
 
-    content_store_has_item('/search/news-and-communications', finder_fixture)
+    content_store_has_item("/search/news-and-communications", finder_fixture)
   end
 
   def content_store_has_government_finder
-    base_path = '/government/policies/benefits-reform'
-    finder = govuk_content_schema_example('finder').merge('base_path' => base_path)
-    finder['details']["sort"] = [
+    base_path = "/government/policies/benefits-reform"
+    finder = govuk_content_schema_example("finder").merge("base_path" => base_path)
+    finder["details"]["sort"] = [
       {
         "name": "Most viewed",
         "key": "-popularity"
@@ -243,56 +243,56 @@ module DocumentHelper
   end
 
   def content_store_has_services_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'services.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "services.json"))
 
-    content_store_has_item('/search/services', finder_fixture)
+    content_store_has_item("/search/services", finder_fixture)
   end
 
   def content_store_has_government_finder_with_10_items
-    base_path = '/government/policies/benefits-reform'
-    content_item = govuk_content_schema_example('finder').merge('base_path' => base_path)
-    content_item['details']['default_documents_per_page'] = 10
+    base_path = "/government/policies/benefits-reform"
+    content_item = govuk_content_schema_example("finder").merge("base_path" => base_path)
+    content_item["details"]["default_documents_per_page"] = 10
     content_store_has_item(base_path, content_item.to_json)
   end
 
   def content_store_has_statistics_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'statistics.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "statistics.json"))
 
-    content_store_has_item('/search/research-and-statistics', finder_fixture)
+    content_store_has_item("/search/research-and-statistics", finder_fixture)
   end
 
   def content_store_has_aaib_reports_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'aaib_reports_example.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "aaib_reports_example.json"))
 
-    content_store_has_item('/aaib-reports', finder_fixture)
+    content_store_has_item("/aaib-reports", finder_fixture)
   end
 
   def content_store_has_all_content_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'all_content.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "all_content.json"))
 
-    content_store_has_item('/search/all', finder_fixture)
+    content_store_has_item("/search/all", finder_fixture)
   end
 
   def content_store_has_policy_and_engagement_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'policy_and_engagement.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "policy_and_engagement.json"))
 
-    content_store_has_item('/search/policy-papers-and-consultations', finder_fixture)
+    content_store_has_item("/search/policy-papers-and-consultations", finder_fixture)
   end
 
   def content_store_has_business_finder_qa
-    content_store_has_item(business_readiness_qa_config['base_path'], business_readiness_qa_config)
+    content_store_has_item(business_readiness_qa_config["base_path"], business_readiness_qa_config)
   end
 
   def content_store_has_business_readiness_finder
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'business_readiness.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "business_readiness.json"))
 
-    content_store_has_item('/find-eu-exit-guidance-business', finder_fixture)
+    content_store_has_item("/find-eu-exit-guidance-business", finder_fixture)
   end
 
   def content_store_has_business_readiness_email_signup
-    finder_fixture = File.read(Rails.root.join('features', 'fixtures', 'business_readiness_email_signup.json'))
+    finder_fixture = File.read(Rails.root.join("features", "fixtures", "business_readiness_email_signup.json"))
 
-    content_store_has_item('/find-eu-exit-guidance-business/email-signup', finder_fixture)
+    content_store_has_item("/find-eu-exit-guidance-business/email-signup", finder_fixture)
   end
 
   def search_params(params = {})
@@ -439,9 +439,9 @@ module DocumentHelper
       to_return(body: all_cma_case_documents_json)
 
     open_cma_case_documents_params = cma_case_search_params.merge(
-      'filter_case_state' => "open",
-      'order' => '-public_timestamp',
-      'filter_closed_date' => 'from:2015-11-01'
+      "filter_case_state" => "open",
+      "order" => "-public_timestamp",
+      "filter_closed_date" => "from:2015-11-01"
     )
 
     stub_request(:get, SEARCH_ENDPOINT).
@@ -499,29 +499,29 @@ module DocumentHelper
 
   def rummager_newest_news_and_communications_params
     news_and_communications_search_params.merge(
-      'order' => '-public_timestamp',
-      'count' => "20",
+      "order" => "-public_timestamp",
+      "count" => "20",
     )
   end
 
   def rummager_popular_news_and_communications_params
     news_and_communications_search_params.merge(
-      'order' => '-popularity',
-      'count' => "20",
+      "order" => "-popularity",
+      "count" => "20",
     )
   end
 
   def rummager_popular_services_params
     services_search_params.merge(
-      'order' => '-popularity',
-      'count' => "20",
+      "order" => "-popularity",
+      "count" => "20",
     )
   end
 
   def rummager_alphabetical_services_params
     services_search_params.merge(
-      'order' => 'title',
-      'count' => "20",
+      "order" => "title",
+      "count" => "20",
     )
   end
 
@@ -1986,12 +1986,12 @@ module DocumentHelper
 
   def business_readiness_results_json
     @business_readiness_results_json ||=
-      File.read(Rails.root.join('features', 'fixtures', 'business_readiness_results.json'))
+      File.read(Rails.root.join("features", "fixtures", "business_readiness_results.json"))
   end
 
   def filtered_business_readiness_results_json
     @filtered_business_readiness_results_json ||=
-      File.read(Rails.root.join('features', 'fixtures', 'business_readiness_filtered_results.json'))
+      File.read(Rails.root.join("features", "fixtures", "business_readiness_filtered_results.json"))
   end
 
   def visit_filtered_finder(facets = {})

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,16 +4,16 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
-require 'cucumber/rails'
-require 'cucumber/rspec/doubles'
+require "cucumber/rails"
+require "cucumber/rspec/doubles"
 
-require 'webmock/cucumber'
+require "webmock/cucumber"
 WebMock.disable_net_connect!(allow_localhost: true)
 
-require 'slimmer/test'
+require "slimmer/test"
 
 GovukTest.configure
 

--- a/features/support/qa_helper.rb
+++ b/features/support/qa_helper.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec/support/fixtures_helper'
+require_relative "../../spec/support/fixtures_helper"
 
 module QAHelper
   include FixturesHelper
@@ -9,33 +9,33 @@ module QAHelper
   end
 
   def stub_last_page_url
-    allow_any_instance_of(QaController).to receive(:next_page_url).and_return(mock_qa_config['finder_base_path'])
+    allow_any_instance_of(QaController).to receive(:next_page_url).and_return(mock_qa_config["finder_base_path"])
   end
 
   def qa_path
-    '/prepare-business-uk-leaving-eu'
+    "/prepare-business-uk-leaving-eu"
   end
 
   def mock_qa_config
-    @mock_qa_config ||= YAML.load_file('./features/fixtures/aaib_reports_qa.yaml')
+    @mock_qa_config ||= YAML.load_file("./features/fixtures/aaib_reports_qa.yaml")
   end
 
   def first_question
-    mock_qa_config["pages"].values.first['question']
+    mock_qa_config["pages"].values.first["question"]
   end
 
   def get_question_by_type(type)
     selected_questions = mock_qa_config["pages"].select do |_key, value|
       value["question_type"] == type
     end
-    selected_questions.values.first['question']
+    selected_questions.values.first["question"]
   end
 
   def get_question_with_custom_options
     selected_questions = mock_qa_config["pages"].select do |_key, value|
       value["question_type"] == "single" && value["custom_options"].present?
     end
-    selected_questions.values.first['question']
+    selected_questions.values.first["question"]
   end
 
   def get_page_number(question)

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -28,27 +28,27 @@ module RummagerUrlHelper
 
   def news_and_communications_search_params
     base_search_params.merge(
-      'filter_content_purpose_supergroup' => 'news_and_communications'
+      "filter_content_purpose_supergroup" => "news_and_communications"
     )
   end
 
   def services_search_params
     base_search_params.merge(
-      'filter_content_purpose_supergroup' => 'services',
+      "filter_content_purpose_supergroup" => "services",
     )
   end
 
   def policy_papers_params
     base_search_params.merge(
-      'filter_content_purpose_supergroup' => 'policy_and_engagement',
-      'count' => "20",
-      'order' => '-public_timestamp',
+      "filter_content_purpose_supergroup" => "policy_and_engagement",
+      "count" => "20",
+      "order" => "-public_timestamp",
     )
   end
 
   def all_content_params
     base_search_params.merge(
-      'count' => "20",
+      "count" => "20",
     )
   end
 

--- a/lib/brexit_checker/action.rb
+++ b/lib/brexit_checker/action.rb
@@ -1,7 +1,7 @@
 class BrexitChecker::Action
   include ActiveModel::Validations
 
-  CONFIG_PATH = Rails.root.join('lib', 'brexit_checker', 'actions.yaml')
+  CONFIG_PATH = Rails.root.join("lib", "brexit_checker", "actions.yaml")
 
   validates_presence_of :id, :title, :consequence, :criteria
   validates_inclusion_of :audience, in: %w(business citizen)
@@ -23,7 +23,7 @@ class BrexitChecker::Action
 
   def self.load(params)
     parsed_params = params.dup
-    parsed_params['id'] = params['action_id']
+    parsed_params["id"] = params["action_id"]
     new(parsed_params)
   end
 
@@ -33,6 +33,6 @@ class BrexitChecker::Action
 
   def self.load_all
     @load_all = nil if Rails.env.development?
-    @load_all ||= YAML.load_file(CONFIG_PATH)['actions'].map { |a| load(a) }
+    @load_all ||= YAML.load_file(CONFIG_PATH)["actions"].map { |a| load(a) }
   end
 end

--- a/lib/brexit_checker/change_note.rb
+++ b/lib/brexit_checker/change_note.rb
@@ -1,7 +1,7 @@
 class BrexitChecker::ChangeNote
   include ActiveModel::Validations
 
-  CONFIG_PATH = Rails.root.join('lib', 'brexit_checker', 'change_notes.yaml')
+  CONFIG_PATH = Rails.root.join("lib", "brexit_checker", "change_notes.yaml")
 
   validates_presence_of :action_id
   validates_inclusion_of :type, in: %w(addition content_change)
@@ -22,13 +22,13 @@ class BrexitChecker::ChangeNote
 
   def self.load(params)
     parsed_params = params.dup
-    parsed_params['id'] = params['uuid']
-    parsed_params['date'] = params['date'].to_s
+    parsed_params["id"] = params["uuid"]
+    parsed_params["date"] = params["date"].to_s
     new(parsed_params)
   end
 
   def self.load_all
-    @load_all ||= YAML.load_file(CONFIG_PATH)['change_notes'].to_a
+    @load_all ||= YAML.load_file(CONFIG_PATH)["change_notes"].to_a
       .map { |c| load(c) }
   end
 

--- a/lib/brexit_checker/criterion.rb
+++ b/lib/brexit_checker/criterion.rb
@@ -1,7 +1,7 @@
 class BrexitChecker::Criterion
   include ActiveModel::Validations
 
-  CONFIG_PATH = Rails.root.join('lib', 'brexit_checker', 'criteria.yaml')
+  CONFIG_PATH = Rails.root.join("lib", "brexit_checker", "criteria.yaml")
 
   validates_presence_of :key, :text
 
@@ -14,7 +14,7 @@ class BrexitChecker::Criterion
 
   def self.load_all
     @load_all = nil if Rails.env.development?
-    @load_all ||= YAML.load_file(CONFIG_PATH)['criteria'].map { |c| new(c) }
+    @load_all ||= YAML.load_file(CONFIG_PATH)["criteria"].map { |c| new(c) }
   end
 
   def self.load_by(criteria_keys)

--- a/lib/brexit_checker/question.rb
+++ b/lib/brexit_checker/question.rb
@@ -1,7 +1,7 @@
 class BrexitChecker::Question
   include ActiveModel::Validations
 
-  CONFIG_PATH = Rails.root.join('lib', 'brexit_checker', 'questions.yaml')
+  CONFIG_PATH = Rails.root.join("lib", "brexit_checker", "questions.yaml")
 
   validates_presence_of :key, :text
   validates_inclusion_of :type, in: %w(single single_wrapped multiple multiple_grouped)
@@ -36,14 +36,14 @@ class BrexitChecker::Question
 
   def self.load(params)
     parsed_params = params.dup
-    parsed_params['text'] = params['question']
-    parsed_params['options'] = Option.load_all(params['options'])
-    parsed_params['type'] = params['question_type']
+    parsed_params["text"] = params["question"]
+    parsed_params["options"] = Option.load_all(params["options"])
+    parsed_params["type"] = params["question_type"]
     new(parsed_params)
   end
 
   def self.load_all
     @load_all = nil if Rails.env.development?
-    @load_all ||= YAML.load_file(CONFIG_PATH)['questions'] .map { |q| load(q) }
+    @load_all ||= YAML.load_file(CONFIG_PATH)["questions"] .map { |q| load(q) }
   end
 end

--- a/lib/brexit_checker/question/option.rb
+++ b/lib/brexit_checker/question/option.rb
@@ -16,7 +16,7 @@ class BrexitChecker::Question::Option
 
   def self.load(params)
     parsed_params = params.dup
-    parsed_params['sub_options'] = load_all(params['options'].to_a)
+    parsed_params["sub_options"] = load_all(params["options"].to_a)
     new(parsed_params)
   end
 

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,4 +1,4 @@
-require 'addressable/uri'
+require "addressable/uri"
 
 class EmailAlertSignupAPI
   def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, default_frequency: nil, email_filter_by: nil)
@@ -13,9 +13,9 @@ class EmailAlertSignupAPI
 
   def signup_url
     if @default_frequency
-      add_url_param(subscriber_list['subscription_url'], default_frequency: @default_frequency)
+      add_url_param(subscriber_list["subscription_url"], default_frequency: @default_frequency)
     else
-      subscriber_list['subscription_url']
+      subscriber_list["subscription_url"]
     end
   end
 
@@ -31,7 +31,7 @@ private
   end
 
   def subscriber_list
-    Services.email_alert_api.find_or_create_subscriber_list(subscriber_list_options).dig('subscriber_list')
+    Services.email_alert_api.find_or_create_subscriber_list(subscriber_list_options).dig("subscriber_list")
   end
 
   def subscriber_list_options
@@ -50,7 +50,7 @@ private
 
   def link_based_subscriber_list?
     content_types = %w[organisations people world_locations part_of_taxonomy_tree]
-    keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, '') }
+    keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, "") }
     (keys & content_types).present?
   end
 
@@ -71,8 +71,8 @@ private
 
   def split_key(full_key)
     matches = full_key.match(/^((?<operator>any|all)_)?(?<key>.*)$/)
-    operator = matches[:operator] || 'any'
-    key = matches[:key] == 'part_of_taxonomy_tree' ? 'taxon_tree' : matches[:key]
+    operator = matches[:operator] || "any"
+    key = matches[:key] == "part_of_taxonomy_tree" ? "taxon_tree" : matches[:key]
     [operator, key]
   end
 
@@ -80,11 +80,11 @@ private
     return values unless %w[organisations people world_locations].include?(key)
 
     registry = Registries::BaseRegistries.new.all[key]
-    values.map { |value| registry[value]['content_id'] }
+    values.map { |value| registry[value]["content_id"] }
   end
 
   def facet_filter_keys
-    @facet_filter_keys ||= facets.map { |f| f['filter_key'] || f['facet_id'] }
+    @facet_filter_keys ||= facets.map { |f| f["filter_key"] || f["facet_id"] }
   end
 
   def facet_groups?
@@ -102,15 +102,15 @@ private
   end
 
   def facet_values?
-    email_filter_by == 'facet_values'
+    email_filter_by == "facet_values"
   end
 
   def facet_values
     @facet_values ||= filter_keys.each_with_object({}) { |key, links_hash|
       values = values_for_key(key)
-      links_hash['facet_values'] ||= {}
-      links_hash['facet_values'][:any] ||= []
-      links_hash['facet_values'][:any] = links_hash.dig('facet_values', :any).concat(values).uniq
+      links_hash["facet_values"] ||= {}
+      links_hash["facet_values"][:any] ||= []
+      links_hash["facet_values"][:any] = links_hash.dig("facet_values", :any).concat(values).uniq
     }
   end
 
@@ -150,9 +150,9 @@ private
 
   def facet_choice_filter_values(facet, values)
     facet
-      .fetch('facet_choices', [])
-      .select { |option| values.include?(option['key']) }
-      .flat_map { |option| option['filter_values'] }
+      .fetch("facet_choices", [])
+      .select { |option| values.include?(option["key"]) }
+      .flat_map { |option| option["filter_values"] }
   end
 
   def facet_by_key(key)
@@ -160,6 +160,6 @@ private
   end
 
   def is_all_field?(key)
-    key[0..3] == 'all_'
+    key[0..3] == "all_"
   end
 end

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -38,7 +38,7 @@ private
   end
 
   def singular_suffix
-    facet_key = facets.first['filter_key'] || facets.first['facet_id']
+    facet_key = facets.first["filter_key"] || facets.first["facet_id"]
 
     if dynamic_filter_option?(facet_key)
       return dynamic_facet_sentence(facet_key, selected_facets.first["facet_name"])
@@ -77,7 +77,7 @@ private
   end
 
   def grouped_facets
-    selected_facets.group_by { |facet| facet['filter_key'] || facet['facet_id'] }
+    selected_facets.group_by { |facet| facet["filter_key"] || facet["facet_id"] }
   end
 
   def dynamic_facet_sentence(facet_key, facet_name)

--- a/lib/facet_extractor.rb
+++ b/lib/facet_extractor.rb
@@ -6,30 +6,30 @@ class FacetExtractor
   end
 
   def extract
-    facets_in_links = content_item.dig('links', 'facet_group', 0, 'links', 'facets') || []
-    facets_in_details = content_item.dig('details', 'facets') || []
+    facets_in_links = content_item.dig("links", "facet_group", 0, "links", "facets") || []
+    facets_in_details = content_item.dig("details", "facets") || []
     facets_in_details + facets_in_links.map { |facet_in_link| transform_hash(facet_in_link) }
   end
 
 private
 
   def transform_hash(facet_in_links)
-    facet_details = facet_in_links['details']
+    facet_details = facet_in_links["details"]
     {
-      'name' => facet_details['name'],
-      'short_name' => facet_details['short_name'],
-      'key' => facet_details['key'],
-      'display_as_result_metadata' => facet_details['display_as_result_metadata'],
-      'filterable' => facet_details['filterable'],
-      'filter_key' => facet_details['filter_key'],
-      'combine_mode' => facet_details['combine_mode'] || 'and',
-      'preposition' => facet_details['preposition'],
-      'type' => facet_details['type'],
-      'allowed_values' => facet_in_links.dig('links', 'facet_values').map do |facet_value|
+      "name" => facet_details["name"],
+      "short_name" => facet_details["short_name"],
+      "key" => facet_details["key"],
+      "display_as_result_metadata" => facet_details["display_as_result_metadata"],
+      "filterable" => facet_details["filterable"],
+      "filter_key" => facet_details["filter_key"],
+      "combine_mode" => facet_details["combine_mode"] || "and",
+      "preposition" => facet_details["preposition"],
+      "type" => facet_details["type"],
+      "allowed_values" => facet_in_links.dig("links", "facet_values").map do |facet_value|
         {
-          'label' => facet_value.dig('details', 'label'),
-          'value' => facet_value.dig('details', 'value'),
-          'content_id' => facet_value['content_id']
+          "label" => facet_value.dig("details", "label"),
+          "value" => facet_value.dig("details", "value"),
+          "content_id" => facet_value["content_id"]
         }
       end
     }.compact

--- a/lib/facets_builder.rb
+++ b/lib/facets_builder.rb
@@ -7,7 +7,7 @@ class FacetsBuilder
 
   def facets
     facet_hashes.map do |facet_hash|
-      facet_hash_with_allowed_values = facet_hash.merge('allowed_values' => allowed_values(facet_hash))
+      facet_hash_with_allowed_values = facet_hash.merge("allowed_values" => allowed_values(facet_hash))
       build_facet(facet_hash_with_allowed_values)
     end
   end
@@ -17,11 +17,11 @@ private
   attr_reader :content_item, :search_results, :value_hash
 
   def filters_on_brexit_topic?
-    @value_hash['topic'] == ContentItem::BREXIT_CONTENT_ID
+    @value_hash["topic"] == ContentItem::BREXIT_CONTENT_ID
   end
 
   def is_related_to_brexit_checkbox?(facet_hash)
-    facet_hash['key'] == "related_to_brexit" && facet_hash['filter_value'] == ContentItem::BREXIT_CONTENT_ID
+    facet_hash["key"] == "related_to_brexit" && facet_hash["filter_value"] == ContentItem::BREXIT_CONTENT_ID
   end
 
   def facet_hashes
@@ -34,28 +34,28 @@ private
   end
 
   def build_facet(facet_hash)
-    if facet_hash['filterable']
-      case facet_hash['type']
-      when 'text', 'content_id'
-        OptionSelectFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'topical'
-        TopicalFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'taxon'
-        TaxonFacet.new(facet_hash, value_hash.slice(*facet_hash['keys']))
-      when 'date'
-        DateFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'hidden'
-        HiddenFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'checkbox'
-        CheckboxFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'radio'
-        RadioFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'hidden_clearable'
-        HiddenClearableFacet.new(facet_hash, value_hash[facet_hash['key']])
-      when 'research_and_statistics'
-        RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash['key']], ::Filters::ResearchAndStatsHashes.new.call)
-      when 'official_documents'
-        RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash['key']], ::Filters::OfficialDocumentsHashes.new.call)
+    if facet_hash["filterable"]
+      case facet_hash["type"]
+      when "text", "content_id"
+        OptionSelectFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "topical"
+        TopicalFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "taxon"
+        TaxonFacet.new(facet_hash, value_hash.slice(*facet_hash["keys"]))
+      when "date"
+        DateFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "hidden"
+        HiddenFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "checkbox"
+        CheckboxFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "radio"
+        RadioFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "hidden_clearable"
+        HiddenClearableFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "research_and_statistics"
+        RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash["key"]], ::Filters::ResearchAndStatsHashes.new.call)
+      when "official_documents"
+        RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash["key"]], ::Filters::OfficialDocumentsHashes.new.call)
       else
         raise ArgumentError.new("Unknown filterable facet type: #{facet_hash['type']}")
       end
@@ -65,7 +65,7 @@ private
   end
 
   def allowed_values(facet_hash)
-    return facet_hash['allowed_values'] unless facet_hash['allowed_values'].blank?
+    return facet_hash["allowed_values"] unless facet_hash["allowed_values"].blank?
 
     facet_key = facet_hash["key"]
     if registries.all.has_key?(facet_key)

--- a/lib/filters/checkbox_filter.rb
+++ b/lib/filters/checkbox_filter.rb
@@ -6,7 +6,7 @@ module Filters
       # 'params' for a checkbox should be true or false. the value
       # we send to rummager can be params or a static value provided in
       # the finder content item
-      @value ||= params.nil? ? nil : facet['filter_value'] || params
+      @value ||= params.nil? ? nil : facet["filter_value"] || params
     end
   end
 end

--- a/lib/filters/content_id_filter.rb
+++ b/lib/filters/content_id_filter.rb
@@ -11,11 +11,11 @@ module Filters
     end
 
     def content_id_map
-      @content_id_map = allowed_values.to_h { |v| [v['value'], v['content_id']] }
+      @content_id_map = allowed_values.to_h { |v| [v["value"], v["content_id"]] }
     end
 
     def allowed_values
-      facet['allowed_values']
+      facet["allowed_values"]
     end
   end
 end

--- a/lib/filters/filter.rb
+++ b/lib/filters/filter.rb
@@ -6,7 +6,7 @@ module Filters
     end
 
     def key
-      facet['filter_key'] || facet['key']
+      facet["filter_key"] || facet["key"]
     end
 
     def active?
@@ -36,11 +36,11 @@ module Filters
     end
 
     def multi_value?
-      facet.has_key?('option_lookup')
+      facet.has_key?("option_lookup")
     end
 
     def option_lookup
-      @option_lookup ||= facet['option_lookup']
+      @option_lookup ||= facet["option_lookup"]
     end
   end
 end

--- a/lib/filters/radio_filter.rb
+++ b/lib/filters/radio_filter.rb
@@ -25,8 +25,8 @@ module Filters
     end
 
     def default_allowed_value
-      @default_allowed_value ||= facet['allowed_values'].find(Proc.new { {} }) { |option| option['default'] }
-      @default_allowed_value['value']
+      @default_allowed_value ||= facet["allowed_values"].find(Proc.new { {} }) { |option| option["default"] }
+      @default_allowed_value["value"]
     end
 
     def acceptable_param?
@@ -34,7 +34,7 @@ module Filters
     end
 
     def param_is_part_of_allowed_values
-      facet['allowed_values'].any? { |option| option['value'] == params }
+      facet["allowed_values"].any? { |option| option["value"] == params }
     end
   end
 end

--- a/lib/filters/radio_filter_for_multiple_fields.rb
+++ b/lib/filters/radio_filter_for_multiple_fields.rb
@@ -1,7 +1,7 @@
 module Filters
   class RadioFilterForMultipleFields < Filter
     def query_hash
-      find_filter(value)['filter']
+      find_filter(value)["filter"]
     end
 
     def filter_hashes
@@ -15,15 +15,15 @@ module Filters
     end
 
     def default_value
-      filter_hashes.find { |filter| filter['default'] }.fetch('value')
+      filter_hashes.find { |filter| filter["default"] }.fetch("value")
     end
 
     def validated_value(value)
-      filter_hashes.map { |filter| filter['value'] }.include?(value) ? value : default_value
+      filter_hashes.map { |filter| filter["value"] }.include?(value) ? value : default_value
     end
 
     def find_filter(value)
-      filter_hashes.find { |filter| filter['value'] == value }
+      filter_hashes.find { |filter| filter["value"] == value }
     end
   end
 end

--- a/lib/filters/taxon_filter.rb
+++ b/lib/filters/taxon_filter.rb
@@ -4,8 +4,8 @@ module Filters
 
     def value
       @value ||= begin
-        topic = params['level_one_taxon']
-        subtopic = params['level_two_taxon']
+        topic = params["level_one_taxon"]
+        subtopic = params["level_two_taxon"]
 
         # we send a conjunctive query to rummager for part_of_taxonomy_tree
         [topic, subtopic]

--- a/lib/filters/topical_filter.rb
+++ b/lib/filters/topical_filter.rb
@@ -9,8 +9,8 @@ module Filters
     def fetch_value
       return nil if params.blank?
 
-      user_has_selected_open = params.include?(facet['open_value']['value'])
-      user_has_selected_closed = params.include?(facet['closed_value']['value'])
+      user_has_selected_open = params.include?(facet["open_value"]["value"])
+      user_has_selected_closed = params.include?(facet["closed_value"]["value"])
 
       # with both or neither selected, the filter is not used
       if user_has_selected_open && !user_has_selected_closed

--- a/lib/publications_routes.rb
+++ b/lib/publications_routes.rb
@@ -1,49 +1,49 @@
 module PublicationsRoutes
   PUBLICATIONS_ROUTES = {
-    'consultations' => {
-      base_path: 'search/policy-papers-and-consultations',
+    "consultations" => {
+      base_path: "search/policy-papers-and-consultations",
       special_params: {
         content_store_document_type: %w[open_consultations closed_consultations],
       }
     },
-    'closed-consultations' => {
-      base_path: 'search/policy-papers-and-consultations',
+    "closed-consultations" => {
+      base_path: "search/policy-papers-and-consultations",
       special_params: {
-        content_store_document_type: 'closed_consultations',
+        content_store_document_type: "closed_consultations",
       }
     },
-    'open-consultations' => {
-      base_path: 'search/policy-papers-and-consultations',
+    "open-consultations" => {
+      base_path: "search/policy-papers-and-consultations",
       special_params: {
-        content_store_document_type: 'open_consultations',
+        content_store_document_type: "open_consultations",
       }
     },
-    'foi-releases' => {
-      base_path: 'search/transparency-and-freedom-of-information-releases'
+    "foi-releases" => {
+      base_path: "search/transparency-and-freedom-of-information-releases"
     },
-    'transparency-data' => {
-      base_path: 'search/transparency-and-freedom-of-information-releases'
+    "transparency-data" => {
+      base_path: "search/transparency-and-freedom-of-information-releases"
     },
-    'guidance' => {
-      base_path: 'search/guidance-and-regulation'
+    "guidance" => {
+      base_path: "search/guidance-and-regulation"
     },
-    'policy-papers' => {
-      base_path: 'search/policy-papers-and-consultations',
+    "policy-papers" => {
+      base_path: "search/policy-papers-and-consultations",
       special_params: {
-        content_store_document_type: 'policy_papers'
+        content_store_document_type: "policy_papers"
       }
     },
-    'forms' => {
-      base_path: 'search/services'
+    "forms" => {
+      base_path: "search/services"
     },
-    'research-and-analysis' => {
-      base_path: 'search/research-and-statistics',
+    "research-and-analysis" => {
+      base_path: "search/research-and-statistics",
       special_params: {
-        content_store_document_type: 'research'
+        content_store_document_type: "research"
       }
     },
-    'statistics' => {
-      base_path: 'search/research-and-statistics'
+    "statistics" => {
+      base_path: "search/research-and-statistics"
     }
   }.freeze
 end

--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -1,16 +1,16 @@
 module Registries
-  NAMESPACE = 'registries'.freeze
+  NAMESPACE = "registries".freeze
 
   class BaseRegistries
     def all
       @all ||= {
-        'world_locations' => world_locations,
-        'all_part_of_taxonomy_tree' => topic_taxonomy,
-        'part_of_taxonomy_tree' => topic_taxonomy,
-        'people' => people,
-        'organisations' => organisations,
-        'manual' => manuals,
-        'full_topic_taxonomy' => full_topic_taxonomy
+        "world_locations" => world_locations,
+        "all_part_of_taxonomy_tree" => topic_taxonomy,
+        "part_of_taxonomy_tree" => topic_taxonomy,
+        "people" => people,
+        "organisations" => organisations,
+        "manual" => manuals,
+        "full_topic_taxonomy" => full_topic_taxonomy
       }
     end
 

--- a/lib/registries/full_topic_taxonomy_registry.rb
+++ b/lib/registries/full_topic_taxonomy_registry.rb
@@ -26,10 +26,10 @@ module Registries
 
     def format_taxon(taxon)
       {
-        taxon['content_id'] =>
+        taxon["content_id"] =>
         {
-          'title' => taxon['title'],
-          'base_path' => taxon['base_path']
+          "title" => taxon["title"],
+          "base_path" => taxon["base_path"]
         }
       }
     end
@@ -42,7 +42,7 @@ module Registries
       return {} if taxons.empty?
 
       taxons.inject({}) do |result, taxon|
-        child_taxons = taxon.dig('links', 'child_taxons') || []
+        child_taxons = taxon.dig("links", "child_taxons") || []
 
         taxon_hash = format_taxon(taxon)
         child_taxon_hashes = flatten_taxonomy(child_taxons)
@@ -58,11 +58,11 @@ module Registries
     end
 
     def fetch_level_one_taxons_from_api
-      taxons = fetch_taxon.dig('links', 'level_one_taxons') || []
-      taxons.map { |taxon| fetch_taxon(taxon['base_path']) }
+      taxons = fetch_taxon.dig("links", "level_one_taxons") || []
+      taxons.map { |taxon| fetch_taxon(taxon["base_path"]) }
     end
 
-    def fetch_taxon(base_path = '/')
+    def fetch_taxon(base_path = "/")
       Services.cached_content_item(base_path)
     end
   end

--- a/lib/registries/manuals_registry.rb
+++ b/lib/registries/manuals_registry.rb
@@ -11,7 +11,7 @@ module Registries
     end
 
     def cache_key
-      'registries/manuals'
+      "registries/manuals"
     end
 
   private
@@ -25,15 +25,15 @@ module Registries
     end
 
     def report_error
-      GovukStatsd.increment('registries.manuals_api_errors')
+      GovukStatsd.increment("registries.manuals_api_errors")
     end
 
     def manuals_as_hash
-      GovukStatsd.time('registries.manuals.request_time') do
+      GovukStatsd.time("registries.manuals.request_time") do
         fetch_manuals_from_rummager
-          .reject { |manual| manual['_id'].empty? || manual['title'].empty? }
+          .reject { |manual| manual["_id"].empty? || manual["title"].empty? }
           .each_with_object({}) { |manual, manuals|
-            manuals[manual['_id']] = { 'title' => manual['title'], 'slug' => manual['_id'] }
+            manuals[manual["_id"]] = { "title" => manual["title"], "slug" => manual["_id"] }
           }
       end
     end
@@ -44,7 +44,7 @@ module Registries
           fields: %w(title),
           count: 1500,
       }
-      Services.rummager.search(params)['results']
+      Services.rummager.search(params)["results"]
     end
   end
 end

--- a/lib/registries/organisations_registry.rb
+++ b/lib/registries/organisations_registry.rb
@@ -31,24 +31,24 @@ module Registries
     def organisations_as_hash
       GovukStatsd.time("registries.organisations.request_time") do
         fetch_organisations_from_rummager
-          .reject { |result| result['slug'].empty? || result['title'].empty? }
-          .sort_by { |result| result['title'].sub("Closed organisation: ", "ZZ").upcase }
+          .reject { |result| result["slug"].empty? || result["title"].empty? }
+          .sort_by { |result| result["title"].sub("Closed organisation: ", "ZZ").upcase }
           .each_with_object({}) { |result, orgs|
-            slug = result['slug']
-            orgs[slug] = result.slice('title', 'slug', 'acronym', 'content_id')
+            slug = result["slug"]
+            orgs[slug] = result.slice("title", "slug", "acronym", "content_id")
           }
       end
     end
 
     def fetch_organisations_from_rummager
       params = {
-        filter_format: 'organisation',
+        filter_format: "organisation",
         fields: %w(title slug acronym content_id),
         count: 1500,
-        order: 'title'
+        order: "title"
       }
       response = Services.rummager.search(params)
-      response['results']
+      response["results"]
     end
   end
 end

--- a/lib/registries/people_registry.rb
+++ b/lib/registries/people_registry.rb
@@ -32,20 +32,20 @@ module Registries
       GovukStatsd.time("registries.people.request_time") do
         people = fetch_people_from_rummager || {}
 
-        people.reject { |result| result.dig('value', 'slug').blank? || result.dig('value', 'title').blank? }
+        people.reject { |result| result.dig("value", "slug").blank? || result.dig("value", "title").blank? }
           .each_with_object({}) { |result, orgs|
-            slug = result['value']['slug']
-            orgs[slug] = result['value'].slice('title', 'slug', 'content_id')
+            slug = result["value"]["slug"]
+            orgs[slug] = result["value"].slice("title", "slug", "content_id")
           }
       end
     end
 
     def fetch_people_from_rummager
       params = {
-        facet_people: '1500,examples:0,order:value.title',
+        facet_people: "1500,examples:0,order:value.title",
         count: 0,
       }
-      Services.rummager.search(params).dig('facets', 'people', 'options')
+      Services.rummager.search(params).dig("facets", "people", "options")
     end
   end
 end

--- a/lib/registries/topic_taxonomy_registry.rb
+++ b/lib/registries/topic_taxonomy_registry.rb
@@ -27,36 +27,36 @@ module Registries
     def taxonomy_tree_as_hash
       GovukStatsd.time("registries.topic_taxonomy.request_time") do
         fetch_level_one_taxons_from_api.each_with_object({}) { |taxon, taxonomy|
-          taxonomy[taxon['content_id']] = format_taxon(taxon)
+          taxonomy[taxon["content_id"]] = format_taxon(taxon)
         }
       end
     end
 
     def format_taxon(taxon, parent_id = nil)
       {
-        'title' => taxon['title'],
-        'content_id' => taxon['content_id'],
-        'children' => format_child_taxons(taxon),
-        'parent' => parent_id
+        "title" => taxon["title"],
+        "content_id" => taxon["content_id"],
+        "children" => format_child_taxons(taxon),
+        "parent" => parent_id
       }
     end
 
     def format_child_taxons(taxon)
-      children = taxon.dig('links', 'child_taxons') || []
+      children = taxon.dig("links", "child_taxons") || []
       formatted_children = children.map { |child_taxon|
-        format_taxon(child_taxon, taxon['content_id'])
+        format_taxon(child_taxon, taxon["content_id"])
       }
 
-      formatted_children.sort_by { |child_taxon| child_taxon['title'] }
+      formatted_children.sort_by { |child_taxon| child_taxon["title"] }
     end
 
     def fetch_level_one_taxons_from_api
-      taxons = fetch_taxon.dig('links', 'level_one_taxons') || []
-      sorted = taxons.sort_by { |taxon| taxon['title'] }
-      sorted.map { |taxon| fetch_taxon(taxon['base_path']) }
+      taxons = fetch_taxon.dig("links", "level_one_taxons") || []
+      sorted = taxons.sort_by { |taxon| taxon["title"] }
+      sorted.map { |taxon| fetch_taxon(taxon["base_path"]) }
     end
 
-    def fetch_taxon(base_path = '/')
+    def fetch_taxon(base_path = "/")
       Services.cached_content_item(base_path)
     end
   end

--- a/lib/registries/world_locations_registry.rb
+++ b/lib/registries/world_locations_registry.rb
@@ -31,7 +31,7 @@ module Registries
     def locations
       GovukStatsd.time("registries.world_locations.request_time") do
         fetch_locations.each_with_object({}) { |hash, result_hash|
-          result_hash[hash['slug']] = hash
+          result_hash[hash["slug"]] = hash
         }
       end
     end
@@ -39,9 +39,9 @@ module Registries
     def fetch_locations
       fetch_locations_from_worldwide_api.map { |result|
         {
-          'title' => result['title'],
-          'slug' => result.dig('details', 'slug'),
-          'content_id' => result['content_id']
+          "title" => result["title"],
+          "slug" => result.dig("details", "slug"),
+          "content_id" => result["content_id"]
         }
       }
     end

--- a/lib/search/facet_query_builder.rb
+++ b/lib/search/facet_query_builder.rb
@@ -18,7 +18,7 @@ module Search
         # "1500,order:value.title" is specifying that we want 1500 results back
         # which are ordered by the title attribute of each value (option)
         # that is returned
-        key = (facet['filter_key'] || facet['key'])
+        key = (facet["filter_key"] || facet["key"])
         query.merge(key => "1500,order:value.title")
       }
     end
@@ -28,15 +28,15 @@ module Search
     attr_reader :facets
 
     def dynamic_facets
-      facets_that_could_be_dynamic.select { |f| f['allowed_values'].blank? }
+      facets_that_could_be_dynamic.select { |f| f["allowed_values"].blank? }
     end
 
     def facets_that_could_be_dynamic
-      filterable_facets.select { |f| %w(text hidden_clearable).include? f['type'] }
+      filterable_facets.select { |f| %w(text hidden_clearable).include? f["type"] }
     end
 
     def filterable_facets
-      facets.select { |f| f['filterable'] }
+      facets.select { |f| f["filterable"] }
     end
   end
 end

--- a/lib/search/filter_query_builder.rb
+++ b/lib/search/filter_query_builder.rb
@@ -18,31 +18,31 @@ module Search
     attr_reader :facets, :user_params
 
     def filters
-      facets.select { |f| f['filterable'] }.map { |f| build_filter(f) }
+      facets.select { |f| f["filterable"] }.map { |f| build_filter(f) }
     end
 
     def build_filter(facet)
       filter_class = {
-        'checkbox' => Filters::CheckboxFilter,
-        'date' => Filters::DateFilter,
-        'hidden' => Filters::HiddenFilter,
-        'text' => Filters::TextFilter,
-        'dropdown_select' => Filters::DropdownSelectFilter,
-        'topical' => Filters::TopicalFilter,
-        'taxon' => Filters::TaxonFilter,
-        'radio' => Filters::RadioFilter,
-        'content_id' => Filters::ContentIdFilter,
-        'hidden_clearable' => Filters::HiddenClearableFilter,
-        'research_and_statistics' => Filters::ResearchAndStatisticsFilter,
-        'official_documents' => Filters::OfficialDocumentsFilter
-      }.fetch(facet['type'])
+        "checkbox" => Filters::CheckboxFilter,
+        "date" => Filters::DateFilter,
+        "hidden" => Filters::HiddenFilter,
+        "text" => Filters::TextFilter,
+        "dropdown_select" => Filters::DropdownSelectFilter,
+        "topical" => Filters::TopicalFilter,
+        "taxon" => Filters::TaxonFilter,
+        "radio" => Filters::RadioFilter,
+        "content_id" => Filters::ContentIdFilter,
+        "hidden_clearable" => Filters::HiddenClearableFilter,
+        "research_and_statistics" => Filters::ResearchAndStatisticsFilter,
+        "official_documents" => Filters::OfficialDocumentsFilter
+      }.fetch(facet["type"])
 
       filter_class.new(facet, params(facet))
     end
 
     def params(facet)
-      facet_key = facet['key']
-      facet_keys = facet['keys']
+      facet_key = facet["key"]
+      facet_keys = facet["keys"]
 
       if facet_keys
         return facet_keys.each_with_object({}) { |key, result_hash|

--- a/lib/search/order_query_builder.rb
+++ b/lib/search/order_query_builder.rb
@@ -27,33 +27,33 @@ module Search
     attr_reader :content_item, :params, :keywords, :override_sort_for_feed
 
     def order_by_relevance?(sort_option)
-      %w(relevance -relevance topic -topic).include?(sort_option.dig('key'))
+      %w(relevance -relevance topic -topic).include?(sort_option.dig("key"))
     end
 
     def public_timestamp_unsupported
-      %w(upcoming_statistics cancelled_statistics).include?(params['content_store_document_type'])
+      %w(upcoming_statistics cancelled_statistics).include?(params["content_store_document_type"])
     end
 
     def release_timestamp_unsupported
-      %w(published_statistics research).include?(params['content_store_document_type'])
+      %w(published_statistics research).include?(params["content_store_document_type"])
     end
 
     def order_by_release_timestamp?(sort_option)
-      public_timestamp_chosen = %w(-public_timestamp public_timestamp).include?(sort_option.dig('key'))
+      public_timestamp_chosen = %w(-public_timestamp public_timestamp).include?(sort_option.dig("key"))
       public_timestamp_chosen && public_timestamp_unsupported
     end
 
     def order_by_public_timestamp?(sort_option)
-      release_timestamp_chosen = %w(-release_timestamp release_timestamp).include?(sort_option.dig('key'))
+      release_timestamp_chosen = %w(-release_timestamp release_timestamp).include?(sort_option.dig("key"))
       release_timestamp_chosen && release_timestamp_unsupported
     end
 
     def order_by_public_timestamp
-      { 'order' => '-public_timestamp' }
+      { "order" => "-public_timestamp" }
     end
 
     def order_by_release_timestamp
-      { 'order' => '-release_timestamp' }
+      { "order" => "-release_timestamp" }
     end
 
     def order_by_relevance_query
@@ -65,7 +65,7 @@ module Search
     end
 
     def order_by_sort_option_query
-      { 'order' => sort_option['key'] }
+      { "order" => sort_option["key"] }
     end
 
     def order_presenter
@@ -80,7 +80,7 @@ module Search
 
     def default_order
       if order_presenter.default_option
-        order_presenter.default_option['key']
+        order_presenter.default_option["key"]
       else
         content_item.default_order
       end

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -9,9 +9,9 @@ module Search
       @override_sort_for_feed = override_sort_for_feed
       @order =
         if override_sort_for_feed
-          'most-recent'
+          "most-recent"
         else
-          filter_params['order']
+          filter_params["order"]
         end
     end
 
@@ -46,12 +46,12 @@ module Search
 
     def sort_batch_results(raw_results)
       case @order
-      when 'most-viewed'
-        raw_results.sort_by { |hash| hash['popularity'] }.reverse
-      when 'most-recent'
-        raw_results.sort_by { |hash| hash['public_timestamp'] }.reverse
-      when 'a-to-z'
-        raw_results.sort_by { |hash| hash['title'] }
+      when "most-viewed"
+        raw_results.sort_by { |hash| hash["popularity"] }.reverse
+      when "most-recent"
+        raw_results.sort_by { |hash| hash["public_timestamp"] }.reverse
+      when "a-to-z"
+        raw_results.sort_by { |hash| hash["title"] }
       else
         sort_by_relevance(raw_results)
       end
@@ -60,11 +60,11 @@ module Search
     def sort_by_relevance(raw_results)
       return raw_results unless relevance_scores_exist?(raw_results)
 
-      raw_results.sort_by { |hash| hash['es_score'] }.reverse
+      raw_results.sort_by { |hash| hash["es_score"] }.reverse
     end
 
     def relevance_scores_exist?(results)
-      results.all? { |result| result['es_score'].present? }
+      results.all? { |result| result["es_score"].present? }
     end
 
     def fetch_search_response(content_item)

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -92,7 +92,7 @@ module Search
 
     def metadata_fields
       raw_facets.map { |f|
-        unfilterise(f['filter_key'] || f['key'])
+        unfilterise(f["filter_key"] || f["key"])
       }
     end
 
@@ -100,7 +100,7 @@ module Search
       finder_content_item.raw_facets
     end
 
-    def unfilterise(field = '')
+    def unfilterise(field = "")
       # Removes filter-y prefixes from facet keys.
       # For example, filter_x or filter_all_x will become x.
       field.gsub(/^(?'full_name'(?'operation'filter|reject|any|all)_(?:(?'multivalue_query'any|all)_)?(?'name'.*))$/, '\k<name>')
@@ -130,11 +130,11 @@ module Search
     end
 
     def remove_stopwords
-      keywords = params["keywords"].split(' ')
+      keywords = params["keywords"].split(" ")
       keywords.delete_if do |keyword|
-        stopwords.include?(keyword.downcase.gsub(/\W/, ''))
+        stopwords.include?(keyword.downcase.gsub(/\W/, ""))
       end
-      keywords.join(' ')
+      keywords.join(" ")
     end
 
     def base_filter_query
@@ -159,7 +159,7 @@ module Search
 
     def and_facets
       raw_facets.select do |facet|
-        facet.fetch('combine_mode', 'and') == 'and'
+        facet.fetch("combine_mode", "and") == "and"
       end
     end
 
@@ -179,7 +179,7 @@ module Search
 
     def or_facets
       raw_facets.select do |facet|
-        facet.fetch('combine_mode', 'and') == 'or'
+        facet.fetch("combine_mode", "and") == "or"
       end
     end
 
@@ -231,7 +231,7 @@ module Search
     end
 
     def ab_query
-      ab_params.any? ? { 'ab_tests' => ab_params.map { |k, v| "#{k}:#{v}" }.join(',') } : {}
+      ab_params.any? ? { "ab_tests" => ab_params.map { |k, v| "#{k}:#{v}" }.join(",") } : {}
     end
 
     def suggest_query

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,6 @@
-require 'gds_api/content_store'
-require 'gds_api/rummager'
-require 'gds_api/email_alert_api'
+require "gds_api/content_store"
+require "gds_api/rummager"
+require "gds_api/email_alert_api"
 
 module Services
   def self.content_store
@@ -24,7 +24,7 @@ module Services
   end
 
   def self.worldwide_api
-    GdsApi::Worldwide.new(Plek.find('whitehall-admin'))
+    GdsApi::Worldwide.new(Plek.find("whitehall-admin"))
   end
 
   def self.registries

--- a/lib/services/email_alert_api.rb
+++ b/lib/services/email_alert_api.rb
@@ -1,4 +1,4 @@
-require 'digest'
+require "digest"
 
 class Services::EmailAlertApi
   delegate :find_or_create_subscriber_list,

--- a/lib/tasks/jasmine_rails.rake
+++ b/lib/tasks/jasmine_rails.rake
@@ -1,5 +1,5 @@
 # The jasmine-rails gem isn't loaded in production, so only evaluate
 # this code if it's relevant
-if Rake::Task.task_defined? 'spec:javascript'
-  task default: 'spec:javascript'
+if Rake::Task.task_defined? "spec:javascript"
+  task default: "spec:javascript"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
 task default: :lint
 desc "Run govuk-lint and StandardJS with similar params to CI"
 task :lint do
-  sh "bundle exec govuk-lint-ruby --format clang app config features Gemfile lib spec"
+  sh "bundle exec govuk-lint-ruby --format clang"
   sh "yarn run lint"
 end

--- a/script/cucumber
+++ b/script/cucumber
@@ -4,7 +4,7 @@ vendored_cucumber_bin = Dir["#{File.dirname(__FILE__)}/../vendor/{gems,plugins}/
 if vendored_cucumber_bin
   load File.expand_path(vendored_cucumber_bin)
 else
-  require 'rubygems' unless ENV['NO_RUBYGEMS']
-  require 'cucumber'
+  require "rubygems" unless ENV["NO_RUBYGEMS"]
+  require "cucumber"
   load Cucumber::BINARY
 end

--- a/spec/components/date_filter_spec.rb
+++ b/spec/components/date_filter_spec.rb
@@ -1,25 +1,25 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'components/_date-filter.html.erb', type: :view do
+describe "components/_date-filter.html.erb", type: :view do
   it "returns nothing when no key or name provided" do
     render
-    expect(rendered).to eql('')
+    expect(rendered).to eql("")
   end
 
   it "returns two text fields with associated labels when key and name provided" do
-    render partial: 'components/date-filter', locals: { key: 'key', name: 'name' }
+    render partial: "components/date-filter", locals: { key: "key", name: "name" }
 
     expect(rendered).to have_selector(".app-c-date-filter")
 
     expect(rendered).to have_selector("input[name='key\[to\]']")
     expect(rendered).to have_selector("input[name='key\[from\]']")
 
-    expect(rendered).to have_selector("label[for='key\[to\]']", text: 'name before')
-    expect(rendered).to have_selector("label[for='key\[from\]']", text: 'name after')
+    expect(rendered).to have_selector("label[for='key\[to\]']", text: "name before")
+    expect(rendered).to have_selector("label[for='key\[from\]']", text: "name after")
   end
 
   it "prefills user values" do
-    render partial: 'components/date-filter', locals: { from_value: 'user from', to_value: 'user to', key: 'key', name: 'name' }
+    render partial: "components/date-filter", locals: { from_value: "user from", to_value: "user to", key: "key", name: "name" }
 
     expect(rendered).to have_selector("input[name='key\[to\]'][value='user to']")
     expect(rendered).to have_selector("input[name='key\[from\]'][value='user from']")

--- a/spec/components/expander_spec.rb
+++ b/spec/components/expander_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "expander", type: :view do
   def component_name

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'components/_option-select.html.erb', type: :view do
+describe "components/_option-select.html.erb", type: :view do
   def component_name
-    'option-select'
+    "option-select"
   end
 
   def render_component(component_arguments)
@@ -71,7 +71,7 @@ describe 'components/_option-select.html.erb', type: :view do
 
   it "renders a heading for the option select box containing the title" do
     render_component(option_select_arguments)
-    expect(rendered).to have_selector(".app-c-option-select__title", text: 'Market sector')
+    expect(rendered).to have_selector(".app-c-option-select__title", text: "Market sector")
   end
 
   it "renders a container with the id passed in" do
@@ -92,8 +92,8 @@ describe 'components/_option-select.html.erb', type: :view do
     arguments[:show_filter] = true
     render_component(arguments)
 
-    expect(rendered).to have_selector('.app-c-option-select[data-filter-element]')
-    expect(rendered).to have_selector('.app-c-option-select__count')
+    expect(rendered).to have_selector(".app-c-option-select[data-filter-element]")
+    expect(rendered).to have_selector(".app-c-option-select__count")
   end
 
   it "does not show a filter control" do
@@ -102,7 +102,7 @@ describe 'components/_option-select.html.erb', type: :view do
     render_component(arguments)
 
     expect(rendered).to have_no_selector('.app-c-option-select .gem-c-input[name="option-select-filter"]')
-    expect(rendered).to have_no_selector('.app-c-option-select__count')
+    expect(rendered).to have_no_selector(".app-c-option-select__count")
   end
 
   it "adds alternative styling" do
@@ -110,7 +110,7 @@ describe 'components/_option-select.html.erb', type: :view do
     arguments[:expander_style] = true
     render_component(arguments)
 
-    expect(rendered).to have_selector('.app-c-option-select.app-c-option-select--expander')
+    expect(rendered).to have_selector(".app-c-option-select.app-c-option-select--expander")
   end
 
   def expect_label_and_checked_checkbox(label, id, value)

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/content_store'
-require 'gds_api/test_helpers/email_alert_api'
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+require "gds_api/test_helpers/email_alert_api"
 
 describe EmailAlertSubscriptionsController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
@@ -31,19 +31,19 @@ describe EmailAlertSubscriptionsController, type: :controller do
     stub_organisations_registry_request
   end
 
-  describe 'GET #new' do
+  describe "GET #new" do
     describe "finder email signup item doesn't exist" do
-      it 'returns a 404, rather than 5xx' do
-        content_store_does_not_have_item('/does-not-exist/email-signup')
-        get :new, params: { slug: 'does-not-exist' }
+      it "returns a 404, rather than 5xx" do
+        content_store_does_not_have_item("/does-not-exist/email-signup")
+        get :new, params: { slug: "does-not-exist" }
         expect(response.status).to eq(404)
       end
     end
 
     describe "finder email signup item does exist" do
-      it 'returns a success' do
-        content_store_has_item('/does-exist/email-signup', signup_finder)
-        get :new, params: { slug: 'does-exist' }
+      it "returns a success" do
+        content_store_has_item("/does-exist/email-signup", signup_finder)
+        get :new, params: { slug: "does-exist" }
 
         expect(response).to be_successful
       end
@@ -52,42 +52,42 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
   describe 'POST "#create"' do
     before do
-      content_store_has_item('/cma-cases', cma_cases_content_item)
-      content_store_has_item('/cma-cases/email-signup', cma_cases_signup_content_item)
+      content_store_has_item("/cma-cases", cma_cases_content_item)
+      content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
     end
 
     context "finder has default filters" do
       it "fails if the relevant filters are not provided" do
-        post :create, params: { slug: 'cma-cases' }
+        post :create, params: { slug: "cma-cases" }
         expect(response).to be_successful
-        expect(response).to render_template('new')
+        expect(response).to render_template("new")
       end
 
-      it 'redirects to the correct email subscription url' do
+      it "redirects to the correct email subscription url" do
         email_alert_api_has_subscriber_list(
           "tags" => {
             "case_type" => { any: %w[ca98-and-civil-cartels] },
             "format" => { any: %w[cma_case] },
           },
-          "subscription_url" => 'http://www.example.com'
+          "subscription_url" => "http://www.example.com"
         )
 
         post :create, params: {
-          slug: 'cma-cases',
+          slug: "cma-cases",
           filter: {
-            'case_type' => %w[ca98-and-civil-cartels]
+            "case_type" => %w[ca98-and-civil-cartels]
           }
         }
-        expect(subject).to redirect_to('http://www.example.com')
+        expect(subject).to redirect_to("http://www.example.com")
       end
     end
   end
 
   context "with a multi facet signup" do
     describe 'POST "#create"' do
-      it 'redirects to the correct email subscription url' do
-        content_store_has_item('/cma-cases', cma_cases_content_item)
-        content_store_has_item('/cma-cases/email-signup', cma_cases_with_multi_facets_signup_content_item)
+      it "redirects to the correct email subscription url" do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", cma_cases_with_multi_facets_signup_content_item)
 
         email_alert_api_has_subscriber_list(
           "tags" => {
@@ -95,62 +95,62 @@ describe EmailAlertSubscriptionsController, type: :controller do
             "case_state" => { any: %w(open) },
             "format" => { any: %w[cma_case] },
           },
-          "subscription_url" => 'http://www.example.com'
+          "subscription_url" => "http://www.example.com"
         )
 
         post :create, params: {
-          slug: 'cma-cases',
+          slug: "cma-cases",
           filter: {
-            'case_type' => %w[ca98-and-civil-cartels],
-            'case_state' => %w(open),
+            "case_type" => %w[ca98-and-civil-cartels],
+            "case_state" => %w(open),
           }
         }
 
-        expect(subject).to redirect_to('http://www.example.com')
+        expect(subject).to redirect_to("http://www.example.com")
       end
 
-      it 'redirects to the correct email subscription url with subscriber_list_params' do
-        content_store_has_item('/news-and-communications', news_and_communications_content_item)
-        content_store_has_item('/news-and-communications/email-signup', news_and_communications_signup_content_item)
+      it "redirects to the correct email subscription url with subscriber_list_params" do
+        content_store_has_item("/news-and-communications", news_and_communications_content_item)
+        content_store_has_item("/news-and-communications/email-signup", news_and_communications_signup_content_item)
 
         email_alert_api_has_subscriber_list(
-          'links' => {
+          "links" => {
             "content_purpose_subgroup" =>
               {
                 "any" => %w[news speeches_and_statements]
               }
           },
-          'subscription_url' => 'http://www.example.com'
+          "subscription_url" => "http://www.example.com"
         )
 
         post :create, params: {
-          slug: 'news-and-communications',
+          slug: "news-and-communications",
           subscriber_list_params: {},
         }
-        expect(subject).to redirect_to('http://www.example.com')
+        expect(subject).to redirect_to("http://www.example.com")
       end
 
 
-      it 'will not include a facet that is not in the signup content item in the redirect' do
-        content_store_has_item('/cma-cases', cma_cases_content_item)
-        content_store_has_item('/cma-cases/email-signup', cma_cases_signup_content_item)
+      it "will not include a facet that is not in the signup content item in the redirect" do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
         email_alert_api_has_subscriber_list(
-          'tags' => {
-            'case_type' => { any: %w[ca98-and-civil-cartels] },
-            'format' => { any: %w[cma_case] },
+          "tags" => {
+            "case_type" => { any: %w[ca98-and-civil-cartels] },
+            "format" => { any: %w[cma_case] },
           },
-          'subscription_url' => 'http://www.example.com'
+          "subscription_url" => "http://www.example.com"
         )
 
         post :create, params: {
-          slug: 'cma-cases',
+          slug: "cma-cases",
           subscriber_list_params: { part_of_taxonomy_tree: %w(some-taxon) },
           filter: {
-            'case_type' => %w[ca98-and-civil-cartels],
-            'case_state' => %w(open),
+            "case_type" => %w[ca98-and-civil-cartels],
+            "case_state" => %w(open),
           }
         }
-        expect(subject).to redirect_to('http://www.example.com')
+        expect(subject).to redirect_to("http://www.example.com")
       end
     end
   end
@@ -158,25 +158,25 @@ describe EmailAlertSubscriptionsController, type: :controller do
   context "with email_filter_by set to 'facet_values'" do
     describe 'POST "#create"' do
       before do
-        content_store_has_item('/find-eu-exit-guidance-business', business_readiness_content_item)
-        content_store_has_item('/find-eu-exit-guidance-business/email-signup', business_readiness_signup_content_item)
+        content_store_has_item("/find-eu-exit-guidance-business", business_readiness_content_item)
+        content_store_has_item("/find-eu-exit-guidance-business/email-signup", business_readiness_signup_content_item)
       end
 
       it "should call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
         email_alert_api_has_subscriber_list(
-          'links' => {
-            'facet_values' => { any: %w(aerospace) },
+          "links" => {
+            "facet_values" => { any: %w(aerospace) },
           },
-          'subscription_url' => 'http://www.itstartshear.com',
-          'email_filter_by' => 'facet_values'
+          "subscription_url" => "http://www.itstartshear.com",
+          "email_filter_by" => "facet_values"
         )
 
         allow(EmailAlertListTitleBuilder).to receive(:call)
 
         post :create, params: {
-          slug: 'find-eu-exit-guidance-business',
+          slug: "find-eu-exit-guidance-business",
           filter: {
-            'sector_business_area' => %w(aerospace),
+            "sector_business_area" => %w(aerospace),
           }
         }
 
@@ -188,13 +188,13 @@ describe EmailAlertSubscriptionsController, type: :controller do
   context "with blank email_filter_by" do
     describe 'POST "#create"' do
       it "should not call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
-        content_store_has_item('/cma_cases', cma_cases_content_item)
-        content_store_has_item('/cma_cases/email-signup', cma_cases_signup_content_item)
+        content_store_has_item("/cma_cases", cma_cases_content_item)
+        content_store_has_item("/cma_cases/email-signup", cma_cases_signup_content_item)
 
         email_alert_api_has_subscriber_list(
-          'tags' => {
-            'format' => { any: %w[cma_case] },
-            'case_type' => { any: %w[markets] }
+          "tags" => {
+            "format" => { any: %w[cma_case] },
+            "case_type" => { any: %w[markets] }
           },
           "subscription_url" => "http://www.gov.uk",
         )
@@ -202,9 +202,9 @@ describe EmailAlertSubscriptionsController, type: :controller do
         allow(EmailAlertTitleBuilder).to receive(:call)
 
         post :create, params: {
-          slug: 'cma_cases',
+          slug: "cma_cases",
           filter: {
-            'case_type' => %w[markets],
+            "case_type" => %w[markets],
           }
         }
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/content_store'
-require 'gds_api/test_helpers/rummager'
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+require "gds_api/test_helpers/rummager"
 
 describe FindersController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
@@ -12,9 +12,9 @@ describe FindersController, type: :controller do
   render_views
 
   let(:lunch_finder) do
-    finder = govuk_content_schema_example('finder').to_hash.merge(
-      'title' => 'Lunch Finder',
-      'base_path' => '/lunch-finder',
+    finder = govuk_content_schema_example("finder").to_hash.merge(
+      "title" => "Lunch Finder",
+      "base_path" => "/lunch-finder",
     )
 
     finder["details"]["default_documents_per_page"] = 10
@@ -30,8 +30,8 @@ describe FindersController, type: :controller do
 
   describe "GET show" do
     let(:all_content_finder) do
-      finder = govuk_content_schema_example('finder').to_hash.merge(
-        'base_path' => '/search/all',
+      finder = govuk_content_schema_example("finder").to_hash.merge(
+        "base_path" => "/search/all",
       )
 
       finder["details"]["default_documents_per_page"] = 10
@@ -42,7 +42,7 @@ describe FindersController, type: :controller do
     describe "a finder content item exists" do
       before do
         content_store_has_item(
-          '/lunch-finder',
+          "/lunch-finder",
           lunch_finder
         )
 
@@ -71,7 +71,7 @@ describe FindersController, type: :controller do
       end
 
       it "correctly renders a finder page" do
-        get :show, params: { slug: 'lunch-finder' }
+        get :show, params: { slug: "lunch-finder" }
         expect(response.status).to eq(200)
         expect(response).to render_template("finders/show")
       end
@@ -81,7 +81,7 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/atom+xml")
         expect(response).to render_template("finders/show")
-        expect(response.headers['Cache-Control']).to eq("max-age=300, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
 
       it "can respond with JSON" do
@@ -100,11 +100,11 @@ describe FindersController, type: :controller do
 
     describe "a finder content item with a default order exists" do
       it "sorts the finder results by public timestamp" do
-        sort_options = [{ 'name' => 'Closing date', 'key' => '-closing_date', 'default' => true, }]
+        sort_options = [{ "name" => "Closing date", "key" => "-closing_date", "default" => true, }]
 
         content_store_has_item(
-          '/lunch-finder',
-          lunch_finder.merge('details' => lunch_finder['details'].merge('sort' => sort_options))
+          "/lunch-finder",
+          lunch_finder.merge("details" => lunch_finder["details"].merge("sort" => sort_options))
         )
 
         rummager_response = %|{
@@ -128,7 +128,7 @@ describe FindersController, type: :controller do
           )
           .to_return(status: 200, body: rummager_response, headers: {})
 
-        get :show, params: { format: :atom, slug: 'lunch-finder' }
+        get :show, params: { format: :atom, slug: "lunch-finder" }
         expect(stub).to have_been_requested
         expect(response.status).to eq(200)
       end
@@ -136,15 +136,15 @@ describe FindersController, type: :controller do
 
     describe "finder item doesn't exist" do
       before do
-        content_store_does_not_have_item('/does-not-exist')
+        content_store_does_not_have_item("/does-not-exist")
       end
 
-      it 'returns a 404, rather than 5xx' do
-        get :show, params: { slug: 'does-not-exist' }
+      it "returns a 404, rather than 5xx" do
+        get :show, params: { slug: "does-not-exist" }
         expect(response.status).to eq(404)
       end
 
-      it 'returns a 404, rather than 5xx for the atom feed' do
+      it "returns a 404, rather than 5xx for the atom feed" do
         get :show, params: { slug: "does-not-exist", format: "atom" }
 
         expect(response.status).to eq(404)
@@ -156,24 +156,24 @@ describe FindersController, type: :controller do
         stub_request(:get, "#{Plek.find('content-store')}/content/unpublished-finder").to_return(
           status: 200,
           body: {
-            document_type: 'redirect',
-            schema_name: 'redirect',
+            document_type: "redirect",
+            schema_name: "redirect",
             redirects: [
-              { path: '/unpublished-finder', type: 'exact', destination: '/replacement' }
+              { path: "/unpublished-finder", type: "exact", destination: "/replacement" }
             ]
           }.to_json,
           headers: {}
         )
       end
 
-      it 'returns a message indicating the atom feed has ended' do
+      it "returns a message indicating the atom feed has ended" do
         get :show, params: { slug: "unpublished-finder", format: "atom" }
 
         expect(response.status).to eq(200)
         expect(response.body).to include("This feed no longer exists")
       end
 
-      it 'returns a 404 for json responses' do
+      it "returns a 404 for json responses" do
         get :show, params: { slug: "unpublished-finder", format: "json" }
 
         expect(response.status).to eq(404)
@@ -185,17 +185,17 @@ describe FindersController, type: :controller do
           stub_request(:get, "#{Plek.find('content-store')}/content/government/policies/cats").to_return(
             status: 200,
             body: {
-              document_type: 'redirect',
-              schema_name: 'redirect',
+              document_type: "redirect",
+              schema_name: "redirect",
               redirects: [
-                { path: '/government/policies/cats', type: 'exact', destination: '/cats' }
+                { path: "/government/policies/cats", type: "exact", destination: "/cats" }
               ]
             }.to_json,
             headers: {}
           )
         end
 
-        it 'returns a policy specific message indicating the atom feed has ended' do
+        it "returns a policy specific message indicating the atom feed has ended" do
           get :show, params: { slug: "government/policies/cats", format: "atom" }
 
           expect(response.status).to eq(200)
@@ -206,8 +206,8 @@ describe FindersController, type: :controller do
 
     describe "Show/Hiding site search form" do
       before do
-        content_store_has_item('/search/all', all_content_finder)
-        content_store_has_item('/lunch-finder', lunch_finder)
+        content_store_has_item("/search/all", all_content_finder)
+        content_store_has_item("/lunch-finder", lunch_finder)
 
         rummager_response = %|{
           "results": [],
@@ -231,13 +231,13 @@ describe FindersController, type: :controller do
           .to_return(status: 200, body: rummager_response, headers: {})
       end
 
-      it 'all content finder tells Slimmer to hide the form' do
-        get :show, params: { slug: 'search/all' }
+      it "all content finder tells Slimmer to hide the form" do
+        get :show, params: { slug: "search/all" }
         expect(response.headers["X-Slimmer-Remove-Search"]).to eq("true")
       end
 
-      it 'any other finder does not tell Slimmer to hide the form' do
-        get :show, params: { slug: 'lunch-finder' }
+      it "any other finder does not tell Slimmer to hide the form" do
+        get :show, params: { slug: "lunch-finder" }
         expect(response.headers).not_to include("X-Slimmer-Remove-Search")
       end
     end
@@ -245,10 +245,10 @@ describe FindersController, type: :controller do
 
   describe "Search cluster AB tests" do
     let(:breakfast_finder) do
-      finder = govuk_content_schema_example('finder').to_hash.merge(
-        'title' => 'Breakfast Finder',
-        'base_path' => '/breakfast-finder',
-        'content_id' => '42ce66de-04f3-4192-bf31-8394538e0734'
+      finder = govuk_content_schema_example("finder").to_hash.merge(
+        "title" => "Breakfast Finder",
+        "base_path" => "/breakfast-finder",
+        "content_id" => "42ce66de-04f3-4192-bf31-8394538e0734"
       )
 
       finder["details"]["default_documents_per_page"] = 10
@@ -256,11 +256,11 @@ describe FindersController, type: :controller do
       finder
     end
 
-    let(:filter_params) { double(:filter_params, keywords: '') }
+    let(:filter_params) { double(:filter_params, keywords: "") }
     let(:finder_presenter) { FinderPresenter.new(breakfast_finder, {}, filter_params) }
 
     before do
-      content_store_has_item(breakfast_finder['base_path'], breakfast_finder)
+      content_store_has_item(breakfast_finder["base_path"], breakfast_finder)
       rummager_response = %|{
         "results": [],
         "total": 0,
@@ -272,7 +272,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant Default sets use_default_cluster? and not use_b_cluster?" do
-      with_variant SearchClusterQueryABTest: 'Default' do
+      with_variant SearchClusterQueryABTest: "Default" do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(true)
         expect(subject.use_b_cluster?).to eq(false)
@@ -280,7 +280,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant A does not set use_default_cluster? or use_b_cluster?" do
-      with_variant SearchClusterQueryABTest: 'A' do
+      with_variant SearchClusterQueryABTest: "A" do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(false)
@@ -288,7 +288,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant 'B' sets use_b_cluster? and not use_default_cluster?" do
-      with_variant SearchClusterQueryABTest: 'B' do
+      with_variant SearchClusterQueryABTest: "B" do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(true)
@@ -298,10 +298,10 @@ describe FindersController, type: :controller do
 
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
-      finder = govuk_content_schema_example('finder').to_hash.merge(
-        'title' => 'Breakfast Finder',
-        'base_path' => '/breakfast-finder',
-        'content_id' => '42ce66de-04f3-4192-bf31-8394538e0734'
+      finder = govuk_content_schema_example("finder").to_hash.merge(
+        "title" => "Breakfast Finder",
+        "base_path" => "/breakfast-finder",
+        "content_id" => "42ce66de-04f3-4192-bf31-8394538e0734"
       )
 
       finder["details"]["default_documents_per_page"] = 10
@@ -310,7 +310,7 @@ describe FindersController, type: :controller do
     end
 
     before do
-      content_store_has_item(breakfast_finder['base_path'], breakfast_finder)
+      content_store_has_item(breakfast_finder["base_path"], breakfast_finder)
       rummager_response = %|{
         "results": [],
         "total": 0,
@@ -332,8 +332,8 @@ describe FindersController, type: :controller do
   end
 
   def path_for(content_item, locale = nil)
-    base_path = content_item['base_path'].sub(/^\//, '')
-    base_path.gsub!(/\.#{locale}$/, '') if locale
+    base_path = content_item["base_path"].sub(/^\//, "")
+    base_path.gsub!(/\.#{locale}$/, "") if locale
     base_path
   end
 end

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
-require 'json'
+require "spec_helper"
+require "json"
 
-describe 'Healthcheck' do
+describe "Healthcheck" do
   before do
     Rails.cache.clear
   end
@@ -10,13 +10,13 @@ describe 'Healthcheck' do
     Rails.cache.clear
   end
 
-  context 'when everything is fine', type: :request do
+  context "when everything is fine", type: :request do
     before do
       fill_registries
     end
 
     it "returns an OK status" do
-      get '/healthcheck.json'
+      get "/healthcheck.json"
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
@@ -29,13 +29,13 @@ describe 'Healthcheck' do
     end
   end
 
-  context 'when registries have no data', type: :request do
+  context "when registries have no data", type: :request do
     before do
       Rails.cache.clear
     end
 
     it "returns a warning status" do
-      get '/healthcheck.json'
+      get "/healthcheck.json"
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {

--- a/spec/controllers/qa_controller_spec.rb
+++ b/spec/controllers/qa_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/content_store'
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
 
 describe QaController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
@@ -74,9 +74,9 @@ describe QaController, type: :controller do
 
       context "on the last page" do
         let(:last_facet_key)  { aaib_reports_finder_facets.last["key"] }
-        let(:last_filters)    { aaib_reports_finder_facets.last['allowed_values'] }
-        let(:first_filter)    { last_filters.first['value'] }
-        let(:last_filter)     { last_filters.last['value'] }
+        let(:last_filters)    { aaib_reports_finder_facets.last["allowed_values"] }
+        let(:first_filter)    { last_filters.first["value"] }
+        let(:last_filter)     { last_filters.last["value"] }
         let(:params)          { { page: aaib_reports_finder_facets.count } }
 
         before { get:show, params: params }

--- a/spec/controllers/qa_to_content_controller_spec.rb
+++ b/spec/controllers/qa_to_content_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/content_store'
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
 
 describe QaToContentController, type: :controller do
   include FixturesHelper
@@ -51,10 +51,10 @@ describe QaToContentController, type: :controller do
       end
 
       context "when the option is invalid" do
-        let(:params) { { question["id"] => '/non-matching-url' } }
+        let(:params) { { question["id"] => "/non-matching-url" } }
 
         it "renders the question" do
-          expect(response).to render_template('qa_to_content/show')
+          expect(response).to render_template("qa_to_content/show")
         end
       end
     end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -1,14 +1,14 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe RedirectionController, type: :controller do
   include TaxonomySpecHelper
 
-  describe '#announcements' do
+  describe "#announcements" do
     it "redirects to the news-and-comms page" do
       get :announcements
-      expect(response).to redirect_to finder_path('search/news-and-communications')
+      expect(response).to redirect_to finder_path("search/news-and-communications")
     end
-    it 'passes on a set of params' do
+    it "passes on a set of params" do
       get :announcements, params: {
         keywords: %w[one two],
         taxons: %w[one],
@@ -16,26 +16,26 @@ describe RedirectionController, type: :controller do
         people: %w[one two],
         departments: %w[one two],
         world_locations: %w[one two],
-        from_date: '01/01/2014',
-        to_date: '01/01/2014'
+        from_date: "01/01/2014",
+        to_date: "01/01/2014"
       }
-      expect(response).to redirect_to finder_path('search/news-and-communications', params: {
+      expect(response).to redirect_to finder_path("search/news-and-communications", params: {
         keywords: %w[one two],
-        level_one_taxon: 'one',
-        level_two_taxon: 'two',
+        level_one_taxon: "one",
+        level_two_taxon: "two",
         people: %w[one two],
         organisations: %w[one two],
         world_locations: %w[one two],
-        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+        public_timestamp: { from: "01/01/2014", to: "01/01/2014" }
       })
     end
-    it 'redirects to the atom feed' do
+    it "redirects to the atom feed" do
       get :announcements, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/news-and-communications', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path("search/news-and-communications", format: :atom, params: { keywords: %w[one two] })
     end
   end
 
-  describe '#publications' do
+  describe "#publications" do
     let(:received_params) {
       {
         keywords: %w[one two],
@@ -43,185 +43,185 @@ describe RedirectionController, type: :controller do
         subtaxons: %w[two],
         departments: %w[one two],
         world_locations: %w[one two],
-        from_date: '01/01/2014',
-        to_date: '01/01/2014'
+        from_date: "01/01/2014",
+        to_date: "01/01/2014"
       }
     }
 
     let(:converted_params) {
       {
         keywords: %w[one two],
-        level_one_taxon: 'one',
-        level_two_taxon: 'two',
+        level_one_taxon: "one",
+        level_two_taxon: "two",
         organisations: %w[one two],
         world_locations: %w[one two],
-        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+        public_timestamp: { from: "01/01/2014", to: "01/01/2014" }
       }
     }
 
     it "redirects to the all page by default" do
       get :publications
-      expect(response).to redirect_to finder_path('search/all')
+      expect(response).to redirect_to finder_path("search/all")
     end
-    it 'passes on a set of params' do
+    it "passes on a set of params" do
       get :publications, params: received_params
-      expect(response).to redirect_to finder_path('search/all', params: converted_params)
+      expect(response).to redirect_to finder_path("search/all", params: converted_params)
     end
-    it 'redirects when consultations is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'consultations')
+    it "redirects when consultations is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "consultations")
       expect(response).to redirect_to finder_path(
-        'search/policy-papers-and-consultations',
+        "search/policy-papers-and-consultations",
         params: converted_params.merge(content_store_document_type: %w[open_consultations closed_consultations])
       )
     end
-    it 'redirects when closed-consultations is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'closed-consultations')
+    it "redirects when closed-consultations is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "closed-consultations")
       expect(response).to redirect_to finder_path(
-        'search/policy-papers-and-consultations',
-        params: converted_params.merge(content_store_document_type: 'closed_consultations')
+        "search/policy-papers-and-consultations",
+        params: converted_params.merge(content_store_document_type: "closed_consultations")
       )
     end
-    it 'redirects when open-consultations is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'open-consultations')
+    it "redirects when open-consultations is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "open-consultations")
       expect(response).to redirect_to finder_path(
-        'search/policy-papers-and-consultations',
-        params: converted_params.merge(content_store_document_type: 'open_consultations')
+        "search/policy-papers-and-consultations",
+        params: converted_params.merge(content_store_document_type: "open_consultations")
       )
     end
-    it 'redirects when foi-releases is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'foi-releases')
+    it "redirects when foi-releases is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "foi-releases")
       expect(response).to redirect_to finder_path(
-        'search/transparency-and-freedom-of-information-releases',
+        "search/transparency-and-freedom-of-information-releases",
         params: converted_params
       )
     end
-    it 'redirects when transparency-data is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'transparency-data')
+    it "redirects when transparency-data is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "transparency-data")
       expect(response).to redirect_to finder_path(
-        'search/transparency-and-freedom-of-information-releases',
+        "search/transparency-and-freedom-of-information-releases",
         params: converted_params
       )
     end
-    it 'redirects when guidance is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'guidance')
+    it "redirects when guidance is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "guidance")
       expect(response).to redirect_to finder_path(
-        'search/guidance-and-regulation',
+        "search/guidance-and-regulation",
         params: converted_params
       )
     end
-    it 'redirects when policy-papers is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'policy-papers')
+    it "redirects when policy-papers is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "policy-papers")
       expect(response).to redirect_to finder_path(
-        'search/policy-papers-and-consultations',
-        params: converted_params.merge(content_store_document_type: 'policy_papers')
+        "search/policy-papers-and-consultations",
+        params: converted_params.merge(content_store_document_type: "policy_papers")
       )
     end
-    it 'redirects when forms is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'forms')
+    it "redirects when forms is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "forms")
       expect(response).to redirect_to finder_path(
-        'search/services',
+        "search/services",
         params: converted_params
       )
     end
-    it 'redirects when research-and-analysis is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'research-and-analysis')
+    it "redirects when research-and-analysis is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "research-and-analysis")
       expect(response).to redirect_to finder_path(
-        'search/research-and-statistics',
-        params: converted_params.merge(content_store_document_type: 'research')
+        "search/research-and-statistics",
+        params: converted_params.merge(content_store_document_type: "research")
       )
     end
-    it 'redirects when statistics is selected' do
-      get :publications, params: received_params.merge(publication_filter_option: 'statistics')
+    it "redirects when statistics is selected" do
+      get :publications, params: received_params.merge(publication_filter_option: "statistics")
       expect(response).to redirect_to finder_path(
-        'search/research-and-statistics',
+        "search/research-and-statistics",
         params: converted_params
       )
     end
-    it 'redirects to the atom feed' do
+    it "redirects to the atom feed" do
       get :publications, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/all', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path("search/all", format: :atom, params: { keywords: %w[one two] })
     end
   end
 
-  describe '#published_statistics' do
+  describe "#published_statistics" do
     it "redirects to the statistics page" do
       get :published_statistics
-      expect(response).to redirect_to finder_path('search/statistics')
+      expect(response).to redirect_to finder_path("search/statistics")
     end
-    it 'passes on a set of params' do
+    it "passes on a set of params" do
       get :published_statistics, params: {
         keywords: %w[one two],
         taxons: %w[one],
         departments: %w[one two],
-        from_date: '01/01/2014',
-        to_date: '01/01/2014'
+        from_date: "01/01/2014",
+        to_date: "01/01/2014"
       }
-      expect(response).to redirect_to finder_path('search/statistics', params: {
+      expect(response).to redirect_to finder_path("search/statistics", params: {
         keywords: %w[one two],
-        level_one_taxon: 'one',
+        level_one_taxon: "one",
         organisations: %w[one two],
-        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+        public_timestamp: { from: "01/01/2014", to: "01/01/2014" }
       })
     end
-    it 'redirects to the atom feed' do
+    it "redirects to the atom feed" do
       get :published_statistics, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two] })
+      expect(response).to redirect_to finder_path("search/statistics", format: :atom, params: { keywords: %w[one two] })
     end
   end
 
-  describe '#upcoming_statistics' do
+  describe "#upcoming_statistics" do
     it "redirects to the statistics page" do
       get :upcoming_statistics
-      expect(response).to redirect_to finder_path('search/statistics', params: { content_store_document_type: :statistics_upcoming })
+      expect(response).to redirect_to finder_path("search/statistics", params: { content_store_document_type: :statistics_upcoming })
     end
-    it 'passes on a set of params' do
+    it "passes on a set of params" do
       get :upcoming_statistics, params: {
         keywords: %w[one two],
         topics: %w[one],
         organisations: %w[one two],
-        from_date: '01/01/2014',
-        to_date: '01/01/2014'
+        from_date: "01/01/2014",
+        to_date: "01/01/2014"
       }
-      expect(response).to redirect_to finder_path('search/statistics', params: {
+      expect(response).to redirect_to finder_path("search/statistics", params: {
         keywords: %w[one two],
-        level_one_taxon: 'one',
+        level_one_taxon: "one",
         organisations: %w[one two],
         content_store_document_type: :statistics_upcoming,
-        public_timestamp: { from: '01/01/2014', to: '01/01/2014' }
+        public_timestamp: { from: "01/01/2014", to: "01/01/2014" }
       })
     end
-    it 'redirects to the atom feed' do
+    it "redirects to the atom feed" do
       get :upcoming_statistics, params: { keywords: %w[one two] }, format: :atom
-      expect(response).to redirect_to finder_path('search/statistics', format: :atom, params: { keywords: %w[one two], content_store_document_type: :statistics_upcoming })
+      expect(response).to redirect_to finder_path("search/statistics", format: :atom, params: { keywords: %w[one two], content_store_document_type: :statistics_upcoming })
     end
   end
 
-  describe '#advanced_search' do
+  describe "#advanced_search" do
     before :each do
       Rails.cache.clear
-      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'content_id', base_path: '/path/topic')])
+      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: "content_id", base_path: "/path/topic")])
     end
-    it 'redirects to news and comms finder' do
-      get :advanced_search, params: { group: 'news_and_communications' }
+    it "redirects to news and comms finder" do
+      get :advanced_search, params: { group: "news_and_communications" }
       expect(response).to redirect_to finder_path("search/news-and-communications")
     end
-    it 'redirects the services finder' do
-      get :advanced_search, params: { group: 'services' }
+    it "redirects the services finder" do
+      get :advanced_search, params: { group: "services" }
       expect(response).to redirect_to finder_path("search/services", params: {})
     end
-    it 'redirects with a topic parameter, translating the base path to content_id' do
-      get :advanced_search, params: { group: 'services', topic: '/path/topic' }
-      expect(response).to redirect_to finder_path("search/services", params: { topic: 'content_id' })
+    it "redirects with a topic parameter, translating the base path to content_id" do
+      get :advanced_search, params: { group: "services", topic: "/path/topic" }
+      expect(response).to redirect_to finder_path("search/services", params: { topic: "content_id" })
     end
-    context 'The topic does not exist' do
-      it 'redirects ignoring the topic' do
-        get :advanced_search, params: { group: 'services', topic: '/path/does-not-exist' }
+    context "The topic does not exist" do
+      it "redirects ignoring the topic" do
+        get :advanced_search, params: { group: "services", topic: "/path/does-not-exist" }
         expect(response).to redirect_to finder_path("search/services", params: {})
       end
     end
-    context 'The group does not exist' do
-      it 'returns 404' do
-        get :advanced_search, params: { group: 'does-not-exist', topic: '/path/topic' }
+    context "The group does not exist" do
+      it "returns 404" do
+        get :advanced_search, params: { group: "does-not-exist", topic: "/path/topic" }
         expect(response.status).to eq(404)
       end
     end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/content_store'
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
 
 describe SearchController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
@@ -8,9 +8,9 @@ describe SearchController, type: :controller do
 
   before do
     content_store_has_item(
-      '/search',
-      base_path: '/search',
-      title: 'Search'
+      "/search",
+      base_path: "/search",
+      title: "Search"
     )
 
     rummager_response = %|{

--- a/spec/factories/brexit_checker/action.rb
+++ b/spec/factories/brexit_checker/action.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :brexit_checker_action, class: BrexitChecker::Action do
-    title { 'A title' }
-    title_url { 'http://www.gov.uk' }
+    title { "A title" }
+    title_url { "http://www.gov.uk" }
     id { SecureRandom.uuid }
-    consequence { 'A consequence' }
+    consequence { "A consequence" }
     criteria { %w(construction) }
-    audience { 'citizen' }
+    audience { "citizen" }
     priority { 5 }
 
     initialize_with { BrexitChecker::Action.new(attributes) }

--- a/spec/factories/brexit_checker/question.rb
+++ b/spec/factories/brexit_checker/question.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :brexit_checker_question, class: BrexitChecker::Question do
-    text { 'A title' }
+    text { "A title" }
     key { SecureRandom.uuid }
-    type { 'single' }
+    type { "single" }
     options { [] }
 
     initialize_with { BrexitChecker::Question.new(attributes) }

--- a/spec/factories/date_facet.rb
+++ b/spec/factories/date_facet.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :date_facet, class: DateFacet do
-    key { 'published_at' }
+    key { "published_at" }
     filterable { true }
-    type { 'date' }
+    type { "date" }
     display_as_result_metadata { true }
     initialize_with { new(attributes.deep_stringify_keys, {}) }
   end

--- a/spec/factories/document_hash.rb
+++ b/spec/factories/document_hash.rb
@@ -15,9 +15,9 @@ FactoryBot.define do
     document_type { "answer" }
     organisations {
       [{
-          'acronym' => 'DWP',
-          'content_id' => 'b548a09f-8b35-4104-89f4-f1a40bf3136d',
-          'title' => 'Department for Work and Pensions'
+          "acronym" => "DWP",
+          "content_id" => "b548a09f-8b35-4104-89f4-f1a40bf3136d",
+          "title" => "Department for Work and Pensions"
        }]
     }
     content_purpose_supergroup { "guidance_and_regulation" }

--- a/spec/factories/option_select_facet.rb
+++ b/spec/factories/option_select_facet.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :option_select_facet, class: OptionSelectFacet do
-    key { 'organisations' }
+    key { "organisations" }
     filterable { true }
-    type { 'text' }
+    type { "text" }
     display_as_result_metadata { true }
     transient do
       values { nil }

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require 'gds_api/test_helpers/email_alert_api'
+require "gds_api/test_helpers/email_alert_api"
 
 RSpec.feature "Brexit Checker email signup", type: :feature do
   include GdsApi::TestHelpers::ContentStore

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,18 +1,18 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ApplicationHelper, type: :helper do
   describe ".input_checked" do
     it "should find a match in an array" do
       allow(helper).to receive(:params).and_return("my_key" => %w(one two))
-      expect(helper.input_checked('my_key', 'one')).to eql(' checked="checked"')
-      expect(helper.input_checked('my_key', 'two')).to eql(' checked="checked"')
-      expect(helper.input_checked('my_key', 'three')).to be_nil
+      expect(helper.input_checked("my_key", "one")).to eql(' checked="checked"')
+      expect(helper.input_checked("my_key", "two")).to eql(' checked="checked"')
+      expect(helper.input_checked("my_key", "three")).to be_nil
     end
 
     it "should find a match in string" do
-      allow(helper).to receive(:params).and_return("my_key" => 'one')
-      expect(helper.input_checked('my_key', 'one')).to eql(' checked="checked"')
-      expect(helper.input_checked('my_key', 'two')).to be_nil
+      allow(helper).to receive(:params).and_return("my_key" => "one")
+      expect(helper.input_checked("my_key", "one")).to eql(' checked="checked"')
+      expect(helper.input_checked("my_key", "two")).to be_nil
     end
   end
 end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe BrexitCheckerHelper, type: :helper do
   describe "#filter_items" do
@@ -53,8 +53,8 @@ describe BrexitCheckerHelper, type: :helper do
 
     subject { persistent_criteria_keys(question_criteria_keys) }
 
-    it 'returns all but the questions criteria' do
-      expect(subject).to contain_exactly('A', 'B')
+    it "returns all but the questions criteria" do
+      expect(subject).to contain_exactly("A", "B")
     end
   end
 end

--- a/spec/integration/brexit_checker_spec.rb
+++ b/spec/integration/brexit_checker_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe "Brexit checker data integrity" do
   let(:validator) { BrexitChecker::CriteriaLogic::Validator }

--- a/spec/lib/brexit_checker/convert_csv_to_yaml/actions_processor_spec.rb
+++ b/spec/lib/brexit_checker/convert_csv_to_yaml/actions_processor_spec.rb
@@ -30,7 +30,7 @@ describe BrexitChecker::ConvertCsvToYaml::ActionsProcessor do
     end
 
     it "ignores empty criteria field" do
-      record.delete('criteria')
+      record.delete("criteria")
       result = described_class.new.process(record)
       expect(result).not_to include("criteria" => nil)
     end

--- a/spec/lib/brexit_checker/criteria_logic/evaluator_spec.rb
+++ b/spec/lib/brexit_checker/criteria_logic/evaluator_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe BrexitChecker::CriteriaLogic::Evaluator do
   let(:selected_criteria) { [] }

--- a/spec/lib/brexit_checker/page_service_spec.rb
+++ b/spec/lib/brexit_checker/page_service_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe BrexitChecker::PageService do
   let(:questions) {
@@ -10,71 +10,71 @@ describe BrexitChecker::PageService do
     ]
   }
 
-  describe '#next_page' do
-    it 'returns nil if the last page has been reached' do
+  describe "#next_page" do
+    it "returns nil if the last page has been reached" do
       subject = BrexitChecker::PageService.new(questions: questions,
                                             current_page_from_params: questions.count,
                                             criteria_keys: [])
       expect(subject.next_page).to be nil
     end
-    it 'returns the next viewable page + 1 if in range' do
+    it "returns the next viewable page + 1 if in range" do
       subject = BrexitChecker::PageService.new(questions: questions,
                                             current_page_from_params: 0,
                                             criteria_keys: [])
       expect(subject.next_page).to be 1
     end
   end
-  describe '#redirect_to_results?' do
-    it 'return true  if the end of the questions has been reached' do
+  describe "#redirect_to_results?" do
+    it "return true  if the end of the questions has been reached" do
       subject = BrexitChecker::PageService.new(questions: questions,
                                             current_page_from_params: questions.count,
                                             criteria_keys: [])
       expect(subject.redirect_to_results?).to be true
     end
-    it 'returns false if the end of the questions has not been reached' do
+    it "returns false if the end of the questions has not been reached" do
       subject = BrexitChecker::PageService.new(questions: questions,
                                             current_page_from_params: questions.count - 1,
                                             criteria_keys: %w[c])
       expect(subject.redirect_to_results?).to be false
     end
   end
-  describe '#page' do
+  describe "#page" do
     let(:subject) {
       BrexitChecker::PageService.new(questions: questions, current_page_from_params: current_page_from_params, criteria_keys: criteria_keys).current_page
     }
     let(:criteria_keys) { [] }
     let(:current_page_from_params) { nil }
 
-    context 'the page on the form is 0' do
+    context "the page on the form is 0" do
       let(:current_page_from_params) { 0 }
-      it 'returns the page from the form ' do
+      it "returns the page from the form " do
         expect(subject).to eq(0)
       end
     end
-    context 'the page on the form is 1 and the criteria_keys match question_two' do
+    context "the page on the form is 1 and the criteria_keys match question_two" do
       let(:current_page_from_params) { 1 }
       let(:criteria_keys) { %w[c d] }
-      it 'returns the page for question_two' do
+      it "returns the page for question_two" do
         expect(subject).to eq(2)
       end
     end
-    context 'the page on the form is 1 and the criteria_keys match question_three' do
+    context "the page on the form is 1 and the criteria_keys match question_three" do
       let(:current_page_from_params) { 1 }
       let(:criteria_keys) { %w[c] }
-      it 'returns the page for question_three' do
+      it "returns the page for question_three" do
         expect(subject).to eq(3)
       end
     end
-    context 'the page on the form is 1 and the criteria_keys do not match anything' do
+    context "the page on the form is 1 and the criteria_keys do not match anything" do
       let(:current_page_from_params) { 1 }
       let(:criteria_keys) { %w[e] }
-      it 'returns nil' do
+      it "returns nil" do
         expect(subject).to be nil
       end
     end
-    context 'the page on the form is higher than the number of questions' do
+    context "the page on the form is higher than the number of questions" do
       let(:current_page_from_params) { questions.count + 1 }
-      it 'returns nil' do
+      it "returns nil" do
         expect(subject).to be nil
       end
     end

--- a/spec/lib/email_alert_list_title_builder_spec.rb
+++ b/spec/lib/email_alert_list_title_builder_spec.rb
@@ -13,7 +13,7 @@ describe EmailAlertListTitleBuilder do
   let(:subscription_list_title_prefix) { "EU Exit guidance" }
   let(:facets) do
     signup_json = JSON.parse(File.read(Rails.root.join("features", "fixtures", "business_readiness_email_signup.json")))
-    signup_json.fetch('details').fetch('email_filter_facets')
+    signup_json.fetch("details").fetch("email_filter_facets")
   end
 
   context "one choice for one facet selected" do

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
-require 'email_alert_signup_api'
-require 'gds_api/test_helpers/email_alert_api'
+require "spec_helper"
+require "email_alert_signup_api"
+require "gds_api/test_helpers/email_alert_api"
 
 describe EmailAlertSignupAPI do
   include GdsApi::TestHelpers::EmailAlertApi
@@ -49,7 +49,7 @@ describe EmailAlertSignupAPI do
       describe "#signup_url" do
         let(:subscription_url) { "http://www.example.org/news_and_comms/signup" }
         let(:default_filters) do
-          { "content_purpose_supergroup" => 'news_and_communications' }
+          { "content_purpose_supergroup" => "news_and_communications" }
         end
 
         it "will send email_alert_api the default attributes" do
@@ -113,8 +113,8 @@ describe EmailAlertSignupAPI do
     let(:subscription_url) { "http://www.example.org/list-id/signup" }
 
 
-    describe '#signup_url' do
-      it 'returns the url email-alert-api gives back' do
+    describe "#signup_url" do
+      it "returns the url email-alert-api gives back" do
         email_alert_api_has_subscriber_list(
           "tags" => {
             format: { any: %w(test-reports) },
@@ -125,8 +125,8 @@ describe EmailAlertSignupAPI do
         expect(signup_api_wrapper.signup_url).to eql subscription_url
       end
 
-      context 'with multiple choices selected and a title prefix' do
-        it 'asks email-alert-api to find or create the subscriber list' do
+      context "with multiple choices selected and a title prefix" do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -140,14 +140,14 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'with one choice selected and a title prefix' do
+      context "with one choice selected and a title prefix" do
         let(:applied_filters) do
           {
             format: { any: %w(test-reports) },
             alert_type: %w[first],
           }
         end
-        it 'asks email-alert-api to find or create the subscriber list' do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -161,8 +161,8 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'without a title prefix' do
-        it 'asks email-alert-api to find or create the subscriber list' do
+      context "without a title prefix" do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -176,11 +176,11 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'no options available' do
+      context "no options available" do
         let(:facets) { [] }
         let(:finder_format) { "test-reports" }
 
-        it 'asks email-alert-api to find or create the subscriber list' do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -256,8 +256,8 @@ describe EmailAlertSignupAPI do
       )
     end
 
-    describe '#signup_url' do
-      it 'returns the url email-alert-api gives back' do
+    describe "#signup_url" do
+      it "returns the url email-alert-api gives back" do
         email_alert_api_has_subscriber_list(
           "tags" => {
             format: { any: %w(test-reports) },
@@ -268,8 +268,8 @@ describe EmailAlertSignupAPI do
         expect(signup_api_wrapper.signup_url).to eql subscription_url
       end
 
-      context 'with multiple choices selected and a title prefix' do
-        it 'asks email-alert-api to find or create the subscriber list' do
+      context "with multiple choices selected and a title prefix" do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -284,7 +284,7 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'with one choice selected and a title prefix' do
+      context "with one choice selected and a title prefix" do
         let(:finder_format) { "test-reports" }
         let(:applied_filters) do
           {
@@ -293,7 +293,7 @@ describe EmailAlertSignupAPI do
           }
         end
 
-        it 'asks email-alert-api to find or create the subscriber list' do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -308,8 +308,8 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'without a title prefix' do
-        it 'asks email-alert-api to find or create the subscriber list' do
+      context "without a title prefix" do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -324,11 +324,11 @@ describe EmailAlertSignupAPI do
         end
       end
 
-      context 'no options available' do
+      context "no options available" do
         let(:facets) { [] }
         let(:finder_format) { "test-reports" }
 
-        it 'asks email-alert-api to find or create the subscriber list' do
+        it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w(test-reports) },
@@ -369,7 +369,7 @@ describe EmailAlertSignupAPI do
       let(:signup_content_id) { "not-the-business-readiness-signup-content-id" }
 
 
-      it 'asks email-alert-api to find or create the subscriber list' do
+      it "asks email-alert-api to find or create the subscriber list" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             "facet_groups" => { any: %w(52435175-82ed-4a04-adef-74c0199d0f46) },
@@ -409,7 +409,7 @@ describe EmailAlertSignupAPI do
       ]
     end
 
-    it 'asks email-alert-api to find or create the subscriber list' do
+    it "asks email-alert-api to find or create the subscriber list" do
       req = email_alert_api_has_subscriber_list(
         "tags" => {
           persons: { any: %w(harry_potter harry john) },
@@ -429,7 +429,7 @@ describe EmailAlertSignupAPI do
         "content_purpose_subgroup": %w[news speeches_and_statements]
       }
     }
-    describe 'part_of_taxonomy_tree facet' do
+    describe "part_of_taxonomy_tree facet" do
       let(:applied_filters) do
         { "all_part_of_taxonomy_tree" => %w(content_id_1 content_id_2) }
       end
@@ -441,7 +441,7 @@ describe EmailAlertSignupAPI do
           }
         ]
       end
-      it 'translates all_part_of_taxonomy_tree to taxon_tree and does not convert values' do
+      it "translates all_part_of_taxonomy_tree to taxon_tree and does not convert values" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             taxon_tree: { all: %w(content_id_1 content_id_2) },
@@ -453,7 +453,7 @@ describe EmailAlertSignupAPI do
         assert_requested(req)
       end
     end
-    describe 'content_store_document_type' do
+    describe "content_store_document_type" do
       let(:applied_filters) do
         { "content_store_document_type" => %w(document_type_1 document_type_2) }
       end
@@ -469,7 +469,7 @@ describe EmailAlertSignupAPI do
           }
         ]
       end
-      it 'It does not convert values' do
+      it "It does not convert values" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             content_store_document_type: { any: %w(document_type_1 document_type_2) },
@@ -480,11 +480,11 @@ describe EmailAlertSignupAPI do
         expect(subject.signup_url).to eql subscription_url
         assert_requested(req)
       end
-      describe 'handling default values' do
+      describe "handling default values" do
         let(:default_filters) do
-          { "content_purpose_subgroup" => 'one_thing' }
+          { "content_purpose_subgroup" => "one_thing" }
         end
-        it 'it converting scalar values to arrays' do
+        it "it converting scalar values to arrays" do
           req = email_alert_api_has_subscriber_list(
             "links" => {
               content_store_document_type: { any: %w(document_type_1 document_type_2) },
@@ -497,7 +497,7 @@ describe EmailAlertSignupAPI do
         end
       end
     end
-    describe 'organisation facet' do
+    describe "organisation facet" do
       let(:applied_filters) do
         { "organisations" => %w(death-eaters ministry-of-magic) }
       end
@@ -512,7 +512,7 @@ describe EmailAlertSignupAPI do
       before :each do
         stub_organisations_registry_request
       end
-      it 'asks email-alert-api to find or create the subscriber list' do
+      it "asks email-alert-api to find or create the subscriber list" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             organisations: { any: %w(content_id_for_death-eaters content_id_for_ministry-of-magic) },
@@ -525,7 +525,7 @@ describe EmailAlertSignupAPI do
       end
     end
 
-    describe 'world facet' do
+    describe "world facet" do
       let(:applied_filters) do
         { "world_locations" => %w(location_1 location_2) }
       end
@@ -541,13 +541,13 @@ describe EmailAlertSignupAPI do
         world_locations = {
           "results": [
             {
-              "content_id": 'location_id_1',
+              "content_id": "location_id_1",
               "details": {
                 "slug": "location_1",
               }
             },
             {
-              "content_id": 'location_id_2',
+              "content_id": "location_id_2",
               "details": {
                 "slug": "location_2",
               },
@@ -559,7 +559,7 @@ describe EmailAlertSignupAPI do
           .to_return(body: world_locations.to_json)
       end
 
-      it 'asks email-alert-api to find or create the subscriber list' do
+      it "asks email-alert-api to find or create the subscriber list" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             world_locations: { any: %w(location_id_1 location_id_2) },
@@ -571,7 +571,7 @@ describe EmailAlertSignupAPI do
         assert_requested(req)
       end
     end
-    describe 'people facet' do
+    describe "people facet" do
       let(:applied_filters) do
         { "people" => %w(albus-dumbledore ron-weasley) }
       end
@@ -587,7 +587,7 @@ describe EmailAlertSignupAPI do
         stub_people_registry_request
       end
 
-      it 'asks email-alert-api to find or create the subscriber list' do
+      it "asks email-alert-api to find or create the subscriber list" do
         req = email_alert_api_has_subscriber_list(
           "links" => {
             people: { any: %w(content_id_for_albus-dumbledore content_id_for_ron-weasley) },

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'email_alert_title_builder'
+require "spec_helper"
+require "email_alert_title_builder"
 
 describe EmailAlertTitleBuilder do
   include TaxonomySpecHelper
@@ -29,150 +29,150 @@ describe EmailAlertTitleBuilder do
     stub_organisations_registry_request
   end
 
-  context 'when there are no facets' do
+  context "when there are no facets" do
     let(:filter) { nil }
-    let(:subscription_list_title_prefix) { 'Prefix' }
+    let(:subscription_list_title_prefix) { "Prefix" }
     let(:facets) { [] }
 
     it { is_expected.to eq(subscription_list_title_prefix) }
   end
 
-  context 'when there is one facet' do
+  context "when there is one facet" do
     let(:subscription_list_title_prefix) do
-      { 'singular' => 'Prefix:', 'plural' => 'Prefixes:' }
+      { "singular" => "Prefix:", "plural" => "Prefixes:" }
     end
     let(:facets) do
       [
         {
-          'facet_id' => 'facet_id',
-          'facet_name' => 'facet name',
-          'facet_choices' => [
+          "facet_id" => "facet_id",
+          "facet_name" => "facet name",
+          "facet_choices" => [
             {
-              'key' => 'key_one',
-              'radio_button_name' => 'radio button name one',
-              'topic_name' => 'topic name one',
-              'prechecked' => false
+              "key" => "key_one",
+              "radio_button_name" => "radio button name one",
+              "topic_name" => "topic name one",
+              "prechecked" => false
             },
             {
-              'key' => 'key_two',
-              'radio_button_name' => 'radio button name two',
-              'topic_name' => 'topic name two',
-              'prechecked' => false
+              "key" => "key_two",
+              "radio_button_name" => "radio button name two",
+              "topic_name" => "topic name two",
+              "prechecked" => false
             }
           ],
         }
       ]
     end
 
-    context 'when no choice is selected' do
+    context "when no choice is selected" do
       let(:filter) { {} }
 
-      it { is_expected.to eq('Prefixes:') }
+      it { is_expected.to eq("Prefixes:") }
     end
 
-    context 'when one choice is selected' do
-      let(:filter) { { 'facet_id' => %w(key_one) } }
+    context "when one choice is selected" do
+      let(:filter) { { "facet_id" => %w(key_one) } }
 
-      it { is_expected.to eq('Prefix: topic name one') }
+      it { is_expected.to eq("Prefix: topic name one") }
     end
 
-    context 'when two choices are selected' do
-      let(:filter) { { 'facet_id' => %w(key_one key_two) } }
+    context "when two choices are selected" do
+      let(:filter) { { "facet_id" => %w(key_one key_two) } }
 
-      it { is_expected.to eq('Prefixes: topic name one and topic name two') }
+      it { is_expected.to eq("Prefixes: topic name one and topic name two") }
     end
   end
 
-  context 'when there are multiple facets' do
-    let(:subscription_list_title_prefix) { 'Prefix: ' }
+  context "when there are multiple facets" do
+    let(:subscription_list_title_prefix) { "Prefix: " }
     let(:facets) do
       [
         {
-          'facet_id' => 'facet_id_one',
-          'facet_name' => 'facet name one',
-          'facet_choices' => [
+          "facet_id" => "facet_id_one",
+          "facet_name" => "facet name one",
+          "facet_choices" => [
             {
-              'key' => 'key_one',
-              'radio_button_name' => 'radio button name one',
-              'topic_name' => 'topic name one',
-              'prechecked' => false
+              "key" => "key_one",
+              "radio_button_name" => "radio button name one",
+              "topic_name" => "topic name one",
+              "prechecked" => false
             },
             {
-              'key' => 'key_two',
-              'radio_button_name' => 'radio button name two',
-              'topic_name' => 'topic name two',
-              'prechecked' => false
+              "key" => "key_two",
+              "radio_button_name" => "radio button name two",
+              "topic_name" => "topic name two",
+              "prechecked" => false
             }
           ],
         },
         {
-          'facet_id' => 'facet_id_two',
-          'facet_name' => 'facet name two',
-          'facet_choices' => [
+          "facet_id" => "facet_id_two",
+          "facet_name" => "facet name two",
+          "facet_choices" => [
             {
-              'key' => 'key_three',
-              'radio_button_name' => 'radio button name three',
-              'topic_name' => 'topic name three',
-              'prechecked' => false
+              "key" => "key_three",
+              "radio_button_name" => "radio button name three",
+              "topic_name" => "topic name three",
+              "prechecked" => false
             },
             {
-              'key' => 'key_four',
-              'radio_button_name' => 'radio button name four',
-              'topic_name' => 'topic name four',
-              'prechecked' => false
+              "key" => "key_four",
+              "radio_button_name" => "radio button name four",
+              "topic_name" => "topic name four",
+              "prechecked" => false
             }
           ],
         }
       ]
     end
 
-    context 'when no choice is selected' do
+    context "when no choice is selected" do
       let(:filter) { {} }
 
-      it { is_expected.to eq('Prefix:') }
+      it { is_expected.to eq("Prefix:") }
     end
 
-    context 'when one facet is selected' do
-      context 'when one choice is selected' do
-        let(:filter) { { 'facet_id_one' => %w(key_one) } }
+    context "when one facet is selected" do
+      context "when one choice is selected" do
+        let(:filter) { { "facet_id_one" => %w(key_one) } }
 
-        it { is_expected.to eq('Prefix: with facet name one of topic name one') }
+        it { is_expected.to eq("Prefix: with facet name one of topic name one") }
       end
 
-      context 'when two choices are selected' do
-        let(:filter) { { 'facet_id_one' => %w(key_one key_two) } }
+      context "when two choices are selected" do
+        let(:filter) { { "facet_id_one" => %w(key_one key_two) } }
 
-        it { is_expected.to eq('Prefix: with facet name one of topic name one and topic name two') }
+        it { is_expected.to eq("Prefix: with facet name one of topic name one and topic name two") }
       end
     end
 
-    context 'when one dynamic facet is selected' do
-      let(:subscription_list_title_prefix) { 'Prefix ' }
+    context "when one dynamic facet is selected" do
+      let(:subscription_list_title_prefix) { "Prefix " }
       let(:facets) do
         [{ "facet_id" => "people", "facet_name" => "people" }]
       end
       let(:filter) do
-        { 'people' => %w(harry-potter ron-weasley) }
+        { "people" => %w(harry-potter ron-weasley) }
       end
 
-      it { is_expected.to eq('Prefix with people of Harry Potter and Ron Weasley') }
+      it { is_expected.to eq("Prefix with people of Harry Potter and Ron Weasley") }
     end
 
 
-    context 'when two facets are selected' do
+    context "when two facets are selected" do
       let(:filter) do
         {
-          'facet_id_one' => %w(key_one key_two),
-          'facet_id_two' => %w(key_three key_four),
+          "facet_id_one" => %w(key_one key_two),
+          "facet_id_two" => %w(key_three key_four),
         }
       end
 
-      it { is_expected.to eq('Prefix: with facet name one of topic name one and topic name two and facet name two of topic name three and topic name four') }
+      it { is_expected.to eq("Prefix: with facet name one of topic name one and topic name two and facet name two of topic name three and topic name four") }
     end
   end
 
   context "when there are multiple facets with the same filter_key" do
-    let(:subscription_list_title_prefix) { 'News and communicatons ' }
+    let(:subscription_list_title_prefix) { "News and communicatons " }
     let(:facets) do
       [
         { "facet_id" => "politicians", "facet_name" => "people", "filter_key" => "people" },
@@ -189,15 +189,15 @@ describe EmailAlertTitleBuilder do
     end
     let(:filter) do
       {
-        'people' => %w(harry-potter ron-weasley albus-dumbledore cornelius-fudge rufus-scrimgeour),
-        'organisations' => %w(ministry-of-magic gringots hogwarts),
-        'part_of_taxonomy_tree' => %w(magical-education d6c2de5d-ef90-45d1-82d4-5f2438369eea herbology),
-        'document_type' => %w(OWL NEWT),
+        "people" => %w(harry-potter ron-weasley albus-dumbledore cornelius-fudge rufus-scrimgeour),
+        "organisations" => %w(ministry-of-magic gringots hogwarts),
+        "part_of_taxonomy_tree" => %w(magical-education d6c2de5d-ef90-45d1-82d4-5f2438369eea herbology),
+        "document_type" => %w(OWL NEWT),
       }
     end
 
     it {
-      is_expected.to eq('News and communicatons with people of Harry Potter, Ron Weasley, Albus Dumbledore, Cornelius Fudge, and Rufus Scrimgeour, organisations of Ministry of Magic, Gringots, and 1 other organisation, topics of Magical Education, Brexit, and Herbology, and 2 document types')
+      is_expected.to eq("News and communicatons with people of Harry Potter, Ron Weasley, Albus Dumbledore, Cornelius Fudge, and Rufus Scrimgeour, organisations of Ministry of Magic, Gringots, and 1 other organisation, topics of Magical Education, Brexit, and Herbology, and 2 document types")
     }
   end
 end

--- a/spec/lib/facet_extractor_spec.rb
+++ b/spec/lib/facet_extractor_spec.rb
@@ -1,45 +1,45 @@
-require 'spec_helper'
+require "spec_helper"
 
 
 describe FacetExtractor do
   let(:facets) { described_class.new(finder).extract }
 
-  context 'with facets in details' do
+  context "with facets in details" do
     let(:finder) { ContentItem.new(finder_hash) }
     let(:finder_hash) do
       {
         details: {
           facets: [
-            { some: 'facet details' },
-            { some: 'more facet details' }
+            { some: "facet details" },
+            { some: "more facet details" }
           ]
         }
       }.deep_stringify_keys
     end
 
-    it 'returns the facets directly from the finder' do
+    it "returns the facets directly from the finder" do
       expect(facets).to eq([
-        { 'some' => 'facet details' },
-        { 'some' => 'more facet details' }
+        { "some" => "facet details" },
+        { "some" => "more facet details" }
       ])
     end
   end
 
-  context 'with  facets under facet_group in links' do
+  context "with  facets under facet_group in links" do
     let(:sector_facet_values) do
       [
         {
-          content_id: 'ed94c9f5-22ea-4fa5-aee1-7ccea25d412e',
+          content_id: "ed94c9f5-22ea-4fa5-aee1-7ccea25d412e",
           details: {
-            label: 'Aerospace',
-            value: 'aerospace'
+            label: "Aerospace",
+            value: "aerospace"
           }
         },
         {
-          content_id: 'b7c4eccf-a1e8-4a95-9988-4db6c5cd889e',
+          content_id: "b7c4eccf-a1e8-4a95-9988-4db6c5cd889e",
           details: {
-            label: 'Computer services',
-            value: 'computer-services'
+            label: "Computer services",
+            value: "computer-services"
           }
         }
       ]
@@ -47,17 +47,17 @@ describe FacetExtractor do
     let(:eu_citizen_facet_values) do
       [
         {
-          content_id: 'd09d441f-7cef-40f3-9767-8cd5a84fff72',
+          content_id: "d09d441f-7cef-40f3-9767-8cd5a84fff72",
           details: {
-            label: 'EU Citizens',
-            value: 'yes'
+            label: "EU Citizens",
+            value: "yes"
           }
         },
         {
-          content_id: '66fc5add-c79c-41ed-9286-ae2d150e5deb',
+          content_id: "66fc5add-c79c-41ed-9286-ae2d150e5deb",
           details: {
-            label: 'No EU Citizens',
-            value: 'no'
+            label: "No EU Citizens",
+            value: "no"
           }
         }
       ]
@@ -71,14 +71,14 @@ describe FacetExtractor do
               facets: [
                 {
                   details: {
-                    name: 'Sector / Business Area',
-                    key: 'sector_business_area',
-                    filter_key: 'any_facet_values',
+                    name: "Sector / Business Area",
+                    key: "sector_business_area",
+                    filter_key: "any_facet_values",
                     display_as_result_metadata: true,
                     filterable: true,
-                    combine_mode: 'or',
-                    preposition: 'your business is in',
-                    type: 'content_id'
+                    combine_mode: "or",
+                    preposition: "your business is in",
+                    type: "content_id"
                   },
                   links: {
                     facet_values: sector_facet_values
@@ -86,13 +86,13 @@ describe FacetExtractor do
                 },
                 {
                   details: {
-                    name: 'Who you employ',
-                    short_name: 'Employing EU citizens',
-                    key: 'employ_eu_citizens',
-                    filter_key: 'any_facet_values',
+                    name: "Who you employ",
+                    short_name: "Employing EU citizens",
+                    key: "employ_eu_citizens",
+                    filter_key: "any_facet_values",
                     filterable: true,
-                    preposition: 'you',
-                    type: 'content_id'
+                    preposition: "you",
+                    type: "content_id"
                   },
                   links: {
                     facet_values: eu_citizen_facet_values
@@ -105,49 +105,49 @@ describe FacetExtractor do
       }.deep_stringify_keys
     end
 
-    it 'returns facets in the correct format' do
+    it "returns facets in the correct format" do
       expected_facets = [
         {
-          name: 'Sector / Business Area',
-          key: 'sector_business_area',
+          name: "Sector / Business Area",
+          key: "sector_business_area",
           display_as_result_metadata: true,
           filterable: true,
-          filter_key: 'any_facet_values',
-          combine_mode: 'or',
-          preposition: 'your business is in',
-          type: 'content_id',
+          filter_key: "any_facet_values",
+          combine_mode: "or",
+          preposition: "your business is in",
+          type: "content_id",
           allowed_values: [
             {
-              label: 'Aerospace',
-              value: 'aerospace',
-              content_id: 'ed94c9f5-22ea-4fa5-aee1-7ccea25d412e'
+              label: "Aerospace",
+              value: "aerospace",
+              content_id: "ed94c9f5-22ea-4fa5-aee1-7ccea25d412e"
             },
             {
-              label: 'Computer services',
-              value: 'computer-services',
-              content_id: 'b7c4eccf-a1e8-4a95-9988-4db6c5cd889e'
+              label: "Computer services",
+              value: "computer-services",
+              content_id: "b7c4eccf-a1e8-4a95-9988-4db6c5cd889e"
             }
           ]
         },
         {
-          name: 'Who you employ',
-          short_name: 'Employing EU citizens',
-          key: 'employ_eu_citizens',
+          name: "Who you employ",
+          short_name: "Employing EU citizens",
+          key: "employ_eu_citizens",
           filterable: true,
-          filter_key: 'any_facet_values',
-          combine_mode: 'and', #defaults to `and`,
-          preposition: 'you',
-          type: 'content_id',
+          filter_key: "any_facet_values",
+          combine_mode: "and", #defaults to `and`,
+          preposition: "you",
+          type: "content_id",
           allowed_values: [
             {
-              label: 'EU Citizens',
-              value: 'yes',
-              content_id: 'd09d441f-7cef-40f3-9767-8cd5a84fff72'
+              label: "EU Citizens",
+              value: "yes",
+              content_id: "d09d441f-7cef-40f3-9767-8cd5a84fff72"
             },
             {
-              label: 'No EU Citizens',
-              value: 'no',
-              content_id: '66fc5add-c79c-41ed-9286-ae2d150e5deb'
+              label: "No EU Citizens",
+              value: "no",
+              content_id: "66fc5add-c79c-41ed-9286-ae2d150e5deb"
             }
           ]
         }

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -99,14 +99,14 @@ describe FacetsBuilder do
   }
 
   let(:content_item_hash) {
-    govuk_content_schema_example('finder').merge(detail_hash).deep_stringify_keys
+    govuk_content_schema_example("finder").merge(detail_hash).deep_stringify_keys
   }
 
   let(:content_item) {
     ContentItem.new(content_item_hash)
   }
 
-  describe 'Remove brexit checkbox filter' do
+  describe "Remove brexit checkbox filter" do
     subject(:facets) do
       FacetsBuilder.new(content_item: content_item, search_results: {}, value_hash: value_hash).facets
     end
@@ -122,29 +122,29 @@ describe FacetsBuilder do
         }
       }
     }
-    context 'The page is filtered on the brexit topic' do
+    context "The page is filtered on the brexit topic" do
       let(:value_hash) {
         {
-          'topic' => ContentItem::BREXIT_CONTENT_ID
+          "topic" => ContentItem::BREXIT_CONTENT_ID
         }
       }
-      it 'contains no related to brexit taxon' do
-        expect(facets).to_not include(an_object_satisfying { |facet| facet.key == 'related_to_brexit' })
+      it "contains no related to brexit taxon" do
+        expect(facets).to_not include(an_object_satisfying { |facet| facet.key == "related_to_brexit" })
       end
     end
-    context 'The page is not filtered on the brexit topic' do
+    context "The page is not filtered on the brexit topic" do
       let(:value_hash) {
         {
           related_to_brexit: ContentItem::BREXIT_CONTENT_ID
         }
       }
-      it 'contains a related to brexit taxon' do
-        expect(facets).to include(an_object_satisfying { |facet| facet.key == 'related_to_brexit' })
+      it "contains a related to brexit taxon" do
+        expect(facets).to include(an_object_satisfying { |facet| facet.key == "related_to_brexit" })
       end
     end
   end
 
-  describe 'facets' do
+  describe "facets" do
     subject(:facet) do
       FacetsBuilder.new(content_item: content_item, search_results: {}, value_hash: {}).facets.first
     end
@@ -157,73 +157,73 @@ describe FacetsBuilder do
         }
       }
     }
-    context 'option_select_facet_hash facet' do
+    context "option_select_facet_hash facet" do
       let(:hash_under_test) {
         option_select_facet_hash
       }
-      it 'builds a option_select facet' do
+      it "builds a option_select facet" do
         expect(facet).to be_a(OptionSelectFacet)
         expect(facet.key).to eq("people")
       end
     end
 
-    context 'taxon facet' do
+    context "taxon facet" do
       let(:hash_under_test) {
         taxon_facet_hash
       }
-      it 'builds a taxon facet' do
+      it "builds a taxon facet" do
         expect(facet).to be_a(TaxonFacet)
         expect(facet.keys).to eq(%w[level_one_taxon level_two_taxon])
       end
     end
-    context 'date facet' do
+    context "date facet" do
       let(:hash_under_test) {
         date_facet_hash
       }
-      it 'builds a taxon facet' do
+      it "builds a taxon facet" do
         expect(facet).to be_a(DateFacet)
-        expect(facet.key).to eq('public_timestamp')
+        expect(facet.key).to eq("public_timestamp")
       end
     end
-    context 'hidden facet' do
+    context "hidden facet" do
       let(:hash_under_test) {
         hidden_facet_hash
       }
-      it 'builds a hidden facet' do
+      it "builds a hidden facet" do
         expect(facet).to be_a(HiddenFacet)
-        expect(facet.key).to eq('topic')
+        expect(facet.key).to eq("topic")
       end
     end
-    context 'checkbox facet' do
+    context "checkbox facet" do
       let(:hash_under_test) {
         checkbox_facet_hash
       }
-      it 'builds a checkbox facet' do
+      it "builds a checkbox facet" do
         expect(facet).to be_a(CheckboxFacet)
-        expect(facet.key).to eq('checkbox')
+        expect(facet.key).to eq("checkbox")
       end
     end
-    context 'radio facet' do
+    context "radio facet" do
       let(:hash_under_test) {
         radio_facet_hash
       }
-      it 'builds a checkbox facet' do
+      it "builds a checkbox facet" do
         expect(facet).to be_a(RadioFacet)
-        expect(facet.key).to eq('content_store_document_type')
+        expect(facet.key).to eq("content_store_document_type")
       end
     end
-    context 'hidden_clearable facet' do
+    context "hidden_clearable facet" do
       let(:hash_under_test) {
         hidden_clearable_facet_hash
       }
-      it 'builds a checkbox facet' do
+      it "builds a checkbox facet" do
         expect(facet).to be_a(HiddenClearableFacet)
-        expect(facet.key).to eq('manual')
+        expect(facet.key).to eq("manual")
       end
     end
   end
 
-  describe 'allowed values' do
+  describe "allowed values" do
     subject(:facet) do
       FacetsBuilder.new(content_item: content_item, search_results: search_results, value_hash: {}).facets.first
     end
@@ -234,7 +234,7 @@ describe FacetsBuilder do
     let(:rummager_params) {
       {
         count: 0,
-        facet_people: '1500,examples:0,order:value.title'
+        facet_people: "1500,examples:0,order:value.title"
       }
     }
     let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -248,24 +248,24 @@ describe FacetsBuilder do
         }
       }
     }
-    context 'The allowed values are in the content item hash' do
+    context "The allowed values are in the content item hash" do
       let(:hash_under_test) {
         option_select_facet_hash
       }
-      it 'copies allowed values from the hash' do
+      it "copies allowed values from the hash" do
         expect(facet.allowed_values).to eq([{ "value" => "me" }, { "value" => "you" }])
       end
     end
-    context 'The allowed values are in the registry' do
+    context "The allowed values are in the registry" do
       let(:hash_under_test) {
         option_select_facet_hash.except(:allowed_values)
       }
-      it 'gets values from the registry' do
+      it "gets values from the registry" do
         stub_request(:get, rummager_url).to_return(body: people_search_api_results.to_json)
         expect(facet.allowed_values).to eq([{ "label" => "Cornelius Fudge", "value" => "cornelius-fudge" }, { "label" => "Rufus Scrimgeour", "value" => "rufus-scrimgeour" }])
       end
     end
-    context 'The allowed values are in the search results' do
+    context "The allowed values are in the search results" do
       let(:hash_under_test) {
         {
           "filterable": true,
@@ -276,7 +276,7 @@ describe FacetsBuilder do
       let(:search_results) {
         topical_events_search_results.deep_stringify_keys
       }
-      it 'gets the allowed values from the search results' do
+      it "gets the allowed values from the search results" do
         expect(facet.allowed_values).to eq([{ "label" => "First World War Centenary", "value" => "first-world-war-centenary" },
                                             { "label" => "Farming", "value" => "farming" },
                                             { "label" => "Ebola Virus Government Response (EVGR)", "value" => "ebola-virus-government-response" }])

--- a/spec/lib/filters/official_documents_filter_spec.rb
+++ b/spec/lib/filters/official_documents_filter_spec.rb
@@ -8,10 +8,10 @@ describe Filters::OfficialDocumentsFilter do
     Filters::OfficialDocumentsHashes.new.call
   }
 
-  let(:facet) { { 'key' => 'content_store_document_type' } }
+  let(:facet) { { "key" => "content_store_document_type" } }
 
-  describe '#filter_hashes' do
-    it 'returns valid official_documents filter hashes' do
+  describe "#filter_hashes" do
+    it "returns valid official_documents filter hashes" do
       expect(filter.filter_hashes).to eq(hashes)
     end
   end

--- a/spec/lib/filters/radio_filter_for_multiple_fields_spec.rb
+++ b/spec/lib/filters/radio_filter_for_multiple_fields_spec.rb
@@ -6,57 +6,57 @@ describe Filters::RadioFilterForMultipleFields do
     def filter_hashes
       [
         {
-          'value' => 'value_1',
-          'label' => 'label_1',
-          'filter' => {
-            'field' => 'value_1',
+          "value" => "value_1",
+          "label" => "label_1",
+          "filter" => {
+            "field" => "value_1",
           }
         },
         {
-          'value' => 'default_value',
-          'label' => 'default_label',
-          'filter' => {
-            'field' => 'default_value'
+          "value" => "default_value",
+          "label" => "default_label",
+          "filter" => {
+            "field" => "default_value"
           },
-          'default' => true
+          "default" => true
         }
       ]
     end
   end
 
-  let(:facet) { { 'key' => 'content_store_document_type' } }
+  let(:facet) { { "key" => "content_store_document_type" } }
 
-  describe '#query_hash' do
+  describe "#query_hash" do
     let(:filter) { TestFilter.new(facet, params_value) }
     let(:invalid_filter) { InvalidFilter.new(facet, "params_value") }
 
-    context 'no filter hashes are given' do
-      it 'throws and error' do
+    context "no filter hashes are given" do
+      it "throws and error" do
         expect { invalid_filter.query_hash }.to raise_error(NotImplementedError)
       end
     end
 
-    context 'empty parameter' do
+    context "empty parameter" do
       let(:params_value) { nil }
 
-      it 'returns the default query hash' do
-        expect(filter.query_hash).to eq('field' => 'default_value')
+      it "returns the default query hash" do
+        expect(filter.query_hash).to eq("field" => "default_value")
       end
     end
 
-    context 'invalid parameter' do
+    context "invalid parameter" do
       let(:params_value) { "I'm not valid" }
 
-      it 'returns the default query hash' do
-        expect(filter.query_hash).to eq('field' => 'default_value')
+      it "returns the default query hash" do
+        expect(filter.query_hash).to eq("field" => "default_value")
       end
     end
 
-    context 'valid parameter' do
+    context "valid parameter" do
       let(:params_value) { "value_1" }
 
-      it 'returns valid query hash' do
-        expect(filter.query_hash).to eq('field' => 'value_1')
+      it "returns valid query hash" do
+        expect(filter.query_hash).to eq("field" => "value_1")
       end
     end
   end

--- a/spec/lib/filters/radio_filter_spec.rb
+++ b/spec/lib/filters/radio_filter_spec.rb
@@ -5,7 +5,7 @@ describe Filters::RadioFilter do
     Filters::RadioFilter.new(facet, params)
   }
 
-  let(:facet) { { "allowed_values" => allowed_values, 'key' => 'radio_key' } }
+  let(:facet) { { "allowed_values" => allowed_values, "key" => "radio_key" } }
   let(:params) { nil }
   let(:default_value) { %w(policy_papers) }
   let(:option_lookup) {
@@ -99,13 +99,13 @@ describe Filters::RadioFilter do
         let(:params) { "open_consultations" }
 
         it "should return the option as an array" do
-          expect(radio_filter.query_hash).to eq('radio_key' => %w(open_consultations))
+          expect(radio_filter.query_hash).to eq("radio_key" => %w(open_consultations))
         end
       end
 
       context "when no option is provided and a default value is set" do
         it "should return the default value" do
-          expect(radio_filter.query_hash).to eq('radio_key' => default_value)
+          expect(radio_filter.query_hash).to eq("radio_key" => default_value)
         end
       end
 
@@ -113,7 +113,7 @@ describe Filters::RadioFilter do
         let(:params) { [] }
 
         it "should return the default value" do
-          expect(radio_filter.query_hash).to eq('radio_key' => default_value)
+          expect(radio_filter.query_hash).to eq("radio_key" => default_value)
         end
       end
 
@@ -122,14 +122,14 @@ describe Filters::RadioFilter do
 
         context "a default option is set" do
           it "should return the default value" do
-            expect(radio_filter.query_hash).to eq('radio_key' => default_value)
+            expect(radio_filter.query_hash).to eq("radio_key" => default_value)
           end
         end
 
         context "a default option is NOT provided" do
           let(:allowed_values) { [] }
           it "should return an empty array" do
-            expect(radio_filter.query_hash).to eq('radio_key' => [])
+            expect(radio_filter.query_hash).to eq("radio_key" => [])
           end
         end
       end
@@ -146,7 +146,7 @@ describe Filters::RadioFilter do
 
       context "when no option is selected" do
         it "should return the corresponding default values from the option_lookup" do
-          expect(radio_filter.query_hash).to eq('radio_key' => %w(guidance))
+          expect(radio_filter.query_hash).to eq("radio_key" => %w(guidance))
         end
       end
 
@@ -155,7 +155,7 @@ describe Filters::RadioFilter do
 
         context "when a default value is set" do
           it "should return the corresponding default values from the option_lookup" do
-            expect(radio_filter.query_hash).to eq('radio_key' => %w(guidance))
+            expect(radio_filter.query_hash).to eq("radio_key" => %w(guidance))
           end
         end
 
@@ -163,7 +163,7 @@ describe Filters::RadioFilter do
           let(:allowed_values) { [] }
 
           it "should return an empty array" do
-            expect(radio_filter.query_hash).to eq('radio_key' => [])
+            expect(radio_filter.query_hash).to eq("radio_key" => [])
           end
         end
       end
@@ -171,7 +171,7 @@ describe Filters::RadioFilter do
       context "when an allowed option is selected" do
         let(:params) { "open_consultations" }
         it "should return the corresponding values from the option_lookup" do
-          expect(radio_filter.query_hash).to eq('radio_key' => %w(open closed))
+          expect(radio_filter.query_hash).to eq("radio_key" => %w(open closed))
         end
       end
     end

--- a/spec/lib/filters/research_and_statistics_filter_spec.rb
+++ b/spec/lib/filters/research_and_statistics_filter_spec.rb
@@ -8,10 +8,10 @@ describe Filters::ResearchAndStatisticsFilter do
     Filters::ResearchAndStatsHashes.new.call
   }
 
-  let(:facet) { { 'key' => 'content_store_document_type' } }
+  let(:facet) { { "key" => "content_store_document_type" } }
 
-  describe '#filter_hashes' do
-    it 'returns valid reearch and stats filter hashes' do
+  describe "#filter_hashes" do
+    it "returns valid reearch and stats filter hashes" do
       expect(filter.filter_hashes).to eq(hashes)
     end
   end

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 require "gds_api/test_helpers/worldwide"
 
 RSpec.describe Healthchecks::RegistriesCache do

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 require "gds_api/test_helpers/worldwide"
 
 RSpec.describe Registries::BaseRegistries do
@@ -18,20 +18,20 @@ RSpec.describe Registries::BaseRegistries do
   }
 
   it "fetches all registries" do
-    expect(subject.all).to have_key('manual')
-    expect(subject.all).to have_key('full_topic_taxonomy')
-    expect(subject.all).to have_key('world_locations')
-    expect(subject.all).to have_key('part_of_taxonomy_tree')
-    expect(subject.all).to have_key('organisations')
-    expect(subject.all).to have_key('people')
+    expect(subject.all).to have_key("manual")
+    expect(subject.all).to have_key("full_topic_taxonomy")
+    expect(subject.all).to have_key("world_locations")
+    expect(subject.all).to have_key("part_of_taxonomy_tree")
+    expect(subject.all).to have_key("organisations")
+    expect(subject.all).to have_key("people")
   end
 
   it "provides world_locations registry" do
-    expect(subject.all['world_locations']).to be_instance_of Registries::WorldLocationsRegistry
+    expect(subject.all["world_locations"]).to be_instance_of Registries::WorldLocationsRegistry
   end
 
   it "provides topic_taxonomy registry as part_of_taxonomy_tree" do
-    expect(subject.all['part_of_taxonomy_tree']).to be_instance_of Registries::TopicTaxonomyRegistry
+    expect(subject.all["part_of_taxonomy_tree"]).to be_instance_of Registries::TopicTaxonomyRegistry
   end
 
   describe "#refresh_cache" do

--- a/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/full_topic_taxonomy_registry_spec.rb
@@ -1,5 +1,5 @@
 require "securerandom"
-require 'spec_helper'
+require "spec_helper"
 require "registries/base_registries"
 
 RSpec.describe Registries::FullTopicTaxonomyRegistry do
@@ -44,12 +44,12 @@ RSpec.describe Registries::FullTopicTaxonomyRegistry do
 
     it "can look up a child taxon by basepath" do
       fetched_document = registry[child_content_id]
-      expect(fetched_document['base_path']).to eq(child_base_path)
+      expect(fetched_document["base_path"]).to eq(child_base_path)
     end
 
     it "can look up a level one taxon by basepath" do
       fetched_document = registry[first_level_content_id]
-      expect(fetched_document['base_path']).to eq(first_level_base_path)
+      expect(fetched_document["base_path"]).to eq(first_level_base_path)
     end
   end
 

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Registries::ManualsRegistry do
-  let(:slug) { '/guidance/care-and-use-of-a-nimbus-2000' }
+  let(:slug) { "/guidance/care-and-use-of-a-nimbus-2000" }
   let(:rummager_params) {
     {
       filter_document_type: %w(manual service_manual_homepage service_manual_guide),
@@ -20,13 +20,13 @@ RSpec.describe Registries::ManualsRegistry do
     it "will fetch manual information by slug" do
       manual = described_class.new
       expect(manual[slug]).to eq(
-        'title' => 'Care and use of a Nimbus 2000',
-        'slug' => slug
+        "title" => "Care and use of a Nimbus 2000",
+        "slug" => slug
       )
       expect(manual.values).to eq(
         slug => {
-              'title' => 'Care and use of a Nimbus 2000',
-              'slug' => slug
+              "title" => "Care and use of a Nimbus 2000",
+              "slug" => slug
            }
        )
     end
@@ -37,16 +37,16 @@ RSpec.describe Registries::ManualsRegistry do
     end
   end
 
-  describe 'there is no id or title' do
-    it 'will remove those results' do
+  describe "there is no id or title" do
+    it "will remove those results" do
       stub_request(:get, rummager_url).to_return(
         body: {
           "results": [
             {
-              'title' => '',
-              'index' => 'govuk',
-              'es_score' => nil,
-              '_id' => ''
+              "title" => "",
+              "index" => "govuk",
+              "es_score" => nil,
+              "_id" => ""
             }
           ]
         }

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Registries::OrganisationsRegistry do
   include RegistrySpecHelper
 
-  let(:slug) { 'ministry-of-magic' }
+  let(:slug) { "ministry-of-magic" }
   let(:rummager_params) {
     {
       "count" => 1500,
       "fields" => %w(slug title acronym content_id),
       "filter_format" => "organisation",
-      "order" => 'title',
+      "order" => "title",
     }
   }
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -23,10 +23,10 @@ RSpec.describe Registries::OrganisationsRegistry do
     it "will fetch organisation information by slug" do
       organisation = described_class.new[slug]
       expect(organisation).to eq(
-        'title' => 'Ministry of Magic',
-        'acronym' => 'MOM',
-        'slug' => slug,
-        'content_id' => 'content_id_for_ministry-of-magic'
+        "title" => "Ministry of Magic",
+        "acronym" => "MOM",
+        "slug" => slug,
+        "content_id" => "content_id_for_ministry-of-magic"
       )
     end
 

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Registries::PeopleRegistry do
-  let(:slug) { 'cornelius-fudge' }
+  let(:slug) { "cornelius-fudge" }
   let(:rummager_params) {
     {
       count: 0,
-      facet_people: '1500,examples:0,order:value.title'
+      facet_people: "1500,examples:0,order:value.title"
     }
   }
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -19,8 +19,8 @@ RSpec.describe Registries::PeopleRegistry do
     it "will fetch person information by slug" do
       person = described_class.new[slug]
       expect(person).to eq(
-        'title' => 'Cornelius Fudge',
-        'slug' => slug
+        "title" => "Cornelius Fudge",
+        "slug" => slug
       )
     end
 
@@ -32,8 +32,8 @@ RSpec.describe Registries::PeopleRegistry do
     end
   end
 
-  describe 'there is no slug or title' do
-    it 'will remove those results' do
+  describe "there is no slug or title" do
+    it "will remove those results" do
       stub_request(:get, rummager_url).to_return(
         body: {
           "facets": {

--- a/spec/lib/registries/registry_spec.rb
+++ b/spec/lib/registries/registry_spec.rb
@@ -1,10 +1,10 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Registries::Registry do
   subject(:registry) { described_class.new }
 
-  describe '#can_refresh_cache?' do
-    it 'returns false' do
+  describe "#can_refresh_cache?" do
+    it "returns false" do
       expect(registry.can_refresh_cache?).to be false
     end
   end

--- a/spec/lib/registries/topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/topic_taxonomy_registry_spec.rb
@@ -1,5 +1,5 @@
 require "securerandom"
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Registries::TopicTaxonomyRegistry do
   include TaxonomySpecHelper
@@ -35,12 +35,12 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
 
     it "will fetch an expanded topic taxon by content_id" do
       fetched_document = registry[content_id_one]
-      expect(fetched_document['content_id']).to eq(content_id_one)
-      expect(fetched_document['title']).to eq(top_level_taxon_one['title'])
+      expect(fetched_document["content_id"]).to eq(content_id_one)
+      expect(fetched_document["title"]).to eq(top_level_taxon_one["title"])
 
       fetched_document = registry[content_id_two]
-      expect(fetched_document['content_id']).to eq(content_id_two)
-      expect(fetched_document['title']).to eq(top_level_taxon_two['title'])
+      expect(fetched_document["content_id"]).to eq(content_id_two)
+      expect(fetched_document["title"]).to eq(top_level_taxon_two["title"])
     end
   end
 end

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -1,11 +1,11 @@
 require "securerandom"
-require 'spec_helper'
+require "spec_helper"
 require "gds_api/test_helpers/worldwide"
 
 RSpec.describe Registries::WorldLocationsRegistry do
   include GdsApi::TestHelpers::Worldwide
 
-  let(:slug) { 'privet-drive' }
+  let(:slug) { "privet-drive" }
 
   describe "when world locations api is available" do
     before do
@@ -20,9 +20,9 @@ RSpec.describe Registries::WorldLocationsRegistry do
     it "will fetch an expanded world location by slug" do
       fetched_document = registry[slug]
       expect(fetched_document).to eq(
-        'title' => 'Privet Drive',
-        'slug' => slug,
-        'content_id' => 'content_id_for_privet-drive'
+        "title" => "Privet Drive",
+        "slug" => slug,
+        "content_id" => "content_id_for_privet-drive"
       )
     end
 

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -20,20 +20,20 @@ describe Search::Query do
   let(:facets) {
     [
       {
-        'key' => "alpha",
-        'filterable' => true,
-        'type' => "text"
+        "key" => "alpha",
+        "filterable" => true,
+        "type" => "text"
       },
       {
-        'key' => "beta",
-        'filterable' => true,
-        'type' => "text",
-        'combine_mode' => "or"
+        "key" => "beta",
+        "filterable" => true,
+        "type" => "text",
+        "combine_mode" => "or"
       },
     ]
   }
-  let(:filter_params) { { 'alpha' => 'foo' } }
-  let(:batch_search_filter_params) { { 'alpha' => 'foo', 'beta' => 'bar' } }
+  let(:filter_params) { { "alpha" => "foo" } }
+  let(:batch_search_filter_params) { { "alpha" => "foo", "beta" => "bar" } }
 
   def result_item(id, title, score:, popularity:, updated:)
     {
@@ -67,9 +67,9 @@ describe Search::Query do
   end
 
   context "when merging, de-duplicating and sorting" do
-    shared_examples 'sorts by other fields' do
-      context 'most-recent' do
-        subject { described_class.new(content_item, batch_search_filter_params.merge('order' => 'most-recent')).search_results }
+    shared_examples "sorts by other fields" do
+      context "most-recent" do
+        subject { described_class.new(content_item, batch_search_filter_params.merge("order" => "most-recent")).search_results }
 
         it "de-duplicates and sorts by public_updated descending" do
           results = subject.fetch("results")
@@ -78,8 +78,8 @@ describe Search::Query do
         end
       end
 
-      context 'most-viewed' do
-        subject { described_class.new(content_item, batch_search_filter_params.merge('order' => 'most-viewed')).search_results }
+      context "most-viewed" do
+        subject { described_class.new(content_item, batch_search_filter_params.merge("order" => "most-viewed")).search_results }
 
         it "de-duplicates and sorts by popularity descending" do
           results = subject.fetch("results")
@@ -88,8 +88,8 @@ describe Search::Query do
         end
       end
 
-      context 'a-to-z' do
-        subject { described_class.new(content_item, batch_search_filter_params.merge('order' => 'a-to-z')).search_results }
+      context "a-to-z" do
+        subject { described_class.new(content_item, batch_search_filter_params.merge("order" => "a-to-z")).search_results }
 
         it "de-duplicates and sorts by title descending" do
           results = subject.fetch("results")
@@ -99,7 +99,7 @@ describe Search::Query do
       end
     end
 
-    context 'when keywords are not used' do #Rummager returns nil for es_score
+    context "when keywords are not used" do #Rummager returns nil for es_score
       before do
         stub_batch_search.to_return(body:
           {
@@ -119,9 +119,9 @@ describe Search::Query do
           }.to_json)
       end
 
-      it_behaves_like 'sorts by other fields'
+      it_behaves_like "sorts by other fields"
 
-      context 'default' do
+      context "default" do
         subject { described_class.new(content_item, batch_search_filter_params).search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
@@ -131,8 +131,8 @@ describe Search::Query do
         end
       end
 
-      context 'most-relevant' do
-        subject { described_class.new(content_item, batch_search_filter_params.merge('order' => 'most-relevant')).search_results }
+      context "most-relevant" do
+        subject { described_class.new(content_item, batch_search_filter_params.merge("order" => "most-relevant")).search_results }
 
         it "de-duplicates and returns in the order rummager returns" do
           results = subject.fetch("results")
@@ -142,7 +142,7 @@ describe Search::Query do
       end
     end
 
-    context 'when keywords exist in search' do
+    context "when keywords exist in search" do
       before do
         stub_batch_search.to_return(body:
         {
@@ -162,9 +162,9 @@ describe Search::Query do
        }.to_json)
       end
 
-      it_behaves_like 'sorts by other fields'
+      it_behaves_like "sorts by other fields"
 
-      context 'default' do
+      context "default" do
         subject { described_class.new(content_item, batch_search_filter_params).search_results }
 
         it "de-duplicates and sorts by es_score descending" do
@@ -174,8 +174,8 @@ describe Search::Query do
         end
       end
 
-      context 'most-relevant' do
-        subject { described_class.new(content_item, batch_search_filter_params.merge('order' => 'most-relevant')).search_results }
+      context "most-relevant" do
+        subject { described_class.new(content_item, batch_search_filter_params.merge("order" => "most-relevant")).search_results }
 
         it "de-duplicates and sorts by es_score descending" do
           results = subject.fetch("results")

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -12,13 +12,13 @@ describe Search::QueryBuilder do
 
   let(:finder_content_item) {
     ContentItem.new(
-      'base_path' => '/finder-path',
-      'details' => {
-        'facets' => facets,
-        'filter' => filter,
-        'reject' => reject,
-        'default_order' => default_order,
-        'default_documents_per_page' => nil,
+      "base_path" => "/finder-path",
+      "details" => {
+        "facets" => facets,
+        "filter" => filter,
+        "reject" => reject,
+        "default_order" => default_order,
+        "default_documents_per_page" => nil,
       }
 )
   }
@@ -37,12 +37,12 @@ describe Search::QueryBuilder do
   context "with pagination" do
     let(:finder_content_item) {
       ContentItem.new(
-        'details' => {
-          'facets' => facets,
-          'filter' => filter,
-          'reject' => reject,
-          'default_order' => default_order,
-          'default_documents_per_page' => 10
+        "details" => {
+          "facets" => facets,
+          "filter" => filter,
+          "reject" => reject,
+          "default_order" => default_order,
+          "default_documents_per_page" => 10
         }
 )
     }
@@ -67,12 +67,12 @@ describe Search::QueryBuilder do
     let(:facets) {
       [
         {
-          'key' => "alpha",
-          'filterable' => false,
+          "key" => "alpha",
+          "filterable" => false,
         },
         {
-          'key' => "beta",
-          'filterable' => false,
+          "key" => "beta",
+          "filterable" => false,
         },
       ]
     }
@@ -174,18 +174,18 @@ describe Search::QueryBuilder do
         }
       end
 
-      context 'with `and` combine_mode' do
-        it 'adds a `filter_facet_values` filter with the content_id' do
+      context "with `and` combine_mode" do
+        it "adds a `filter_facet_values` filter with the content_id" do
           expect(query["filter_any_facet_values"]).to eq(%w[yes-cont-id copyright-cont-id patents-cont-id])
         end
       end
 
-      context 'with `or` combine_mode' do
+      context "with `or` combine_mode" do
         before do
-          facets.second["combine_mode"] = 'or'
+          facets.second["combine_mode"] = "or"
         end
 
-        it 'sends the correct `filter_any_facet_values` to each query' do
+        it "sends the correct `filter_any_facet_values` to each query" do
           expect(queries.first["filter_any_facet_values"]).to eq(%w[yes-cont-id])
           expect(queries.second["filter_any_facet_values"]).to eq(%w[copyright-cont-id patents-cont-id])
         end
@@ -253,13 +253,13 @@ describe Search::QueryBuilder do
     context "with stopwords" do
       let(:finder_content_item) {
         ContentItem.new(
-          'base_path' => '/find-eu-exit-guidance-business',
-          'details' => {
-            'facets' => facets,
-            'filter' => filter,
-            'reject' => reject,
-            'default_order' => default_order,
-            'default_documents_per_page' => 10
+          "base_path" => "/find-eu-exit-guidance-business",
+          "details" => {
+            "facets" => facets,
+            "filter" => filter,
+            "reject" => reject,
+            "default_order" => default_order,
+            "default_documents_per_page" => 10
           }
 )
       }
@@ -342,8 +342,8 @@ describe Search::QueryBuilder do
   context "with A/B parameters" do
     let(:ab_params) {
       {
-        test_one: 'a',
-        test_two: 'b',
+        test_one: "a",
+        test_two: "b",
       }
     }
 
@@ -365,35 +365,35 @@ describe Search::QueryBuilder do
     end
   end
 
-  describe '#start' do
-    it 'starts at zero by default' do
+  describe "#start" do
+    it "starts at zero by default" do
       query = query_with_params({})
 
-      expect(query['start']).to eql(0)
+      expect(query["start"]).to eql(0)
     end
 
-    it 'starts at zero when page param is zero' do
+    it "starts at zero when page param is zero" do
       query = query_with_params("page" => 0)
 
-      expect(query['start']).to eql(0)
+      expect(query["start"]).to eql(0)
     end
 
-    it 'starts at zero when page param is nil' do
+    it "starts at zero when page param is nil" do
       query = query_with_params("page" => nil)
 
-      expect(query['start']).to eql(0)
+      expect(query["start"]).to eql(0)
     end
 
-    it 'starts at zero when page param is empty' do
+    it "starts at zero when page param is empty" do
       query = query_with_params("page" => "")
 
-      expect(query['start']).to eql(0)
+      expect(query["start"]).to eql(0)
     end
 
-    it 'is paginated' do
+    it "is paginated" do
       query = query_with_params("page" => "10")
 
-      expect(query['start']).to eql(13500)
+      expect(query["start"]).to eql(13500)
     end
 
     def query_with_params(params)

--- a/spec/lib/services/email_alert_api_spec.rb
+++ b/spec/lib/services/email_alert_api_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require 'gds_api/test_helpers/email_alert_api'
+require "spec_helper"
+require "gds_api/test_helpers/email_alert_api"
 
 describe Services::EmailAlertApi do
   include GdsApi::TestHelpers::EmailAlertApi
@@ -27,12 +27,12 @@ describe Services::EmailAlertApi do
       end
 
       it "returns a subscriber list if one exists" do
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
       end
 
       it "returns a cached subscriber list on subsequent requests" do
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
         expect(@stub).to have_been_requested.times(1)
       end
     end
@@ -44,12 +44,12 @@ describe Services::EmailAlertApi do
       end
 
       it "returns a newly created subscriber list" do
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
       end
 
       it "caches the subscriber list once created" do
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
-        expect(subject.dig('subscriber_list', 'slug')).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
+        expect(subject.dig("subscriber_list", "slug")).to eq(subscriber_list_slug)
         expect(@not_found_stub).to have_been_requested.times(1)
         expect(@creation_stub).to have_been_requested.times(1)
       end

--- a/spec/lib/url_builder_spec.rb
+++ b/spec/lib/url_builder_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe UrlBuilder do
   let(:builder) { described_class.new(path, query_params) }
   let(:extra_params) { {} }
-  let(:path) { '/search/all' }
+  let(:path) { "/search/all" }
 
   describe "#url_builder" do
     context "when given a path and query params" do
@@ -11,8 +11,8 @@ describe UrlBuilder do
 
       let(:query_params) {
         {
-          keywords: 'harry potter',
-          order: 'relevance',
+          keywords: "harry potter",
+          order: "relevance",
           public_timestamp: {
             from: 2005,
             to: 2015,
@@ -25,16 +25,16 @@ describe UrlBuilder do
       }
 
       it "builds a url with a query" do
-        expect(url).to eq('/search/all?' + query_params.to_query)
+        expect(url).to eq("/search/all?" + query_params.to_query)
       end
     end
 
     context "when given a path, query params, and additional params" do
       subject(:url) { builder.url(page: 20) }
-      let(:query_params) { { keywords: 'dumbledore' } }
+      let(:query_params) { { keywords: "dumbledore" } }
 
       it "builds a url that includes the additional params" do
-        expect(url).to eq('/search/all?keywords=dumbledore&page=20')
+        expect(url).to eq("/search/all?keywords=dumbledore&page=20")
       end
     end
   end

--- a/spec/models/checkbox_facet_spec.rb
+++ b/spec/models/checkbox_facet_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 describe CheckboxFacet do
   let(:facet_data) {
     {
-      'type' => "checkbox",
-      'filter_value' => 'selectedvalue',
-      'key' => "show_extra_information",
-      'name' => "Show extra information",
-      'short_name' => "Show more",
-      'value' => "yes",
-      'preposition' => "of value",
+      "type" => "checkbox",
+      "filter_value" => "selectedvalue",
+      "key" => "show_extra_information",
+      "name" => "Show extra information",
+      "short_name" => "Show more",
+      "value" => "yes",
+      "preposition" => "of value",
     }
   }
 
@@ -18,9 +18,9 @@ describe CheckboxFacet do
       subject { CheckboxFacet.new(facet_data, "yes") }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Show more")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("show_extra_information")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Show more")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("show_extra_information")
       }
     end
 
@@ -29,9 +29,9 @@ describe CheckboxFacet do
         subject { CheckboxFacet.new(facet_data, true) }
 
         specify {
-          expect(subject.sentence_fragment['preposition']).to eql("of value")
-          expect(subject.sentence_fragment['values'].count).to eql 1
-          expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("show_extra_information")
+          expect(subject.sentence_fragment["preposition"]).to eql("of value")
+          expect(subject.sentence_fragment["values"].count).to eql 1
+          expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("show_extra_information")
         }
       end
 

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -31,7 +31,7 @@ describe ContentItem do
 
     context "when document_type is search" do
       it "returns true when document_type is search" do
-        finder_content_item.merge!("document_type" => 'search')
+        finder_content_item.merge!("document_type" => "search")
         expect(subject.is_search?).to be true
       end
     end
@@ -44,7 +44,7 @@ describe ContentItem do
 
     context "when document_type is not a finder" do
       it "returns false when document_type is finder" do
-        finder_content_item.merge!("document_type" => 'search')
+        finder_content_item.merge!("document_type" => "search")
         expect(subject.is_finder?).to be false
       end
     end
@@ -57,7 +57,7 @@ describe ContentItem do
 
     context "when document_type is redirect" do
       it "returns true when document_type is redirect" do
-        finder_content_item.merge!("document_type" => 'redirect')
+        finder_content_item.merge!("document_type" => "redirect")
         expect(subject.is_redirect?).to be true
       end
     end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe DateFacet do
   let(:facet_data) {
     {
-      'type' => "date",
-      'name' => "Occurred",
-      'key' => "date_of_occurrence",
-      'preposition' => "occurred",
+      "type" => "date",
+      "name" => "Occurred",
+      "key" => "date_of_occurrence",
+      "preposition" => "occurred",
     }
   }
 
@@ -16,9 +16,9 @@ describe DateFacet do
       subject { DateFacet.new(facet_data, value) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("occurred after")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 1988")
-        expect(subject.sentence_fragment['key']).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment["preposition"]).to eql("occurred after")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("22 September 1988")
+        expect(subject.sentence_fragment["key"]).to eql("date_of_occurrence")
       }
     end
 
@@ -27,9 +27,9 @@ describe DateFacet do
       subject { DateFacet.new(facet_data, value) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("occurred before")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 2014")
-        expect(subject.sentence_fragment['key']).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment["preposition"]).to eql("occurred before")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("22 September 2014")
+        expect(subject.sentence_fragment["key"]).to eql("date_of_occurrence")
       }
     end
 
@@ -43,10 +43,10 @@ describe DateFacet do
       subject { DateFacet.new(facet_data, value) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("occurred between")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("22 September 1988")
-        expect(subject.sentence_fragment['values'].last['label']).to eql("22 September 2014")
-        expect(subject.sentence_fragment['key']).to eql("date_of_occurrence")
+        expect(subject.sentence_fragment["preposition"]).to eql("occurred between")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("22 September 1988")
+        expect(subject.sentence_fragment["values"].last["label"]).to eql("22 September 2014")
+        expect(subject.sentence_fragment["key"]).to eql("date_of_occurrence")
       }
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -26,15 +26,15 @@ describe Document do
   end
 
   describe "initialization" do
-    it 'defaults to nil without a public timestamp' do
-      document_hash = FactoryBot.build(:document_hash).except('public_timestamp')
+    it "defaults to nil without a public timestamp" do
+      document_hash = FactoryBot.build(:document_hash).except("public_timestamp")
       document = described_class.new(document_hash, finder, 0)
 
       expect(document.public_timestamp).to be_nil
     end
 
-    it 'returns a link as a path' do
-      document_hash = FactoryBot.build(:document_hash, link: 'https://link.com/mature-cheeses')
+    it "returns a link as a path" do
+      document_hash = FactoryBot.build(:document_hash, link: "https://link.com/mature-cheeses")
       document = described_class.new(document_hash, finder, 0)
 
       expect(document.path).to eq("https://link.com/mature-cheeses")
@@ -49,7 +49,7 @@ describe Document do
       let(:document_hash) {
         FactoryBot.build(:document_hash, a_filter_key: "2019")
       }
-      it 'gets the metadata' do
+      it "gets the metadata" do
         expected_hash =
           {
             name: "A filter key",
@@ -59,35 +59,35 @@ describe Document do
         expect(Document.new(document_hash, finder, 1).metadata).to eq([expected_hash])
       end
     end
-    context 'There is one facet with type text' do
+    context "There is one facet with type text" do
       let(:facets) {
-        [FactoryBot.build(:option_select_facet, key: 'a_filter_key')]
+        [FactoryBot.build(:option_select_facet, key: "a_filter_key")]
       }
-      describe 'The document is tagged to a single value of the facet filter key' do
+      describe "The document is tagged to a single value of the facet filter key" do
         let(:document_hash) {
           FactoryBot.build(:document_hash, a_filter_key: "metadata_label")
         }
-        it 'gets metadata for a simple text value' do
+        it "gets metadata for a simple text value" do
           expected_hash =
             {
-              id: 'a_filter_key',
-              name: 'A filter key',
+              id: "a_filter_key",
+              name: "A filter key",
               value:  "metadata_label",
               labels: %w[metadata_label],
               type: "text",
             }
           expect(Document.new(document_hash, finder, 1).metadata).to eq([expected_hash])
         end
-        describe 'There is a short name in the facet' do
+        describe "There is a short name in the facet" do
           let(:facets) {
-            [FactoryBot.build(:option_select_facet, short_name: 'short name')]
+            [FactoryBot.build(:option_select_facet, short_name: "short name")]
           }
-          it 'replaces the name field in the metafata by the short name from the facet' do
-            expect(Document.new(document_hash, finder, 1).metadata).to match([include(name: 'short name')])
+          it "replaces the name field in the metafata by the short name from the facet" do
+            expect(Document.new(document_hash, finder, 1).metadata).to match([include(name: "short name")])
           end
         end
       end
-      describe 'The document is tagged to a multiple values of the facet filter key' do
+      describe "The document is tagged to a multiple values of the facet filter key" do
         let(:document_hash) {
           FactoryBot.build(:document_hash,
                            a_filter_key:
@@ -97,11 +97,11 @@ describe Document do
                                { "label" => "metadata_label_3" }
                              ])
         }
-        it 'gets the metadata' do
+        it "gets the metadata" do
           expected_hash =
             {
-              id: 'a_filter_key',
-              name: 'A filter key',
+              id: "a_filter_key",
+              name: "A filter key",
               value:  "metadata_label_1 and 2 others",
               labels: %w[metadata_label_1 metadata_label_2 metadata_label_3],
               type: "text",
@@ -110,31 +110,31 @@ describe Document do
         end
       end
     end
-    describe 'The facet key is an organisation or a document collection' do
+    describe "The facet key is an organisation or a document collection" do
       let(:facets) {
-        [FactoryBot.build(:option_select_facet, key: 'organisations'),
-         FactoryBot.build(:option_select_facet, key: 'document_collections')]
+        [FactoryBot.build(:option_select_facet, key: "organisations"),
+         FactoryBot.build(:option_select_facet, key: "document_collections")]
       }
       let(:document_hash) {
         FactoryBot.build(:document_hash,
                          organisations: [{ "title" => "org_title" }],
                          document_collections: [{ "title" => "dc_title" }])
       }
-      it 'uses title instead of label' do
+      it "uses title instead of label" do
         expect(Document.new(document_hash, finder, 1).metadata).
-          to match_array([include(value: 'org_title'), include(value: 'dc_title')])
+          to match_array([include(value: "org_title"), include(value: "dc_title")])
       end
     end
-    describe 'the facet key is an organisation and the document is a mainstream document' do
+    describe "the facet key is an organisation and the document is a mainstream document" do
       let(:facets) {
-        [FactoryBot.build(:option_select_facet, key: 'organisations')]
+        [FactoryBot.build(:option_select_facet, key: "organisations")]
       }
       let(:document_hash) {
         FactoryBot.build(:document_hash,
                          organisations: [{ "title" => "org_title" }],
-                         content_store_document_type: 'answer')
+                         content_store_document_type: "answer")
       }
-      it 'does not display metadata because we are not interested in who publishes a mainstream document' do
+      it "does not display metadata because we are not interested in who publishes a mainstream document" do
         expect(Document.new(document_hash, finder, 1).metadata).to be_empty
       end
     end
@@ -148,19 +148,19 @@ describe Document do
     end
   end
 
-  describe '#truncated_description' do
-    describe 'shows the truncated (first sentence) description when a description is present' do
+  describe "#truncated_description" do
+    describe "shows the truncated (first sentence) description when a description is present" do
       description = "The government has many departments. These departments are part of the government."
       truncated_description = "The government has many departments."
 
       let(:with_description_hash) { FactoryBot.build(:document_hash, description: description) }
       let(:without_description) { FactoryBot.build(:document_hash, description: nil) }
 
-      it 'should have truncated description' do
+      it "should have truncated description" do
         expect(Document.new(with_description_hash, finder, 1).truncated_description).to eq(truncated_description)
       end
 
-      it 'should not have truncated description' do
+      it "should not have truncated description" do
         expect(Document.new(without_description, finder, 1).truncated_description).to eq(nil)
       end
     end

--- a/spec/models/filterable_facet_spec.rb
+++ b/spec/models/filterable_facet_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe FilterableFacet do
   let(:facet_data) {
     {
-      'key' => "test_facet",
-      'name' => "Test facet",
-      'preposition' => "of value"
+      "key" => "test_facet",
+      "name" => "Test facet",
+      "preposition" => "of value"
     }
   }
 
@@ -24,20 +24,20 @@ describe FilterableFacet do
     end
   end
 
-  describe '#preposition' do
+  describe "#preposition" do
     let(:default_preposition) {
       facet_class.new(
-        'key' => "test_facet",
-        'name' => "Facet without preposition"
+        "key" => "test_facet",
+        "name" => "Facet without preposition"
       )
     }
 
     it "has a default preposition" do
-      expect(default_preposition.preposition).to eq('related to')
+      expect(default_preposition.preposition).to eq("related to")
     end
 
     it "has a preposition specified in the facet content" do
-      expect(subject.preposition).to eq(facet_data['preposition'])
+      expect(subject.preposition).to eq(facet_data["preposition"])
     end
   end
 end

--- a/spec/models/hidden_clearable_facet_spec.rb
+++ b/spec/models/hidden_clearable_facet_spec.rb
@@ -1,29 +1,29 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe HiddenClearableFacet do
   let(:allowed_values) {
     [
         {
-            'label' => "Allowed value 1",
-            'value' => "allowed-value-1"
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1"
         },
         {
-            'label' => "Allowed value 2",
-            'value' => "allowed-value-2"
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2"
         },
         {
-            'label' => "Allowed value 3",
-            'value' => "allowed-value-3"
+            "label" => "Allowed value 3",
+            "value" => "allowed-value-3"
         }
     ]
   }
 
   let(:facet_data) {
     {
-      'key' => "test_facet",
-      'name' => "Test facet",
-      'preposition' => "of value",
-      'allowed_values' => allowed_values
+      "key" => "test_facet",
+      "name" => "Test facet",
+      "preposition" => "of value",
+      "allowed_values" => allowed_values
     }
   }
 
@@ -35,9 +35,9 @@ describe HiddenClearableFacet do
       subject { facet_class.new(facet_data, %w[allowed-value-1]) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_facet")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("test_facet")
       }
     end
 
@@ -45,12 +45,12 @@ describe HiddenClearableFacet do
       subject { facet_class.new(facet_data, %w[allowed-value-1 allowed-value-2]) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_facet")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("test_facet")
 
-        expect(subject.sentence_fragment['values'].last['label']).to eql("Allowed value 2")
-        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("test_facet")
+        expect(subject.sentence_fragment["values"].last["label"]).to eql("Allowed value 2")
+        expect(subject.sentence_fragment["values"].last["parameter_key"]).to eql("test_facet")
       }
     end
 

--- a/spec/models/hidden_facet_spec.rb
+++ b/spec/models/hidden_facet_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe HiddenFacet do
   let(:facet_data) {
     {
-      'key' => "test_facet",
-      'name' => "Test facet",
-      'preposition' => "of value",
-      'allowed_values' => [{ "value" => "hidden_value" }]
+      "key" => "test_facet",
+      "name" => "Test facet",
+      "preposition" => "of value",
+      "allowed_values" => [{ "value" => "hidden_value" }]
     }
   }
 
@@ -21,27 +21,27 @@ describe HiddenFacet do
 
   describe "#query_params" do
     context "value selected" do
-      it 'returns the value' do
+      it "returns the value" do
         facet = HiddenFacet.new(facet_data, "hidden_value")
         expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
       end
     end
     context "invalid value selected" do
-      it 'removes the invalid values' do
+      it "removes the invalid values" do
         facet = HiddenFacet.new(facet_data, "not_allowed_value")
         expect(facet.query_params).to eql("test_facet" => [])
       end
     end
-    context 'no allowed values specified' do
+    context "no allowed values specified" do
       let(:facet_data) {
         {
-          'key' => "test_facet",
-          'name' => "Test facet",
-          'preposition' => "of value",
-          'allowed_values' => []
+          "key" => "test_facet",
+          "name" => "Test facet",
+          "preposition" => "of value",
+          "allowed_values" => []
         }
       }
-      it 'returns the values without validation' do
+      it "returns the values without validation" do
         facet = HiddenFacet.new(facet_data, "hidden_value")
         expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
       end

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -9,35 +9,35 @@ describe KeywordFacet do
     context "keywords without quotes" do
       subject { KeywordFacet.new(query) }
 
-      let(:first_word) { subject.sentence_fragment['values'].first }
-      let(:second_word) { subject.sentence_fragment['values'].second }
+      let(:first_word) { subject.sentence_fragment["values"].first }
+      let(:second_word) { subject.sentence_fragment["values"].second }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("containing")
-        expect(first_word['parameter_key']).to eql("keywords")
-        expect(first_word['label']).to eql("Happy")
-        expect(second_word['label']).to eql("Christmas")
+        expect(subject.sentence_fragment["preposition"]).to eql("containing")
+        expect(first_word["parameter_key"]).to eql("keywords")
+        expect(first_word["label"]).to eql("Happy")
+        expect(second_word["label"]).to eql("Christmas")
 
-        expect(subject.sentence_fragment['word_connectors'][:words_connector]).to eql("")
+        expect(subject.sentence_fragment["word_connectors"][:words_connector]).to eql("")
       }
     end
 
     context "keywords with quotes" do
       subject { KeywordFacet.new(query_with_quotes) }
-      let(:labels) { subject.sentence_fragment['values'].map { |v| v['label'] } }
+      let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("containing")
+        expect(subject.sentence_fragment["preposition"]).to eql("containing")
         expect(labels).to eql(["\"Merry Christmas\""])
       }
     end
 
     context "keywords with multiple quotes" do
       subject { KeywordFacet.new(query_with_multiple_quotes) }
-      let(:labels) { subject.sentence_fragment['values'].map { |v| v['label'] } }
+      let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("containing")
+        expect(subject.sentence_fragment["preposition"]).to eql("containing")
         expect(labels).to eql(["\"Merry Christmas\"", "\" Happy Birthday\"", "i'm", "100", "today"])
       }
     end

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -4,27 +4,27 @@ describe OptionSelectFacet do
   let(:allowed_values) {
     [
       {
-        'label' => "Allowed value 1",
-        'value' => "allowed-value-1"
+        "label" => "Allowed value 1",
+        "value" => "allowed-value-1"
       },
       {
-        'label' => "Allowed value 2",
-        'value' => "allowed-value-2"
+        "label" => "Allowed value 2",
+        "value" => "allowed-value-2"
       },
       {
-        'label' => "Remittals",
-        'value' => "remittals"
+        "label" => "Remittals",
+        "value" => "remittals"
       }
     ]
   }
 
   let(:facet_data) {
     {
-      'type' => "multi-select",
-      'name' => "Test values",
-      'key' => "test_values",
-      'preposition' => "of value",
-      'allowed_values' => allowed_values,
+      "type" => "multi-select",
+      "name" => "Test values",
+      "key" => "test_values",
+      "preposition" => "of value",
+      "allowed_values" => allowed_values,
     }
   }
 
@@ -34,9 +34,9 @@ describe OptionSelectFacet do
       subject { OptionSelectFacet.new(facet_data, %w[allowed-value-1]) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_values")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("test_values")
       }
     end
 
@@ -44,12 +44,12 @@ describe OptionSelectFacet do
       subject { OptionSelectFacet.new(facet_data, %w[allowed-value-1 allowed-value-2]) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Allowed value 1")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("test_values")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("test_values")
 
-        expect(subject.sentence_fragment['values'].last['label']).to eql("Allowed value 2")
-        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("test_values")
+        expect(subject.sentence_fragment["values"].last["label"]).to eql("Allowed value 2")
+        expect(subject.sentence_fragment["values"].last["parameter_key"]).to eql("test_values")
       }
     end
 
@@ -78,15 +78,15 @@ describe OptionSelectFacet do
     context "some selected values" do
       let(:facet_data) {
         {
-          'type' => "multi-select",
-          'name' => "Test values",
-          'key' => "test_values",
-          'preposition' => "of value",
-          'allowed_values' => [{ 'label' => 'One', 'value' => '1' }],
+          "type" => "multi-select",
+          "name" => "Test values",
+          "key" => "test_values",
+          "preposition" => "of value",
+          "allowed_values" => [{ "label" => "One", "value" => "1" }],
         }
       }
 
-      subject { OptionSelectFacet.new(facet_data, '1') }
+      subject { OptionSelectFacet.new(facet_data, "1") }
 
       specify do
         expect(subject.unselected?).to be false

--- a/spec/models/radio_facet_for_multiple_filters_spec.rb
+++ b/spec/models/radio_facet_for_multiple_filters_spec.rb
@@ -3,71 +3,71 @@ require "spec_helper"
 describe RadioFacetForMultipleFilters do
   let(:facet_data) {
     {
-      'type' => "radio_facet",
-      'key' => "type",
-      'value' => "selected_value",
+      "type" => "radio_facet",
+      "key" => "type",
+      "value" => "selected_value",
       "allowed_values" => [{ "value" => "selected_value" }],
-      'filterable' => true
+      "filterable" => true
     }
   }
 
   let(:filter_hashes) {
     [
       {
-        'value' => 'value_1',
-        'label' => 'label_1',
-        'filter' => {
-          'field' => "value_1",
+        "value" => "value_1",
+        "label" => "label_1",
+        "filter" => {
+          "field" => "value_1",
         }
       },
       {
-        'value' => 'value_2',
-        'label' => 'label_2',
-        'filter' => {
-          'field' => "value_2"
+        "value" => "value_2",
+        "label" => "label_2",
+        "filter" => {
+          "field" => "value_2"
         }
       },
       {
-        'value' => 'default_value',
-        'label' => 'default_label',
-        'filter' => {
-          'field' => "default_feld"
+        "value" => "default_value",
+        "label" => "default_label",
+        "filter" => {
+          "field" => "default_feld"
         },
-        'default' => true
+        "default" => true
       }
     ]
   }
 
   describe "#options" do
-    context 'valid value' do
+    context "valid value" do
       subject { described_class.new(facet_data, "value_1", filter_hashes) }
-      it 'sets the options, selecting the correct value' do
+      it "sets the options, selecting the correct value" do
         expect(subject.options).to eq([
                                         {
-                                          value: 'value_1',
-                                          text: 'label_1',
+                                          value: "value_1",
+                                          text: "label_1",
                                           checked: true,
                                         },
                                         {
-                                          value: 'value_2',
-                                          text: 'label_2',
+                                          value: "value_2",
+                                          text: "label_2",
                                           checked: false,
                                         },
                                         {
-                                          value: 'default_value',
-                                          text: 'default_label',
+                                          value: "default_value",
+                                          text: "default_label",
                                           checked: false
                                         }
                                       ])
       end
     end
 
-    context 'invalid value' do
+    context "invalid value" do
       subject { described_class.new(facet_data, "something", filter_hashes) }
-      it 'sets the options, selecting the default value' do
+      it "sets the options, selecting the default value" do
         expect(subject.options).to include(
-          value: 'default_value',
-          text: 'default_label',
+          value: "default_value",
+          text: "default_label",
           checked: true,
                                    )
       end

--- a/spec/models/radio_facet_spec.rb
+++ b/spec/models/radio_facet_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe RadioFacet do
   let(:facet_data) {
     {
-      'type' => "radio_facet",
-      'key' => "type",
-      'value' => "selected_value",
+      "type" => "radio_facet",
+      "key" => "type",
+      "value" => "selected_value",
       "allowed_values" => [{ "value" => "selected_value" }],
-      'filterable' => true
+      "filterable" => true
     }
   }
 

--- a/spec/models/search_parameters_spec.rb
+++ b/spec/models/search_parameters_spec.rb
@@ -5,27 +5,27 @@ RSpec.describe SearchParameters do
     described_class.new(ActionController::Parameters.new(params))
   end
 
-  context '#count' do
-    it 'default to default page size' do
+  context "#count" do
+    it "default to default page size" do
       params = search_params
 
       expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
     end
 
-    it 'default to default page size when count < 1' do
+    it "default to default page size when count < 1" do
       params = search_params(count: -50)
 
       expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
     end
 
-    it 'allow at most a hundred results' do
+    it "allow at most a hundred results" do
       params = search_params(count: 10_000)
 
       expect(params.count).to eq(100)
     end
   end
 
-  context '#suggest' do
+  context "#suggest" do
     it "requests the spelling suggester by default" do
       params = search_params
 
@@ -33,8 +33,8 @@ RSpec.describe SearchParameters do
     end
   end
 
-  context '#start' do
-    it 'start at 0 if start < 1' do
+  context "#start" do
+    it "start at 0 if start < 1" do
       params = search_params(start: -1)
 
       expect(params.start).to eq(0)
@@ -49,7 +49,7 @@ RSpec.describe SearchParameters do
     end
 
     it "pass on filter_organisations as an array if provided as single value" do
-      params = search_params("filter_organisations" => 'ministry-of-silly-walks')
+      params = search_params("filter_organisations" => "ministry-of-silly-walks")
 
       expect(params.rummager_parameters[:filter_organisations]).to eq(%w[ministry-of-silly-walks])
     end

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -6,8 +6,8 @@ describe TaxonFacet do
   before :each do
     Rails.cache.clear
     topic_taxonomy_has_taxons([
-      FactoryBot.build(:level_one_taxon_hash, content_id: 'allowed-value-1', title: 'allowed-value-1', number_of_children: 1),
-      FactoryBot.build(:level_one_taxon_hash, content_id: 'allowed-value-2', title: 'allowed-value-2', number_of_children: 1),
+      FactoryBot.build(:level_one_taxon_hash, content_id: "allowed-value-1", title: "allowed-value-1", number_of_children: 1),
+      FactoryBot.build(:level_one_taxon_hash, content_id: "allowed-value-2", title: "allowed-value-2", number_of_children: 1),
     ])
   end
 
@@ -20,12 +20,12 @@ describe TaxonFacet do
 
   let(:facet_data) {
     {
-      'type' => "text",
+      "type" => "text",
       "keys" => %w(level_one_taxon level_two_taxon),
-      'name' => "Test values",
-      'key' => "test_values",
-      'preposition' => "of value",
-      'allowed_values' => allowed_values,
+      "name" => "Test values",
+      "key" => "test_values",
+      "preposition" => "of value",
+      "allowed_values" => allowed_values,
     }
   }
 
@@ -52,7 +52,7 @@ describe TaxonFacet do
     end
 
     it "will have a default option" do
-      expect(subject.topics.first[:text]).to eql('All topics')
+      expect(subject.topics.first[:text]).to eql("All topics")
     end
   end
 
@@ -75,7 +75,7 @@ describe TaxonFacet do
     end
 
     it "will have a default option" do
-      expect(subject.sub_topics.first[:text]).to eql('All sub-topics')
+      expect(subject.sub_topics.first[:text]).to eql("All sub-topics")
     end
   end
 
@@ -84,9 +84,9 @@ describe TaxonFacet do
       subject { TaxonFacet.new(facet_data, allowed_values) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("allowed-value-1")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("level_one_taxon")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("allowed-value-1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("level_one_taxon")
       }
     end
 

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -3,17 +3,17 @@ require "spec_helper"
 describe TopicalFacet do
   let(:facet_data) {
     {
-      'type' => "topical",
-      'name' => "State",
-      'key' => "end_date",
-      'preposition' => "of value",
-      'open_value' => {
-        'label' => "Open",
-        'value' => "open"
+      "type" => "topical",
+      "name" => "State",
+      "key" => "end_date",
+      "preposition" => "of value",
+      "open_value" => {
+        "label" => "Open",
+        "value" => "open"
       },
-      'closed_value' => {
-        'label' => "Closed",
-        'value' => "closed"
+      "closed_value" => {
+        "label" => "Closed",
+        "value" => "closed"
       }
     }
   }
@@ -25,9 +25,9 @@ describe TopicalFacet do
       subject { TopicalFacet.new(facet_data, value) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Open")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("end_date")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Open")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("end_date")
       }
     end
 
@@ -36,12 +36,12 @@ describe TopicalFacet do
       subject { TopicalFacet.new(facet_data, value) }
 
       specify {
-        expect(subject.sentence_fragment['preposition']).to eql("of value")
-        expect(subject.sentence_fragment['values'].first['label']).to eql("Open")
-        expect(subject.sentence_fragment['values'].first['parameter_key']).to eql("end_date")
+        expect(subject.sentence_fragment["preposition"]).to eql("of value")
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Open")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("end_date")
 
-        expect(subject.sentence_fragment['values'].last['label']).to eql("Closed")
-        expect(subject.sentence_fragment['values'].last['parameter_key']).to eql("end_date")
+        expect(subject.sentence_fragment["values"].last["label"]).to eql("Closed")
+        expect(subject.sentence_fragment["values"].last["parameter_key"]).to eql("end_date")
       }
     end
 

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -42,7 +42,7 @@ describe DateParser do
             "01/11/2014" => Date.new(2014, 11, 1),
 
             # Future date
-            '22/09/25' => Date.new(2025, 9, 22),
+            "22/09/25" => Date.new(2025, 9, 22),
 
             # Blank dates
             "" => nil,
@@ -68,7 +68,7 @@ describe DateParser do
   end
 
   it "handles dates without years correctly" do
-    date_to_parse = '26 november'
+    date_to_parse = "26 november"
 
     year = 2001
 

--- a/spec/parsers/facet_parser_spec.rb
+++ b/spec/parsers/facet_parser_spec.rb
@@ -1,27 +1,27 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe FacetParser do
   context "with a select facet definition" do
     let(:facet_definition) {
       {
-        'type' => "text",
-        'filterable' => true,
-        'display_as_result_metadata' => true,
-        'name' => "Case type",
-        'key' => "case_type",
-        'preposition' => "of type",
-        'allowed_values' => [
+        "type" => "text",
+        "filterable" => true,
+        "display_as_result_metadata" => true,
+        "name" => "Case type",
+        "key" => "case_type",
+        "preposition" => "of type",
+        "allowed_values" => [
           {
-            'label' => "Airport price control reviews",
-            'value' => "airport-price-control-reviews"
+            "label" => "Airport price control reviews",
+            "value" => "airport-price-control-reviews"
           },
           {
-            'label' => "Market investigations",
-            'value' => "market-investigations"
+            "label" => "Market investigations",
+            "value" => "market-investigations"
           },
           {
-            'label' => "Remittals",
-            'value' => "remittals"
+            "label" => "Remittals",
+            "value" => "remittals"
           }
         ],
       }
@@ -34,10 +34,10 @@ describe FacetParser do
     specify { expect(subject.preposition).to eql("of type") }
 
     it "should build a list of allowed values" do
-      expect(subject.allowed_values[0]['label']).to eql("Airport price control reviews")
-      expect(subject.allowed_values[0]['value']).to eql("airport-price-control-reviews")
-      expect(subject.allowed_values[2]['label']).to eql("Remittals")
-      expect(subject.allowed_values[2]['value']).to eql("remittals")
+      expect(subject.allowed_values[0]["label"]).to eql("Airport price control reviews")
+      expect(subject.allowed_values[0]["value"]).to eql("airport-price-control-reviews")
+      expect(subject.allowed_values[2]["label"]).to eql("Remittals")
+      expect(subject.allowed_values[2]["value"]).to eql("remittals")
     end
   end
 end

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe ResultSetParser do
   context "with a result set hash with some documents" do

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe AtomPresenter do
   subject(:instance) { described_class.new(finder, results, facet_tags) }
@@ -11,13 +11,13 @@ RSpec.describe AtomPresenter do
     double(
       FinderPresenter,
       slug: "/search/news-and-communications",
-      name: 'News and communications',
+      name: "News and communications",
       results: result_set,
-      document_noun: 'case',
+      document_noun: "case",
       total: 20,
       filters: [a_facet, another_facet, a_date_facet],
       facets: [a_facet, another_facet, a_date_facet],
-      keywords: '',
+      keywords: "",
       atom_url: "/a-finder.atom",
       default_documents_per_page: 10,
       values: {},
@@ -29,19 +29,19 @@ RSpec.describe AtomPresenter do
     FacetTagsPresenter.new(finder, sort_presenter)
   }
 
-  let(:filter_params) { double(:filter_params, keywords: '') }
+  let(:filter_params) { double(:filter_params, keywords: "") }
   let(:sort_presenter) { double(:sort_presenter, selected_option: nil) }
 
   let(:a_facet) do
     double(
       OptionSelectFacet,
-      key: 'key_1',
+      key: "key_1",
       sentence_fragment: {
-      'key' => 'key_1',
-      'type' => 'text',
-      'preposition' => 'About',
-      'values' => first_facet_values,
-      'word_connectors' => { words_connector: 'and' }
+      "key" => "key_1",
+      "type" => "text",
+      "preposition" => "About",
+      "values" => first_facet_values,
+      "word_connectors" => { words_connector: "and" }
       },
         has_filters?: true,
         value: %w[brexit harry-potter],
@@ -50,20 +50,20 @@ RSpec.describe AtomPresenter do
   end
 
   let(:first_facet_values) do
-    [{ 'label' => 'Brexit' }, { 'label' => 'Harry Potter' }]
+    [{ "label" => "Brexit" }, { "label" => "Harry Potter" }]
   end
 
   let(:second_facet_values) do
-    [{ 'label' => 'Farming' }, { 'label' => 'Chemicals' }]
+    [{ "label" => "Farming" }, { "label" => "Chemicals" }]
   end
 
   let(:a_date_facet) do
     double(
       OptionSelectFacet,
-      'key' => 'closed_date',
+      "key" => "closed_date",
       sentence_fragment: nil,
       has_filters?: false,
-      'word_connectors' => { words_connector: 'or' },
+      "word_connectors" => { words_connector: "or" },
       hide_facet_tag?: false
     )
   end
@@ -75,18 +75,18 @@ RSpec.describe AtomPresenter do
   let(:another_facet) do
     double(
       OptionSelectFacet,
-      key: 'key_2',
-      preposition: 'About',
+      key: "key_2",
+      preposition: "About",
       sentence_fragment: {
-      'key' => 'key_2',
-      'type' => 'text',
-      'preposition' => 'Related to',
-      'values' => second_facet_values,
-      'word_connectors' => { words_connector: 'or' }
+      "key" => "key_2",
+      "type" => "text",
+      "preposition" => "Related to",
+      "values" => second_facet_values,
+      "word_connectors" => { words_connector: "or" }
       },
         has_filters?: true,
         value: %w[farming chemicals],
-        'word_connectors' => { words_connector: 'or' },
+        "word_connectors" => { words_connector: "or" },
         hide_facet_tag?: false
     )
   end

--- a/spec/presenters/facet_tag_presenter_spec.rb
+++ b/spec/presenters/facet_tag_presenter_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe FacetTagPresenter do
-  context 'taxonomy tags' do
-    it 'hides the taxonomy tags when requested from a topic page' do
+  context "taxonomy tags" do
+    it "hides the taxonomy tags when requested from a topic page" do
       presenter = described_class.new(
         fragment,
         false,
@@ -12,7 +12,7 @@ describe FacetTagPresenter do
       expect(presenter.present.map { |value| value[:data_facet] }).to eq(expected_keys(true))
     end
 
-    it 'shows the taxonomy tags when requested from any other page' do
+    it "shows the taxonomy tags when requested from any other page" do
       presenter = described_class.new(
         fragment,
         false,
@@ -24,21 +24,21 @@ describe FacetTagPresenter do
 
     def fragment
       {
-        'preposition' => 'about',
-        'word_connectors' => { words_connector: 'and' },
-        'values' => [
-          { 'label' => 'foo', 'name' => 'bar', 'value' => 'baz', 'parameter_key' => 'level_one_taxon' },
-          { 'label' => 'foo', 'name' => 'bar', 'value' => 'baz', 'parameter_key' => 'level_two_taxon' },
-          { 'label' => 'foo', 'name' => 'bar', 'value' => 'baz', 'parameter_key' => 'organisation' },
-          { 'label' => 'foo', 'name' => 'bar', 'value' => 'baz', 'parameter_key' => 'magic' },
+        "preposition" => "about",
+        "word_connectors" => { words_connector: "and" },
+        "values" => [
+          { "label" => "foo", "name" => "bar", "value" => "baz", "parameter_key" => "level_one_taxon" },
+          { "label" => "foo", "name" => "bar", "value" => "baz", "parameter_key" => "level_two_taxon" },
+          { "label" => "foo", "name" => "bar", "value" => "baz", "parameter_key" => "organisation" },
+          { "label" => "foo", "name" => "bar", "value" => "baz", "parameter_key" => "magic" },
         ],
       }
     end
 
     def expected_keys(i_am_a_topic_page_finder)
-      keys = fragment['values'].map do |value|
-        if !i_am_a_topic_page_finder || !(%w[level_one_taxon level_two_taxon].include? value['parameter_key'])
-          value['parameter_key']
+      keys = fragment["values"].map do |value|
+        if !i_am_a_topic_page_finder || !(%w[level_one_taxon level_two_taxon].include? value["parameter_key"])
+          value["parameter_key"]
         end
       end
       keys.compact

--- a/spec/presenters/facet_tags_presenter_spec.rb
+++ b/spec/presenters/facet_tags_presenter_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require_relative './helpers/facets_helper'
+require_relative "./helpers/facets_helper"
 
 describe FacetTagsPresenter do
   include FacetsHelper
@@ -29,20 +29,20 @@ describe FacetTagsPresenter do
     end
   end
 
-  describe '#selected_filter_descriptions' do
-    it 'includes prepositions for each facet' do
+  describe "#selected_filter_descriptions" do
+    it "includes prepositions for each facet" do
       applied_filters = presenter.selected_filter_descriptions.flat_map { |filter| filter }
       prepositions = applied_filters.flat_map { |filter| filter[:preposition] }.reject { |preposition| preposition == "or" }
 
       finder_presenter.filters.reject { |filter| filter.sentence_fragment.nil? }.each do |fragment|
-        expect(prepositions).to include(fragment.sentence_fragment['preposition'])
+        expect(prepositions).to include(fragment.sentence_fragment["preposition"])
       end
     end
 
-    context 'when keywords have been searched for' do
+    context "when keywords have been searched for" do
       let(:keywords) { "my search term" }
 
-      it 'includes the keywords' do
+      it "includes the keywords" do
         applied_filters = presenter.selected_filter_descriptions.flat_map { |filter| filter }
         text_values = applied_filters.flat_map { |filter| filter[:text] }
 
@@ -50,10 +50,10 @@ describe FacetTagsPresenter do
       end
     end
 
-    context 'when XSS attack keywords have been searched for' do
+    context "when XSS attack keywords have been searched for" do
       let(:keywords) { '"><script>alert("hello")</script>' }
 
-      it 'escapes keywords appropriately' do
+      it "escapes keywords appropriately" do
         applied_filters = presenter.selected_filter_descriptions.flat_map { |filter| filter }
         text_values = applied_filters.flat_map { |filter| filter[:text] }
 

--- a/spec/presenters/finder_breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/finder_breadcrumbs_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe FinderBreadcrumbsPresenter do
   let(:finder_hash) { JSON.parse(File.read(Rails.root.join("features", "fixtures", "aaib_reports_example.json"))) }

--- a/spec/presenters/finder_presenter_spec.rb
+++ b/spec/presenters/finder_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe FinderPresenter do
   include GovukContentSchemaExamples
@@ -90,7 +90,7 @@ RSpec.describe FinderPresenter do
     end
   end
 
-  describe 'url helpers' do
+  describe "url helpers" do
     let(:hidden_facet_hash) {
       {
         "filter_key": "hidden",
@@ -186,7 +186,7 @@ RSpec.describe FinderPresenter do
     end
 
     context "beta message is set" do
-      let(:content_item) { create_content_item("phase" => 'beta', "details" => { "beta_message" => message }) }
+      let(:content_item) { create_content_item("phase" => "beta", "details" => { "beta_message" => message }) }
       it "returns html_safe beta message" do
         expect(subject.phase_message).to eql message
       end
@@ -278,8 +278,8 @@ RSpec.describe FinderPresenter do
       ]
     }
 
-    it 'returns all relevant query parameters' do
-      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'taxon', title: 'taxon')])
+    it "returns all relevant query parameters" do
+      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: "taxon", title: "taxon")])
 
       query_params = Rack::Utils.parse_nested_query URI.parse(subject.atom_url).query
       expect(query_params).to eq("checkbox" => "filter_value",
@@ -293,7 +293,7 @@ RSpec.describe FinderPresenter do
   end
 
   describe "#all_content_finder?" do
-    it 'returns false by default' do
+    it "returns false by default" do
       expect(subject.all_content_finder?).to eq false
     end
 
@@ -301,14 +301,14 @@ RSpec.describe FinderPresenter do
       let(:content_item) {
         create_content_item(content_id: "dd395436-9b40-41f3-8157-740a453ac972")
       }
-      it 'returns true' do
+      it "returns true" do
         expect(subject.all_content_finder?).to eq true
       end
     end
   end
 
   describe "#eu_exit_finder?" do
-    it 'returns false by default' do
+    it "returns false by default" do
       expect(subject.eu_exit_finder?).to eq false
     end
 
@@ -316,7 +316,7 @@ RSpec.describe FinderPresenter do
       let(:content_item) {
         create_content_item(content_id: "42ce66de-04f3-4192-bf31-8394538e0734")
       }
-      it 'returns true' do
+      it "returns true" do
         expect(subject.eu_exit_finder?).to eq true
       end
     end
@@ -346,7 +346,7 @@ RSpec.describe FinderPresenter do
 private
 
   def create_content_item(options = {})
-    finder_example = govuk_content_schema_example('finder').merge(options)
+    finder_example = govuk_content_schema_example("finder").merge(options)
 
     dummy_http_response = double(
       "net http response",

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe GroupedResultSetPresenter do
   subject(:presenter) { GroupedResultSetPresenter.new(finder_presenter, filter_params, sort_presenter, metadata_presenter_class) }
@@ -11,7 +11,7 @@ RSpec.describe GroupedResultSetPresenter do
     FactoryBot.build(:content_item, finder_name: finder_name)
   }
 
-  let(:finder_name) { 'A finder' }
+  let(:finder_name) { "A finder" }
 
   let(:finder_presenter) do
     FinderPresenter.new(content_item, facets, search_results)
@@ -23,54 +23,54 @@ RSpec.describe GroupedResultSetPresenter do
 
   let(:first_facet) do
     FactoryBot.build(:option_select_facet,
-                     key: 'first_facet_key',
-                     short_name: 'Primary Facet Short Name',
+                     key: "first_facet_key",
+                     short_name: "Primary Facet Short Name",
                      allowed_values: [
                        {
-                         'value' => 'first_value_1',
-                         'label' => 'Primary Label 1',
-                         'content_id' => 'first_value_1_content_id'
+                         "value" => "first_value_1",
+                         "label" => "Primary Label 1",
+                         "content_id" => "first_value_1_content_id"
                        },
                        {
-                         'value' => 'first_value_2',
-                         'label' => 'Primary Label 2',
-                         'content_id' => 'first_value_2_content_id'
+                         "value" => "first_value_2",
+                         "label" => "Primary Label 2",
+                         "content_id" => "first_value_2_content_id"
                        },
                      ])
   end
 
   let(:second_facet) do
     FactoryBot.build(:option_select_facet,
-                     key: 'second_facet_key',
-                     short_name: 'Secondary Facet Short Name',
+                     key: "second_facet_key",
+                     short_name: "Secondary Facet Short Name",
                      allowed_values: [
                        {
-                         'value' => 'second_value_1',
-                         'label' => 'secondary Label 1',
-                         'content_id' => 'second_value_1_content_id'
+                         "value" => "second_value_1",
+                         "label" => "secondary Label 1",
+                         "content_id" => "second_value_1_content_id"
                        },
                        {
-                         'value' => 'second_value_2',
-                         'label' => 'Secondary Label 2',
-                         'content_id' => 'second_value_2_content_id'
+                         "value" => "second_value_2",
+                         "label" => "Secondary Label 2",
+                         "content_id" => "second_value_2_content_id"
                        }
                      ])
   end
 
   let(:third_facet) do
     FactoryBot.build(:option_select_facet,
-                     key: 'third_facet_key',
-                     short_name: 'Tertiary Facet Short Name',
+                     key: "third_facet_key",
+                     short_name: "Tertiary Facet Short Name",
                      allowed_values: [
                        {
-                         'value' => 'third_value_1',
-                         'label' => 'tertiary Label 1',
-                         'content_id' => 'third_value_1_content_id'
+                         "value" => "third_value_1",
+                         "label" => "tertiary Label 1",
+                         "content_id" => "third_value_1_content_id"
                        },
                        {
-                         'value' => 'third_value_2',
-                         'label' => 'Tertiary Label 2',
-                         'content_id' => 'third_value_2_content_id'
+                         "value" => "third_value_2",
+                         "label" => "Tertiary Label 2",
+                         "content_id" => "third_value_2_content_id"
                        },
                      ])
   end
@@ -86,7 +86,7 @@ RSpec.describe GroupedResultSetPresenter do
     end
 
     context "Ordering is not set to topic, so there is no grouping" do
-      let(:filter_params) { { order: 'a-z' } }
+      let(:filter_params) { { order: "a-z" } }
       let(:search_results) { { "results" => [FactoryBot.build(:document_hash)], "total" => 1 } }
 
       it "returns an empty array" do
@@ -95,7 +95,7 @@ RSpec.describe GroupedResultSetPresenter do
     end
 
     context "The user has not selected any facets" do
-      let(:filter_params) { { order: 'topic' } }
+      let(:filter_params) { { order: "topic" } }
       let(:search_results) {
         {
           "results" => [
@@ -124,7 +124,7 @@ RSpec.describe GroupedResultSetPresenter do
     context "The user has not selected only the primary facet" do
       let(:filter_params) {
         {
-          order: 'topic',
+          order: "topic",
           first_facet_key: %W(first_value_1),
         }
       }
@@ -151,7 +151,7 @@ RSpec.describe GroupedResultSetPresenter do
         expect(subject.search_results_content[:grouped_document_list_component_data]).
           to eq([
                   {
-                    group_name: 'Primary Label 1',
+                    group_name: "Primary Label 1",
                     documents: [build_document_list_component(document, 1)]
                   }
                 ])
@@ -188,7 +188,7 @@ RSpec.describe GroupedResultSetPresenter do
 
       let(:filter_params) {
         {
-          order: 'topic',
+          order: "topic",
           first_facet_key: %W(first_value_1),
           second_facet_key: %W(second_value_1),
           third_facet_key: %W(third_value_1),
@@ -199,15 +199,15 @@ RSpec.describe GroupedResultSetPresenter do
         expect(subject.search_results_content[:grouped_document_list_component_data]).
           to eq([
                   {
-                    group_name: 'Primary Label 1',
+                    group_name: "Primary Label 1",
                     documents: [build_document_list_component(tagged_to_first_facet_document, 2)]
                   },
                   {
-                    group_name: 'Secondary Facet Short Name',
+                    group_name: "Secondary Facet Short Name",
                     documents: [build_document_list_component(tagged_to_second_and_third_facet_document, 2)]
                   },
                   {
-                    group_name: 'Tertiary Facet Short Name',
+                    group_name: "Tertiary Facet Short Name",
                     documents: [build_document_list_component(tagged_to_second_and_third_facet_document, 2)]
                   }
 
@@ -224,7 +224,7 @@ RSpec.describe GroupedResultSetPresenter do
       }
       let(:filter_params) {
         {
-          order: 'topic',
+          order: "topic",
           first_facet_key: %W(first_value_1),
         }
       }
@@ -242,7 +242,7 @@ RSpec.describe GroupedResultSetPresenter do
         expect(subject.search_results_content[:grouped_document_list_component_data]).
           to eq([
                   {
-                    group_name: 'All businesses',
+                    group_name: "All businesses",
                     documents: [build_document_list_component(document, 1)]
                   }
                 ])
@@ -273,13 +273,13 @@ RSpec.describe GroupedResultSetPresenter do
         end
       end
       context "with a 'topic' sort param" do
-        let(:filter_params) { { 'order' => 'topic' } }
+        let(:filter_params) { { "order" => "topic" } }
         it "is true" do
           expect(grouped_display).to be true
         end
       end
       context "with non-topic sort param" do
-        let(:filter_params) { { order: 'most-viewed' } }
+        let(:filter_params) { { order: "most-viewed" } }
         it "is false" do
           expect(grouped_display).to be false
         end

--- a/spec/presenters/helpers/facets_helper.rb
+++ b/spec/presenters/helpers/facets_helper.rb
@@ -4,40 +4,40 @@ module FacetsHelper
   def a_facet
     double(
       OptionSelectFacet,
-      key: 'key_1',
+      key: "key_1",
       selected_values: [
       {
-        'value' => 'ca98-and-civil-cartels',
-        'label' => 'CA98 and civil cartels'
+        "value" => "ca98-and-civil-cartels",
+        "label" => "CA98 and civil cartels"
       },
       {
-        'value' => 'mergers',
-        'label' => 'Mergers'
+        "value" => "mergers",
+        "label" => "Mergers"
       },
     ],
       allowed_values: [
       {
-        'value' => 'ca98-and-civil-cartels',
-        'label' => 'CA98 and civil cartels'
+        "value" => "ca98-and-civil-cartels",
+        "label" => "CA98 and civil cartels"
       },
       {
-        'value' => 'mergers',
-        'label' => 'Mergers'
+        "value" => "mergers",
+        "label" => "Mergers"
       },
     ],
       sentence_fragment: {
-      'key' => 'key_1',
-      'type' => 'text',
-      'preposition' => 'Of Type',
-      'values' => [
+      "key" => "key_1",
+      "type" => "text",
+      "preposition" => "Of Type",
+      "values" => [
         {
-          'label' => 'CA98 and civil cartels',
+          "label" => "CA98 and civil cartels",
         },
         {
-          'label' => 'Mergers',
+          "label" => "Mergers",
         },
       ],
-      'word_connectors' => { words_connector: 'or' }
+      "word_connectors" => { words_connector: "or" }
     },
       has_filters?: true,
       labels: %W(ca98-and-civil-cartels mergers),
@@ -49,35 +49,35 @@ module FacetsHelper
   def another_facet
     double(
       OptionSelectFacet,
-      key: 'key_2',
-      preposition: 'About',
+      key: "key_2",
+      preposition: "About",
       selected_values: [
       {
-        'value' => 'farming',
-        'label' => 'Farming'
+        "value" => "farming",
+        "label" => "Farming"
       },
       {
-        'value' => 'chemicals',
-        'label' => 'Chemicals'
+        "value" => "chemicals",
+        "label" => "Chemicals"
       },
     ],
       sentence_fragment: {
-      'key' => 'key_2',
-      'type' => 'text',
-      'preposition' => 'About',
-      'values' => [
+      "key" => "key_2",
+      "type" => "text",
+      "preposition" => "About",
+      "values" => [
         {
-          'label' => 'Farming',
+          "label" => "Farming",
         },
         {
-          'label' => 'Chemicals',
+          "label" => "Chemicals",
         },
       ],
-      'word_connectors' => { words_connector: 'or' }
+      "word_connectors" => { words_connector: "or" }
     },
       has_filters?: true,
       value: %w[farming chemicals],
-      'word_connectors' => { words_connector: 'or' },
+      "word_connectors" => { words_connector: "or" },
       hide_facet_tag?: false
     )
   end
@@ -85,10 +85,10 @@ module FacetsHelper
   def a_date_facet
     double(
       OptionSelectFacet,
-      'key' => 'closed_date',
+      "key" => "closed_date",
       sentence_fragment: nil,
       has_filters?: false,
-      'word_connectors' => { words_connector: 'or' },
+      "word_connectors" => { words_connector: "or" },
       hide_facet_tag?: false
     )
   end

--- a/spec/presenters/metadata_presenter_spec.rb
+++ b/spec/presenters/metadata_presenter_spec.rb
@@ -1,25 +1,25 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetadataPresenter do
   subject(:presenter) { described_class.new(raw_metadata) }
 
   let(:raw_metadata) {
     [
-      { id: 'case-state', name: 'Case state', value: 'Open', type: 'text' },
-      { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
-      { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text' },
+      { id: "case-state", name: "Case state", value: "Open", type: "text" },
+      { id: "opened-date", name: "Opened date", value: "2006-7-14", type: "date" },
+      { id: "case-type", name: "Case type", value: "CA98 and civil cartels", type: "text" },
     ]
   }
   let(:formatted_metadata) {
     [
-      { id: 'case-state', label: "Case state", value: "Open", is_text: true, labels: nil },
+      { id: "case-state", label: "Case state", value: "Open", is_text: true, labels: nil },
       { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
-      { id: 'case-type', label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
+      { id: "case-type", label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
     ]
   }
 
-  describe '#present' do
-    it 'presents the metadata' do
+  describe "#present" do
+    it "presents the metadata" do
       expect(subject.present).to eq(formatted_metadata)
     end
   end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe PaginationPresenter do
   subject(:links) { presenter.next_and_prev_links }
@@ -13,7 +13,7 @@ describe PaginationPresenter do
   let(:per_page) {}
   let(:start_offset) {}
   let(:total_results) {}
-  let(:url_builder) { UrlBuilder.new('/search') }
+  let(:url_builder) { UrlBuilder.new("/search") }
 
   describe "#next_and_prev_links" do
     context "when per_page is unset" do

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
-require_relative './helpers/facets_helper'
+require "spec_helper"
+require_relative "./helpers/facets_helper"
 
 RSpec.describe ResultSetPresenter do
   include FacetsHelper
@@ -12,12 +12,12 @@ RSpec.describe ResultSetPresenter do
     double(
       FinderPresenter,
       slug: "/a-finder",
-      name: 'A finder',
+      name: "A finder",
       results: results,
       document_noun: document_noun,
       display_metadata?: true,
       sort_options: sort_presenter,
-      total: '20 cases',
+      total: "20 cases",
       facets: [a_facet, another_facet, a_date_facet],
       keywords: keywords,
       show_summaries?: true,
@@ -47,10 +47,10 @@ RSpec.describe ResultSetPresenter do
     )
   end
 
-  let(:filter_params) { { keywords: 'test' } }
+  let(:filter_params) { { keywords: "test" } }
 
-  let(:keywords) { '' }
-  let(:document_noun) { 'case' }
+  let(:keywords) { "" }
+  let(:document_noun) { "case" }
   let(:total) { 20 }
 
   let(:results) do
@@ -63,39 +63,39 @@ RSpec.describe ResultSetPresenter do
   let(:document) do
     double(
       Document,
-      title: 'Investigation into the distribution of road fuels in parts of Scotland',
-      path: 'slug-1',
+      title: "Investigation into the distribution of road fuels in parts of Scotland",
+      path: "slug-1",
       metadata: [
-        { id: 'case-state', name: 'Case state', value: 'Open', type: 'text', labels: %W(open) },
-        { id: 'opened-date', name: 'Opened date', value: '2006-7-14', type: 'date' },
-        { id: 'case-type', name: 'Case type', value: 'CA98 and civil cartels', type: 'text', labels: %W(ca98-and-civil-cartels) },
+        { id: "case-state", name: "Case state", value: "Open", type: "text", labels: %W(open) },
+        { id: "opened-date", name: "Opened date", value: "2006-7-14", type: "date" },
+        { id: "case-type", name: "Case type", value: "CA98 and civil cartels", type: "text", labels: %W(ca98-and-civil-cartels) },
       ],
-      truncated_description: 'I am a document',
+      truncated_description: "I am a document",
       is_historic: true,
-      government_name: 'The Government!',
-      format: 'transaction',
+      government_name: "The Government!",
+      format: "transaction",
       index: 1,
       es_score: 0.005,
-      content_id: 'content_id',
+      content_id: "content_id",
     )
   end
 
   let(:expected_document_content) do
     {
       link: {
-        text: 'Investigation into the distribution of road fuels in parts of Scotland',
-        path: 'slug-1',
-        description: 'I am a document',
+        text: "Investigation into the distribution of road fuels in parts of Scotland",
+        path: "slug-1",
+        description: "I am a document",
         data_attributes: {
-          ecommerce_path: 'slug-1',
-          ecommerce_content_id: 'content_id',
+          ecommerce_path: "slug-1",
+          ecommerce_content_id: "content_id",
           ecommerce_row: 1,
-          track_category: 'navFinderLinkClicked',
-          track_action: 'A finder.1',
-          track_label: 'slug-1',
+          track_category: "navFinderLinkClicked",
+          track_action: "A finder.1",
+          track_label: "slug-1",
           track_options: {
             dimension28: 1,
-            dimension29: 'Investigation into the distribution of road fuels in parts of Scotland'
+            dimension29: "Investigation into the distribution of road fuels in parts of Scotland"
           }
         }
       },
@@ -134,12 +134,12 @@ RSpec.describe ResultSetPresenter do
     double(
       SortPresenter,
       has_options?: false,
-      selected_option: { "name" => 'Relevance', "key" => '-relevance' },
+      selected_option: { "name" => "Relevance", "key" => "-relevance" },
       to_hash: {
         options: [
           {
-            data_track_category: 'dropDownClicked',
-            data_track_action: 'clicked',
+            data_track_category: "dropDownClicked",
+            data_track_action: "clicked",
             data_track_label: "Relevance",
             label: "Relevance",
             value: "relevance",
@@ -158,12 +158,12 @@ RSpec.describe ResultSetPresenter do
   end
 
   describe "#displayed_total" do
-    it 'combines total with document noun' do
+    it "combines total with document noun" do
       expect(presenter.displayed_total).to eql("#{total} cases")
     end
   end
 
-  describe '#documents' do
+  describe "#documents" do
     context "has one document" do
       let(:results) do
         ResultSet.new(
@@ -172,7 +172,7 @@ RSpec.describe ResultSetPresenter do
         )
       end
 
-      it 'creates a new search_result_presenter hash for each result' do
+      it "creates a new search_result_presenter hash for each result" do
         search_result_objects = presenter.search_results_content[:document_list_component_data]
         expect(search_result_objects.count).to eql(1)
         expect(search_result_objects.first).to be_a(Hash)
@@ -187,7 +187,7 @@ RSpec.describe ResultSetPresenter do
         )
       end
 
-      it 'creates a new document for each result' do
+      it "creates a new document for each result" do
         search_result_objects = presenter.search_results_content[:document_list_component_data]
         expect(search_result_objects.count).to eql(3)
       end
@@ -201,7 +201,7 @@ RSpec.describe ResultSetPresenter do
         )
       end
 
-      it 'has the right data' do
+      it "has the right data" do
         search_result_objects = presenter.search_results_content[:document_list_component_data]
         expect(search_result_objects.first).to eql(expected_document_content)
       end
@@ -214,13 +214,13 @@ RSpec.describe ResultSetPresenter do
         "<span class=\"published-by\">First published during the The Government!</span><span class=\"debug-results debug-results--link\">slug-1</span><span class=\"debug-results debug-results--meta\">Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: transaction</span>"
       end
 
-      it 'shows debug metadata' do
+      it "shows debug metadata" do
         search_result_objects = presenter.search_results_content[:document_list_component_data]
         expect(search_result_objects.first[:subtext]).to eql(expected_document_content_with_debug)
       end
     end
 
-    context 'check top result' do
+    context "check top result" do
       subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, metadata_presenter_class, true) }
 
       before(:each) do
@@ -231,16 +231,16 @@ RSpec.describe ResultSetPresenter do
       let(:document_with_higher_es_score) do
         double(
           Document,
-          title: 'Investigation into the distribution of road fuels in parts of Scotland',
+          title: "Investigation into the distribution of road fuels in parts of Scotland",
           description: "Some description about the Department",
-          path: 'slug-1',
+          path: "slug-1",
           metadata: [],
-          summary: 'Higher score',
+          summary: "Higher score",
           is_historic: false,
-          government_name: 'The Government!',
-          format: 'transaction',
+          government_name: "The Government!",
+          format: "transaction",
           es_score: 1000.0,
-          content_id: 'content_id',
+          content_id: "content_id",
           index: 1
         )
       end
@@ -248,20 +248,20 @@ RSpec.describe ResultSetPresenter do
       let(:document_with_lower_es_score) do
         double(
           Document,
-          title: 'Investigation into the distribution of road fuels in parts of Scotland',
-          path: 'slug-2',
+          title: "Investigation into the distribution of road fuels in parts of Scotland",
+          path: "slug-2",
           metadata: [],
-          truncated_description: 'Lower score',
+          truncated_description: "Lower score",
           is_historic: false,
-          government_name: 'The Government!',
-          format: 'transaction',
+          government_name: "The Government!",
+          format: "transaction",
           es_score: 100.0,
-          content_id: 'content_id',
+          content_id: "content_id",
           index: 2
         )
       end
 
-      context 'top result set if best bet' do
+      context "top result set if best bet" do
         let(:results) do
           ResultSet.new(
             [document_with_higher_es_score, document_with_lower_es_score],
@@ -269,7 +269,7 @@ RSpec.describe ResultSetPresenter do
           )
         end
 
-        it 'has top result true' do
+        it "has top result true" do
           search_result_objects = presenter.search_results_content[:document_list_component_data]
           expect(search_result_objects[0][:highlight]).to eql(true)
           expect(search_result_objects[0][:highlight_text]).to eql("Most relevant result")
@@ -277,7 +277,7 @@ RSpec.describe ResultSetPresenter do
         end
       end
 
-      context 'top result not set if no best bet' do
+      context "top result not set if no best bet" do
         let(:results) do
           ResultSet.new(
             [document, document],
@@ -285,16 +285,16 @@ RSpec.describe ResultSetPresenter do
           )
         end
 
-        it 'has no top result' do
+        it "has no top result" do
           search_result_objects = presenter.search_results_content[:document_list_component_data]
           expect(search_result_objects[0][:highlight]).to_not eql(true)
         end
       end
 
-      context 'top result not set if show top result is false' do
+      context "top result not set if show top result is false" do
         subject(:presenter) { ResultSetPresenter.new(finder, filter_params, sort_presenter, metadata_presenter_class, false) }
 
-        it 'has no top result' do
+        it "has no top result" do
           search_result_objects = presenter.search_results_content[:document_list_component_data]
           expect(search_result_objects[0][:highlight]).to_not eql(true)
         end
@@ -306,10 +306,10 @@ RSpec.describe ResultSetPresenter do
     let(:primary_facet) do
       double(
         OptionSelectFacet,
-        key: 'sector_business_area',
+        key: "sector_business_area",
         allowed_values: [
-          { 'value' => 'aerospace', 'label' => 'Aerospace' },
-          { 'value' => 'agriculture', 'label' => 'Agriculture' },
+          { "value" => "aerospace", "label" => "Aerospace" },
+          { "value" => "agriculture", "label" => "Agriculture" },
         ],
         value: %W(aerospace agriculture),
         labels: %W(aerospace agriculture),
@@ -317,14 +317,14 @@ RSpec.describe ResultSetPresenter do
     end
   end
 
-  describe '#signup_links' do
-    context 'has both signup links' do
+  describe "#signup_links" do
+    context "has both signup links" do
       before(:each) do
         allow(finder).to receive(:atom_url).and_return("/finder.atom")
         allow(finder).to receive(:email_alert_signup_url).and_return("/email_signup")
       end
 
-      it 'returns both signup links' do
+      it "returns both signup links" do
         expect(presenter.signup_links).to eq(email_signup_link: "/email_signup",
                                              feed_link: "/finder.atom",
                                              hide_heading: true,
@@ -332,13 +332,13 @@ RSpec.describe ResultSetPresenter do
       end
     end
 
-    context 'has just has the atom signup link' do
+    context "has just has the atom signup link" do
       before(:each) do
         allow(finder).to receive(:atom_url).and_return("/finder.atom")
         allow(finder).to receive(:email_alert_signup_url).and_return("")
       end
 
-      it 'returns just the atom link' do
+      it "returns just the atom link" do
         expect(presenter.signup_links).to eq(feed_link: "/finder.atom", hide_heading: true,
                                              small_form: true)
       end

--- a/spec/presenters/screen_reader_filter_description_presenter_spec.rb
+++ b/spec/presenters/screen_reader_filter_description_presenter_spec.rb
@@ -1,46 +1,46 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe ScreenReaderFilterDescriptionPresenter do
   subject(:presenter) { ScreenReaderFilterDescriptionPresenter.new([a_facet, a_facet_without_facet_tags], sort_option) }
 
-  let(:sort_option) { { "key" => 'updated-newest', "name" => 'Updated (newest)' } }
+  let(:sort_option) { { "key" => "updated-newest", "name" => "Updated (newest)" } }
   let(:a_facet) do
     double(
       OptionSelectFacet,
-      key: 'key_1',
+      key: "key_1",
       selected_values: [
           {
-              'value' => 'ca98-and-civil-cartels',
-              'label' => 'CA98 and civil cartels'
+              "value" => "ca98-and-civil-cartels",
+              "label" => "CA98 and civil cartels"
           },
           {
-              'value' => 'mergers',
-              'label' => 'Mergers'
+              "value" => "mergers",
+              "label" => "Mergers"
           },
       ],
       allowed_values: [
           {
-              'value' => 'ca98-and-civil-cartels',
-              'label' => 'CA98 and civil cartels'
+              "value" => "ca98-and-civil-cartels",
+              "label" => "CA98 and civil cartels"
           },
           {
-              'value' => 'mergers',
-              'label' => 'Mergers'
+              "value" => "mergers",
+              "label" => "Mergers"
           },
       ],
       sentence_fragment: {
-          'key' => 'key_1',
-          'type' => 'text',
-          'preposition' => 'Of Type',
-          'values' => [
+          "key" => "key_1",
+          "type" => "text",
+          "preposition" => "Of Type",
+          "values" => [
               {
-                  'label' => 'CA98 and civil cartels',
+                  "label" => "CA98 and civil cartels",
               },
               {
-                  'label' => 'Mergers',
+                  "label" => "Mergers",
               },
           ],
-          'word_connectors' => { words_connector: 'or' }
+          "word_connectors" => { words_connector: "or" }
       },
       has_filters?: true,
       labels: %W(ca98-and-civil-cartels mergers),
@@ -52,21 +52,21 @@ RSpec.describe ScreenReaderFilterDescriptionPresenter do
   let(:a_facet_without_facet_tags) do
     double(
       RadioFacet,
-      key: 'key_3',
-      preposition: 'that are',
+      key: "key_3",
+      preposition: "that are",
       allowed_values: [
           {
-              'value' => 'statistics_published',
-              'label' => 'Statistics (published)',
-              'default' => true
+              "value" => "statistics_published",
+              "label" => "Statistics (published)",
+              "default" => true
           },
           {
-              'value' => 'statistics_upcoming',
-              'label' => 'Statistics (upcoming)'
+              "value" => "statistics_upcoming",
+              "label" => "Statistics (upcoming)"
           },
           {
-              'value' => 'research',
-              'label' => 'Research'
+              "value" => "research",
+              "label" => "Research"
           },
       ],
       has_filters?: true,
@@ -74,37 +74,37 @@ RSpec.describe ScreenReaderFilterDescriptionPresenter do
       value: "something",
       sort: [
           {
-              'value' => 'most-viewed',
-              'name' => 'Most viewed'
+              "value" => "most-viewed",
+              "name" => "Most viewed"
           }
       ]
     )
   end
-  describe '#hidden_text' do
-    it 'creates appropriate hidden text for the facet without a facet tag for a default value' do
+  describe "#hidden_text" do
+    it "creates appropriate hidden text for the facet without a facet tag for a default value" do
       expect(presenter.present).to eql("that are Statistics (published), sorted by Updated (newest)")
     end
 
-    it 'creates appropriate hidden text for the facet without a facet tag for a non default value' do
+    it "creates appropriate hidden text for the facet without a facet tag for a non default value" do
       allow(a_facet_without_facet_tags).to receive(:value).and_return("research")
       expect(presenter.present).to eql("that are Research, sorted by Updated (newest)")
     end
 
-    it 'will not include a facet without a facet tag if there is no selected value or default value' do
+    it "will not include a facet without a facet tag if there is no selected value or default value" do
       allow(a_facet_without_facet_tags).to receive(:value).and_return("")
       allow(a_facet_without_facet_tags).to receive(:allowed_values).and_return(
         [
           {
-              'value' => 'statistics_published',
-              'label' => 'Statistics (published)'
+              "value" => "statistics_published",
+              "label" => "Statistics (published)"
           },
           {
-              'value' => 'statistics_upcoming',
-              'label' => 'Statistics (upcoming)'
+              "value" => "statistics_upcoming",
+              "label" => "Statistics (upcoming)"
           },
           {
-              'value' => 'research',
-              'label' => 'Research'
+              "value" => "research",
+              "label" => "Research"
           },
         ]
       )

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe SearchResultPresenter do
   let(:content_item) do
@@ -36,19 +36,19 @@ RSpec.describe SearchResultPresenter do
                      link: link,
                      description: description,
                      is_historic: is_historic,
-                     government_name: 'Government!',
-                     format: 'cake',
+                     government_name: "Government!",
+                     format: "cake",
                      es_score: 0.005,
-                     content_id: 'content_id',
-                     filter_key: 'filter_value',
+                     content_id: "content_id",
+                     filter_key: "filter_value",
                      finder: finder_presenter,
                      index: 1)
   }
 
   let(:is_historic) { false }
-  let(:title) { 'Investigation into the distribution of road fuels in parts of Scotland' }
-  let(:link) { 'link-1' }
-  let(:description) { 'I am a document. I am full of words and that.' }
+  let(:title) { "Investigation into the distribution of road fuels in parts of Scotland" }
+  let(:link) { "link-1" }
+  let(:description) { "I am a document. I am full of words and that." }
 
   describe "#govuk_component_data" do
     it "returns a hash of the data we need to show the document" do
@@ -56,10 +56,10 @@ RSpec.describe SearchResultPresenter do
         link: {
           text: title,
           path: link,
-          description: 'I am a document.',
+          description: "I am a document.",
           data_attributes: {
             ecommerce_path: link,
-            ecommerce_content_id: 'content_id',
+            ecommerce_content_id: "content_id",
             ecommerce_row: 1,
             track_category: "navFinderLinkClicked",
             track_action: "finder-title.1",
@@ -81,14 +81,14 @@ RSpec.describe SearchResultPresenter do
   end
 
   describe "structure_metadata" do
-    let(:facets) { [FactoryBot.build(:option_select_facet, 'key' => 'filter_key')] }
-    context 'The content_id is the eu exit finder' do
+    let(:facets) { [FactoryBot.build(:option_select_facet, "key" => "filter_key")] }
+    context "The content_id is the eu exit finder" do
       let(:content_id) { "42ce66de-04f3-4192-bf31-8394538e0734" }
       it "does not show metadata" do
         expect(subject.document_list_component_data[:metadata]).to be_empty
       end
     end
-    context 'The content_id is something else than the eu exit finder' do
+    context "The content_id is something else than the eu exit finder" do
       let(:content_id) { "not_eu_exit_content_id" }
       it "shows some metadata" do
         expect(subject.document_list_component_data[:metadata]).to_not be_empty
@@ -96,21 +96,21 @@ RSpec.describe SearchResultPresenter do
     end
 
 
-    context 'A text based facet and a document tagged to the key of the facet' do
-      let(:facets) { [FactoryBot.build(:option_select_facet, key: 'a_key_to_filter_on')] }
+    context "A text based facet and a document tagged to the key of the facet" do
+      let(:facets) { [FactoryBot.build(:option_select_facet, key: "a_key_to_filter_on")] }
       let(:document) {
-        FactoryBot.build(:document, a_key_to_filter_on: 'a_filter_value', finder: finder_presenter, index: 1)
+        FactoryBot.build(:document, a_key_to_filter_on: "a_filter_value", finder: finder_presenter, index: 1)
       }
-      it 'displays text based metadata' do
+      it "displays text based metadata" do
         expect(presenter.document_list_component_data[:metadata]).to eq("A key to filter on" => "A key to filter on: a_filter_value")
       end
     end
-    context 'A date based facet and a document tagged to the key of the facet' do
-      let(:facets) { [FactoryBot.build(:date_facet, 'key' => 'a_key_to_filter_on')] }
+    context "A date based facet and a document tagged to the key of the facet" do
+      let(:facets) { [FactoryBot.build(:date_facet, "key" => "a_key_to_filter_on")] }
       let(:document) {
-        FactoryBot.build(:document, a_key_to_filter_on: '10-10-2009', finder: finder_presenter, index: 1)
+        FactoryBot.build(:document, a_key_to_filter_on: "10-10-2009", finder: finder_presenter, index: 1)
       }
-      it 'displays date based metadata' do
+      it "displays date based metadata" do
         expect(presenter.document_list_component_data[:metadata]).
           to eq("A key to filter on" => 'A key to filter on: <time datetime="2009-10-10">10 October 2009</time>')
       end
@@ -129,21 +129,21 @@ RSpec.describe SearchResultPresenter do
       expect(subject.document_list_component_data[:subtext]).to eql(nil)
     end
 
-    context 'The document is historic' do
+    context "The document is historic" do
       let(:is_historic) { true }
       it "returns 'Published by' text" do
         expect(subject.document_list_component_data[:subtext]).to eql(historic_subtext)
       end
     end
 
-    context 'debug_score is true' do
+    context "debug_score is true" do
       let(:debug_score) { true }
       it "returns debug metadata" do
         expect(subject.document_list_component_data[:subtext]).to eql(debug_subtext)
       end
     end
 
-    context 'The document is historic and the debug_score is true' do
+    context "The document is historic and the debug_score is true" do
       let(:is_historic) { true }
       let(:debug_score) { true }
       it "returns 'Published by' and debug metadata together" do
@@ -153,32 +153,32 @@ RSpec.describe SearchResultPresenter do
   end
 
   describe "#summary_text" do
-    context 'The highlighted parameter is set to true on SearchResultPresenter' do
+    context "The highlighted parameter is set to true on SearchResultPresenter" do
       let(:highlight) { true }
-      context 'The finder content item has show_summaries set to true' do
+      context "The finder content item has show_summaries set to true" do
         let(:show_summaries) { true }
-        it 'returns the truncated description' do
+        it "returns the truncated description" do
           expect(subject.document_list_component_data[:link][:description]).to eql("I am a document.")
         end
       end
-      context 'The finder content item has show_summaries set to false' do
+      context "The finder content item has show_summaries set to false" do
         let(:show_summaries) { false }
-        it 'also returns the truncated description' do
+        it "also returns the truncated description" do
           expect(subject.document_list_component_data[:link][:description]).to eql("I am a document.")
         end
       end
     end
-    context 'The highlighted parameter is set to false on SearchResultPresenter' do
+    context "The highlighted parameter is set to false on SearchResultPresenter" do
       let(:highlight) { false }
-      context 'The finder content item has show_summaries set to true' do
+      context "The finder content item has show_summaries set to true" do
         let(:show_summaries) { true }
-        it 'returns the truncated description' do
+        it "returns the truncated description" do
           expect(subject.document_list_component_data[:link][:description]).to eql("I am a document.")
         end
       end
-      context 'The finder content item has show_summaries set to false' do
+      context "The finder content item has show_summaries set to false" do
         let(:show_summaries) { false }
-        it 'returns the truncated description' do
+        it "returns the truncated description" do
           expect(subject.document_list_component_data[:link][:description]).to be_nil
         end
       end
@@ -186,13 +186,13 @@ RSpec.describe SearchResultPresenter do
   end
 
   describe "#highlight_text" do
-    context 'The highlighted parameter is set to false on SearchResultPresenter' do
+    context "The highlighted parameter is set to false on SearchResultPresenter" do
       let(:highlight) { false }
       it "returns nothing" do
         expect(subject.document_list_component_data[:highlight_text]).to be nil
       end
     end
-    context 'The highlighted parameter is set to true on SearchResultPresenter' do
+    context "The highlighted parameter is set to true on SearchResultPresenter" do
       let(:highlight) { true }
       it "returns 'Most relevant result'" do
         expect(subject.document_list_component_data[:highlight_text]).to eq("Most relevant result")

--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -6,7 +6,7 @@ describe SignupPresenter do
   let(:params) {
     ActionController::Parameters.new({})
   }
-  describe 'single facet' do
+  describe "single facet" do
     let(:content_item) {
       {
         "details" =>
@@ -20,8 +20,8 @@ describe SignupPresenter do
            "email_filter_name" => "Alert Type", }
       }
     }
-    describe '#choices' do
-      it 'returns an array of signup facets' do
+    describe "#choices" do
+      it "returns an array of signup facets" do
         expect(SignupPresenter.new(content_item, params).choices).
           to eq([
                   { "facet_choices" => [{ "key" => "devices",
@@ -33,19 +33,19 @@ describe SignupPresenter do
                 ])
       end
     end
-    describe '#choices?' do
-      it 'returns true' do
+    describe "#choices?" do
+      it "returns true" do
         expect(SignupPresenter.new(content_item, params).choices?).to be true
       end
     end
-    describe '#can_modify_choices?' do
-      it 'returns false' do
+    describe "#can_modify_choices?" do
+      it "returns false" do
         expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be true
       end
     end
   end
 
-  describe 'multiple facets' do
+  describe "multiple facets" do
     let(:content_item) {
       {
         "details" => {
@@ -62,8 +62,8 @@ describe SignupPresenter do
         }
       }
     }
-    describe '#choices' do
-      it 'returns an array of signup facets' do
+    describe "#choices" do
+      it "returns an array of signup facets" do
         expect(SignupPresenter.new(content_item, params).choices).
           to eq([
                   {
@@ -77,19 +77,19 @@ describe SignupPresenter do
 ])
       end
     end
-    describe '#choices?' do
-      it 'returns true' do
+    describe "#choices?" do
+      it "returns true" do
         expect(SignupPresenter.new(content_item, params).choices?).to be true
       end
     end
-    describe '#can_modify_choices?' do
-      it 'returns false' do
+    describe "#can_modify_choices?" do
+      it "returns false" do
         expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be false
       end
     end
   end
 
-  describe 'no facets in email signup' do
+  describe "no facets in email signup" do
     let(:content_item) {
       {
         "details" => {
@@ -97,18 +97,18 @@ describe SignupPresenter do
         }
       }
     }
-    describe '#choices' do
-      it 'returns an empty array' do
+    describe "#choices" do
+      it "returns an empty array" do
         expect(SignupPresenter.new(content_item, params).choices).to eq([])
       end
     end
-    describe '#choices?' do
-      it 'returns false' do
+    describe "#choices?" do
+      it "returns false" do
         expect(SignupPresenter.new(content_item, params).choices?).to be false
       end
     end
-    describe '#can_modify_choices?' do
-      it 'returns an empty array' do
+    describe "#can_modify_choices?" do
+      it "returns an empty array" do
         expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be false
       end
     end

--- a/spec/presenters/sort_option_presenter_spec.rb
+++ b/spec/presenters/sort_option_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe SortOptionPresenter do
   subject(:sort_option) { described_class.new(label: "Updated (newest)", key: "-public_timestamp") }

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe SortPresenter do
   include GovukContentSchemaExamples
@@ -52,8 +52,8 @@ RSpec.describe SortPresenter do
       expect(presenter_with_sort.to_hash).to eq(
         options: [
           {
-            data_track_category: 'dropDownClicked',
-            data_track_action: 'clicked',
+            data_track_category: "dropDownClicked",
+            data_track_action: "clicked",
             data_track_label: "Most viewed",
             label: "Most viewed",
             value: "most-viewed",
@@ -61,8 +61,8 @@ RSpec.describe SortPresenter do
             selected: false,
           },
           {
-            data_track_category: 'dropDownClicked',
-            data_track_action: 'clicked',
+            data_track_category: "dropDownClicked",
+            data_track_action: "clicked",
             data_track_label: "Updated (newest)",
             label: "Updated (newest)",
             value: "updated-newest",
@@ -86,8 +86,8 @@ RSpec.describe SortPresenter do
     it "sets an option as selected if a valid order is provided by the user" do
       expect(presenter_with_relevance_selected.to_hash[:options].find { |o| o[:selected] }).
         to eq(
-          data_track_category: 'dropDownClicked',
-          data_track_action: 'clicked',
+          data_track_category: "dropDownClicked",
+          data_track_action: "clicked",
           data_track_label: "Relevance",
           label: "Relevance",
           value: "relevance",
@@ -98,7 +98,7 @@ RSpec.describe SortPresenter do
 
     it "should disable the relevance option if keywords are not present" do
       expect(presenter_with_relevance.to_hash[:options].find { |o|
-        o[:value] == 'relevance'
+        o[:value] == "relevance"
       }[:disabled]).to be true
     end
 
@@ -107,7 +107,7 @@ RSpec.describe SortPresenter do
 
       it "should not disable relevance" do
         expect(presenter_with_relevance.to_hash[:options].find { |o|
-          o[:value] == 'relevance'
+          o[:value] == "relevance"
         }[:disabled]).to be false
       end
     end
@@ -186,7 +186,7 @@ RSpec.describe SortPresenter do
     context "a default option is specified in the content item" do
       it "returns the default SortOptionPresenter" do
         expect(presenter_with_default.default_option).to be_instance_of(SortOptionPresenter)
-        expect(presenter_with_default.default_option.label).to eq('Updated (oldest)')
+        expect(presenter_with_default.default_option.label).to eq("Updated (oldest)")
       end
     end
 
@@ -200,8 +200,8 @@ RSpec.describe SortPresenter do
 private
 
   def content_item(sort_options: nil)
-    finder_example = govuk_content_schema_example('finder')
-    finder_example['details']['sort'] = sort_options
+    finder_example = govuk_content_schema_example("finder")
+    finder_example["details"]["sort"] = sort_options
     ContentItem.new(finder_example)
   end
 end

--- a/spec/presenters/statistics_metadata_presenter_spec.rb
+++ b/spec/presenters/statistics_metadata_presenter_spec.rb
@@ -1,41 +1,41 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe StatisticsMetadataPresenter do
   let(:raw_metadata_announcement) {
     [
-      { name: 'Updated', value: '2000-01-02T13:54:00.000+01:00', type: 'date' },
-      { name: 'Release date', value: '2004-05-06T09:30:00.000+01:00', type: 'date' }
+      { name: "Updated", value: "2000-01-02T13:54:00.000+01:00", type: "date" },
+      { name: "Release date", value: "2004-05-06T09:30:00.000+01:00", type: "date" }
     ]
   }
 
   let(:raw_metadata_published) {
     [
-      { name: 'Updated', value: '2000-01-02T13:54:00.000+01:00', type: 'date' }
+      { name: "Updated", value: "2000-01-02T13:54:00.000+01:00", type: "date" }
     ]
   }
 
   let(:formatted_metadata_announcement) {
     [
-      { label: 'Release date', is_date: true, machine_date: "2004-05-06", human_date: "6 May 2004" }
+      { label: "Release date", is_date: true, machine_date: "2004-05-06", human_date: "6 May 2004" }
     ]
   }
 
   let(:formatted_metadata_published) {
     [
-      { label: 'Updated', is_date: true, machine_date: "2000-01-02", human_date: "2 January 2000" }
+      { label: "Updated", is_date: true, machine_date: "2000-01-02", human_date: "2 January 2000" }
     ]
   }
 
-  describe '#present' do
-    context 'when both release date and updated dates' do
-      it 'formats the metadata' do
+  describe "#present" do
+    context "when both release date and updated dates" do
+      it "formats the metadata" do
         presenter = described_class.new(raw_metadata_announcement)
         expect(presenter.present).to eq(formatted_metadata_announcement)
       end
     end
 
-    context 'when only updated date' do
-      it 'formats the metadata' do
+    context "when only updated date" do
+      it "formats the metadata" do
         presenter = described_class.new(raw_metadata_published)
         expect(presenter.present).to eq(formatted_metadata_published)
       end

--- a/spec/presenters/statistics_sort_presenter_spec.rb
+++ b/spec/presenters/statistics_sort_presenter_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe StatisticsSortPresenter do
   let(:stats_finder) {
@@ -11,7 +11,7 @@ RSpec.describe StatisticsSortPresenter do
 
   let(:keywords_query) { { "keywords" => "cats" } }
 
-  let(:most_viewed_query) { { 'order' => "most-viewed" } }
+  let(:most_viewed_query) { { "order" => "most-viewed" } }
 
   let(:bad_sort_option_query) { { "order" => "blah blah" } }
 
@@ -63,34 +63,34 @@ RSpec.describe StatisticsSortPresenter do
     context "when published_statistics is selected" do
       let(:query) { published_statistics_query }
       it "returns updated newest" do
-        expect_default('Updated (newest)', 'updated-newest')
+        expect_default("Updated (newest)", "updated-newest")
       end
     end
 
     context "when research is selected" do
       let(:query) { research_query }
       it "returns updated newest" do
-        expect_default('Updated (newest)', 'updated-newest')
+        expect_default("Updated (newest)", "updated-newest")
       end
     end
 
     context "when upcoming_statistics is selected" do
       let(:query) { upcoming_statistics_query }
       it "returns release timestamp" do
-        expect_default('Release date (soonest)', 'release-date-oldest')
+        expect_default("Release date (soonest)", "release-date-oldest")
       end
     end
 
     context "when cancelled_statistics is selected" do
       let(:query) { cancelled_statistics_query }
       it "returns public timestamp" do
-        expect_default('Updated (newest)', 'updated-newest')
+        expect_default("Updated (newest)", "updated-newest")
       end
     end
 
     context "when no value is selected" do
       it "returns updated newest as the default" do
-        expect_default('Updated (newest)', 'updated-newest')
+        expect_default("Updated (newest)", "updated-newest")
       end
     end
   end
@@ -116,7 +116,7 @@ RSpec.describe StatisticsSortPresenter do
     end
 
     context "an unpermitted option is selected by the user" do
-      let(:order) { { 'order' => 'bad input!' } }
+      let(:order) { { "order" => "bad input!" } }
 
       it "returns the default option" do
         returns_the_default_option
@@ -160,7 +160,7 @@ RSpec.describe StatisticsSortPresenter do
     end
 
     context "Release date (latest) is selected by the user" do
-      let(:order) { { 'order' => 'release-date-latest' } }
+      let(:order) { { "order" => "release-date-latest" } }
       let(:query) { order }
 
       it "returns Updated (newest)" do
@@ -178,7 +178,7 @@ RSpec.describe StatisticsSortPresenter do
       end
 
       context "Updated (oldest) is selected by the user" do
-        let(:order) { { 'order' => 'updated-oldest' } }
+        let(:order) { { "order" => "updated-oldest" } }
         let(:query) { order }
 
         it "returns Updated (oldest)" do
@@ -202,7 +202,7 @@ RSpec.describe StatisticsSortPresenter do
     end
 
     context "Sort option release-date-oldest is selected by the user" do
-      let(:order) { { 'order' => 'release-date-oldest' } }
+      let(:order) { { "order" => "release-date-oldest" } }
 
       context "upcoming statistics is selected" do
         let(:query) { order.merge(upcoming_statistics_query) }
@@ -233,7 +233,7 @@ RSpec.describe StatisticsSortPresenter do
     end
 
     def relevance_value_is_set
-      expect(presenter.to_hash[:relevance_value]).to eq('relevance')
+      expect(presenter.to_hash[:relevance_value]).to eq("relevance")
     end
 
     def has_four_options
@@ -242,7 +242,7 @@ RSpec.describe StatisticsSortPresenter do
 
     def relevance_disabled?
       presenter.to_hash[:options].find { |o|
-        o[:value] == 'relevance'
+        o[:value] == "relevance"
       }[:disabled]
     end
 
@@ -338,8 +338,8 @@ RSpec.describe StatisticsSortPresenter do
       it "sets the default option as selected" do
         expect(presenter.to_hash[:options].find { |o| o[:selected] }).
           to eq(
-            data_track_category: 'dropDownClicked',
-            data_track_action: 'clicked',
+            data_track_category: "dropDownClicked",
+            data_track_action: "clicked",
             data_track_label: "Updated (newest)",
             label: "Updated (newest)",
             value: "updated-newest",

--- a/spec/presenters/subscriber_list_params_presenter_spec.rb
+++ b/spec/presenters/subscriber_list_params_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SubscriberListParamsPresenter do
 
   let(:signup_finder) { news_and_communications_signup_content_item }
 
-  describe '#subscriber_list_params' do
+  describe "#subscriber_list_params" do
     it "returns empty hash if none passed in" do
       params = {}
       presenter = described_class.new(signup_finder, params)
@@ -14,34 +14,34 @@ RSpec.describe SubscriberListParamsPresenter do
 
     it "returns hash with values if they are included in the content_item" do
       signup_finder_content_item = signup_finder.tap do |content_item|
-        content_item['details']['email_filter_facets'] = [
+        content_item["details"]["email_filter_facets"] = [
           {
-            'facet_id' => 'filter_part_of_taxonomy'
+            "facet_id" => "filter_part_of_taxonomy"
           }
         ]
       end
 
-      params = { 'filter_part_of_taxonomy' => 'some-taxon' }
+      params = { "filter_part_of_taxonomy" => "some-taxon" }
       presenter = described_class.new(signup_finder_content_item, params)
-      expect(presenter.subscriber_list_params).to eql('filter_part_of_taxonomy' => %w(some-taxon))
+      expect(presenter.subscriber_list_params).to eql("filter_part_of_taxonomy" => %w(some-taxon))
     end
 
     it "returns hash with values if they are dynamic attributes" do
       params = {
-        'organisations' => %w[academy-for-social-justice-commissioning accelerated-access-review],
-        'people' => %w[sir-philip-jones mark-stanhope],
-        'level_one_taxon' => %w[c58fdadd-7743-46d6-9629-90bb3ccc4ef0],
-        'related_to_brexit' => 'true'
+        "organisations" => %w[academy-for-social-justice-commissioning accelerated-access-review],
+        "people" => %w[sir-philip-jones mark-stanhope],
+        "level_one_taxon" => %w[c58fdadd-7743-46d6-9629-90bb3ccc4ef0],
+        "related_to_brexit" => "true"
       }
 
       presenter = described_class.new(signup_finder, params)
       expect(presenter.subscriber_list_params).to eql(
-        'organisations' => %w(
+        "organisations" => %w(
           academy-for-social-justice-commissioning
           accelerated-access-review
         ),
-        'people' => %w(sir-philip-jones mark-stanhope),
-        'all_part_of_taxonomy_tree' => %w(
+        "people" => %w(sir-philip-jones mark-stanhope),
+        "all_part_of_taxonomy_tree" => %w(
           c58fdadd-7743-46d6-9629-90bb3ccc4ef0
           d6c2de5d-ef90-45d1-82d4-5f2438369eea
         ),
@@ -50,14 +50,14 @@ RSpec.describe SubscriberListParamsPresenter do
 
     it "returns empty hash if email_filter_facet includes facet_choices in the content_item" do
       signup_finder_content_item = signup_finder.tap do |content_item|
-        content_item['details']['email_filter_facets'] = [
+        content_item["details"]["email_filter_facets"] = [
           {
-            'facet_name' => 'filter_part_of_taxonomy',
-            'facet_choices' => [
+            "facet_name" => "filter_part_of_taxonomy",
+            "facet_choices" => [
               {
-                "key": 'taxon',
-                "radio_button_name": 'Filter by some taxon',
-                "topic_name": 'Some taxon',
+                "key": "taxon",
+                "radio_button_name": "Filter by some taxon",
+                "topic_name": "Some taxon",
                 "prechecked": false
               }
             ]
@@ -65,30 +65,30 @@ RSpec.describe SubscriberListParamsPresenter do
         ]
       end
 
-      params = { 'filter_part_of_taxonomy' => 'some-taxon' }
+      params = { "filter_part_of_taxonomy" => "some-taxon" }
       presenter = described_class.new(signup_finder_content_item, params)
       expect(presenter.subscriber_list_params).to eql({})
     end
 
     it "translates a facet id into a filter key if it is present" do
       signup_finder_content_item = signup_finder.tap do |content_item|
-        content_item['details']['email_filter_facets'] = [
+        content_item["details"]["email_filter_facets"] = [
           {
-            'facet_id' => 'some_arbitrary_facet_id',
-            'facet_name' => 'some_arbitrary_facet_name',
-            'filter_key' => 'a_filter_key_rummager_can_filter_by',
+            "facet_id" => "some_arbitrary_facet_id",
+            "facet_name" => "some_arbitrary_facet_name",
+            "filter_key" => "a_filter_key_rummager_can_filter_by",
           }
         ]
       end
 
-      params = { 'some_arbitrary_facet_id' => 'some-taxon' }
+      params = { "some_arbitrary_facet_id" => "some-taxon" }
       presenter = described_class.new(signup_finder_content_item, params)
-      expect(presenter.subscriber_list_params).to eql('a_filter_key_rummager_can_filter_by' => %w(some-taxon))
+      expect(presenter.subscriber_list_params).to eql("a_filter_key_rummager_can_filter_by" => %w(some-taxon))
     end
 
     it "translates option_lookup values into a filter key if they are present" do
       signup_finder_content_item = signup_finder.tap do |content_item|
-        content_item['details']['email_filter_facets'] = [
+        content_item["details"]["email_filter_facets"] = [
           {
             "facet_id" => "content_store_document_type",
             "facet_name" => "document types",
@@ -101,10 +101,10 @@ RSpec.describe SubscriberListParamsPresenter do
         ]
       end
 
-      params = { 'content_store_document_type' => %w(policy_papers open_consultations) }
+      params = { "content_store_document_type" => %w(policy_papers open_consultations) }
       presenter = described_class.new(signup_finder_content_item, params)
       expect(presenter.subscriber_list_params).to eql(
-        'content_store_document_type' => %w(
+        "content_store_document_type" => %w(
           impact_assessment
           case_study
           policy_paper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,18 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
-require 'slimmer/test'
+require "slimmer/test"
 
-ENV["RAILS_ENV"] ||= 'test'
-ENV['GOVUK_WEBSITE_ROOT'] ||= 'https://www.test.gov.uk'
-require File.expand_path('../config/environment', __dir__)
-require 'rspec/rails'
-require 'webmock/rspec'
+ENV["RAILS_ENV"] ||= "test"
+ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.test.gov.uk"
+require File.expand_path("../config/environment", __dir__)
+require "rspec/rails"
+require "webmock/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/content_helper.rb
+++ b/spec/support/content_helper.rb
@@ -7,10 +7,10 @@
 #
 #   $ GOVUK_CONTENT_SCHEMAS_PATH=/some/dir/govuk-content-schemas bundle exec rake
 #
-require 'gds_api/test_helpers/content_store'
+require "gds_api/test_helpers/content_store"
 
 GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = 'frontend'
+  config.schema_type = "frontend"
   config.project_root = Rails.root
 end
 
@@ -21,7 +21,7 @@ module GovukContentSchemaExamples
     include GdsApi::TestHelpers::ContentStore
 
     # Returns a hash representing an finder content item from govuk-content-schemas
-    def govuk_content_schema_example(name, format = 'finder')
+    def govuk_content_schema_example(name, format = "finder")
       string = GovukContentSchemaTestHelpers::Examples.new.get(format, name)
       JSON.parse(string)
     end

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -3,7 +3,7 @@ module RegistrySpecHelper
     stub_request(:get, "http://search.dev.gov.uk/search.json")
         .with(query: {
             count: 0,
-            facet_people: '1500,examples:0,order:value.title'
+            facet_people: "1500,examples:0,order:value.title"
         })
         .to_return(body: {
             results: [],
@@ -63,7 +63,7 @@ module RegistrySpecHelper
       count: 1500,
       fields: %w(slug title acronym content_id),
       filter_format: %(organisation),
-      order: 'title'
+      order: "title"
     })
     .to_return(body: { results: [
       {

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -24,8 +24,8 @@ private
     return if taxon_hashes.nil?
 
     taxon_hashes.each do |taxon_hash|
-      content_store_has_item(taxon_hash['base_path'], taxon_hash)
-      has_taxons(taxon_hash.dig('links', 'child_taxons'))
+      content_store_has_item(taxon_hash["base_path"], taxon_hash)
+      has_taxons(taxon_hash.dig("links", "child_taxons"))
     end
   end
 end


### PR DESCRIPTION
    Previously we allowed any style of quotation between files and within
    the same file, which only serves to increase the mental load when trying
    to write consistent code. It would be quite a large change to reenable
    the associated RuboCop across the whole of GOV.UK, but this change will
    help reduce the quotation choice overhead for at least this repo.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
