### PR TITLE
Add group_id when creating Brexit subscriber lists

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -1,5 +1,8 @@
 class BrexitCheckerController < ApplicationController
   include BrexitCheckerHelper
+
+  SUBSCRIBER_LIST_GROUP_ID = "5a7c11f2-e737-4531-a0bc-b5f707046607".freeze
+
   layout "finder_layout"
 
   protect_from_forgery except: :confirm_email_signup
@@ -44,6 +47,7 @@ private
     {
       "title" => "Your Get ready for Brexit results",
       "description" => "[You can view a copy of your results on GOV.UK.](#{Plek.new.website_root}#{path})",
+      "group_id" => SUBSCRIBER_LIST_GROUP_ID,
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,
     }

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -9,9 +9,10 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     {
       "title" => "Your Get ready for Brexit results",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your results on GOV.UK.](http://www.test.gov.uk/results?c[]=does-not-own-business&c[]=eu-national)",
+      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/get-ready-brexit-check/results?c%5B%5D=does-not-own-business&c%5B%5D=eu-national)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[does-not-own-business eu-national] } },
-      "url" => "/results?c[]=does-not-own-business&c[]=eu-national"
+      "url" => "/get-ready-brexit-check/results?c%5B%5D=does-not-own-business&c%5B%5D=eu-national",
+      "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
     }
   end
 
@@ -27,6 +28,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     and_email_alert_api_does_not_have_subscriber_list
     and_email_alert_api_creates_subscriber_list
     then_i_click_to_signup_to_emails
+    and_the_subscriber_list_was_created
     and_i_am_taken_to_email_alert_frontend
   end
 
@@ -43,12 +45,17 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   def and_email_alert_api_creates_subscriber_list
-    stub_email_alert_api_creates_subscriber_list(subscriber_list)
+    @create_request = stub_email_alert_api_creates_subscriber_list(subscriber_list)
+                        .with(body: subscriber_list.except("slug").as_json)
   end
 
   def then_i_click_to_signup_to_emails
     click_on "Subscribe" # on main results page
     click_on "Subscribe" # on overview of subscription page
+  end
+
+  def and_the_subscriber_list_was_created
+    expect(@create_request).to have_been_requested
   end
 
   def and_i_am_taken_to_email_alert_frontend


### PR DESCRIPTION
Trello: https://trello.com/c/sWBqpBeQ/84-create-an-id-to-represent-a-family-of-subscriberlists

~This is a draft until https://github.com/alphagov/email-alert-api/pull/973 is merged and deployed to prod.~ - This is now deployed.

This adds an id that can be used to group together all the different
lists that are created for the Get ready for brexit checker. This can be
used as a means to query data for all the lists that are variants.

This also updates the feature test to verify that the create request has
performed with the parameters we anticipate. There were a few of these I
had to resolve.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1546.herokuapp.com/search/all
- http://finder-frontend-pr-1546.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1546.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1546.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1546.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1546.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1546.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1546.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1546.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1546.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
