### PR TITLE
Rename SearchClusterQuery A/B test

### DIFF
--- a/app/controllers/concerns/search_cluster_ab_testable.rb
+++ b/app/controllers/concerns/search_cluster_ab_testable.rb
@@ -11,7 +11,7 @@ module SearchClusterABTestable
   # anything else = use default cluster
   def search_cluster_test
     @search_cluster_test ||= GovukAbTesting::AbTest.new(
-      'SearchClusterQueryABTest',
+      'SearchClusterQuery2ABTest',
       dimension: CUSTOM_DIMENSION,
       allowed_variants: %w[Default A B],
       control_variant: 'Default',

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -272,7 +272,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant Default sets use_default_cluster? and not use_b_cluster?" do
-      with_variant SearchClusterQueryABTest: 'Default' do
+      with_variant SearchClusterQuery2ABTest: 'Default' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(true)
         expect(subject.use_b_cluster?).to eq(false)
@@ -280,7 +280,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant A does not set use_default_cluster? or use_b_cluster?" do
-      with_variant SearchClusterQueryABTest: 'A' do
+      with_variant SearchClusterQuery2ABTest: 'A' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(false)
@@ -288,7 +288,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant 'B' sets use_b_cluster? and not use_default_cluster?" do
-      with_variant SearchClusterQueryABTest: 'B' do
+      with_variant SearchClusterQuery2ABTest: 'B' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(true)


### PR DESCRIPTION
This should be deployed after ending the old one and before starting
the new one.  There's no need to change the test name in search-api,
so that can remain the same.

[Trello card](https://trello.com/c/xut9Rm2q/1006-rename-a-b-test)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1552.herokuapp.com/search/all
- http://finder-frontend-pr-1552.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1552.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1552.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1552.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1552.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1552.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1552.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1552.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1552.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
