### PR TITLE
Rename CriteriaLogic to Criteria

### DIFF
--- a/lib/brexit_checker/action.rb
+++ b/lib/brexit_checker/action.rb
@@ -18,7 +18,7 @@ class BrexitChecker::Action
   end
 
   def show?(selected_criteria)
-    BrexitChecker::CriteriaLogic::Evaluator.evaluate(criteria, selected_criteria)
+    BrexitChecker::Criteria::Evaluator.evaluate(criteria, selected_criteria)
   end
 
   def self.load(params)

--- a/lib/brexit_checker/convert_csv_to_yaml/actions_processor.rb
+++ b/lib/brexit_checker/convert_csv_to_yaml/actions_processor.rb
@@ -30,7 +30,7 @@ module BrexitChecker
 
       def parse_logic_fields(record)
         LOGIC_FIELDS.each_with_object(record) do |field, hash|
-          hash[field] = BrexitChecker::CriteriaLogic::Parser.parse(hash[field].strip) if hash[field]
+          hash[field] = BrexitChecker::Criteria::Parser.parse(hash[field].strip) if hash[field]
         end
       end
 

--- a/lib/brexit_checker/criteria/evaluator.rb
+++ b/lib/brexit_checker/criteria/evaluator.rb
@@ -1,4 +1,4 @@
-class BrexitChecker::CriteriaLogic::Evaluator
+class BrexitChecker::Criteria::Evaluator
   def initialize(expression, selected_criteria)
     @expression = expression
     @selected_criteria = selected_criteria

--- a/lib/brexit_checker/criteria/parser.rb
+++ b/lib/brexit_checker/criteria/parser.rb
@@ -1,4 +1,4 @@
-class BrexitChecker::CriteriaLogic::Parser
+class BrexitChecker::Criteria::Parser
   def self.parse(string)
     tokens = Lexer.tokenise(string)
     ast = AST.parse(tokens)

--- a/lib/brexit_checker/criteria/validator.rb
+++ b/lib/brexit_checker/criteria/validator.rb
@@ -1,6 +1,6 @@
 require "set"
 
-class BrexitChecker::CriteriaLogic::Validator
+class BrexitChecker::Criteria::Validator
   def initialize(expression)
     @expression = expression
   end

--- a/lib/brexit_checker/question.rb
+++ b/lib/brexit_checker/question.rb
@@ -26,7 +26,7 @@ class BrexitChecker::Question
   end
 
   def show?(selected_criteria)
-    BrexitChecker::CriteriaLogic::Evaluator.evaluate(criteria, selected_criteria)
+    BrexitChecker::Criteria::Evaluator.evaluate(criteria, selected_criteria)
   end
 
   def possible_values

--- a/lib/brexit_checker/question/option.rb
+++ b/lib/brexit_checker/question/option.rb
@@ -11,7 +11,7 @@ class BrexitChecker::Question::Option
   end
 
   def show?(criteria_keys)
-    BrexitChecker::CriteriaLogic::Evaluator.evaluate(criteria, criteria_keys)
+    BrexitChecker::Criteria::Evaluator.evaluate(criteria, criteria_keys)
   end
 
   def self.load(params)

--- a/spec/integration/brexit_checker_spec.rb
+++ b/spec/integration/brexit_checker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe "Brexit checker data integrity" do
-  let(:validator) { BrexitChecker::CriteriaLogic::Validator }
+  let(:validator) { BrexitChecker::Criteria::Validator }
 
   it "has questions that reference valid criteria" do
     BrexitChecker::Question.load_all.each do |question|

--- a/spec/lib/brexit_checker/criteria/evaluator_spec.rb
+++ b/spec/lib/brexit_checker/criteria/evaluator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe BrexitChecker::CriteriaLogic::Evaluator do
+RSpec.describe BrexitChecker::Criteria::Evaluator do
   let(:selected_criteria) { [] }
   subject(:evaluation) { described_class.evaluate(expression, selected_criteria) }
 

--- a/spec/lib/brexit_checker/criteria/parser_spec.rb
+++ b/spec/lib/brexit_checker/criteria/parser_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe BrexitChecker::CriteriaLogic::Parser do
+RSpec.describe BrexitChecker::Criteria::Parser do
   let(:input) { nil }
   subject(:output) { described_class.parse(input) }
 

--- a/spec/lib/brexit_checker/criteria/validator_spec.rb
+++ b/spec/lib/brexit_checker/criteria/validator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe BrexitChecker::CriteriaLogic::Validator do
+RSpec.describe BrexitChecker::Criteria::Validator do
   before do
     allow(BrexitChecker::Criterion).to receive(:load_all).and_return([
       double(key: "a"), double(key: "b"), double(key: "c")


### PR DESCRIPTION
https://trello.com/c/8GrUatcO/255-filter-criteria-to-support-changing-answers-to-questions

This renames the CriteriaLogic so it's more open to other classes - we'd
like to add a Criteria::Filter class. Irrespective of this, the classes
are sufficiently well named that the word 'logic' is redundant.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
