### PR TITLE
Bring back spelling suggestions

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -17,6 +17,7 @@
     this.$loadingBlock = options.$results.find('#js-loading-message')
     this.$sortBlock = options.$results.find('#js-sort-options')
     this.$paginationBlock = options.$results.find('#js-pagination')
+    this.$suggestionsBlock = this.$form.find('#js-spelling-suggestions')
     this.action = this.$form.attr('action') + '.json'
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink
     this.baseTitle = $("meta[name='govuk:base_title']").attr('content') || document.title
@@ -219,6 +220,31 @@
     this.bindSortElements()
   }
 
+  LiveSearch.prototype.updateSpellingSuggestions = function (results) {
+    // bail out, as this is only set up on search/all
+    if (this.$suggestionsBlock.length === 0) { return }
+    var suggestionsPresent = results.suggestions.length !== 0
+
+    if (suggestionsPresent) {
+      // there might be more than one suggestion in the future
+      // so we're removing all previous ones before adding new one
+      // as there might be fewer or more new suggestions
+      this.$suggestionsBlock.find('a').remove()
+      for (var i = 0; i < results.suggestions.length; i++) {
+        var suggestion = results.suggestions[i]
+        var $suggestionLink = $('<a>', {
+          text: suggestion.keywords,
+          href: suggestion.link,
+          class: 'govuk-link govuk-!-font-weight-bold'
+        })
+        this.$suggestionsBlock.find('p').append($suggestionLink)
+      }
+    }
+
+    // checks results for any suggestions and hides/shows the container accordingly
+    this.$suggestionsBlock.attr('class', suggestionsPresent ? 'spelling-suggestions--visible' : 'spelling-suggestions')
+  }
+
   LiveSearch.prototype.bindSortElements = function bindSortElements () {
     this.$orderSelect = this.$form.find('.js-order-results')
     this.$relevanceOrderOption = this.$orderSelect.find('option[value=' + this.$orderSelect.data('relevance-sort-option') + ']')
@@ -321,6 +347,7 @@
       this.updateElement(this.$countBlock, results.total)
       this.updateElement(this.$paginationBlock, results.next_and_prev_links)
       this.updateSortOptions(results, action)
+      this.updateSpellingSuggestions(results)
       this.$atomAutodiscoveryLink.attr('href', results.atom_url)
       this.$loadingBlock.text('').hide()
     }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -214,7 +214,11 @@ mark {
 
 .facet-toggle {
   display: none;
-  margin-bottom: govuk-spacing(6);
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(6);
+  }
 }
 
 .js-enabled {
@@ -268,10 +272,19 @@ mark {
   }
 }
 
-.result-region-header__sort-label {
+.sort-options__label {
   @include govuk-responsive-padding(1, "right");
   display: inline-block;
   margin-bottom: govuk-spacing(3);
+  @include govuk-media-query($from: tablet) {
+    font-size: 16px;
+  }
+}
+
+.sort-options__select {
+  @include govuk-media-query($from: tablet) {
+    font-size: 16px;
+  }
 }
 
 .result-info {
@@ -331,5 +344,32 @@ mark {
   &::-moz-focus-inner {
     padding: 0;
     border: 0;
+  }
+}
+
+//show spelling suggestion container only if suggestions are availble
+.spelling-suggestions {
+  display: none;
+  margin-top: -(govuk-spacing(1));
+  margin-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: -(govuk-spacing(2));
+    margin-bottom: govuk-spacing(7);
+
+    // We need to keep font size consistently 16 pixels when above tablet
+    // breakpoint
+    .govuk-body {
+      font-size: 16px;
+    }
+  }
+}
+.spelling-suggestions--visible {
+  display: block;
+}
+
+.gem-c-subscription-links {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(2);
   }
 }

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -32,6 +32,13 @@
             value: result_set_presenter.user_supplied_keywords,
           } %>
         </div>
+        <div class="spelling-suggestions<%= ' spelling-suggestions--visible' if @suggestions.any? %>" id="js-spelling-suggestions">
+          <p class="govuk-body">Did you mean 
+            <% @suggestions.each do |suggestion| %>
+              <%= link_to suggestion[:keywords], suggestion[:link], class: "govuk-link govuk-!-font-weight-bold" %>
+            <% end %>
+          </p>
+        </div>
       <% elsif topic_finder?(filter_params) %>
         <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -32,10 +32,14 @@
             value: result_set_presenter.user_supplied_keywords,
           } %>
         </div>
-        <div class="spelling-suggestions<%= ' spelling-suggestions--visible' if @suggestions.any? %>" id="js-spelling-suggestions">
+        <div class="spelling-suggestions<%= ' spelling-suggestions--visible' if @suggestions.any? %>" id="js-spelling-suggestions" data-analytics-contentid="<%= content_item.as_hash['content_id'] %>">
           <p class="govuk-body">Did you mean 
             <% @suggestions.each do |suggestion| %>
-              <%= link_to suggestion[:keywords], suggestion[:link], class: "govuk-link govuk-!-font-weight-bold" %>
+              <%= link_to suggestion[:keywords], suggestion[:link],
+                "data-analytics-list": "Search spelling suggestions",
+                "data-analytics-dimension71": "#{result_set_presenter.user_supplied_keywords}",
+                "data-analytics-dimension81": "#{suggestion[:keywords]}",
+                class: "govuk-link govuk-!-font-weight-bold" %>
             <% end %>
           </p>
         </div>

--- a/app/views/finders/_sort_options.html.erb
+++ b/app/views/finders/_sort_options.html.erb
@@ -1,8 +1,8 @@
 <% if local_assigns[:options] %>
-  <div class="govuk-form-group">
-    <label for="order" class="result-region-header__sort-label govuk-label">Sort by</label>
+  <div class="govuk-form-group sort-options">
+    <label for="order" class="sort-options__label govuk-label">Sort by</label>
     <select
-      class="js-order-results govuk-select"
+      class="js-order-results govuk-select sort-options__select"
       name="order"
       id="order"
       aria-controls="js-search-results-info"

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -491,4 +491,38 @@ describe('liveSearch', function () {
       expect($('#order option:selected').length).toBe(1)
     })
   })
+
+  describe('spelling suggestions', function () {
+    var $suggestionBlock = $('<div class="spelling-suggestions" id="js-spelling-suggestions"><p class="govuk-body">Did you mean </p></div>')
+    var responseWithSpellingSuggestions = {
+      'suggestions': [{
+        'keywords': 'driving license',
+        'link': '/search/all?keywords=driving+license&order=relevance'
+      }]
+    }
+
+    var responseWithNoSpellingSuggestions = {
+      'suggestions': []
+    }
+    beforeEach(function () {
+      $form.append($suggestionBlock)
+      liveSearch = new GOVUK.LiveSearch({ $form: $form, $results: $results, $suggestionBlock: $suggestionBlock, $atomAutodiscoveryLink: $atomAutodiscoveryLink })
+    })
+
+    afterEach(function () {
+      $form.remove()
+    })
+
+    it('are shown if there are available in the data', function () {
+      liveSearch.updateSpellingSuggestions(responseWithSpellingSuggestions)
+      expect($('#js-spelling-suggestions').hasClass('spelling-suggestions--visible')).toBe(true)
+      expect($('#js-spelling-suggestions a').text()).toBe('driving license')
+      expect($('#js-spelling-suggestions a').attr('href')).toBe('/search/all?keywords=driving+license&order=relevance')
+    })
+
+    it('are not shown if there are none available in the data', function () {
+      liveSearch.updateSpellingSuggestions(responseWithNoSpellingSuggestions)
+      expect($('#js-spelling-suggestions').hasClass('spelling-suggestions--visible')).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
Coauthored with @SamJamCul 

**_Back by popular demand!_**

We used to have spelling suggestions. We [blogged](https://insidegovuk.blog.gov.uk/2015/12/30/site-search-improvements-quick-wins/) about them as well

This works enables spelling suggestions on search/all finder only.

<img width="691" alt="Screen Shot 2019-09-13 at 15 43 12" src="https://user-images.githubusercontent.com/3758555/64871468-390ccc80-d63d-11e9-986d-727199a52eee.png">

Changes made to design 
![image](https://user-images.githubusercontent.com/25597009/65058044-835aba00-d96b-11e9-992b-4e1929d46a78.png)

![image](https://user-images.githubusercontent.com/25597009/65058054-88b80480-d96b-11e9-8774-f37e846ddd95.png)

TODO: 

- implement analytics tests

URLs to test
**Present** on https://finder-frontend-pr-1554.herokuapp.com/search/all
**Not present** on https://finder-frontend-pr-1554.herokuapp.com/cma-cases

Trello ticket: https://trello.com/c/fCavIyMo/888-bring-back-spelling-suggestions