### PR TITLE
Pre-warm content items in cache

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ FinderFrontend::Application.routes.draw do
 
   get '/healthcheck.json', to: GovukHealthcheck.rack_response(
     Healthchecks::RegistriesCache,
+    Healthchecks::ContentItemsCache,
   )
   get '/healthcheck', to: proc { [200, {}, %w[OK]] }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -13,6 +13,10 @@ every cache_refresh_schedule.minutes do
   rake "registries:cache_refresh"
 end
 
+every cache_refresh_schedule.minutes do
+  rake "content_store:refresh_cache_hard"
+end
+
 # Example:
 #
 # set :output, "/path/to/my/cron_log.log"

--- a/lib/fetch_finders.rb
+++ b/lib/fetch_finders.rb
@@ -1,0 +1,11 @@
+class FetchFinders
+  def self.from_search_api
+    GovukStatsd.time("fetch_finders.from_search_api.request_time") do
+      Services.rummager.search(
+        filter_rendering_app: 'finder-frontend',
+        fields: %w(link),
+        count: 1500,
+      ).dig('results')
+    end
+  end
+end

--- a/lib/fetch_finders.rb
+++ b/lib/fetch_finders.rb
@@ -1,6 +1,6 @@
 class FetchFinders
   def self.from_search_api
-    GovukStatsd.time("fetch_finders.from_search_api.request_time") do
+    GovukStatsd.time("rummager.fetch_finders") do
       Services.rummager.search(
         filter_rendering_app: 'finder-frontend',
         fields: %w(link),

--- a/lib/healthchecks/content_items_cache.rb
+++ b/lib/healthchecks/content_items_cache.rb
@@ -1,0 +1,59 @@
+module Healthchecks
+  class ContentItemsCache
+    def name
+      :content_items_are_cached
+    end
+
+    def status
+      if in_warning_state?
+        :warning
+      else
+        :ok
+      end
+    rescue StandardError
+      :warning
+    end
+
+    def message
+      if in_warning_state?
+        <<~WARNING
+          Content items aren't cached. Searches may be slower. Is content store unavailable?
+          These content items are uncached:
+          #{uncached_content_items.to_sentence}
+        WARNING
+      else
+        "OK"
+      end
+    rescue StandardError => e
+      <<~WARNING
+        A #{e.class} error occurred when checking the content item cache health:
+        #{e.message}
+      WARNING
+    end
+
+    # Optional
+    def enabled?
+      true # false if the check is not relevant at this time
+    end
+
+  private
+
+    def in_warning_state?
+      uncached_content_items.any?
+    end
+
+    def uncached_content_items
+      @uncached_content_items ||= finder_paths.select { |path|
+        Rails.cache.fetch(Services.content_store.cache_key(path)).nil?
+      }
+    end
+
+    def finder_paths
+      FetchFinders.from_search_api.map { |result| result['link'] }.compact
+    end
+
+    def registries
+      Registries::BaseRegistries.new.all
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -3,16 +3,12 @@ require 'gds_api/rummager'
 require 'gds_api/email_alert_api'
 
 module Services
-  def self.content_store
-    GdsApi::ContentStore.new(Plek.find("content-store"))
+  def self.cached_content_item(path)
+    content_store.cached_content_item(path)
   end
 
-  def self.cached_content_item(base_path)
-    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 10.minutes) do
-      GovukStatsd.time("content_store.fetch_request_time") do
-        content_store.content_item(base_path).to_h
-      end
-    end
+  def self.content_store
+    Services::ContentStore.new
   end
 
   def self.rummager

--- a/lib/services/content_store.rb
+++ b/lib/services/content_store.rb
@@ -29,7 +29,7 @@ private
       content_store.content_item(base_path).to_h
     end
   rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
-    GovukStatsd.increment("content_store_service.connection_error")
+    GovukStatsd.increment("content_store.connection_error")
     raise
   end
 

--- a/lib/services/content_store.rb
+++ b/lib/services/content_store.rb
@@ -1,0 +1,43 @@
+class Services::ContentStore
+  def hard_refresh_cache
+    finder_paths.map do |base_path|
+      item = content_item(base_path)
+      Rails.cache.write(cache_key(base_path), item)
+    end
+  end
+
+  def soft_refresh_cache
+    finder_paths.map do |base_path|
+      cached_content_item(base_path)
+    end
+  end
+
+  def cached_content_item(base_path)
+    Rails.cache.fetch(cache_key(base_path)) do
+      content_item(base_path)
+    end
+  end
+
+  def cache_key(base_path)
+    "finder-frontend_content_items#{base_path}"
+  end
+
+private
+
+  def content_item(base_path)
+    GovukStatsd.time("content_store.fetch_request_time") do
+      content_store.content_item(base_path).to_h
+    end
+  rescue GdsApi::HTTPServerError, GdsApi::HTTPBadGateway
+    GovukStatsd.increment("content_store_service.connection_error")
+    raise
+  end
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.find("content-store"))
+  end
+
+  def finder_paths
+    FetchFinders.from_search_api.map { |result| result['link'] }.compact
+  end
+end

--- a/lib/tasks/content_store.rake
+++ b/lib/tasks/content_store.rake
@@ -1,0 +1,25 @@
+namespace :content_store do
+  desc "
+  Fetch content items from content store and add to cache
+  Fetching content store data takes a while. Rather than have a user
+  experience a delay while we read-through an empty cache, we write ahead to
+  the cache with this job at regular intervals.
+  "
+  task refresh_cache_hard: :environment do
+    puts "Refreshing content store cache..."
+    Services::ContentStore.new.hard_refresh_cache
+    puts "Finished refreshing content store cache."
+  end
+
+  desc "
+  Fetch data for content items and add to cache _if they are not already present_.
+  This job will be used as part of the deploy.  It should only affect servers with
+  empty caches (which are probably new).
+  Caches are refreshed on a schedule with content_store:cache_refresh.
+  "
+  task refresh_cache_soft: :environment do
+    puts "Ensuring content items are cached..."
+    Services::ContentStore.new.soft_refresh_cache
+    puts "Finished ensuring content items are cached."
+  end
+end

--- a/spec/lib/healthchecks/content_items_cache_spec.rb
+++ b/spec/lib/healthchecks/content_items_cache_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Healthchecks::ContentItemsCache do
+  include ContentStoreServiceHelper
+
+  subject(:check) { described_class.new }
+
+  context "when search api is unavailable" do
+    it "has a warning status" do
+      search_api_isnt_available
+      expect(check.status).to eq :warning
+      expect(check.message).to include 'A GdsApi::HTTPUnavailable error occurred'
+    end
+  end
+
+  context "when content items aren't cached" do
+    it "has a warning status" do
+      search_api_has_finders
+      expect(check.status).to eq :warning
+      message = <<~WARNING
+        Content items aren't cached. Searches may be slower. Is content store unavailable?
+        These content items are uncached:
+        #{finder_content_items.map { |item| item[:link] }.to_sentence}
+      WARNING
+
+      expect(check.message).to eq message
+    end
+  end
+
+  context "when content items are cached" do
+    before do
+      search_api_has_finders
+      content_items_are_already_cached
+    end
+
+    it "has an OK status" do
+      expect(check.status).to eq :ok
+      expect(check.message).to eq "OK"
+    end
+  end
+end

--- a/spec/lib/services/content_store_spec.rb
+++ b/spec/lib/services/content_store_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/search'
+
+describe Services::ContentStore do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::Search
+  include ContentStoreServiceHelper
+
+  subject(:service) { described_class.new }
+  let(:search_path) { '/search/all' }
+
+  describe ".cached_content_item" do
+    subject { described_class.new.cached_content_item(search_path) }
+
+    context "when content store is unavailable" do
+      it "will raise an error" do
+        content_store_isnt_available
+        expect { subject }.to raise_error GdsApi::HTTPServerError
+      end
+    end
+
+    it "will return a content item hash" do
+      stub_content_store_has_item(search_path)
+      expect(subject['base_path']).to eq(search_path)
+    end
+
+    it "will cache a returned content item" do
+      item = content_item_for_base_path(search_path)
+      stub_content_store_has_item(search_path, item)
+      expect { subject }.to(change { cached_item(search_path) }.from(nil).to(item))
+    end
+
+    context "when an item is already cached" do
+      it "won't fetch a fresh one from the content store" do
+        content_store_isnt_available
+        content_items_are_already_cached
+        expect(subject['base_path']).to eq(search_path)
+      end
+    end
+  end
+
+  describe ".soft_refresh_cache" do
+    subject { service.soft_refresh_cache }
+
+    context "when cache is empty" do
+      it "will cache all finder content items" do
+        search_api_has_finders
+        stub_content_store_has_finders
+        subject
+        finder_content_items.each { |item|
+          expect_item_to_be_in_cache(item[:link])
+        }
+      end
+    end
+
+    context "when cache is not empty" do
+      it "WILL NOT overwrite already cached finder content items" do
+        search_api_has_finders
+        content_store_isnt_available
+        content_items_are_already_cached
+        subject
+        finder_content_items.each { |item|
+          expect_item_to_be_in_cache(item[:link])
+        }
+      end
+    end
+
+    context "when content store is unavailable" do
+      it "will raise an error" do
+        search_api_has_finders
+        content_store_isnt_available
+        expect { subject }.to raise_error GdsApi::HTTPServerError
+      end
+    end
+
+    context "when search-api is unavailable" do
+      it "will raise an error" do
+        search_api_isnt_available
+        expect { service.soft_refresh_cache }.to raise_error GdsApi::HTTPServerError
+      end
+    end
+  end
+
+  describe ".hard_refresh_cache" do
+    subject { service.hard_refresh_cache }
+
+    context "when cache is empty" do
+      it "will cache all finder content items" do
+        search_api_has_finders
+        stub_content_store_has_finders
+        subject
+        finder_content_items.each { |item|
+          expect_item_to_be_in_cache(item[:link])
+        }
+      end
+    end
+
+    context "when cache is not empty" do
+      it "WILL overwrite already cached finder content items" do
+        search_api_has_finders
+        item = content_item(search_path)
+        to_date = item['public_updated_at']
+        from_date = "2001-01-01T12:01:00+00:00"
+        item['public_updated_at'] = from_date
+        Rails.cache.write("finder-frontend_content_items#{search_path}", item)
+        stub_content_store_has_finders
+        expect { subject }.to(
+          change {
+            cached_item(search_path)['public_updated_at']
+          }.to(to_date).from(from_date)
+        )
+      end
+    end
+
+    context "when content store is unavailable" do
+      it "will raise an error" do
+        search_api_has_finders
+        content_store_isnt_available
+        expect { subject }.to raise_error GdsApi::HTTPServerError
+      end
+    end
+
+    context "when search-api is unavailable" do
+      it "will raise an error" do
+        search_api_isnt_available
+        expect { subject }.to raise_error GdsApi::HTTPServerError
+      end
+    end
+  end
+end

--- a/spec/support/content_store_service_helper.rb
+++ b/spec/support/content_store_service_helper.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/search'
+
+module ContentStoreServiceHelper
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::Search
+
+  def expect_item_to_be_in_cache(base_path)
+    expect(cached_item(base_path)).to eq(content_item(base_path))
+  end
+
+  def cached_item(base_path)
+    Rails.cache.fetch described_class.new.cache_key(base_path)
+  end
+
+  def content_item(base_path)
+    content_item_for_base_path(base_path)
+  end
+
+  def stub_content_store_has_finders
+    finder_content_items.each do |item|
+      path = item[:link]
+      stub_content_store_has_item(path, content_item(path))
+    end
+  end
+
+  def finder_content_items
+    [
+      { link: '/search/all' },
+      { link: '/breakfast-finder' },
+      { link: '/lunch-finder' },
+      { link: '/dinner-finder' },
+    ]
+  end
+
+  def search_api_has_finders
+    stub_any_search.to_return(body: { results: finder_content_items }.to_json)
+  end
+
+  def search_api_isnt_available
+    stub_any_search.to_return(status: 503)
+  end
+
+  def content_items_are_already_cached
+    finder_content_items.each do |item|
+      base_path = item[:link]
+      content = content_item(base_path)
+      Rails.cache.write("finder-frontend_content_items#{base_path}", content)
+    end
+  end
+end


### PR DESCRIPTION
This should prevent requests from users requiring a content store call, meaning we will return search results to some users faster. This is a similar pattern to registries.

With this change, finder content items are cached ahead of users requests, and are periodically refreshed.

There are rake tasks to refresh the cache during a deploy and on a schedule:

```
# replaces finders in the cache, run on a schedule
rake content_store:refresh_cache_hard
# replaces finders in the cache if they're not already present, run at deploy
rake content_store:refresh_cache_soft
```

The reason we're doing this now is because there are more finder-frontend machines, which makes it more likely for an end user to hit a cold cache.

I added a new healthcheck for the cached content items.

Trello: https://trello.com/c/1PG0oqZg/992

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1558.herokuapp.com/search/all
- http://finder-frontend-pr-1558.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1558.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1558.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1558.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1558.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1558.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1558.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1558.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1558.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
