### PR TITLE
Add highlighted search terms in results decriptions

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -25,6 +25,12 @@
   }
 }
 
+mark {
+  background-color: inherit;
+  color: inherit;
+  @include govuk-typography-weight-bold;
+}
+
 .related-links__link {
   @include govuk-font(16, $weight: bold);
   text-decoration: none;

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -9,7 +9,7 @@ class Document
     @title = document_hash.fetch(:title)
     @link = document_hash.fetch(:link)
     @content_id = document_hash.fetch(:content_id, nil)
-    @description = document_hash.fetch(:description, nil)
+    @description = document_hash.fetch(:description_with_highlighting, nil)
     @public_timestamp = document_hash.fetch(:public_timestamp, nil)
     @release_timestamp = document_hash.fetch(:release_timestamp, nil)
     @document_type = document_hash.fetch(:content_store_document_type, nil)

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -22,7 +22,7 @@ class SearchResultPresenter
       link: {
         text: title,
         path: link,
-        description: summary_text,
+        description: sanitize(summary_text),
         data_attributes: {
           ecommerce_path: link,
           ecommerce_content_id: document.content_id,

--- a/config/initializers/sanitizer.rb
+++ b/config/initializers/sanitizer.rb
@@ -1,0 +1,1 @@
+ActionView::Base.sanitized_allowed_tags << "mark"

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1039,6 +1039,7 @@ module DocumentHelper
           "title": "Register a spell",
           "link": "/register-a-spell",
           "description": "Register a magical spell",
+          "description_with_highlighting": "Register a magical spell",
           "public_timestamp": "2017-12-25T09:00:00Z",
           "part_of_taxonomy_tree": [
             "4bc72a8b-6011-457a-87e0-06dbb427cf36"
@@ -1105,6 +1106,7 @@ module DocumentHelper
           "title": "Register a spell",
           "link": "/register-a-spell",
           "description": "Register a magical spell",
+          "description_with_highlighting": "Register a magical spell",
           "public_timestamp": "2017-12-25T09:00:00Z",
           "part_of_taxonomy_tree": [
             "4bc72a8b-6011-457a-87e0-06dbb427cf36"
@@ -1413,6 +1415,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1543,6 +1546,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1583,6 +1587,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1683,6 +1688,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1783,6 +1789,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1824,6 +1831,7 @@ module DocumentHelper
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "content_id": "1234",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
@@ -1920,6 +1928,7 @@ module DocumentHelper
           "title": "Restrictions on usage of spells within school grounds",
           "link": "/restrictions-on-usage-of-spells-within-school-grounds",
           "description": "Restrictions on usage of spells within school grounds",
+          "description_with_highlighting": "Restrictions on usage of spells within school grounds",
           "public_timestamp": "2017-12-30T10:00:00Z",
           "part_of_taxonomy_tree": [
             "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -93,7 +93,7 @@ module RummagerUrlHelper
     %w(
       title
       link
-      description
+      description_with_highlighting
       public_timestamp
       popularity
       content_purpose_supergroup

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -78,7 +78,7 @@ module Search
       %w(
         title
         link
-        description
+        description_with_highlighting
         public_timestamp
         popularity
         content_purpose_supergroup

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -60,7 +60,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
@@ -119,7 +119,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
@@ -221,7 +221,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -58,7 +58,7 @@ describe Search::QueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id",
+        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id",
       )
     end
   end
@@ -85,7 +85,7 @@ describe Search::QueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,alpha,beta",
+        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,alpha,beta",
       )
     end
 
@@ -102,7 +102,7 @@ describe Search::QueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,zeta,beta",
+          "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,zeta,beta",
         )
       end
     end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -150,8 +150,8 @@ describe Document do
       description = "The government has many departments. These departments are part of the government."
       truncated_description = "The government has many departments."
 
-      let(:with_description_hash) { FactoryBot.build(:document_hash, description: description) }
-      let(:without_description) { FactoryBot.build(:document_hash, description: nil) }
+      let(:with_description_hash) { FactoryBot.build(:document_hash, description_with_highlighting: description) }
+      let(:without_description) { FactoryBot.build(:document_hash, description_with_highlighting: nil) }
 
       it 'should have truncated description' do
         expect(Document.new(with_description_hash, 1).truncated_description).to eq(truncated_description)

--- a/spec/presenters/entry_presenter_spec.rb
+++ b/spec/presenters/entry_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe EntryPresenter do
   describe '#summary' do
     let(:document) {
-      FactoryBot.build(:document, description: 'This is the summary. And this is extra.')
+      FactoryBot.build(:document, description_with_highlighting: 'This is the summary. And this is extra.')
     }
     it 'displays the truncated description' do
       expect(EntryPresenter.new(document, true).summary).to eq('This is the summary.')

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ResultSetPresenter do
                           content_id: "content_id",
                           link: "/path/to/doc",
                           title: 'document_title',
-                          description: 'document_description')]
+                          description_with_highlighting: 'document_description')]
       }
       it 'has the right data' do
         expected_hash = {
@@ -176,8 +176,8 @@ RSpec.describe ResultSetPresenter do
       let(:show_top_result) { true }
       let(:filter_params) { { 'order' => 'relevance' } }
       let(:results) do
-        [FactoryBot.build(:document_hash, es_score: 1.0, description: "A description. With more text"),
-         FactoryBot.build(:document_hash, es_score: 0.1, description: "Another description")]
+        [FactoryBot.build(:document_hash, es_score: 1.0, description_with_highlighting: "A description. With more text"),
+         FactoryBot.build(:document_hash, es_score: 0.1, description_with_highlighting: "Another description")]
       end
 
       context 'top result set if best bet (score > 7*other)' do
@@ -191,8 +191,8 @@ RSpec.describe ResultSetPresenter do
 
       context 'top result not set if no best bet (score < 7*other)' do
         let(:results) do
-          [FactoryBot.build(:document_hash, es_score: 1.0, description: "A description. With more text"),
-           FactoryBot.build(:document_hash, es_score: 0.5, description: "Another description")]
+          [FactoryBot.build(:document_hash, es_score: 1.0, description_with_highlighting: "A description. With more text"),
+           FactoryBot.build(:document_hash, es_score: 0.5, description_with_highlighting: "Another description")]
         end
         it 'has no top result' do
           search_result_objects = subject.search_results_content[:document_list_component_data]

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SearchResultPresenter do
     FactoryBot.build(:document,
                      title: title,
                      link: link,
-                     description: description,
+                     description_with_highlighting: description,
                      is_historic: is_historic,
                      government_name: 'Government!',
                      format: 'cake',


### PR DESCRIPTION
This will make search terms in the search result descriptions appear bold as below.

<img width="658" alt="Screen Shot 2019-09-19 at 10 24 27" src="https://user-images.githubusercontent.com/8124374/65231585-b023e400-dac7-11e9-9b4e-2685d37d94a7.png">

Trello: https://trello.com/c/9q0Utj4U

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1569.herokuapp.com/search/all
- http://finder-frontend-pr-1569.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1569.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1569.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1569.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1569.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1569.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1569.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1569.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1569.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
