### PR TITLE
Revert "Rename SearchClusterQuery A/B test"

### DIFF
--- a/app/controllers/concerns/search_cluster_ab_testable.rb
+++ b/app/controllers/concerns/search_cluster_ab_testable.rb
@@ -11,7 +11,7 @@ module SearchClusterABTestable
   # anything else = use default cluster
   def search_cluster_test
     @search_cluster_test ||= GovukAbTesting::AbTest.new(
-      'SearchClusterQuery2ABTest',
+      'SearchClusterQueryABTest',
       dimension: CUSTOM_DIMENSION,
       allowed_variants: %w[Default A B],
       control_variant: 'Default',

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -272,7 +272,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant Default sets use_default_cluster? and not use_b_cluster?" do
-      with_variant SearchClusterQuery2ABTest: 'Default' do
+      with_variant SearchClusterQueryABTest: 'Default' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(true)
         expect(subject.use_b_cluster?).to eq(false)
@@ -280,7 +280,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant A does not set use_default_cluster? or use_b_cluster?" do
-      with_variant SearchClusterQuery2ABTest: 'A' do
+      with_variant SearchClusterQueryABTest: 'A' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(false)
@@ -288,7 +288,7 @@ describe FindersController, type: :controller do
     end
 
     it "Variant 'B' sets use_b_cluster? and not use_default_cluster?" do
-      with_variant SearchClusterQuery2ABTest: 'B' do
+      with_variant SearchClusterQueryABTest: 'B' do
         get :show, params: { slug: path_for(breakfast_finder) }
         expect(subject.use_default_cluster?).to eq(false)
         expect(subject.use_b_cluster?).to eq(true)


### PR DESCRIPTION
We're switching back to the old A/B test

Reverts alphagov/finder-frontend#1552

---

[Trello card](https://trello.com/c/P4tBmN3u/1017-switch-back-to-previous-a-b-test)