### PR TITLE
Add index attribute to Question

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -13,13 +13,11 @@ class BrexitCheckerController < ApplicationController
 
   def show
     all_questions = BrexitChecker::Question.load_all
-    @question_index = next_question_index(
+    @current_question = next_question(
       all_questions: all_questions,
       criteria_keys: criteria_keys,
       previous_question_index: page
     )
-
-    @current_question = all_questions[@question_index] if @question_index.present?
 
     redirect_to brexit_checker_results_path(c: criteria_keys) if @current_question.nil?
   end

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -38,10 +38,10 @@ module BrexitCheckerHelper
       hint_text: option.hint_text }
   end
 
-  def next_question_index(all_questions:, criteria_keys: [], previous_question_index: 0)
-    available_questions = all_questions[previous_question_index..] || []
+  def next_question(all_questions:, criteria_keys: [], previous_question_index: 0)
+    ordered_questions = all_questions.sort_by(&:index)
+    potential_questions = ordered_questions[previous_question_index..] || []
 
-    relative_next_question_index = available_questions.find_index { |question| question.show?(criteria_keys) }
-    relative_next_question_index ? previous_question_index + relative_next_question_index : nil
+    potential_questions.find { |question| question.show?(criteria_keys) }
   end
 end

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -68,7 +68,7 @@
         <% end %>
         <%= render 'form_data',
           criteria_keys: persistent_criteria_keys(@current_question.all_values),
-          next_page: (@question_index + 1)
+          next_page: (@current_question.index + 1)
         %>
         <%= render 'hint_text', current_question: @current_question %>
         <div class="govuk-form-footer">

--- a/lib/brexit_checker/question.rb
+++ b/lib/brexit_checker/question.rb
@@ -4,11 +4,12 @@ class BrexitChecker::Question
   CONFIG_PATH = Rails.root.join('lib', 'brexit_checker', 'questions.yaml')
 
   validates_presence_of :key, :text
+  validates_numericality_of :index, only_integer: true
   validates_inclusion_of :type, in: %w(single single_wrapped multiple multiple_grouped)
   validate { errors.add("Options is not an array") unless options.is_a? Array }
 
   attr_reader :key, :text, :description, :hint_title, :hint_text,
-              :options, :type, :criteria
+              :options, :type, :criteria, :index
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -1,7 +1,7 @@
 ---
 questions:
   - key: nationality
-    index: 1
+    index: 0
     question_type: single
     question: 'What nationality are you?'
     options:
@@ -15,7 +15,7 @@ questions:
         value: nationality-row
 
   - key: living
-    index: 2
+    index: 1
     question_type: single
     question: 'Where do you live?'
     options:
@@ -29,7 +29,7 @@ questions:
         value: living-row
 
   - key: employment
-    index: 3
+    index: 2
     question_type: multiple_grouped
     question: 'Do you work or study?'
     hint_text: 'Select all that apply. If you do something else, select next.'
@@ -52,7 +52,7 @@ questions:
             value: studying-eu
 
   - key: drive-in-eu
-    index: 4
+    index: 3
     question_type: single
     question: Do you drive in the EU using a UK licence?
     criteria:
@@ -66,7 +66,7 @@ questions:
         value: living-driving-eu-no
 
   - key: travelling
-    index: 5
+    index: 4
     question_type: multiple
     question: 'Where do you plan to travel after 31 October 2019?'
     description: |
@@ -83,7 +83,7 @@ questions:
         value: visiting-row
 
   - key: activities
-    index: 6
+    index: 5
     criteria:
       - any_of:
         - visiting-ie
@@ -99,7 +99,7 @@ questions:
         value: visiting-bring-pet
 
   - key: returning
-    index: 7
+    index: 6
     criteria:
       - all_of:
         - nationality-uk
@@ -115,7 +115,7 @@ questions:
         value: return-to-uk-no
 
   - key: join-family-uk
-    index: 8
+    index: 7
     question_type: single
     question: Do you plan to join an EU family member in the UK?
     criteria:
@@ -133,7 +133,7 @@ questions:
         value: join-family-uk-no
 
   - key: do-you-own-a-business
-    index: 9
+    index: 8
     question_type: "single"
     question: "Are you preparing a business or organisation for Brexit?"
     options:
@@ -143,7 +143,7 @@ questions:
         value: does-not-own-operate-business-organisation
 
   - key: employ-eu-citizens
-    index: 10
+    index: 9
     criteria:
       - owns-operates-business-organisation
     question_type: "single"
@@ -157,7 +157,7 @@ questions:
         value: do-not-employ-eu-citizens
 
   - key: personal-data
-    index: 11
+    index: 10
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -179,7 +179,7 @@ questions:
         value: do-not-personal-eu-org
 
   - key: eu-uk-government-funding
-    index: 12
+    index: 11
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -198,7 +198,7 @@ questions:
         value: do-not-eu-uk-funding
 
   - key: public-sector-procurement
-    index: 13
+    index: 12
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -217,7 +217,7 @@ questions:
         value: do-not-sell-to-public-sector
 
   - key: intellectual-property
-    index: 14
+    index: 13
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -242,7 +242,7 @@ questions:
         value: do-not-ip
 
   - key: business-activity
-    index: 15
+    index: 14
     criteria:
       - owns-operates-business-organisation
     question_type: "multiple"
@@ -262,7 +262,7 @@ questions:
         value: haulage-goods-across-eu-borders
 
   - key: sector-business-area
-    index: 16
+    index: 15
     criteria:
       - owns-operates-business-organisation
     question_type: "multiple_grouped"

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -1,6 +1,7 @@
 ---
 questions:
   - key: nationality
+    index: 1
     question_type: single
     question: 'What nationality are you?'
     options:
@@ -14,6 +15,7 @@ questions:
         value: nationality-row
 
   - key: living
+    index: 2
     question_type: single
     question: 'Where do you live?'
     options:
@@ -27,6 +29,7 @@ questions:
         value: living-row
 
   - key: employment
+    index: 3
     question_type: multiple_grouped
     question: 'Do you work or study?'
     hint_text: 'Select all that apply. If you do something else, select next.'
@@ -49,6 +52,7 @@ questions:
             value: studying-eu
 
   - key: drive-in-eu
+    index: 4
     question_type: single
     question: Do you drive in the EU using a UK licence?
     criteria:
@@ -62,6 +66,7 @@ questions:
         value: living-driving-eu-no
 
   - key: travelling
+    index: 5
     question_type: multiple
     question: 'Where do you plan to travel after 31 October 2019?'
     description: |
@@ -78,6 +83,7 @@ questions:
         value: visiting-row
 
   - key: activities
+    index: 6
     criteria:
       - any_of:
         - visiting-ie
@@ -93,6 +99,7 @@ questions:
         value: visiting-bring-pet
 
   - key: returning
+    index: 7
     criteria:
       - all_of:
         - nationality-uk
@@ -108,6 +115,7 @@ questions:
         value: return-to-uk-no
 
   - key: join-family-uk
+    index: 8
     question_type: single
     question: Do you plan to join an EU family member in the UK?
     criteria:
@@ -125,6 +133,7 @@ questions:
         value: join-family-uk-no
 
   - key: do-you-own-a-business
+    index: 9
     question_type: "single"
     question: "Are you preparing a business or organisation for Brexit?"
     options:
@@ -134,6 +143,7 @@ questions:
         value: does-not-own-operate-business-organisation
 
   - key: employ-eu-citizens
+    index: 10
     criteria:
       - owns-operates-business-organisation
     question_type: "single"
@@ -147,6 +157,7 @@ questions:
         value: do-not-employ-eu-citizens
 
   - key: personal-data
+    index: 11
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -168,6 +179,7 @@ questions:
         value: do-not-personal-eu-org
 
   - key: eu-uk-government-funding
+    index: 12
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -186,6 +198,7 @@ questions:
         value: do-not-eu-uk-funding
 
   - key: public-sector-procurement
+    index: 13
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -204,6 +217,7 @@ questions:
         value: do-not-sell-to-public-sector
 
   - key: intellectual-property
+    index: 14
     criteria:
       - owns-operates-business-organisation
     question_type: "single_wrapped"
@@ -228,6 +242,7 @@ questions:
         value: do-not-ip
 
   - key: business-activity
+    index: 15
     criteria:
       - owns-operates-business-organisation
     question_type: "multiple"
@@ -247,6 +262,7 @@ questions:
         value: haulage-goods-across-eu-borders
 
   - key: sector-business-area
+    index: 16
     criteria:
       - owns-operates-business-organisation
     question_type: "multiple_grouped"

--- a/spec/factories/brexit_checker/question.rb
+++ b/spec/factories/brexit_checker/question.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :brexit_checker_question, class: BrexitChecker::Question do
+    sequence :index
     text { 'A title' }
     key { SecureRandom.uuid }
     type { 'single' }

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -67,7 +67,7 @@ describe BrexitCheckerHelper, type: :helper do
     let(:questions) { [q1, q2, q3, q4] }
 
     subject {
-      next_question_index(
+      next_question(
         all_questions: questions,
         criteria_keys: criteria_keys,
         previous_question_index: previous_question_index
@@ -88,7 +88,7 @@ describe BrexitCheckerHelper, type: :helper do
       let(:previous_question_index) { 0 }
       let(:criteria_keys) { [] }
       it 'returns first question' do
-        expect(subject).to eq(0)
+        expect(subject).to eq(q1)
       end
     end
 
@@ -96,7 +96,7 @@ describe BrexitCheckerHelper, type: :helper do
       let(:previous_question_index) { 1 }
       let(:criteria_keys) { %w[a b] }
       it 'returns question two' do
-        expect(subject).to eq(1)
+        expect(subject).to eq(q2)
       end
     end
 
@@ -104,7 +104,7 @@ describe BrexitCheckerHelper, type: :helper do
       let(:previous_question_index) { 1 }
       let(:criteria_keys) { %w[c d] }
       it 'returns question three' do
-        expect(subject).to eq(2)
+        expect(subject).to eq(q3)
       end
     end
 


### PR DESCRIPTION
This PR poses a change which introduces the index attribute explicitly to the Question class.

Previously, we relied on array order to implicitly define question order. Adding an explicit reference to order in the Question class allows us to further simplify the logic resolve the question to be displayed and decouples the data structure from the underlying persistence layer. 