### PR TITLE
Remove unused SearchParameters methods

### DIFF
--- a/app/models/search_parameters.rb
+++ b/app/models/search_parameters.rb
@@ -1,26 +1,6 @@
 class SearchParameters
-  include Rails.application.routes.url_helpers
-
-  DEFAULT_RESULTS_PER_PAGE = 20
-  MAX_RESULTS_PER_PAGE = 100
-  ALWAYS_FACET_FIELDS = %w{organisations}.freeze
-  ALLOWED_FACET_FIELDS = %w{organisations manual}.freeze
-
   def initialize(params)
     @params = enforce_bounds(search_params(params))
-  end
-
-  def search_params(params)
-    params.
-      permit(:q, :show_organisations_filter, :start, :count,
-             :debug_score, :debug, :format,
-             # allow facets as array values like:
-             #     filter_foo[]=bar&filter_foo[]=baz
-             Hash[ALLOWED_FACET_FIELDS.map { |facet| [:"filter_#{facet}", []] }],
-             # and allow facets as single string values like
-             #     filter_foo=bar
-             *ALLOWED_FACET_FIELDS.map { |facet| :"filter_#{facet}" }).
-      to_h
   end
 
   def search_term
@@ -30,81 +10,30 @@ class SearchParameters
     end
   end
 
-  def show_organisations_filter?
-    params[:show_organisations_filter] == "true"
-  end
-
-  def start
-    params[:start]
-  end
-
-  def count
-    params[:count]
-  end
-
   def no_search?
     search_term.blank?
-  end
-
-  def filter(field)
-    [*(params["filter_#{field}"] || [])]
-  end
-
-  def filtered_by?(field)
-    ! filter(field).empty?
-  end
-
-  def debug_score
-    params[:debug_score]
-  end
-
-  # Build a link to a search results page.
-  def build_link(extra = {})
-    search_path(combine_params(extra).symbolize_keys)
-  end
-
-  def rummager_parameters
-    result = {
-      start: start.to_s,
-      count: count.to_s,
-      q: search_term,
-      fields: %w{
-        title_with_highlighting
-        description_with_highlighting
-        display_type
-        document_series
-        format
-        government_name
-        is_historic
-        link
-        organisations
-        organisation_state
-        public_timestamp
-        slug
-        specialist_sectors
-        title
-        world_locations
-        content_id
-      },
-      debug: params[:debug],
-      suggest: "spelling",
-    }
-    active_facet_fields.each { |field|
-      result["filter_#{field}".to_sym] = filter(field)
-      result["facet_#{field}".to_sym] = "100"
-    }
-    result
-  end
-
-  def active_facet_fields
-    ALLOWED_FACET_FIELDS.select { |field|
-      ALWAYS_FACET_FIELDS.include?(field) || filtered_by?(field)
-    }
   end
 
 private
 
   attr_reader :params
+
+  DEFAULT_RESULTS_PER_PAGE = 20
+  MAX_RESULTS_PER_PAGE = 100
+  ALLOWED_FACET_FIELDS = %w{organisations manual}.freeze
+
+  def search_params(params)
+    params.
+      permit(:q, :start, :count,
+             :debug_score, :debug, :format,
+             # allow facets as array values like:
+             #     filter_foo[]=bar&filter_foo[]=baz
+             Hash[ALLOWED_FACET_FIELDS.map { |facet| [:"filter_#{facet}", []] }],
+             # and allow facets as single string values like
+             #     filter_foo=bar
+             *ALLOWED_FACET_FIELDS.map { |facet| :"filter_#{facet}" }).
+      to_h
+  end
 
   def enforce_bounds(params)
     params.merge(
@@ -131,29 +60,5 @@ private
     else
       count
     end
-  end
-
-  def combine_params(extra)
-    # explicitly set the format to nil so that the path does not point to
-    # /search.json
-    combined_params = params.merge(format: nil).merge(extra)
-
-    # don't include the 'count' query parameter unless we are overriding the
-    # default value with a custom value
-    unless custom_count_value?(combined_params[:count])
-      combined_params.delete(:count)
-    end
-
-    # don't include the start parameter if it's zero
-    if combined_params[:start].zero?
-      combined_params.delete(:start)
-    end
-
-    combined_params
-  end
-
-  def custom_count_value?(count)
-    count.nonzero? &&
-      count != DEFAULT_RESULTS_PER_PAGE
   end
 end

--- a/spec/models/search_parameters_spec.rb
+++ b/spec/models/search_parameters_spec.rb
@@ -5,62 +5,12 @@ RSpec.describe SearchParameters do
     described_class.new(ActionController::Parameters.new(params))
   end
 
-  context '#count' do
-    it 'default to default page size' do
-      params = search_params
-
-      expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
-    end
-
-    it 'default to default page size when count < 1' do
-      params = search_params(count: -50)
-
-      expect(params.count).to eq(described_class::DEFAULT_RESULTS_PER_PAGE)
-    end
-
-    it 'allow at most a hundred results' do
-      params = search_params(count: 10_000)
-
-      expect(params.count).to eq(100)
-    end
-  end
-
-  context '#suggest' do
-    it "requests the spelling suggester by default" do
-      params = search_params
-
-      expect(params.rummager_parameters[:suggest]).to eq("spelling")
-    end
-  end
-
-  context '#start' do
-    it 'start at 0 if start < 1' do
-      params = search_params(start: -1)
-
-      expect(params.start).to eq(0)
-    end
-  end
-
-  context "#filter_organisations" do
-    it "pass on filter_organisations" do
-      params = search_params("filter_organisations" => %w[ministry-of-silly-walks])
-
-      expect(params.rummager_parameters[:filter_organisations]).to eq(%w[ministry-of-silly-walks])
-    end
-
-    it "pass on filter_organisations as an array if provided as single value" do
-      params = search_params("filter_organisations" => 'ministry-of-silly-walks')
-
-      expect(params.rummager_parameters[:filter_organisations]).to eq(%w[ministry-of-silly-walks])
-    end
-  end
-
   context "#search_term" do
     it "truncates a too-long search query" do
       max_length = Search::QueryBuilder::MAX_QUERY_LENGTH
       long_query = "a" * max_length
       params = search_params("q" => "#{long_query}1234567890")
-      expect(params.rummager_parameters[:q]).to eq(long_query)
+      expect(params.search_term).to eq(long_query)
     end
   end
 end


### PR DESCRIPTION
I noticed these methods are no longer used, so we can remove them.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1574.herokuapp.com/search/all
- http://finder-frontend-pr-1574.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1574.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1574.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1574.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1574.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1574.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1574.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1574.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1574.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
