### PR TITLE
Add back link for questions

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -21,6 +21,12 @@ class BrexitCheckerController < ApplicationController
 
     @current_question = all_questions[@question_index] if @question_index.present?
 
+    @previous_page = previous_question_index(
+      all_questions: all_questions,
+      criteria_keys: criteria_keys,
+      current_question_index: page,
+    )
+
     redirect_to brexit_checker_results_path(c: criteria_keys) if @current_question.nil?
   end
 

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -44,4 +44,9 @@ module BrexitCheckerHelper
     relative_next_question_index = available_questions.find_index { |question| question.show?(criteria_keys) }
     relative_next_question_index ? previous_question_index + relative_next_question_index : nil
   end
+
+  def previous_question_index(all_questions:, criteria_keys: [], current_question_index: 0)
+    previous_questions = all_questions[0...current_question_index]
+    previous_questions.rindex { |question| question.show?(criteria_keys) }
+  end
 end

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -30,7 +30,7 @@
 
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
-      href: brexit_checker_questions_path(page: @previous_page),
+      href: brexit_checker_questions_path(page: @previous_page, c: criteria_keys),
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/back_link", {

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -27,6 +27,9 @@
       url: "/get-ready-brexit-check"
     }
   ] %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: brexit_checker_questions_path(page: @previous_page),
+  } %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -27,9 +27,16 @@
       url: "/get-ready-brexit-check"
     }
   ] %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: brexit_checker_questions_path(page: @previous_page),
-  } %>
+
+  <% if @previous_page %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: brexit_checker_questions_path(page: @previous_page),
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: "/get-ready-brexit-check",
+    } %>
+  <% end %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -13,21 +13,6 @@
 %>
 
 <div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [
-    {
-      title: t('brexit_checker.breadcrumbs.home'),
-      url: "/"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-home'),
-      url: "/brexit"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-check'),
-      url: "/get-ready-brexit-check"
-    }
-  ] %>
-
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
       href: brexit_checker_questions_path(page: @previous_page, c: criteria_keys),

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
 
   def when_i_visit_the_brexit_checker_flow
     visit brexit_checker_questions_path
+    expect(page).to have_link("Back", href: "/get-ready-brexit-check")
   end
 
   def and_i_answer_the_nationality_question

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -1,13 +1,12 @@
 require "spec_helper"
 
 RSpec.feature "Navigating Brexit Checker questions", type: :feature do
-  scenario "navigate to previous page" do
+  scenario "navigate to previous question" do
     when_i_visit_the_brexit_checker_flow
-    and_i_answer_the_nationality_question
-    then_i_should_see_the_living_question
-
-    when_i_click_on_the_back_link
-    then_i_should_see_the_nationality_question
+    and_i_answer_travel_questions
+    and_i_click_on_the_back_link
+    then_i_should_see_the_activities_question
+    and_my_previous_activities_choice_is_selected
   end
 
   def when_i_visit_the_brexit_checker_flow
@@ -15,22 +14,23 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
     expect(page).to have_link("Back", href: "/get-ready-brexit-check")
   end
 
-  def and_i_answer_the_nationality_question
-    answer_question("nationality", "British")
+  def and_i_answer_travel_questions
+    3.times { click_on "Next" }
+    answer_question("travelling", "To another EU country, Iceland, Liechtenstein, Norway or Switzerland")
+    answer_question("activities", "Take your pet")
   end
 
-  def then_i_should_see_the_living_question
-    question = BrexitChecker::Question.find_by_key("living")
-    expect(page).to have_content(question.text)
-  end
-
-  def when_i_click_on_the_back_link
+  def and_i_click_on_the_back_link
     click_on "Back"
   end
 
-  def then_i_should_see_the_nationality_question
-    question = BrexitChecker::Question.find_by_key("nationality")
+  def then_i_should_see_the_activities_question
+    question = BrexitChecker::Question.find_by_key("activities")
     expect(page).to have_content(question.text)
+  end
+
+  def and_my_previous_activities_choice_is_selected
+    expect(page).to have_checked_field("Take your pet")
   end
 
   def answer_question(key, *options)

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.feature "Navigating Brexit Checker questions", type: :feature do
+  scenario "navigate to previous page" do
+    when_i_visit_the_brexit_checker_flow
+    and_i_answer_the_nationality_question
+    then_i_should_see_the_living_question
+
+    when_i_click_on_the_back_link
+    then_i_should_see_the_nationality_question
+  end
+
+  def when_i_visit_the_brexit_checker_flow
+    visit brexit_checker_questions_path
+  end
+
+  def and_i_answer_the_nationality_question
+    answer_question("nationality", "British")
+  end
+
+  def then_i_should_see_the_living_question
+    question = BrexitChecker::Question.find_by_key("living")
+    expect(page).to have_content(question.text)
+  end
+
+  def when_i_click_on_the_back_link
+    click_on "Back"
+  end
+
+  def then_i_should_see_the_nationality_question
+    question = BrexitChecker::Question.find_by_key("nationality")
+    expect(page).to have_content(question.text)
+  end
+
+  def answer_question(key, *options)
+    question = BrexitChecker::Question.find_by_key(key)
+    expect(page).to have_content(question.text)
+    options.each { |o| find_field(o).click }
+    click_on "Next"
+  end
+end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -124,4 +124,71 @@ describe BrexitCheckerHelper, type: :helper do
       end
     end
   end
+
+  describe "#previous_question_index" do
+    let(:q1) { FactoryBot.build(:brexit_checker_question) }
+    let(:q2) { FactoryBot.build(:brexit_checker_question, criteria: [{ "all_of" => %w(a b) }]) }
+    let(:q3) { FactoryBot.build(:brexit_checker_question, criteria: [{ "all_of" => %w(c d) }]) }
+    let(:q4) { FactoryBot.build(:brexit_checker_question, criteria: %w(c)) }
+
+    let(:questions) { [q1, q2, q3, q4] }
+
+    subject {
+      previous_question_index(
+        all_questions: questions,
+        criteria_keys: criteria_keys,
+        current_question_index: current_question_index,
+      )
+    }
+
+    context "current_question_index is 3 and the criteria matches question 3" do
+      let(:current_question_index) { 3 }
+      let(:criteria_keys) { %w[c d] }
+
+      before do
+        allow(q3).to receive(:show?) { true }
+      end
+
+      it "returns question 3" do
+        expect(subject).to be(2)
+      end
+    end
+
+    context "current_question_index is 3 and the criteria match question 2" do
+      let(:current_question_index) { 3 }
+      let(:criteria_keys) { %w[a b] }
+
+      before do
+        allow(q2).to receive(:show?) { true }
+        allow(q3).to receive(:show?) { false }
+      end
+
+      it "returns question 2" do
+        expect(subject).to be(1)
+      end
+    end
+
+    context "current_question_index is 2 and the criteria do not match previous questions" do
+      let(:current_question_index) { 2 }
+      let(:criteria_keys) { %w[e] }
+
+      before do
+        allow(q1).to receive(:show?) { false }
+        allow(q2).to receive(:show?) { false }
+      end
+
+      it "does not return a question" do
+        expect(subject).to be nil
+      end
+    end
+
+    context "current_question_index is 0 and there are no previous questions" do
+      let(:current_question_index) { 0 }
+      let(:criteria_keys) { %w[a] }
+
+      it "does not return a question" do
+        expect(subject).to be nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/LVSlwXmo/246-add-back-link-for-questions

This adds a back link to the question pages in the Brexit Checker so that users can navigate to previous questions.  The exception to this is the first question which directs users to the 'start' page of the checker.  Since we now have 'Back' links on question pages, as per the design system we remove breadcrumbs from these pages.

We also ensure that the answers that a user has already selected are passed as params when they click the back link so that the answers are pre-selected on previous pages.  Answers that are changed on previous pages are carried forward to the results and previous answers are removed.

<img width="988" alt="Screen Shot 2019-09-26 at 14 41 29" src="https://user-images.githubusercontent.com/13434452/65693241-e46d4680-e06b-11e9-975b-ba0528e402a2.png">
