### PR TITLE
Refactor part 7

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -44,7 +44,7 @@ class FindersController < ApplicationController
 
 private
 
-  attr_accessor :search_query
+  attr_reader :search_query
 
   helper_method :finder_presenter, :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params
 

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -46,7 +46,7 @@ private
 
   attr_accessor :search_query
 
-  helper_method :finder_presenter, :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links
+  helper_method :finder_presenter, :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params
 
   def redirect_to_destination
     @redirect = content_item.redirect

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -86,11 +86,7 @@ private
   end
 
   def results
-    @results ||= ResultSetParser.parse(
-      search_results.fetch("results"),
-      search_results.fetch("start", 0),
-      search_results.fetch("total"),
-    )
+    @results ||= ResultSetParser.parse(search_results)
   end
 
   def result_set_presenter_class

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,18 +16,4 @@ module ApplicationHelper
   def absolute_url_for(path)
     URI.join(Plek.current.website_root, path)
   end
-
-  def page_metadata(metadata)
-    metadata.inject({}) do |memo, (type, data)|
-      memo.merge(
-        type => data.is_a?(Array) ? arr_to_links(data) : data,
-      )
-    end
-  end
-
-  def arr_to_links(arr)
-    arr.map { |link|
-      link_to(link["title"], link["web_url"])
-    }
-  end
 end

--- a/app/helpers/page_metadata_helper.rb
+++ b/app/helpers/page_metadata_helper.rb
@@ -1,0 +1,12 @@
+module PageMetadataHelper
+  def page_metadata(content_item, filter_params)
+    organisation_links = content_item.organisations.map do |organisation|
+      link_to(organisation['title'], organisation['web_url'])
+    end
+
+    {}.tap do |metadata|
+      metadata[:from] = organisation_links unless organisation_links.blank?
+      metadata[:inverse] = true if topic_finder?(filter_params)
+    end
+  end
+end

--- a/app/helpers/page_metadata_helper.rb
+++ b/app/helpers/page_metadata_helper.rb
@@ -1,7 +1,7 @@
 module PageMetadataHelper
   def page_metadata(content_item, filter_params)
     organisation_links = content_item.organisations.map do |organisation|
-      link_to(organisation['title'], organisation['web_url'])
+      link_to(organisation["title"], organisation["web_url"])
     end
 
     {}.tap do |metadata|

--- a/app/helpers/topic_finder_helper.rb
+++ b/app/helpers/topic_finder_helper.rb
@@ -1,0 +1,9 @@
+module TopicFinderHelper
+  def topic_finder?(filter_params)
+    filter_params.include?('topic') && topic_finder_parent(filter_params)
+  end
+
+  def topic_finder_parent(filter_params)
+    Services.registries.all['full_topic_taxonomy'][filter_params['topic']]
+  end
+end

--- a/app/helpers/topic_finder_helper.rb
+++ b/app/helpers/topic_finder_helper.rb
@@ -1,9 +1,9 @@
 module TopicFinderHelper
   def topic_finder?(filter_params)
-    filter_params.include?('topic') && topic_finder_parent(filter_params)
+    filter_params.include?("topic") && topic_finder_parent(filter_params)
   end
 
   def topic_finder_parent(filter_params)
-    Services.registries.all['full_topic_taxonomy'][filter_params['topic']]
+    Services.registries.all["full_topic_taxonomy"][filter_params["topic"]]
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -145,6 +145,10 @@ class ContentItem
     content_item_hash.dig("redirects", 0, "destination")
   end
 
+  def organisations
+    links.fetch('organisations', [])
+  end
+
 private
 
   attr_reader :content_item_hash

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -149,6 +149,18 @@ class ContentItem
     links.fetch('organisations', [])
   end
 
+  def government?
+    base_path.starts_with?("/government")
+  end
+
+  def government_content_section
+    base_path.split('/')[2]
+  end
+
+  def display_metadata?
+    !eu_exit_finder?
+  end
+
 private
 
   attr_reader :content_item_hash

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -146,7 +146,7 @@ class ContentItem
   end
 
   def organisations
-    links.fetch('organisations', [])
+    links.fetch("organisations", [])
   end
 
   def government?
@@ -154,7 +154,7 @@ class ContentItem
   end
 
   def government_content_section
-    base_path.split('/')[2]
+    base_path.split("/")[2]
   end
 
   def display_metadata?

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -1,5 +1,8 @@
 module ResultSetParser
-  def self.parse(results, start, total)
+  def self.parse(search_results)
+    results = search_results.fetch("results")
+    start = search_results.fetch("start", 0)
+    total = search_results.fetch("total")
     documents = results.each_with_index.map { |document, index| Document.new(document, index + 1) }
 
     ResultSet.new(

--- a/app/presenters/atom_presenter.rb
+++ b/app/presenters/atom_presenter.rb
@@ -6,9 +6,9 @@ class AtomPresenter
   end
 
   def title
-    return "#{finder_presenter.name} #{filters_applied.join(' ')}" if filters_applied.present?
+    return "#{finder_presenter.title} #{filters_applied.join(' ')}" if filters_applied.present?
 
-    finder_presenter.name
+    finder_presenter.title
   end
 
   def filters_applied

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -22,7 +22,8 @@ class FinderPresenter
            :canonical_link?,
            :all_content_finder?,
            :eu_exit_finder?,
-           :title,to: :content_item
+           :title,
+           :base_path, to: :content_item
 
 
   def initialize(content_item, facets, values = {})
@@ -33,20 +34,16 @@ class FinderPresenter
     @keywords = values["keywords"].presence
   end
 
-  def slug
-    content_item.base_path
-  end
-
   def filters
     facets.select(&:filterable?)
   end
 
   def government?
-    slug.starts_with?("/government")
+    base_path.starts_with?("/government")
   end
 
   def government_content_section
-    slug.split("/")[2]
+    base_path.split("/")[2]
   end
 
   def display_metadata?

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -56,23 +56,6 @@ class FinderPresenter
     !eu_exit_finder?
   end
 
-  def page_metadata
-    metadata = {
-      from: organisations,
-    }
-
-    metadata[:inverse] = true if topic_finder?
-    metadata.reject { |_, links| links.blank? }
-  end
-
-  def topic_finder?
-    values.include?("topic") && topic_finder_parent.present?
-  end
-
-  def topic_finder_parent
-    Services.registries.all["full_topic_taxonomy"][values["topic"]]
-  end
-
 private
 
   def is_external?(href)

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -2,7 +2,7 @@ class FinderPresenter
   include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::UrlHelper
 
-  attr_reader :content_item, :organisations, :values, :keywords, :links, :facets
+  attr_reader :content_item, :values, :keywords, :links, :facets
 
   delegate :hide_facets_by_default,
            :show_summaries?,
@@ -25,12 +25,12 @@ class FinderPresenter
            :title,
            :base_path,
            :government?,
-           :government_content_section, to: :content_item
+           :government_content_section,
+           :organisations, to: :content_item
 
 
   def initialize(content_item, facets, values = {})
     @content_item = content_item
-    @organisations = content_item.links.fetch("organisations", [])
     @values = values
     @facets = facets
     @keywords = values["keywords"].presence

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -49,10 +49,4 @@ class FinderPresenter
   def display_metadata?
     !eu_exit_finder?
   end
-
-private
-
-  def is_external?(href)
-    URI.parse(href).host != "www.gov.uk"
-  end
 end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -21,7 +21,8 @@ class FinderPresenter
            :no_index?,
            :canonical_link?,
            :all_content_finder?,
-           :eu_exit_finder?, to: :content_item
+           :eu_exit_finder?,
+           :title,to: :content_item
 
 
   def initialize(content_item, facets, values = {})
@@ -30,10 +31,6 @@ class FinderPresenter
     @values = values
     @facets = facets
     @keywords = values["keywords"].presence
-  end
-
-  def name
-    content_item.title
   end
 
   def slug

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -2,7 +2,7 @@ class FinderPresenter
   include ActionView::Helpers::FormOptionsHelper
   include ActionView::Helpers::UrlHelper
 
-  attr_reader :content_item, :values, :keywords, :links, :facets
+  attr_reader :content_item, :keywords, :facets
 
   delegate :hide_facets_by_default,
            :show_summaries?,
@@ -31,7 +31,6 @@ class FinderPresenter
 
   def initialize(content_item, facets, values = {})
     @content_item = content_item
-    @values = values
     @facets = facets
     @keywords = values["keywords"].presence
   end

--- a/app/presenters/finder_presenter.rb
+++ b/app/presenters/finder_presenter.rb
@@ -23,7 +23,9 @@ class FinderPresenter
            :all_content_finder?,
            :eu_exit_finder?,
            :title,
-           :base_path, to: :content_item
+           :base_path,
+           :government?,
+           :government_content_section, to: :content_item
 
 
   def initialize(content_item, facets, values = {})
@@ -36,17 +38,5 @@ class FinderPresenter
 
   def filters
     facets.select(&:filterable?)
-  end
-
-  def government?
-    base_path.starts_with?("/government")
-  end
-
-  def government_content_section
-    base_path.split("/")[2]
-  end
-
-  def display_metadata?
-    !eu_exit_finder?
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -29,8 +29,8 @@ class ResultSetPresenter
       document_list_component_data: component_data,
       zero_results: total.zero?,
       page_count: component_data.count,
-      finder_name: finder_presenter.name,
-      debug_score: debug_score,
+      finder_name: finder_presenter.title,
+      debug_score: debug_score
     }
   end
 

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -30,7 +30,7 @@ class ResultSetPresenter
       zero_results: total.zero?,
       page_count: component_data.count,
       finder_name: finder_presenter.title,
-      debug_score: debug_score
+      debug_score: debug_score,
     }
   end
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -2,7 +2,7 @@
   <% if !finder_presenter.all_content_finder? %>
     <div id="keywords">
       <% label_text = capture do %>
-        Search <span class="govuk-visually-hidden"><%= finder_presenter.name %></span>
+        Search <span class="govuk-visually-hidden"><%= finder_presenter.title %></span>
       <% end %>
       <%= render "govuk_publishing_components/components/input", {
         controls: "js-search-results-info",

--- a/app/views/finders/_finder_meta.html.erb
+++ b/app/views/finders/_finder_meta.html.erb
@@ -4,7 +4,7 @@
 <% if finder_presenter.no_index? %>
   <meta name="robots" content="noindex">
 <% end %>
-<link rel="alternate" type="application/json" href="/api/content<%= finder_presenter.slug %>">
+<link rel="alternate" type="application/json" href="/api/content<%= finder_presenter.base_path %>">
 
 <%= render 'govuk_publishing_components/components/meta_tags', content_item: finder_presenter.content_item.as_hash %>
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -35,12 +35,12 @@
       <% elsif topic_finder?(filter_params) %>
         <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: finder_presenter.name,
+          title: finder_presenter.title,
           inverse: true,
         } %>
       <% else %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
-          title: finder_presenter.name,
+          title: finder_presenter.title,
         } %>
       <% end %>
 

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -32,8 +32,8 @@
             value: result_set_presenter.user_supplied_keywords,
           } %>
         </div>
-      <% elsif finder_presenter.topic_finder? %>
-        <%= link_to finder_presenter.topic_finder_parent['title'], finder_presenter.topic_finder_parent['base_path'], class: 'topic-finder__taxon-link' %>
+      <% elsif topic_finder?(filter_params) %>
+        <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: finder_presenter.name,
           inverse: true,
@@ -44,8 +44,8 @@
         } %>
       <% end %>
 
-      <% if finder_presenter.page_metadata.any? %>
-        <%= render 'govuk_publishing_components/components/metadata', page_metadata(finder_presenter.page_metadata) %>
+      <% if page_metadata.any? %>
+        <%= render 'govuk_publishing_components/components/metadata', page_metadata %>
       <% end %>
     </div>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -17,7 +17,7 @@
 
 <% content_for :meta_title, finder_presenter.name %>
 
-<% if finder_presenter.topic_finder? && !finder_presenter.all_content_finder? %>
+<% if topic_finder?(filter_params) && !finder_presenter.all_content_finder? %>
   <% content_for :body_classes, "full-width" %>
   <% inverse = true %>
 <% end %>
@@ -29,14 +29,16 @@
   data-search-query="<%= result_set_presenter.user_supplied_keywords %>">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
-  <% if finder_presenter.topic_finder? && !finder_presenter.all_content_finder? %>
+  <% if topic_finder?(filter_params) && !finder_presenter.all_content_finder? %>
     <%= render "govuk_publishing_components/components/inverse_header", {
       full_width: true
     } do %>
-      <%= render partial: 'show_header', locals: { inverse: inverse } %>
+      <%= render partial: 'show_header', locals: { inverse: inverse,
+                                                   page_metadata: page_metadata(content_item, filter_params) } %>
     <% end %>
   <% else %>
-    <%= render partial: 'show_header', locals: { inverse: inverse } %>
+    <%= render partial: 'show_header', locals: { inverse: inverse,
+                                                 page_metadata: page_metadata(content_item, filter_params) } %>
   <% end %>
 
   <div class="govuk-width-container">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -1,7 +1,7 @@
 <% if result_set_presenter.user_supplied_keywords.length > 0 %>
-  <% content_for :title, "#{result_set_presenter.user_supplied_keywords} - #{finder_presenter.name}" %>
+  <% content_for :title, "#{result_set_presenter.user_supplied_keywords} - #{finder_presenter.title}" %>
 <% else %>
-  <% content_for :title, finder_presenter.name %>
+  <% content_for :title, finder_presenter.title %>
 <% end %>
 <% content_for :head do %>
   <%= auto_discovery_link_tag(:atom, signup_links[:feed_link]) %>
@@ -15,7 +15,7 @@
   <%= search_cluster_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
-<% content_for :meta_title, finder_presenter.name %>
+<% content_for :meta_title, finder_presenter.title %>
 
 <% if topic_finder?(filter_params) && !finder_presenter.all_content_finder? %>
   <% content_for :body_classes, "full-width" %>
@@ -25,7 +25,7 @@
 <form method="get" action="<%= finder_presenter.slug %>" class="js-live-search-form"
   data-analytics-ecommerce
   data-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
-  data-list-title="<%= finder_presenter.name %>"
+  data-list-title="<%= finder_presenter.title %>"
   data-search-query="<%= result_set_presenter.user_supplied_keywords %>">
   <input type="hidden" name="parent" value="<%= @parent %>">
 
@@ -43,11 +43,11 @@
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= finder_presenter.name %>">
+      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= finder_presenter.title %>">
         <%= render partial: 'facet_collection'%>
       </div>
 
-      <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder_presenter.name %> search results">
+      <div class="govuk-grid-column-two-thirds js-live-search-results-block filtered-results" role="region" aria-label="<%= finder_presenter.title %> search results">
         <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -22,7 +22,7 @@
   <% inverse = true %>
 <% end %>
 
-<form method="get" action="<%= finder_presenter.slug %>" class="js-live-search-form"
+<form method="get" action="<%= finder_presenter.base_path %>" class="js-live-search-form"
   data-analytics-ecommerce
   data-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
   data-list-title="<%= finder_presenter.title %>"

--- a/spec/helpers/page_metadata_helper_spec.rb
+++ b/spec/helpers/page_metadata_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 require "support/taxonomy_helper"
 
 describe PageMetadataHelper, type: :helper do
@@ -6,8 +6,8 @@ describe PageMetadataHelper, type: :helper do
   include TopicFinderHelper
 
   let(:organisations) {
-    [{ title: 'org1', web_url: 'http://www.gov.uk/org1' },
-     { title: 'org2', web_url: 'http://www.gov.uk/org2' }]
+    [{ title: "org1", web_url: "http://www.gov.uk/org1" },
+     { title: "org2", web_url: "http://www.gov.uk/org2" }]
   }
   let(:content_item) {
     FactoryBot.build(:content_item, links: { organisations: organisations })
@@ -17,26 +17,26 @@ describe PageMetadataHelper, type: :helper do
     page_metadata(content_item, filter_params)
   }
   before :each do
-    topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'existing_content_id')])
+    topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: "existing_content_id")])
   end
   describe "#page_metadata" do
-    it 'contains links to organisations' do
+    it "contains links to organisations" do
       expect(subject[:from]).to match_array(['<a href="http://www.gov.uk/org1">org1</a>',
                                              '<a href="http://www.gov.uk/org2">org2</a>'])
     end
-    describe 'there are no organisations' do
+    describe "there are no organisations" do
       let(:organisations) { [] }
       it 'does not contain the "from" key' do
         expect(subject).to_not have_key(:from)
       end
     end
-    describe 'it is a topic page' do
-      let(:filter_params) { { 'topic' => 'existing_content_id' } }
+    describe "it is a topic page" do
+      let(:filter_params) { { "topic" => "existing_content_id" } }
       it 'does not contain the "inverse" key' do
         expect(subject[:inverse]).to be true
       end
     end
-    describe 'it is not a topic page' do
+    describe "it is not a topic page" do
       it 'does not contain the "inverse" key' do
         expect(subject).to_not have_key(:inverse)
       end

--- a/spec/helpers/page_metadata_helper_spec.rb
+++ b/spec/helpers/page_metadata_helper_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require "support/taxonomy_helper"
+
+describe PageMetadataHelper, type: :helper do
+  include TaxonomySpecHelper
+  include TopicFinderHelper
+
+  let(:organisations) {
+    [{ title: 'org1', web_url: 'http://www.gov.uk/org1' },
+     { title: 'org2', web_url: 'http://www.gov.uk/org2' }]
+  }
+  let(:content_item) {
+    FactoryBot.build(:content_item, links: { organisations: organisations })
+  }
+  let(:filter_params) { {} }
+  subject(:subject) {
+    page_metadata(content_item, filter_params)
+  }
+  before :each do
+    topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'existing_content_id')])
+  end
+  describe "#page_metadata" do
+    it 'contains links to organisations' do
+      expect(subject[:from]).to match_array(['<a href="http://www.gov.uk/org1">org1</a>',
+                                             '<a href="http://www.gov.uk/org2">org2</a>'])
+    end
+    describe 'there are no organisations' do
+      let(:organisations) { [] }
+      it 'does not contain the "from" key' do
+        expect(subject).to_not have_key(:from)
+      end
+    end
+    describe 'it is a topic page' do
+      let(:filter_params) { { 'topic' => 'existing_content_id' } }
+      it 'does not contain the "inverse" key' do
+        expect(subject[:inverse]).to be true
+      end
+    end
+    describe 'it is not a topic page' do
+      it 'does not contain the "inverse" key' do
+        expect(subject).to_not have_key(:inverse)
+      end
+    end
+  end
+end

--- a/spec/helpers/topic_finder_helper_spec.rb
+++ b/spec/helpers/topic_finder_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 require "support/taxonomy_helper"
 
 describe TopicFinderHelper, type: :helper do
@@ -6,14 +6,14 @@ describe TopicFinderHelper, type: :helper do
 
   describe "#topic_finder?" do
     before :each do
-      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'existing_content_id')])
+      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: "existing_content_id")])
     end
-    let(:has_topic) { topic_finder?('topic' => '/path/to_content') }
+    let(:has_topic) { topic_finder?("topic" => "/path/to_content") }
     it "returns true because there is a topic parameter that exists" do
-      expect(topic_finder?('topic' => 'existing_content_id')).to be_truthy
+      expect(topic_finder?("topic" => "existing_content_id")).to be_truthy
     end
     it "returns false because there is a topic parameter that does not exist" do
-      expect(topic_finder?('topic' => 'non_existing_content_id')).to be_falsey
+      expect(topic_finder?("topic" => "non_existing_content_id")).to be_falsey
     end
     it "returns false because there is no topic parameter" do
       expect(topic_finder?({})).to be_falsey

--- a/spec/helpers/topic_finder_helper_spec.rb
+++ b/spec/helpers/topic_finder_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require "support/taxonomy_helper"
+
+describe TopicFinderHelper, type: :helper do
+  include TaxonomySpecHelper
+
+  describe "#topic_finder?" do
+    before :each do
+      topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: 'existing_content_id')])
+    end
+    let(:has_topic) { topic_finder?('topic' => '/path/to_content') }
+    it "returns true because there is a topic parameter that exists" do
+      expect(topic_finder?('topic' => 'existing_content_id')).to be_truthy
+    end
+    it "returns false because there is a topic parameter that does not exist" do
+      expect(topic_finder?('topic' => 'non_existing_content_id')).to be_falsey
+    end
+    it "returns false because there is no topic parameter" do
+      expect(topic_finder?({})).to be_falsey
+    end
+  end
+end

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -6,7 +6,7 @@ describe ResultSetParser do
     let(:total) { 2 }
     let(:start) { 1 }
 
-    subject { ResultSetParser.parse(results, start, total) }
+    subject { ResultSetParser.parse('results' => results, 'start' => start, 'total' => total) }
 
     before do
       allow(Document).to receive(:new).with(:a_document_hash, 1).and_return(:a_document_instance)

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -6,7 +6,7 @@ describe ResultSetParser do
     let(:total) { 2 }
     let(:start) { 1 }
 
-    subject { ResultSetParser.parse('results' => results, 'start' => start, 'total' => total) }
+    subject { ResultSetParser.parse("results" => results, "start" => start, "total" => total) }
 
     before do
       allow(Document).to receive(:new).with(:a_document_hash, 1).and_return(:a_document_instance)

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AtomPresenter do
     double(
       FinderPresenter,
       slug: "/search/news-and-communications",
-      name: "News and communications",
+      title: "News and communications",
       document_noun: "case",
       total: 20,
       filters: [a_facet, another_facet, a_date_facet],

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe GroupedResultSetPresenter do
                                     facet_values: %w[first_value_1_content_id
                                                      second_value_1_content_id
                                                      third_value_1_content_id])
-        ResultSetParser.parse('results' => [document], 'start' => 0, 'total' => 1)
+        ResultSetParser.parse("results" => [document], "start" => 0, "total" => 1)
       }
 
       it "groups all documents in the default group" do
@@ -172,7 +172,7 @@ RSpec.describe GroupedResultSetPresenter do
       let(:search_results) {
         ResultSetParser.parse("results" => [
                                 tagged_to_first_facet_document_hash,
-                                tagged_to_second_and_third_facet_document_hash
+                                tagged_to_second_and_third_facet_document_hash,
                               ], "start" => 0, "total" => 5)
       }
 
@@ -227,7 +227,7 @@ RSpec.describe GroupedResultSetPresenter do
       }
 
       let(:search_results) {
-        ResultSetParser.parse("results" => [document_hash], 'start' => 0, 'total' => 5)
+        ResultSetParser.parse("results" => [document_hash], "start" => 0, "total" => 5)
       }
       let(:document) {
         Document.new(document_hash, 1)

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe GroupedResultSetPresenter do
 
     context "Ordering is not set to topic, so there is no grouping" do
       let(:filter_params) { { order: "a-z" } }
-      let(:search_results) { ResultSetParser.parse([FactoryBot.build(:document_hash)], 0, 1) }
+      let(:search_results) {
+        ResultSetParser.parse("results" => [FactoryBot.build(:document_hash)],
+                                                   "start" => 0,
+                                                   "total" => 1)
+      }
 
       it "returns an empty array" do
         expect(subject.search_results_content[:grouped_document_list_component_data]).to be_empty
@@ -102,7 +106,7 @@ RSpec.describe GroupedResultSetPresenter do
                                     facet_values: %w[first_value_1_content_id
                                                      second_value_1_content_id
                                                      third_value_1_content_id])
-        ResultSetParser.parse([document], 0, 1)
+        ResultSetParser.parse('results' => [document], 'start' => 0, 'total' => 1)
       }
 
       it "groups all documents in the default group" do
@@ -133,7 +137,7 @@ RSpec.describe GroupedResultSetPresenter do
                           ])
       }
 
-      let(:search_results) { ResultSetParser.parse([document_hash], 0, 5) }
+      let(:search_results) { ResultSetParser.parse("results" => [document_hash], "start" => 0, "total" => 5) }
 
       let(:document) {
         Document.new(document_hash, 1)
@@ -166,10 +170,10 @@ RSpec.describe GroupedResultSetPresenter do
       }
 
       let(:search_results) {
-        ResultSetParser.parse([
+        ResultSetParser.parse("results" => [
                                 tagged_to_first_facet_document_hash,
-                                tagged_to_second_and_third_facet_document_hash,
-                              ], 0, 5)
+                                tagged_to_second_and_third_facet_document_hash
+                              ], "start" => 0, "total" => 5)
       }
 
       let(:tagged_to_first_facet_document) {
@@ -223,7 +227,7 @@ RSpec.describe GroupedResultSetPresenter do
       }
 
       let(:search_results) {
-        ResultSetParser.parse([document_hash], 0, 5)
+        ResultSetParser.parse("results" => [document_hash], 'start' => 0, 'total' => 5)
       }
       let(:document) {
         Document.new(document_hash, 1)
@@ -246,7 +250,7 @@ RSpec.describe GroupedResultSetPresenter do
       FactoryBot.build(:document_hash)
     }
 
-    let(:search_results) { ResultSetParser.parse([document_hash], 0, 5) }
+    let(:search_results) { ResultSetParser.parse("results" => [document_hash], "start" => 0, "total" => 5) }
 
     subject(:grouped_display) {
       GroupedResultSetPresenter.new(finder_presenter, search_results, filter_params, sort_presenter, metadata_presenter_class).

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe ResultSetPresenter do
 
   let(:search_results) do
     ResultSetParser.parse(
-      results.map(&:deep_stringify_keys),
-      1,
-      total_number_of_results,
+      "results" => results.map(&:deep_stringify_keys),
+      "start" => 1,
+      "total" => total_number_of_results
 )
   end
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ResultSetPresenter do
     ResultSetParser.parse(
       "results" => results.map(&:deep_stringify_keys),
       "start" => 1,
-      "total" => total_number_of_results
+      "total" => total_number_of_results,
 )
   end
 


### PR DESCRIPTION
More refactoring

This refactor removes much of FinderPresenter, which was a model that contains too much
information. 

```#page_metadata``` and ```#topic_finder``` methods have been moved from FinderPresenter to helpers.
The aliases ```#name``` and ```#slug``` have been removed and delegated to ```ContentItem#title``` and ```ContentItem#base_path``` respectively.

Instantiating ResultSets have been simplified.


## Search page examples to sanity check:

- http://finder-frontend-pr-1587.herokuapp.com/search/all
- http://finder-frontend-pr-1587.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1587.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1587.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1587.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1587.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1587.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1587.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1587.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1587.herokuapp.com/prepare-business-uk-leaving-eu

Trello: https://trello.com/c/FtuwEXUl/1030-refactor-finder-frontend-part-vii
[Other finders](https://live-stuff.herokuapp.com/finders)
