### PR TITLE
Remove redundant Question::Option#parent attribute

### DIFF
--- a/lib/brexit_checker/question/option.rb
+++ b/lib/brexit_checker/question/option.rb
@@ -3,7 +3,7 @@ class BrexitChecker::Question::Option
 
   validates_presence_of :label
 
-  attr_reader :label, :value, :sub_options, :hint_text, :criteria, :parent
+  attr_reader :label, :value, :sub_options, :hint_text, :criteria
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
@@ -14,14 +14,13 @@ class BrexitChecker::Question::Option
     BrexitChecker::Criteria::Evaluator.evaluate(criteria, criteria_keys)
   end
 
-  def self.load(params, parent)
+  def self.load(params)
     parsed_params = params.dup
-    parsed_params["parent"] = parent
-    parsed_params["sub_options"] = load_all(params["options"].to_a, self)
+    parsed_params["sub_options"] = load_all(params["options"].to_a)
     new(parsed_params)
   end
 
-  def self.load_all(options, parent = nil)
-    options.map { |o| load(o, parent) }
+  def self.load_all(options)
+    options.map { |o| load(o) }
   end
 end


### PR DESCRIPTION
This was accidentally left in as part of fe93ce03f.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
