### PR TITLE
Add results page action count tracking

### DIFF
--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -19,6 +19,7 @@
 <% content_for :title, action_based_title %>
 <% content_for :head do %>
   <% page_url = request.base_url + request.path %>
+  <meta name="govuk:search-result-count" content="<%= @actions.count %>">
   <meta name="robots" content="noindex">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="GOV.UK">


### PR DESCRIPTION
# What
A custom dimension that tracks numbers of results presented to users

# Why
If we knew how many results were presented it would help us work out how many users are seeing an unreasonably large number of results. One problem with the Business Readiness finder was that it often gave people an overwhelming number of results - we want to avoid that outcome.

---
Card created based on discussion on: https://trello.com/c/LyUDFNZE/191-discuss-tracking-with-performance-analysis-team

https://trello.com/c/hH1EGTGT/277-track-number-of-results-being-displayed-to-users