### PR TITLE
Add email tracking for dynamic list emails

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module BrexitCheckerHelper
   def format_criteria_list(criteria)
     criteria.map { |criterion| { readable_text: criterion.text } }
@@ -48,5 +50,18 @@ module BrexitCheckerHelper
   def previous_question_index(all_questions:, criteria_keys: [], current_question_index: 0)
     previous_questions = all_questions[0...current_question_index]
     previous_questions.rindex { |question| question.show?(criteria_keys) }
+  end
+
+  def change_note_email_link(non_tracked_url, change_note)
+    url = Addressable::URI.parse(non_tracked_url)
+    return non_tracked_url unless url.host == "www.gov.uk"
+
+    url.query_values = (url.query_values || {}).merge(
+      utm_source: change_note.id,
+      utm_medium: "email",
+      utm_campaign: "govuk-brexit-checker",
+    )
+
+    url.to_s
   end
 end

--- a/app/mailers/brexit_checker_mailer.rb
+++ b/app/mailers/brexit_checker_mailer.rb
@@ -1,4 +1,6 @@
 class BrexitCheckerMailer < ApplicationMailer
+  add_template_helper(BrexitCheckerHelper)
+
   def change_notification(change_note)
     @change_note = change_note
     @action = @change_note.action

--- a/app/views/brexit_checker_mailer/change_notification.text.erb
+++ b/app/views/brexit_checker_mailer/change_notification.text.erb
@@ -1,7 +1,7 @@
 <%= t("brexit_checker_mailer.change_notification.#{@change_note.type}") %>
 
 <% if @action.title_url.present? %>
-[<%= @action.title %>](<%= @action.title_url %>)
+[<%= @action.title %>](<%= change_note_email_link(@action.title_url, @change_note) %>)
 <% else %>
 <%= @action.title %>
 <% end %>
@@ -12,7 +12,7 @@
 
 <% if @action.guidance_url.present? %>
 <%= @action.guidance_prompt || t("brexit_checker_mailer.change_notification.guidance_prompt") %>
-[<%= @action.guidance_link_text %>](<%= @action.guidance_url %>)
+[<%= @action.guidance_link_text %>](<%= change_note_email_link(@action.guidance_url, @change_note)  %>)
 <% end %>
 
 Updated

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -191,4 +191,21 @@ describe BrexitCheckerHelper, type: :helper do
       end
     end
   end
+
+  describe "#change_note_email_link" do
+    let(:change_note) { FactoryBot.build :brexit_checker_change_note }
+
+    it "returns the unchanged link when it's external" do
+      link = change_note_email_link("http://foo.bar", change_note)
+      expect(link).to eq("http://foo.bar")
+    end
+
+    it "adds tracking attributes for internal links" do
+      link = change_note_email_link("http://www.gov.uk", change_note)
+      expect(link).to match("utm_source=#{change_note.id}")
+      expect(link).to match("utm_medium=email")
+      expect(link).to match("utm_campaign=govuk-brexit-checker")
+      expect(link).to match("http://www.gov.uk?")
+    end
+  end
 end


### PR DESCRIPTION
Currently we send out notifications without any tracking on the links they contain. A given notification may have up to 2 links: the title of the action; and a link to some guidance. Note that some links are to external websites and we won't be able to track clicks on those.

After talking to Paul Cronk, we propose to manually inject the following query params into links that go to gov.uk:

   - utm_source = `<uuid of the change note>`
   - utm_medium = email
   - utm_campaign = govuk-brexit-checker

Normally we also set `utm_content = <subscription frequency>`, but we don't have the data to do that upfront. We've also changed the campaign from the normal `govuk-notifications`, which we should bear in mind in for other links in the email e.g. the link to the results list.

Normally an 'Update on GOV.UK' has a title link with tracking attributes automatically injected into it e.g.

https://www.gov.uk/government/news/government-backs-cutting-edge-tech-to-drive-down-shipping-emissions?utm_source=cb68c5c0-974f-46e3-a1db-2287917b17cd&utm_medium=email&utm_campaign=govuk-notifications&utm_content=immediate

Currently our notifications don't have a (title) link, and instead have other custom links in the freeform body, which don't benefit from this automatic injection mechanism.

https://trello.com/c/5UPZU8jc/242-collect-analytics-for-when-users-click-on-action-links-in-notifications
