### PR TITLE
Filter research by format=publication

### DIFF
--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -30,6 +30,7 @@ module Filters
           "label" => "Research",
           "filter" => {
             "content_store_document_type" => %w(dfid_research_output independent_report research),
+            "format" => "publication",
           },
         },
       ]


### PR DESCRIPTION
Here is a corporate information page with
content_store_document_type=research:

https://www.gov.uk/government/organisations/commission-for-countering-extremism/about/research

This is not research.

Fortunately, all real research has format=publication, whereas CIPs
have format=corporate_information_page.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1602.herokuapp.com/search/all
- http://finder-frontend-pr-1602.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1602.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1602.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1602.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1602.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1602.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1602.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1602.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-1602.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
