### PR TITLE
Add criteria rules to change notes

### DIFF
--- a/lib/brexit_checker/change_note.rb
+++ b/lib/brexit_checker/change_note.rb
@@ -9,7 +9,7 @@ class BrexitChecker::ChangeNote
   validates_presence_of :note, if: -> { type == "content_change" }
   validates_length_of :id, is: SecureRandom.uuid.length, message: "ID not a UUID"
 
-  attr_reader :id, :action_id, :type, :note, :date
+  attr_reader :id, :action_id, :type, :note, :date, :criteria_rules
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/brexit_checker/change_note.rb
+++ b/lib/brexit_checker/change_note.rb
@@ -9,7 +9,7 @@ class BrexitChecker::ChangeNote
   validates_presence_of :note, if: -> { type == "content_change" }
   validates_length_of :id, is: SecureRandom.uuid.length, message: "ID not a UUID"
 
-  attr_reader :id, :action_id, :type, :note, :date, :criteria_rules
+  attr_reader :id, :action_id, :type, :note, :date, :criteria
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/tasks/brexit_checker/change_notifications.rake
+++ b/lib/tasks/brexit_checker/change_notifications.rake
@@ -7,14 +7,14 @@ namespace :brexit_checker do
 
     mail = BrexitCheckerMailer.change_notification(change_note)
 
-    criteria_rules = change_note.criteria_rules || change_note.action.criteria
+    criteria = change_note.criteria.presence || change_note.action.criteria
 
     GdsApi.email_alert_api.create_message(
       title: mail.subject,
       url: change_note.action.title_url,
       body: mail.body.raw_source,
       sender_message_id: change_note.id,
-      criteria_rules: criteria_rules(criteria_rules),
+      criteria_rules: criteria_rules(criteria),
     )
 
   rescue GdsApi::HTTPConflict

--- a/lib/tasks/brexit_checker/change_notifications.rake
+++ b/lib/tasks/brexit_checker/change_notifications.rake
@@ -14,14 +14,14 @@ namespace :brexit_checker do
       url: change_note.action.title_url,
       body: mail.body.raw_source,
       sender_message_id: change_note.id,
-      criteria_rules: format_criteria_rules(criteria_rules),
+      criteria_rules: criteria_rules(criteria_rules),
     )
 
   rescue GdsApi::HTTPConflict
     raise "Notification already sent"
   end
 
-  def format_criteria_rules(criteria)
+  def criteria_rules(criteria)
     if criteria.is_a? String
       return {
         type: "tag",
@@ -31,11 +31,11 @@ namespace :brexit_checker do
     end
 
     if criteria.is_a? Hash
-      return Hash[criteria.map { |k, v| [k, format_criteria_rules(v)] }]
+      return Hash[criteria.map { |k, v| [k, criteria_rules(v)] }]
     end
 
     if criteria.is_a? Array
-      return criteria.map { |c| format_criteria_rules(c) }
+      return criteria.map { |c| criteria_rules(c) }
     end
 
     raise "Unexpected criteria class #{criteria}"

--- a/spec/factories/brexit_checker/change_note.rb
+++ b/spec/factories/brexit_checker/change_note.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     type { "addition" }
     date { "2019-08-07" }
 
+    trait :with_criteria_rules do
+      criteria_rules { [{ any_of: %w[forestry] }] }
+    end
+
     initialize_with { BrexitChecker::ChangeNote.new(attributes) }
   end
 end

--- a/spec/factories/brexit_checker/change_note.rb
+++ b/spec/factories/brexit_checker/change_note.rb
@@ -5,10 +5,6 @@ FactoryBot.define do
     type { "addition" }
     date { "2019-08-07" }
 
-    trait :with_criteria_rules do
-      criteria_rules { [{ any_of: %w[forestry] }] }
-    end
-
     initialize_with { BrexitChecker::ChangeNote.new(attributes) }
   end
 end

--- a/spec/lib/tasks/brexit_checker/change_notifications_spec.rb
+++ b/spec/lib/tasks/brexit_checker/change_notifications_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe "Change notifications" do
     before do
       stub_email_alert_api_accepts_message
       Rake::Task["brexit_checker:change_notification"].reenable
-      allow(BrexitChecker::ChangeNote).to receive(:load_all) {
-        [addition, content_change]
-      }
+      allow(BrexitChecker::ChangeNote).to receive(:load_all) { [addition, content_change] }
 
       allow(BrexitChecker::Action).to receive(:load_all) do
         [
@@ -92,102 +90,111 @@ RSpec.describe "Change notifications" do
       end
     end
 
-    describe "asks Email Alert API" do
-      context "when change note has no criteria rules" do
-        it "should notify subscribers based on the action's criteria rules" do
-          Rake::Task["brexit_checker:change_notification"].invoke(content_change.id)
+    it "asks Email Alert API to notify subscribers about content changes" do
+      Rake::Task["brexit_checker:change_notification"].invoke(content_change.id)
 
-          assert_requested(:post, "#{endpoint}/messages") do |request|
-            payload = JSON.parse(request.body)
-            expect(payload["sender_message_id"]).to eq content_change.id
-            expect(payload["body"]).to match(content_change.action.title)
+      assert_requested(:post, "#{endpoint}/messages") do |request|
+        payload = JSON.parse(request.body)
+        expect(payload["sender_message_id"]).to eq content_change.id
+        expect(payload["body"]).to match(content_change.action.title)
 
-            title = I18n.t!("brexit_checker_mailer.change_notification.title")
-            expect(payload["title"]).to eq title
+        title = I18n.t!("brexit_checker_mailer.change_notification.title")
+        expect(payload["title"]).to eq title
 
-            change_text = I18n.t!("brexit_checker_mailer.change_notification.content_change")
-            expect(payload["body"]).to match(change_text)
+        change_text = I18n.t!("brexit_checker_mailer.change_notification.content_change")
+        expect(payload["body"]).to match(change_text)
 
-            date = DateTime.parse(content_change.date)
-            expect(payload["body"]).to match(date.strftime("%-d %B %Y"))
-            expect(payload["body"]).to match(content_change.note)
+        date = DateTime.parse(content_change.date)
+        expect(payload["body"]).to match(date.strftime("%-d %B %Y"))
+        expect(payload["body"]).to match(content_change.note)
 
-            expect(payload["criteria_rules"]).to eq([
+        expect(payload["criteria_rules"]).to eq([
+          {
+            "all_of" => [
               {
-                "all_of" => [
+                "any_of" => [
                   {
-                    "any_of" => [
-                      {
-                        "type" => "tag",
-                        "key" => "brexit_checklist_criteria",
-                        "value" => "nationality-row",
-                      },
-                      {
-                        "type" => "tag",
-                        "key" => "brexit_checklist_criteria",
-                        "value" => "nationality-eu",
-                      },
-                    ],
-                  },
-                  {
-                    "any_of" => [
-                      {
-                        "type" => "tag",
-                        "key" => "brexit_checklist_criteria",
-                        "value" => "living-row",
-                      },
-                      {
-                        "type" => "tag",
-                        "key" => "brexit_checklist_criteria",
-                        "value" => "living-eu",
-                      },
-                    ],
+                    "type" => "tag",
+                    "key" => "brexit_checklist_criteria",
+                    "value" => "nationality-row",
                   },
                   {
                     "type" => "tag",
                     "key" => "brexit_checklist_criteria",
-                    "value" => "join-family-uk-yes",
+                    "value" => "nationality-eu",
                   },
                 ],
               },
-            ])
-          end
-        end
+              {
+                "any_of" => [
+                  {
+                    "type" => "tag",
+                    "key" => "brexit_checklist_criteria",
+                    "value" => "living-row",
+                  },
+                  {
+                    "type" => "tag",
+                    "key" => "brexit_checklist_criteria",
+                    "value" => "living-eu",
+                  },
+                ],
+              },
+              {
+                "type" => "tag",
+                "key" => "brexit_checklist_criteria",
+                "value" => "join-family-uk-yes",
+              },
+            ],
+          },
+        ])
+      end
+    end
 
-        context "when change note has criteira rules" do
-          it "should notify subscribers based on the change note's criteria rules" do
-            content_change.criteria = [{ any_of: %w[forestry] }]
-            Rake::Task["brexit_checker:change_notification"].invoke(content_change.id)
-            assert_requested(:post, "#{endpoint}/messages") do |request|
-              payload = JSON.parse(request.body)
-              expect(payload["criteria_rules"]).to eq([
+    describe "when change note has criteria rules" do
+      let(:content_note_criteria_change) do
+        FactoryBot.build(:brexit_checker_change_note,
+                         type: "content_change",
+                         note: "Something has changed",
+                         action_id: "content_change",
+                         criteria: [{ any_of: %w[forestry] }])
+      end
+
+      before do
+        allow(BrexitChecker::ChangeNote).to receive(:load_all) {
+          [content_note_criteria_change]
+        }
+      end
+
+      it "should notify subscribers based on the change note's criteria rules" do
+        Rake::Task["brexit_checker:change_notification"].invoke(content_note_criteria_change.id)
+        assert_requested(:post, "#{endpoint}/messages") do |request|
+          payload = JSON.parse(request.body)
+          expect(payload["criteria_rules"]).to eq([
+            {
+              "any_of" => [
                 {
-                  "any_of" => [
-                    {
-                      "key" => "brexit_checklist_criteria",
-                      "type" => "tag",
-                      "value" => "forestry",
-                    },
-                  ],
+                  "key" => "brexit_checklist_criteria",
+                  "type" => "tag",
+                  "value" => "forestry",
                 },
-              ])
-            end
-          end
+              ],
+            },
+          ])
         end
       end
+    end
 
-      it "raises an error if the change notification has been sent already" do
-        stub_request(:post, "#{endpoint}/messages")
-          .to_return(status: 409)
+    it "raises an error if the change notification has been sent already" do
+      stub_request(:post, "#{endpoint}/messages")
+        .to_return(status: 409)
 
-        expect { Rake::Task["brexit_checker:change_notification"].invoke(addition.id) }
-          .to raise_error("Notification already sent")
-      end
+      expect { Rake::Task["brexit_checker:change_notification"].invoke(addition.id) }
+        .to raise_error("Notification already sent")
+    end
 
-      it "raises an error if the change note cannot be found" do
-        expect { Rake::Task["brexit_checker:change_notification"].invoke("missing") }
-          .to raise_error("Change note not found")
-      end
+    it "raises an error if the change note cannot be found" do
+      expect { Rake::Task["brexit_checker:change_notification"].invoke("missing") }
+        .to raise_error("Change note not found")
     end
   end
 end

--- a/spec/lib/tasks/brexit_checker/change_notifications_spec.rb
+++ b/spec/lib/tasks/brexit_checker/change_notifications_spec.rb
@@ -22,10 +22,20 @@ RSpec.describe "Change notifications" do
                        action_id: "content_change")
     end
 
+    let(:content_change_with_critiera_rules) do
+      FactoryBot.build(:brexit_checker_change_note,
+                       :with_criteria_rules,
+                       type: "content_change",
+                       note: "Something has changed",
+                       action_id: "content_change")
+    end
+
     before do
       stub_email_alert_api_accepts_message
       Rake::Task["brexit_checker:change_notification"].reenable
-      allow(BrexitChecker::ChangeNote).to receive(:load_all) { [addition, content_change] }
+      allow(BrexitChecker::ChangeNote).to receive(:load_all) {
+        [addition, content_change, content_change_with_critiera_rules]
+      }
 
       allow(BrexitChecker::Action).to receive(:load_all) do
         [
@@ -90,77 +100,114 @@ RSpec.describe "Change notifications" do
       end
     end
 
-    it "asks Email Alert API to notify subscribers about content changes" do
-      Rake::Task["brexit_checker:change_notification"].invoke(content_change.id)
+    describe "asks Email Alert API" do
+      context "when change note has no criteria rules" do
+        it "should notify subscribers based on the action's criteria rules" do
+          Rake::Task["brexit_checker:change_notification"].invoke(content_change.id)
 
-      assert_requested(:post, "#{endpoint}/messages") do |request|
-        payload = JSON.parse(request.body)
-        expect(payload["sender_message_id"]).to eq content_change.id
-        expect(payload["body"]).to match(content_change.action.title)
+          assert_requested(:post, "#{endpoint}/messages") do |request|
+            payload = JSON.parse(request.body)
+            expect(payload["sender_message_id"]).to eq content_change.id
+            expect(payload["body"]).to match(content_change.action.title)
 
-        title = I18n.t!("brexit_checker_mailer.change_notification.title")
-        expect(payload["title"]).to eq title
+            title = I18n.t!("brexit_checker_mailer.change_notification.title")
+            expect(payload["title"]).to eq title
 
-        change_text = I18n.t!("brexit_checker_mailer.change_notification.content_change")
-        expect(payload["body"]).to match(change_text)
+            change_text = I18n.t!("brexit_checker_mailer.change_notification.content_change")
+            expect(payload["body"]).to match(change_text)
 
-        date = DateTime.parse(content_change.date)
-        expect(payload["body"]).to match(date.strftime("%-d %B %Y"))
-        expect(payload["body"]).to match(content_change.note)
+            date = DateTime.parse(content_change.date)
+            expect(payload["body"]).to match(date.strftime("%-d %B %Y"))
+            expect(payload["body"]).to match(content_change.note)
 
-        expect(payload["criteria_rules"]).to eq([
-          {
-            "all_of" => [
+
+            expect(payload["criteria_rules"]).to eq([
               {
-                "any_of" => [
+                "all_of" => [
                   {
-                    "type" => "tag",
-                    "key" => "brexit_checklist_criteria",
-                    "value" => "nationality-row",
+                    "any_of" => [
+                      {
+                        "type" => "tag",
+                        "key" => "brexit_checklist_criteria",
+                        "value" => "nationality-row",
+                      },
+                      {
+                        "type" => "tag",
+                        "key" => "brexit_checklist_criteria",
+                        "value" => "nationality-eu",
+                      },
+                    ],
+                  },
+                  {
+                    "any_of" => [
+                      {
+                        "type" => "tag",
+                        "key" => "brexit_checklist_criteria",
+                        "value" => "living-row",
+                      },
+                      {
+                        "type" => "tag",
+                        "key" => "brexit_checklist_criteria",
+                        "value" => "living-eu",
+                      },
+                    ],
                   },
                   {
                     "type" => "tag",
                     "key" => "brexit_checklist_criteria",
-                    "value" => "nationality-eu",
+                    "value" => "join-family-uk-yes",
                   },
                 ],
               },
-              {
-                "any_of" => [
-                  {
-                    "type" => "tag",
-                    "key" => "brexit_checklist_criteria",
-                    "value" => "living-row",
-                  },
-                  {
-                    "type" => "tag",
-                    "key" => "brexit_checklist_criteria",
-                    "value" => "living-eu",
-                  },
-                ],
-              },
-              {
-                "type" => "tag",
-                "key" => "brexit_checklist_criteria",
-                "value" => "join-family-uk-yes",
-              },
-            ],
-          },
-        ])
+            ])
+          end
+        end
+
+        context "when change note has criteira rules" do
+          it "should notify subscribers based on the change note's criteira rules" do
+            Rake::Task["brexit_checker:change_notification"].invoke(content_change_with_critiera_rules.id)
+            assert_requested(:post, "#{endpoint}/messages") do |request|
+              payload = JSON.parse(request.body)
+              expect(payload["sender_message_id"]).to eq content_change_with_critiera_rules.id
+              expect(payload["body"]).to match(content_change_with_critiera_rules.action.title)
+
+              title = I18n.t!("brexit_checker_mailer.change_notification.title")
+              expect(payload["title"]).to eq title
+
+              change_text = I18n.t!("brexit_checker_mailer.change_notification.content_change")
+              expect(payload["body"]).to match(change_text)
+
+              date = DateTime.parse(content_change_with_critiera_rules.date)
+              expect(payload["body"]).to match(date.strftime("%-d %B %Y"))
+              expect(payload["body"]).to match(content_change_with_critiera_rules.note)
+              expect(payload["criteria_rules"]).to eq([
+                {
+                  "any_of" => [
+                    {
+                      "key" => "brexit_checklist_criteria",
+                      "type" => "tag",
+                      "value" => "forestry",
+                    },
+                  ],
+                },
+              ])
+            end
+          end
+        end
       end
-    end
 
-    it "raises an error if the change notification has been sent already" do
-      stub_request(:post, "#{endpoint}/messages")
-        .to_return(status: 409)
+      it "raises an error if the change notification has been sent already" do
+        stub_request(:post, "#{endpoint}/messages")
+          .to_return(status: 409)
 
-      expect { Rake::Task["brexit_checker:change_notification"].invoke(addition.id) }
-        .to raise_error("Notification already sent")
-    end
+        expect { Rake::Task["brexit_checker:change_notification"].invoke(addition.id) }
+          .to raise_error("Notification already sent")
+      end
 
-    it "raises an error if the change note cannot be found" do
-      expect { Rake::Task["brexit_checker:change_notification"].invoke("missing") }
-        .to raise_error("Change note not found")
+      it "raises an error if the change note cannot be found" do
+        expect { Rake::Task["brexit_checker:change_notification"].invoke("missing") }
+          .to raise_error("Change note not found")
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/fMFEA6y9/294-support-custom-criteria-rules-for-change-notes

If criteria rules are added to change notes they overwrite the critera
rules from the action, used to determine who is notified of changes.

If no criteria rules are specified, defaults back to criteria rules
from action.