### PR TITLE
Remove govuk_frontend_toolkit from finder-frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "govuk_publishing_components", "~> 21.3.0"
 gem "rails", "~> 5.2.3"
 gem "slimmer", "~> 13.1.0"
 
-gem "govuk_frontend_toolkit", "~> 8.2"
 gem "sass-rails", "~> 5.1"
 gem "uglifier", "~> 4.2"
 gem "whenever", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,9 +152,6 @@ GEM
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
     govuk_document_types (0.9.2)
-    govuk_frontend_toolkit (8.2.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (21.3.0)
       gds-api-adapters
       govuk_app_config
@@ -429,7 +426,6 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 2.0.0)
   govuk_document_types (~> 0.9.2)
-  govuk_frontend_toolkit (~> 8.2)
   govuk_publishing_components (~> 21.3.0)
   govuk_schemas (~> 4.0)
   govuk_test

--- a/app/assets/javascripts/govuk_toolkit_for_tests.js
+++ b/app/assets/javascripts/govuk_toolkit_for_tests.js
@@ -1,1 +1,0 @@
-//= require govuk_toolkit

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,3 @@
-@import "shims";
 @import "govuk_publishing_components/all_components_print";
 
 .filter-form,


### PR DESCRIPTION
Removing the final traces of `govuk_frontend_toolkit` from finder-frontend, including the dependency from the Gemfile.

Most of the sass dependencies were removed a while ago, and I'm fairly sure there aren't any JS dependencies, so this isn't a huge change.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1610.herokuapp.com/search/all
- http://finder-frontend-pr-1610.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1610.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1610.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1610.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1610.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1610.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1610.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1610.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1610.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
