### PR TITLE
Improvements to google_drive_csv_downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /coverage/*
 node_modules
 .env
+credentials.json
+token.yaml

--- a/docs/make-changes-to-brexit-checker-content.md
+++ b/docs/make-changes-to-brexit-checker-content.md
@@ -19,13 +19,15 @@ Actions are defined in [an `actions.yaml` file](https://github.com/alphagov/find
 **NOTE: It's a good idea to run `bundle exec rspec spec/integration/brexit_checker_spec.rb` to validate the Yaml locally, before raising a PR.**
 
 ### If the CSV is available from Google Sheets
-1. Create a `.env` file and add the sheet ID (this can be found in the URL of the Google Sheet) as an environment variable. For example:
+1. Create a `.env` file and add the sheet ID (this can be found in the URL of the Google Sheet between `/d/` and `/edit`) as an environment variable. For example:
 
 ```
+# eg. for given sheet https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/edit
+# id="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms"
 GOOGLE_SHEET_ID="a-google-sheet-id"
 ```
 
-2. Before you run the rake task for the first time, you will need to enable to Google Drive API by generating a `credentials.json` file from the API.  Instructions to to this can be found [here](https://developers.google.com/drive/api/v3/quickstart/ruby).  You will not need to do this again when running the rake task in future as long as you have `credentials.json`.
+2. Before you run the rake task for the first time, you will need to enable to Google Drive API by generating a `credentials.json` file from the API and saving it in the root directory of the repo.  Instructions to to this can be found [here](https://developers.google.com/drive/api/v3/quickstart/ruby).  You will not need to do this again when running the rake task in future as long as you have `credentials.json`.
 
 3. Run this take task:
 

--- a/lib/brexit_checker/convert_csv_to_yaml/google_drive_csv_downloader.rb
+++ b/lib/brexit_checker/convert_csv_to_yaml/google_drive_csv_downloader.rb
@@ -41,7 +41,7 @@ module BrexitChecker
           url = authorizer.get_authorization_url(base_url: OOB_URI)
           puts "Open the following URL in the browser and enter the " \
                "resulting code after authorization:\n" + url
-          code = gets
+          code = STDIN.gets
           credentials = authorizer.get_and_store_credentials_from_code(
             user_id: user_id, code: code, base_url: OOB_URI,
           )


### PR DESCRIPTION
## background
The idea of of a one line rake task to speed changes sounded like a great idea,
but I had some problems setting this up.

I think `zsh` doesn't play nice with normal `gets` and I couldn't quite grok the documentation to work out what and where everything had to go.

Made a few changes, i hope are improvements and now mean I can run the `googleSheetsConnection`

## Changes:
  - adds more detail to documentation about first time setup
  - adds credential and generated token.yaml file for Google API auth to gitignore
  - changes use of gets to STDIN.gets to prevent initial try to read file from arg, see here: https://stackoverflow.com/questions/10523536/whats-the-difference-between-gets-chomp-vs-stdin-gets-chomp