### PR TITLE
Send eCommerce tracking to GA for zero results

### DIFF
--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -22,6 +22,13 @@
 <% end %>
 
 <% if local_assigns[:zero_results] %>
+  <%= link_to "ecommerce data", "www.gov.uk",
+    class: "govuk-visually-hidden",
+    :data => {
+      :'ecommerce-content-id' => "99999999-9999-9999-9999-999999999999",
+      :'ecommerce-row' =>"0"
+    } %>
+
   <div class='no-results govuk-!-font-size-19'>
     <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
     <p class='govuk-body'>Improve your search results by:</p>

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -4,12 +4,19 @@ Feature: Analytics
   I want to be able to track user behaviour
 
   @javascript
-  Scenario: Ecommerce tracking
+  Scenario: eCommerce tracking
     When I view the all content finder
     Then the ecommerce tracking tags are present
     And I search for lunch
     And I submit the form
     Then the data-search-query has been updated to lunch
+
+@javascript
+  Scenario: Zero results sends eCommerce tracking
+    When I view the all content finder
+    And I search for superted
+    And I submit the form
+    Then the data-ecommerce-content-id has been updated to 99999999-9999-9999-9999-999999999999
 
   Scenario: Link tracking
     Given a government finder exists

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -37,13 +37,24 @@ Then(/^the ecommerce tracking tags are present$/) do
   expect(first_link["data-ecommerce-content-id"]).to eq("1234")
 end
 
-And(/^I search for lunch$/) do
+And "I search for lunch" do
   stub_rummager_api_request_with_query_param_no_results("lunch")
 
   fill_in "Search", with: "lunch"
 end
 
+And "I search for superted" do
+  stub_rummager_api_request_with_query_param_no_results("superted")
+
+  fill_in "Search", with: "superted"
+end
+
 Then(/^the data-search-query has been updated to (.*)$/) do |query|
   form = page.find("form[data-analytics-ecommerce]")
   expect(form["data-search-query"]).to eq(query)
+end
+
+Then(/^the data-ecommerce-content-id has been updated to (.*)$/) do |query|
+  link = page.find("a[data-ecommerce-content-id]")
+  expect(link["data-ecommerce-content-id"]).to eq(query)
 end


### PR DESCRIPTION
Adds a hidden link with eCommerce data attributes to the HTML displayed if search returns zero results.

---

<img width="506" alt="Screen Shot 2019-10-08 at 15 53 36" src="https://user-images.githubusercontent.com/17908089/66406634-d90f0900-e9e3-11e9-8bde-e0c7be4ae171.png">

---

[Trello card](https://trello.com/c/P6uBkLLW/1046-track-searches-with-no-results-in-enhanced-ecommerce)


## Search page examples to sanity check:

- http://finder-frontend-pr-1620.herokuapp.com/search/all
- http://finder-frontend-pr-1620.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1620.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1620.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1620.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1620.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1620.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1620.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1620.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
