### PR TITLE
Change criteria for S011

### DIFF
--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -167,12 +167,7 @@ actions:
   guidance_url: https://www.gov.uk/guidance/foreign-travel-insurance
   criteria:
   - all_of:
-    - any_of:
-      - nationality-uk
-      - nationality-row
-    - any_of:
-      - living-uk
-      - living-row
+    - nationality-uk
     - visiting-eu
   audience: citizen
 - id: S013

--- a/lib/brexit_checker/notifications.yaml
+++ b/lib/brexit_checker/notifications.yaml
@@ -46,3 +46,14 @@ notifications:
      type: addition
      action_id: T091
      date: 2019-10-07
+   - uuid: "f37f8452-c81d-4cd6-82ce-6930a8a50b6d"
+     type: addition
+     action_id: S011
+     date: 2019-10-07
+     criteria:
+     - all_of:
+       - nationality-uk
+       - any_of:
+         - living-ie
+         - living-eu
+       - visiting-eu


### PR DESCRIPTION
A part of: https://trello.com/c/OBc5NGTY/304-s011-uk-change-criteria-to-nationality-uk-and-visiting-eu
- reduces complexity of criteria, down from nested AND(OR()) to simplier AND()
- criteria now apply to UK nationals visiting the EU
Test link
- https://finder-frontend-pr-1624.herokuapp.com/get-ready-brexit-check/results?c%5B%5D=visiting-eu&c%5B%5D=nationality-uk

@benthorner and I have tested by subscribing on integration him to:
- nationality-uk
- visiting-eu

and he's confirmed that after running the task on integration he has not recieved an email.