### PR TITLE
Change text of do-you-own-a-business question

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -126,7 +126,9 @@ questions:
 
   - key: do-you-own-a-business
     type: "single"
-    text: "Are you preparing a business or organisation for Brexit?"
+    text: "Do you own or help to run a business or organisation?"
+    description: |
+      <p>This includes sole traders (self-employed), limited companies, and small and medium enterprises.</p>
     options:
       - label: "Yes"
         value: owns-operates-business-organisation


### PR DESCRIPTION
relates to: https://trello.com/c/A9VWEZW8/308-improve-wording-for-the-initial-business-question

## Background
Recent research has shown people are confused by the initial business question, and are selecting 'no' when they own a business, but may not feel like they are 'preparing it for Brexit'. We should change this question so that more businesses see it as relevant to their business (even if tiny), and so that it’s relevant even if they aren’t preparing right now.