### PR TITLE
Change business finder title to reflect current question

### DIFF
--- a/app/controllers/qa_controller.rb
+++ b/app/controllers/qa_controller.rb
@@ -52,7 +52,7 @@ private
   end
 
   def title
-    qa_config["title"]
+    [current_facet["question"], qa_config["title"]].compact.join(" - ")
   end
   helper_method :title
 


### PR DESCRIPTION
Relates to: https://trello.com/c/7RccsHQ2/306-change-business-finder-page-titles-to-match-the-question-being-shown

I wasn't sure how or why the previous title was being used from qa_config['title'], so i left it in as a fallback in case this view also renders something which doesn't have a current_facet