### PR TITLE
Send results count as custom dimension 5

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -20,6 +20,7 @@
     this.action = this.$form.attr('action') + '.json'
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink
     this.baseTitle = $("meta[name='govuk:base_title']").attr('content') || document.title
+    this.$resultsCountMetaTag = $("meta[name='govuk:search-result-count']")
     this.$emailLink = $('a[href*="email-signup"]')
     this.previousSearchTerm = ''
 
@@ -213,6 +214,11 @@
     }
   }
 
+  LiveSearch.prototype.updateResultsCountMeta = function updateResultsCountMeta (totalCount) {
+    // update search tracking meta data tag with new value
+    this.$resultsCountMetaTag.attr('content', totalCount)
+  }
+
   LiveSearch.prototype.updateSortOptions = function updateSortOptions (results, action) {
     if (action !== $.param(this.state)) { return }
     this.updateElement(this.$sortBlock, results.sort_options_markup)
@@ -318,9 +324,10 @@
     if (action === $.param(this.state)) {
       this.updateElement(this.$resultsBlock, results.search_results)
       this.updateElement(this.$facetTagBlock, results.facet_tags)
-      this.updateElement(this.$countBlock, results.total)
+      this.updateElement(this.$countBlock, results.display_total)
       this.updateElement(this.$paginationBlock, results.next_and_prev_links)
       this.updateSortOptions(results, action)
+      this.updateResultsCountMeta(results.total)
       this.$atomAutodiscoveryLink.attr('href', results.atom_url)
       this.$loadingBlock.text('').hide()
     }

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -55,7 +55,8 @@ private
 
   def json_response
     {
-      total: result_set_presenter.displayed_total,
+      total: result_set_presenter.total_count,
+      display_total: result_set_presenter.displayed_total,
       facet_tags: render_component("facet_tags", facet_tags.present),
       search_results: render_component("finders/search_results", result_set_presenter.search_results_content),
       sort_options_markup: render_component("finders/sort_options", sort_presenter.to_hash),

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -24,6 +24,10 @@ class ResultSetPresenter
     "#{number_with_delimiter(total)} #{pluralised_document_noun}"
   end
 
+  def total_count
+    @total
+  end
+
   def search_results_content
     component_data = document_list_component_data(documents_to_convert: documents)
     {

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -1,3 +1,6 @@
+<% content_for :head do %>
+  <meta name="govuk:search-result-count" content="<%= result_set_presenter.total_count %>">
+<% end %>
 <% if local_assigns[:display_grouped_results] %>
   <ul class="finder-results js-finder-results" data-module="track-click">
     <% local_assigns[:grouped_document_list_component_data].each do |group| %>

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -4,7 +4,7 @@
 describe('liveSearch', function () {
   var $form, $results, _supportHistory, liveSearch, $atomAutodiscoveryLink, $count
   var dummyResponse = {
-    'total': 1,
+    'display_total': 1,
     'pluralised_document_noun': 'reports',
     'applied_filters': " \u003Cstrong\u003ECommercial - rotorcraft \u003Ca href='?format=json\u0026keywords='\u003E×\u003C/a\u003E\u003C/strong\u003E",
     'atom_url': 'http://an-atom-url.atom?some-query-param',

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -86,6 +86,13 @@ RSpec.describe ResultSetPresenter do
     end
   end
 
+  describe "#total_count" do
+    it "displays the total count" do
+      FactoryBot.build(:option_select_facet, values: [1, 2, 3])
+      expect(subject.total_count).to eql(total_number_of_results)
+    end
+  end
+
   describe "#documents" do
     context "there is one document in the results" do
       let(:total_number_of_results) { 1 }


### PR DESCRIPTION
## Why
This will enable us to see the corresponding result count for a query in Google Analytics

It's particularly useful for identifying queries that return 0 results, to see how we can help those users find what they need.

It's also a useful way to identify cases like 'universalcredit' where there _are_ a few matching results but they're not what users need.

And it enables us to segment the behaviour when there are 0 results, only a few results, or lots of results.

## What
To send dimension5 data to GA we're utilising the `govuk:search-result-count` meta tag in a similar way to [brexit checker](https://github.com/alphagov/finder-frontend/blob/master/app/views/brexit_checker/results.html.erb#L22)

This meta tag is already set up in [alphagov/static analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/custom-dimensions.js#L45) script to send dimension5 data to GA.

This PR adds a `total_count` method to the `to result_set_presenter` that returns a non-formatted integer, which we than add to the content attribute of the meta tag on the search results page. 

This tracks server-side rendered page.

For ajaxed results this PR updates the JSON results data `total` property with a non-formated integer and adds a `displayed_total` property which contains the format number and the noun of the finder (what` total` property used to be).

When results are returned we update the meta tag with the new value using JavaScript before data is sent to GA

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1635.herokuapp.com/search/all
- http://finder-frontend-pr-1635.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1635.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1635.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1635.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1635.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1635.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1635.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1635.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1635.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

Trello https://trello.com/c/lqm0JpMn