### PR TITLE
Fix flourinated-gas registration service url

### DIFF
--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -1460,7 +1460,7 @@ actions:
   priority: 5
   title: Register for the UK fluorinated gas (F gas) quota system (as well as the
     EU quota system)
-  title_url: https://register.fluorinated-gas.service.gov.uk
+  title_url: https://register.fluorinated-gas.service.gov.uk/register
   consequence: You will not be able to import or export F gas products if you do not
     have the right registrations and paperwork.
   lead_time: Do it as soon as possible


### PR DESCRIPTION
The link without the path works, but the user is redirected to /register/index, however we appear to be appending google analytics ids as optional params to URLS when making this hop. If the param is appended to the root it causes a failure of the gas registration app. However if the param is appended to /register, everything continues to work.

Q. Might we have this problem on any other actions that link to other gov services?
Q. What's the deal with this GA stuff?