### PR TITLE
Set year correctly when we guess date

### DIFF
--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -10,10 +10,22 @@ class DateParser
       date_string = date_string.gsub(/(\d{2})(\d{2})(\d{4})/, '\1/\2/\3')
     end
 
+    # Catches if user input could be a month name which chronic would parse as this year
+    # for months prior to now, and next year for months ahead of now
+    if date_string.match?(/^[a-zA-Z]*$/)
+      guessed_date = Chronic.parse(date_string, guess: :begin)
+      if guessed_date
+        guessed_year = Chronic.parse(date_string, guess: :begin).year
+        this_year = Time.now.year
+        date =
+          guessed_year != this_year ? guessed_date - 1.year : guessed_date
+      end
+    end
+
     # Converts spaces or dots with slashes, eg 01.01.2001 to 01/01/2001
     date_string = date_string.gsub(/(\d+)[. ](\d+)[. ]/, '\1/\2/')
 
-    date = Chronic.parse(date_string, guess: :begin, endian_precedence: :little)
+    date ||= Chronic.parse(date_string, guess: :begin, endian_precedence: :little)
     date.to_date if date
   end
 end

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe DateParser do
   # These dates have been chosen based on analytics from site search more info here: https://designpatterns.hackpad.com/Dates-vpx6XlVjIbE
+  this_year = Time.now.year
   dates = { # Zero padded, full year, various delimiters
             "21/01/2002" => Date.new(2002, 1, 21),
             "21.01.2002" => Date.new(2002, 1, 21),
@@ -47,6 +48,20 @@ describe DateParser do
             # Blank dates
             "" => nil,
             nil => nil,
+
+            ## Months only
+            "January"   => Date.new(this_year, 1, 1),
+            "February"  => Date.new(this_year, 2, 1),
+            "March"     => Date.new(this_year, 3, 1),
+            "April"     => Date.new(this_year, 4, 1),
+            "May"       => Date.new(this_year, 5, 1),
+            "June"      => Date.new(this_year, 6, 1),
+            "July"      => Date.new(this_year, 7, 1),
+            "August"    => Date.new(this_year, 8, 1),
+            "September" => Date.new(this_year, 9, 1),
+            "October"   => Date.new(this_year, 10, 1),
+            "November"  => Date.new(this_year, 11, 1),
+            "December"  => Date.new(this_year, 12, 1),
           }
 
   dates.each_pair do |input, expected|


### PR DESCRIPTION
When a user enters a month name to filter by, we helpfully guess that they meant to filter by the first of that month. But the year we guess differently depending on if that month was before or after today. 

## Old

<img width="848" alt="Screen Shot 2019-10-10 at 21 39 07" src="https://user-images.githubusercontent.com/17908089/66604666-7fa30780-eba6-11e9-9a52-32731b2a5e92.png">


## New
<img width="965" alt="Screen Shot 2019-10-10 at 21 39 31" src="https://user-images.githubusercontent.com/17908089/66604681-8c276000-eba6-11e9-9ba9-69bb9729a7fe.png">

---

[trello card](https://trello.com/c/cO3nIze1/1052-spike-investigate-validation-on-user-input-on-date-filter-date-entry)

## Search page examples to sanity check:

- http://finder-frontend-pr-1646.herokuapp.com/search/all
- http://finder-frontend-pr-1646.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1646.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1646.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1646.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1646.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1646.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1646.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1646.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1646.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
