### PR TITLE
Remove user selection from email signup tracking label

### DIFF
--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -13,6 +13,6 @@
     "module": "track-click",
     "track-action": t("brexit_checker.stay_updated.sign_up"),
     "track-category": "StayUpdated",
-    "track-label": brexit_checker_email_signup_path(c: criteria_keys)
+    "track-label": brexit_checker_email_signup_path
   }
 } %>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -71,7 +71,7 @@
             "module": "track-click",
             "track-action": action_based_email_link_label,
             "track-category": "StayUpdated",
-            "track-label": brexit_checker_email_signup_path(c: criteria_keys)
+            "track-label": brexit_checker_email_signup_path
           },
           link_text: action_based_email_link_label,
           link_href: brexit_checker_email_signup_path(c: criteria_keys),


### PR DESCRIPTION
Trello: https://trello.com/c/PLVMkGdl/43-improve-the-tracking-of-the-email-sign-up

## What
PAs have requested that the tracking label is changed so the user selection part of the URL is ommitted. Essentially, we just want to pass in `get-ready-brexit-check/email-signup`.

## Why
The options which a user has selected in the checker are visible in the URL on the results page.
Previously, when clicking one of the email signup links on this page, the full URL was being passed into GA. This was making the GA reports very long and unwieldy as each unique URL is shown as a separate row. In 1 week, over 3000 rows were generated.

## Before
<img width="1035" alt="Screen Shot 2019-10-11 at 09 48 38" src="https://user-images.githubusercontent.com/29889908/66638208-6a60c400-ec0c-11e9-81ef-027348d18ddd.png">

## After
<img width="828" alt="Screen Shot 2019-10-11 at 09 48 22" src="https://user-images.githubusercontent.com/29889908/66638205-6a60c400-ec0c-11e9-8eb4-84f9b59feacf.png">

URL to test: https://finder-frontend-pr-1647.herokuapp.com/get-ready-brexit-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk