### PR TITLE
Add AB test for search popularity

### DIFF
--- a/app/controllers/concerns/finder_popularity_ab_testable.rb
+++ b/app/controllers/concerns/finder_popularity_ab_testable.rb
@@ -1,0 +1,41 @@
+module FinderPopularityAbTestable
+  CUSTOM_DIMENSION = 43
+
+  def self.included(base)
+    base.helper_method(
+      :popularity_variant,
+      :popularity_ab_test,
+      :in_popularity_ab_test_scope?,
+    )
+    base.after_action :set_popularity_response_header
+  end
+
+  def popularity_ab_test
+    if popularity_variant.variant?("A")
+      {}
+    else
+      { popularity: popularity_variant.variant_name }
+    end
+  end
+
+  def popularity_test
+    @popularity_test ||= GovukAbTesting::AbTest.new(
+      "FinderPopularityABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B C),
+      control_variant: "A",
+    )
+  end
+
+  def popularity_variant
+    @popularity_variant ||= popularity_test.requested_variant(request.headers)
+  end
+
+  def set_popularity_response_header
+    popularity_variant.configure_response(response) if in_popularity_ab_test_scope?
+  end
+
+  def in_popularity_ab_test_scope?
+    content_item.is_finder?
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
+  include FinderPopularityAbTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -109,6 +110,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
+      ab_params: popularity_ab_test,
     )
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -12,6 +12,7 @@
   <% end %>
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
+  <%= popularity_variant.analytics_meta_tag.html_safe if in_popularity_ab_test_scope? %>
 <% end %>
 
 <% content_for :meta_title, content_item.title %>


### PR DESCRIPTION
This enables finder-frontend to take an AB test request header and use it to make requests to search-api using the AB test variant provided.

This is part of https://docs.publishing.service.gov.uk/manual/run-ab-test.html#2-how-to-set-up-an-ab-test

Once this is deployed the next step will be to deploy a 100:0 AB test to the CDN.

This is testing a popularity AB test that is already deployed to production in search-api.

Trello: https://trello.com/c/9BTLARZ8/1064-start-ab-test-for-new-popularity


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1655.herokuapp.com/search/all
- http://finder-frontend-pr-1655.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1655.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1655.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1655.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1655.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1655.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1655.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1655.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1655.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
