### PR TITLE
Updated link to guidance

### DIFF
--- a/features/fixtures/uk_nationals_in_eu.yaml
+++ b/features/fixtures/uk_nationals_in_eu.yaml
@@ -5,7 +5,7 @@ questions:
   - id: where_do_you_live
     question: Where do you live?
     hint: |
-      Choose your country or <a href="https://www.gov.uk/guidance/advice-for-british-nationals-travelling-and-living-in-europe">check the guidance for all UK nationals living in the EU</a>.
+      Choose your country or <a href="https://www.gov.uk/guidance/living-in-the-eu-prepare-for-brexit">check the guidance for all UK nationals living in the EU</a>.
     type: radio
     options:
       - text: Austria


### PR DESCRIPTION
Linking to new FCO page with updated guidance for UK nationals living in the EU.

FCO have unpublished and redirected the previous page it was linking to. 

(Wording below was added automatically when I opened this PR)
---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
