### PR TITLE
Exclude living question choice from travel options

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -27,6 +27,8 @@ class BrexitCheckerController < ApplicationController
       current_question_index: page,
     )
 
+    @living_criterion = find_living_criterion
+
     redirect_to brexit_checker_results_path(c: criteria_keys) if @current_question.nil?
   end
 
@@ -70,4 +72,17 @@ private
   def page
     @page ||= ParamsCleaner.new(params).fetch(:page, "0").to_i
   end
+
+  def find_living_criterion
+    living_options = BrexitChecker::Question.find_by_key("living").options
+    living_criteria = living_options.map(&:value)
+    living_criteria.find { |criterion| criteria_keys.include?(criterion) }
+  end
+
+  def travel_question?(question)
+    return unless question
+
+    question.key == "travelling"
+  end
+  helper_method :travel_question?
 end

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -22,6 +22,11 @@ module BrexitCheckerHelper
     items.select { |i| i.show?(criteria_keys) }
   end
 
+  def travel_question_options(options, criterion)
+    location = criterion.split("-").last
+    options.reject { |o| /(#{location})\z/.match?(o.value) }
+  end
+
   def persistent_criteria_keys(question_criteria_keys)
     criteria_keys - question_criteria_keys
   end

--- a/app/views/brexit_checker/_question_multiple_choice.html.erb
+++ b/app/views/brexit_checker/_question_multiple_choice.html.erb
@@ -1,8 +1,16 @@
+<%
+  options = if travel_question?(current_question) && @living_criterion
+              travel_question_options(current_question.options, @living_criterion)
+            else
+              current_question.options
+            end
+%>
+
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "c[]",
   heading: current_question.text,
   description: formatted_description,
   hint_text: current_question.hint_text,
   is_page_heading: true,
-  items: format_question_options(current_question.options, criteria_keys)
+  items: format_question_options(options, criteria_keys)
 } %>

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.feature "Brexit Checker travel question", type: :feature do
+  scenario "User's living question choice is not displayed as a travel question option" do
+    when_i_visit_the_brexit_checker_flow
+    and_i_choose_uk_for_the_living_question
+    then_i_should_not_see_uk_as_an_option_for_the_travel_question
+  end
+
+  def when_i_visit_the_brexit_checker_flow
+    visit brexit_checker_questions_path
+  end
+
+  def and_i_choose_uk_for_the_living_question
+    click_on "Next"
+    answer_question("living", "UK")
+    click_on "Next"
+  end
+
+  def then_i_should_not_see_uk_as_an_option_for_the_travel_question
+    question = BrexitChecker::Question.find_by_key("travelling")
+    expect(page).to have_content(question.text)
+    expect(page).not_to have_content("To the UK")
+  end
+
+  def answer_question(key, *options)
+    question = BrexitChecker::Question.find_by_key(key)
+    expect(page).to have_content(question.text)
+    options.each { |o| find_field(o).click }
+    click_on "Next"
+  end
+end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -208,4 +208,21 @@ describe BrexitCheckerHelper, type: :helper do
       expect(link).to match("http://www.gov.uk?")
     end
   end
+
+  describe "#travel_question_options" do
+    let(:uk_option) { FactoryBot.build(:brexit_checker_option, value: "living-uk") }
+    let(:eu_option) { FactoryBot.build(:brexit_checker_option, value: "living-eu") }
+    let(:ie_option) { FactoryBot.build(:brexit_checker_option, value: "living-ie") }
+    let(:options) { [uk_option, eu_option, ie_option] }
+
+    it "returns a list of options excluding options with a value containing the location given in the criterion" do
+      options_list = travel_question_options(options, %w[ie])
+      expect(options_list).not_to include(ie_option)
+    end
+
+    it "returns all given options if none have a value matching the location given in the criterion" do
+      options_list = travel_question_options(options, %w[row])
+      expect(options_list).to eq(options)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/IwUKz9tE/80-spike-travel-question-is-there-a-solution-thats-not-just-not-logic

Users have fed back that it is confusing to see the place that they live as an
option when asked where they intend to travel to. This captures the option that
a user selects when asked where they live and removes that location as an
option when they see the travel question. Since this is a presentation issue,
it made sense to construct the options that are displayed in a helper that can
be used by the view.