### PR TITLE
Update link to UK nationals living in EU guidance

### DIFF
--- a/features/fixtures/uk_nationals_in_eu.yaml
+++ b/features/fixtures/uk_nationals_in_eu.yaml
@@ -5,7 +5,7 @@ questions:
   - id: where_do_you_live
     question: Where do you live?
     hint: |
-      Choose your country or <a href="https://www.gov.uk/guidance/advice-for-british-nationals-travelling-and-living-in-europe">check the guidance for all UK nationals living in the EU</a>.
+      Choose your country or <a href="https://www.gov.uk/guidance/living-in-the-eu-prepare-for-brexit">check the guidance for all UK nationals living in the EU</a>.
     type: radio
     options:
       - text: Austria

--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -208,7 +208,7 @@ actions:
   lead_time: Do it as soon as possible
   guidance_prompt: Read the guidance
   guidance_link_text: 'Living in the EU: prepare for Brexit'
-  guidance_url: https://www.gov.uk/guidance/advice-for-british-nationals-travelling-and-living-in-europe
+  guidance_url: https://www.gov.uk/guidance/living-in-the-eu-prepare-for-brexit
   criteria:
   - all_of:
     - nationality-uk

--- a/lib/uk_nationals_living_eu.yaml
+++ b/lib/uk_nationals_living_eu.yaml
@@ -5,7 +5,7 @@ questions:
   - id: where_do_you_live
     question: Where do you live?
     hint: |
-      Choose your country or <a href="https://www.gov.uk/guidance/advice-for-british-nationals-travelling-and-living-in-europe">check the guidance for all UK nationals living in the EU</a>.
+      Choose your country or <a href="https://www.gov.uk/guidance/living-in-the-eu-prepare-for-brexit">check the guidance for all UK nationals living in the EU</a>.
     type: radio
     options:
       - text: Austria


### PR DESCRIPTION
The new guidance has been published by the FCO and the old link just redirects to the new one, so this avoids an extra redirect step.

I've opened this as an alternative to #1657.

[Trello Card](https://trello.com/c/RJHGFHNG/1376-deploy-updated-link-on-uk-nationals-living-eu)