### PR TITLE
Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::BaseError, with: :error_503
   rescue_from GdsApi::InvalidUrl, with: :unprocessable_entity
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+  rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPUnprocessableEntity, with: :unprocessable_entity
 
   if ENV["REQUIRE_BASIC_AUTH"]
@@ -45,6 +46,10 @@ private
 
   def error_not_found
     render status: :not_found, plain: "404 error not found"
+  end
+
+  def forbidden
+    render status: :forbidden, plain: "403 forbidden"
   end
 
   def unprocessable_entity

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -143,6 +143,21 @@ describe FindersController, type: :controller do
       end
     end
 
+    describe "finder item returns forbidden response when user not authorised" do
+      let(:forbidden_slug) { "/#{SecureRandom.hex}" }
+
+      before do
+        url = "#{Plek.find('content-store')}/content/#{forbidden_slug}"
+        stub_request(:get, url).to_return(status: 403, headers: {})
+      end
+
+      it "returns 403" do
+        get :show, params: { slug: forbidden_slug }
+
+        expect(response.status).to eq 403
+      end
+    end
+
     describe "finder item has been unpublished" do
       before do
         stub_request(:get, "#{Plek.find('content-store')}/content/unpublished-finder").to_return(


### PR DESCRIPTION
Trello: https://trello.com/c/zmcP9ooB/167-unauthenticated-user-accessing-a-finder-frontend-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment finder-frontend is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)

Note that I've added a test to finders_controller_spec.rb in the
absence of a generic application controller test suite. There are
other places I could have written this test but as they all inherit
from ApplicationController, this would be a lot of unnecessary
duplication.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
