### PR TITLE
Expose selected sort option as data-ecommerce-variant

### DIFF
--- a/app/presenters/grouped_result_set_presenter.rb
+++ b/app/presenters/grouped_result_set_presenter.rb
@@ -22,7 +22,7 @@ private
 
   def grouped_display?
     @grouped_display ||= begin
-      sorts_by_topic = sort_option.dig("key") == "topic"
+      sorts_by_topic = unpresented_sort_option.dig("key") == "topic"
       @filter_params[:order] == "topic" || (!@filter_params.has_key?(:order) && sorts_by_topic)
     end
   end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -43,12 +43,19 @@ class ResultSetPresenter
     @show_top_result &&
       content_item.eu_exit_finder? &&
       documents.length >= 2 &&
-      sort_option.dig("key").eql?("-relevance") &&
+      unpresented_sort_option.dig("key").eql?("-relevance") &&
       best_bet?
   end
 
   def user_supplied_keywords
     @filter_params.fetch("keywords", "")
+  end
+
+  def sort_option
+    presenter = sort_presenter.to_hash
+    return nil unless presenter
+
+    presenter[:options].find { |o| o[:selected] }
   end
 
 private
@@ -78,7 +85,7 @@ private
     end
   end
 
-  def sort_option
+  def unpresented_sort_option
     sort_presenter.selected_option || {}
   end
 end

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -25,6 +25,9 @@
 <form method="get" action="<%= content_item.base_path %>" class="js-live-search-form"
   data-analytics-ecommerce
   data-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
+  <% unless result_set_presenter.sort_option.nil? %>
+    data-ecommerce-variant="<%= result_set_presenter.sort_option[:data_track_label] %>"
+  <% end %>
   data-list-title="<%= content_item.title %>"
   data-search-query="<%= result_set_presenter.user_supplied_keywords %>">
   <input type="hidden" name="parent" value="<%= @parent %>">


### PR DESCRIPTION
Goes with https://github.com/alphagov/static/pull/1914

[Trello card](https://trello.com/c/CCMNeJl4/972-modify-ecommerce-tracking-to-track-sort-order)


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1666.herokuapp.com/search/all
- http://finder-frontend-pr-1666.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1666.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1666.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1666.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1666.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1666.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1666.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1666.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1666.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
