### PR TITLE
Include keywords in atom URLs on initial page load

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -102,7 +102,7 @@ private
   end
 
   def signup_links
-    @signup_links ||= SignupLinksPresenter.new(content_item, facets).signup_links
+    @signup_links ||= SignupLinksPresenter.new(content_item, facets, keywords).signup_links
   end
 
   def initialize_search_query(is_for_feed: false)

--- a/app/presenters/signup_links_presenter.rb
+++ b/app/presenters/signup_links_presenter.rb
@@ -1,7 +1,8 @@
 class SignupLinksPresenter
-  def initialize(content_item, facets)
+  def initialize(content_item, facets, keywords)
     @content_item = content_item
     @facets = facets
+    @keywords = keywords
   end
 
   def signup_links
@@ -15,23 +16,27 @@ class SignupLinksPresenter
 
 private
 
-  attr_reader :content_item, :facets
+  attr_reader :content_item, :facets, :keywords
 
   def email_signup_link
     signup_link = content_item.signup_link
     return signup_link if signup_link.present?
 
-    "#{content_item.email_alert_signup['web_url']}#{alert_query_string}" if content_item.email_alert_signup
+    "#{content_item.email_alert_signup['web_url']}#{query_string(alert_query_params)}" if content_item.email_alert_signup
   end
 
   def feed_link
-    "#{content_item.base_path}.atom#{alert_query_string}"
+    "#{content_item.base_path}.atom#{query_string(alert_query_params.merge(keywords: keywords))}"
   end
 
-  def alert_query_string
+  def alert_query_params
     facets_with_filters = facets.select(&:has_filters?)
     query_params_array = facets_with_filters.map(&:query_params)
-    query_string = query_params_array.inject({}, :merge).to_query
+    query_params_array.inject({}, :merge)
+  end
+
+  def query_string(params)
+    query_string = params.compact.to_query
     query_string.blank? ? query_string : "?#{query_string}"
   end
 end

--- a/spec/presenters/signup_link_presenter_spec.rb
+++ b/spec/presenters/signup_link_presenter_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe SignupLinksPresenter do
   include GovukContentSchemaExamples
   include TaxonomySpecHelper
 
-  subject(:presenter) { described_class.new(content_item, facets) }
+  subject(:presenter) { described_class.new(content_item, facets, keywords) }
+  let(:keywords) { nil }
   let(:facets) { [] }
   let(:content_item) {
     content_item_hash = {
@@ -112,8 +113,12 @@ RSpec.describe SignupLinksPresenter do
           %w[hidden_facet_content_id]
         end
 
+        let(:keywords) do
+          "micropig"
+        end
+
         it "returns the finder URL appended with permitted query params" do
-          expect(subject.signup_links[:feed_link]).to eql("/mosw-reports.atom?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[:feed_link]).to eql("/mosw-reports.atom?keywords=micropig&topic%5B%5D=hidden_facet_content_id")
         end
       end
     end


### PR DESCRIPTION
This is done by the javascript already, so we have an inconsistency.

If you go to /search/all?keywords=bar directly, then the atom link
doesn't include the keywords.  However if you first go to
/search/all?keywords=foo, and then refine your search to be for "bar",
the atom link does include the keywords.

[Trello card](https://trello.com/c/zZ1luCVQ/1078-fix-feed-link-inconsistency)


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1667.herokuapp.com/search/all
- http://finder-frontend-pr-1667.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1667.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1667.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1667.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1667.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1667.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1667.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1667.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1667.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
