### PR TITLE
Clarify brexit checker business questions

### DIFF
--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -337,8 +337,7 @@ actions:
   guidance_url: https://www.gov.uk/guidance/prepare-to-use-the-ukca-mark-after-brexit
   criteria:
   - any_of:
-    - sell-goods-provide-services-in-uk
-    - export-to-eu
+    - owns-operates-business-organisation
   audience: business
 - id: T002
   priority: 8
@@ -392,7 +391,6 @@ actions:
   - any_of:
     - sell-public-sector
     - sell-public-sector-contracts
-    - sell-goods-provide-services-in-uk
   audience: business
 - id: T006
   priority: 8
@@ -482,7 +480,6 @@ actions:
   guidance_url: https://www.gov.uk/government/publications/exhaustion-of-intellectual-property-rights/exhaustion-of-intellectual-property-rights
   criteria:
   - any_of:
-    - sell-goods-provide-services-in-uk
     - import-from-eu
     - export-to-eu
     - provide-services-do-business-in-eu
@@ -752,7 +749,6 @@ actions:
   criteria:
   - any_of:
     - food-drink-tobacco
-    - sell-goods-provide-services-in-uk
     - export-to-eu
   audience: business
 - id: T038
@@ -1043,7 +1039,6 @@ actions:
     - automotive
     - road-passenger-freight
     - motor-trade
-    - sell-goods-provide-services-in-uk
   audience: business
 - id: T067
   priority: 8
@@ -1096,7 +1091,6 @@ actions:
   criteria:
   - any_of:
     - import-from-eu
-    - sell-goods-provide-services-in-uk
   audience: business
 - id: T071
   priority: 8
@@ -1226,7 +1220,6 @@ actions:
   criteria:
   - any_of:
     - import-from-eu
-    - sell-goods-provide-services-in-uk
   audience: business
 - id: T080
   priority: 5

--- a/lib/brexit_checker/criteria.yaml
+++ b/lib/brexit_checker/criteria.yaml
@@ -118,8 +118,6 @@ criteria:
   text: You work in road freight and passenger services
 - key: warehouse-pipeline
   text: You work in warehousing, services and pipelines
-- key: sell-goods-provide-services-in-uk
-  text: Your business sells goods or services in the UK
 - key: import-from-eu
   text: Your business imports goods from the EU
 - key: export-to-eu

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -139,7 +139,7 @@ questions:
 
   - key: do-you-own-a-business
     type: "single"
-    text: "Do you own or help to run a business or organisation?"
+    text: "Do you own or help to run a UK business or organisation?"
     description: |
       <p>This includes sole traders (self-employed), limited companies, and small and medium enterprises.</p>
     options:
@@ -250,8 +250,6 @@ questions:
     description: |
       <p>Importing and exporting includes temporarily taking goods across the EU border, for example to a trade fair.</p>
     options:
-      - label: "Sell goods or provide services in the UK"
-        value: sell-goods-provide-services-in-uk
       - label: "Import from the EU"
         value: import-from-eu
       - label: "Export to the EU"
@@ -266,7 +264,6 @@ questions:
       - owns-operates-business-organisation
     type: "multiple_grouped"
     text: "What does your business or organisation do?"
-    hint_text: "Choose all the sectors and areas that your business or organisation operates in."
     options:
       - label: "Advanced manufacturing and services"
         options:


### PR DESCRIPTION
Relates to: https://trello.com/c/K8jXUOLz/58-update-business-questions-flow-in-checker

---

Last point to clarify:
[This change](https://github.com/alphagov/finder-frontend/pull/1669/files#r337433192) has resulted in a change of criteria. Confirmed with mark it needs to be here.
Therefore we'd need to make changes to existing SQL. @huwd to confirm with @benthorner and @koetsier how and when that should happen.

---

Changes are intended to do three things:
1) User research has shown that business questions need to be "hardened",
we need to clarify that this only applies to UK businesses, as this has
been a reoccurring point of confusion in user testing.

2) User research shows that Users are often not ticking that they "Sell or
provide services in the UK" even when it should apply to them. If we have
clarified (1), we can assume that this is true and reduce the friction.

3) The descriptive text has proven more confusing than helpful, so we're
removing it