### PR TITLE
Add new question about EU business travel

### DIFF
--- a/lib/brexit_checker/criteria.yaml
+++ b/lib/brexit_checker/criteria.yaml
@@ -204,6 +204,10 @@ criteria:
   text: You drive in the EU using a UK licence
 - key: living-driving-eu-no
   text: You do not drive in the EU using a UK licence
+- key: travel-eu-business
+  text: You travel to the EU for Business
+- key: travel-eu-business-no
+  text: You do not travel to the EU for Business
 - key: visiting-ie
   text: You plan to travel to Ireland
 - key: visiting-eu

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -48,6 +48,20 @@ questions:
           - label: "Study in another EU country, Iceland, Liechtenstein, Norway or Switzerland"
             value: studying-eu
 
+  - key: travelling-business
+    type: single
+    text: 'Do you travel to the EU for business?'
+    criteria:
+      - living-uk
+    description: |
+      <p>This also includes Iceland, Liechtenstein, Norway and Switzerland.</p>
+      <p>Business travel includes activities such as travelling for meetings and conferences, providing services, and touring art or music.</p>
+    options:
+      - label: "Yes"
+        value: travel-eu-business
+      - label: "No"
+        value: travel-eu-business-no
+
   - key: drive-in-eu
     type: single
     text: "Do you drive in the EU using a UK licence?"
@@ -63,9 +77,7 @@ questions:
 
   - key: travelling
     type: multiple
-    text: 'Where do you plan to travel after 31 October 2019?'
-    description: |
-      <p>This includes travel that may have started on or before 31 October 2019.</p>
+    text: 'Where do you plan to travel for leisure and tourism?'
     hint_text: Select all that apply. If you do not plan to travel, select next.
     options:
       - label: To the UK
@@ -83,6 +95,7 @@ questions:
         - visiting-ie
         - visiting-eu
         - visiting-uk
+        - travel-eu-business
     type: multiple
     text: 'Do you plan to do either of the following when travelling?'
     hint_text: "Select all that apply. If neither apply, select next."
@@ -266,7 +279,6 @@ questions:
       - owns-operates-business-organisation
     type: "multiple_grouped"
     text: "What does your business or organisation do?"
-    hint_text: "Choose all the sectors and areas that your business or organisation operates in."
     options:
       - label: "Advanced manufacturing and services"
         options:

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -56,6 +56,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     answer_question("nationality", "British")
     answer_question("living", "UK")
     answer_question("employment")
+    answer_question("travelling-business", "Yes")
     answer_question("travelling", "To another EU country, Iceland, Liechtenstein, Norway or Switzerland")
     answer_question("activities", "Take your pet")
   end


### PR DESCRIPTION
relates to: https://trello.com/c/pgzH2wbz/144-business-travel-add-question-to-checker
relates to: https://trello.com/c/IRUvyXEL/128-change-wording-for-existing-travel-question

---

Should be merged at the same time as: [this](https://github.com/alphagov/finder-frontend/pull/1670)

---

Two depts and users in research have said that they don't consider business travel to be business guidance.

So we need to show individuals (citizens) the relevant guidance too.

There are additional things business travellers need to do/check compared to non-business/tourism travellers. 