### PR TITLE
Add exclude_if to options

### DIFF
--- a/app/views/brexit_checker/_question_multiple_choice.html.erb
+++ b/app/views/brexit_checker/_question_multiple_choice.html.erb
@@ -4,5 +4,5 @@
   description: formatted_description,
   hint_text: current_question.hint_text,
   is_page_heading: true,
-  items: format_question_options(current_question.options, criteria_keys)
+  items: format_question_options(current_question.options(criteria_keys), criteria_keys)
 } %>

--- a/app/views/brexit_checker/_question_single_choice.html.erb
+++ b/app/views/brexit_checker/_question_single_choice.html.erb
@@ -4,5 +4,5 @@
   description: formatted_description,
   hint: current_question.hint_text,
   is_page_heading: true,
-  items: format_question_options(current_question.options, criteria_keys)
+  items: format_question_options(current_question.options(criteria_keys), criteria_keys)
 } %>

--- a/app/views/brexit_checker/_question_single_wrapped.html.erb
+++ b/app/views/brexit_checker/_question_single_wrapped.html.erb
@@ -6,14 +6,12 @@
     hint: current_question.hint_text,
     is_page_heading: true,
     items: current_question.options.map do |option|
-      sub_options = filter_items(option.sub_options, criteria_keys)
-
-      checkboxes = if sub_options.present?
+      checkboxes = if option.sub_options.present?
                      render "govuk_publishing_components/components/checkboxes", {
                        name: "c[]",
                        heading: option.label,
                        visually_hide_heading: true,
-                       items: format_question_options(sub_options, criteria_keys)
+                       items: format_question_options(option.sub_options, criteria_keys)
                      }
                    end
 

--- a/docs/brexit-checker.md
+++ b/docs/brexit-checker.md
@@ -117,7 +117,7 @@ A option has the following attributes:
 | value       | string           | criteria key in which to apply to the user if the option is selected                                            | yes      |
 | sub_options | array of Options | additional options that are available if option is selected, primarily used for the 'single_wrapped' type questions | no       |
 | hint_text   | string           | addition context to help the user understand the option                                                         | no       |
-| criteria    | Criteria Rule    | defines which sets of criteria the option should be shown                                                       | no       |
+| exclude_if  | string           | the option will not be shown if the given criterion has been selected.                                                    | no       |
 
 ### Notification
 A notification is used to record changes to actions and to send emails to relevant subscribers.

--- a/lib/brexit_checker/question.rb
+++ b/lib/brexit_checker/question.rb
@@ -7,12 +7,17 @@ class BrexitChecker::Question
   validates_inclusion_of :type, in: %w(single single_wrapped multiple multiple_grouped)
   validate { errors.add("Options is not an array") unless options.is_a? Array }
 
-  attr_reader :key, :text, :description, :hint_title, :hint_text,
-              :options, :type, :criteria
+  attr_reader :key, :text, :description, :hint_title, :hint_text, :type, :criteria
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
     validate!
+  end
+
+  def options(criteria_keys = nil)
+    return @options if criteria_keys.nil?
+
+    @options.reject { |option| criteria_keys.include?(option.exclude_if) }
   end
 
   def multiple?; type == "multiple" end

--- a/lib/brexit_checker/question/option.rb
+++ b/lib/brexit_checker/question/option.rb
@@ -3,7 +3,7 @@ class BrexitChecker::Question::Option
 
   validates_presence_of :label
 
-  attr_reader :label, :value, :sub_options, :hint_text, :criteria
+  attr_reader :label, :value, :sub_options, :hint_text, :criteria, :exclude_if
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/brexit_checker/question/option.rb
+++ b/lib/brexit_checker/question/option.rb
@@ -3,15 +3,11 @@ class BrexitChecker::Question::Option
 
   validates_presence_of :label
 
-  attr_reader :label, :value, :sub_options, :hint_text, :criteria, :exclude_if
+  attr_reader :label, :value, :sub_options, :hint_text, :exclude_if
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
     validate!
-  end
-
-  def show?(criteria_keys)
-    BrexitChecker::Criteria::Evaluator.evaluate(criteria, criteria_keys)
   end
 
   def self.load(params)

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -82,12 +82,16 @@ questions:
     options:
       - label: To the UK
         value: visiting-uk
+        exclude_if: living-uk
       - label: To Ireland
         value: visiting-ie
+        exclude_if: living-ie
       - label: To another EU country, Iceland, Liechtenstein, Norway or Switzerland
         value: visiting-eu
+        exclude_if: living-eu
       - label: To the rest of the world
         value: visiting-row
+        exclude_if: living-row
 
   - key: activities
     criteria:

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.feature "Navigating Brexit Checker questions", type: :feature do
+  include BrexitCheckerHelper
+
   scenario "navigate to previous question" do
     when_i_visit_the_brexit_checker_flow
     and_i_answer_travel_questions
@@ -31,12 +33,5 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
 
   def and_my_previous_activities_choice_is_selected
     expect(page).to have_checked_field("Take your pet")
-  end
-
-  def answer_question(key, *options)
-    question = BrexitChecker::Question.find_by_key(key)
-    expect(page).to have_content(question.text)
-    options.each { |o| find_field(o).click }
-    click_on "Next"
   end
 end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 RSpec.feature "Brexit Checker workflow", type: :feature do
+  include BrexitCheckerHelper
+
   scenario "business questions" do
     when_i_visit_the_brexit_checker_flow
     and_i_answer_citizen_questions
@@ -95,12 +97,5 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     if action.guidance_link_text
       expect(page).to have_link(action.guidance_link_text, href: action.guidance_url)
     end
-  end
-
-  def answer_question(key, *options)
-    question = BrexitChecker::Question.find_by_key(key)
-    expect(page).to have_content(question.text)
-    options.each { |o| find_field(o).click }
-    click_on "Next"
   end
 end

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
-RSpec.feature "Brexit Checker travel question", type: :feature do
+RSpec.feature "Filtering options based on criteria", type: :feature do
+  include BrexitCheckerHelper
+
   scenario "User's living question choice is not displayed as a travel question option" do
     when_i_visit_the_brexit_checker_flow
     and_i_choose_uk_for_the_living_question
@@ -15,18 +17,12 @@ RSpec.feature "Brexit Checker travel question", type: :feature do
     click_on "Next"
     answer_question("living", "UK")
     click_on "Next"
+    click_on "Next"
   end
 
   def then_i_should_not_see_uk_as_an_option_for_the_travel_question
     question = BrexitChecker::Question.find_by_key("travelling")
     expect(page).to have_content(question.text)
     expect(page).not_to have_content("To the UK")
-  end
-
-  def answer_question(key, *options)
-    question = BrexitChecker::Question.find_by_key(key)
-    expect(page).to have_content(question.text)
-    options.each { |o| find_field(o).click }
-    click_on "Next"
   end
 end

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.feature "Brexit Checker travel question", type: :feature do
+  scenario "User's living question choice is not displayed as a travel question option" do
+    when_i_visit_the_brexit_checker_flow
+    and_i_choose_uk_for_the_living_question
+    then_i_should_not_see_uk_as_an_option_for_the_travel_question
+  end
+
+  def when_i_visit_the_brexit_checker_flow
+    visit brexit_checker_questions_path
+  end
+
+  def and_i_choose_uk_for_the_living_question
+    click_on "Next"
+    answer_question("living", "UK")
+    click_on "Next"
+  end
+
+  def then_i_should_not_see_uk_as_an_option_for_the_travel_question
+    question = BrexitChecker::Question.find_by_key("travelling")
+    expect(page).to have_content(question.text)
+    expect(page).not_to have_content("To the UK")
+  end
+
+  def answer_question(key, *options)
+    question = BrexitChecker::Question.find_by_key(key)
+    expect(page).to have_content(question.text)
+    options.each { |o| find_field(o).click }
+    click_on "Next"
+  end
+end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -10,15 +10,6 @@ describe BrexitCheckerHelper, type: :helper do
       results = filter_items([action1, action2], [])
       expect(results).to eq([action1])
     end
-
-    it "filters options that should be shown" do
-      option1 = instance_double BrexitChecker::Question::Option, show?: true
-      option2 = instance_double BrexitChecker::Question::Option, show?: false
-      expect(option1).to receive(:show?).with([])
-      expect(option2).to receive(:show?).with([])
-      results = filter_items([option1, option2], [])
-      expect(results).to eq([option1])
-    end
   end
 
   describe "#format_action_audiences" do

--- a/spec/support/brexit_checker_helper.rb
+++ b/spec/support/brexit_checker_helper.rb
@@ -1,0 +1,8 @@
+module BrexitCheckerHelper
+  def answer_question(key, *options)
+    question = BrexitChecker::Question.find_by_key(key)
+    expect(page).to have_content(question.text)
+    options.each { |o| find_field(o).click }
+    click_on "Next"
+  end
+end


### PR DESCRIPTION
co-author @emmabeynon 

Add 'exclude_if' on options so we can exclude an option

Adds a very simple optional 'exclude_if' to options in the questions.
This stops an option from showing if the given value has been
previously selected by the user.

This commit uses this functionality to update the questions so that
users are no longer asked if they want to travel to the place
they have indicated they live.

Removed functionality to only show an option if a criterion is present
as we're not using this.

trello: https://trello.com/c/IwUKz9tE/80-spike-travel-question-is-there-a-solution-thats-not-just-not-logic

![image](https://user-images.githubusercontent.com/6050162/67297398-c3203e80-f4e1-11e9-9d8c-ab22dbf6a71d.png)
![image](https://user-images.githubusercontent.com/6050162/67297432-ce736a00-f4e1-11e9-867f-09fb63d2ba75.png)


- http://finder-frontend-pr-1676.herokuapp.com/get-ready-brexit-check/questions
