### PR TITLE
Return hint_text to sector business area

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -277,6 +277,7 @@ questions:
       - owns-operates-business-organisation
     type: "multiple_grouped"
     text: "What does your business or organisation do?"
+    hint_text: "Select all that apply."
     options:
       - label: "Advanced manufacturing and services"
         options:


### PR DESCRIPTION
Last min tweak requested to return a "Select all that apply" as hint text to the business sector checker after we removed a redundant line completely in a previous PR.