### PR TITLE
Add A/B test for shingles

### DIFF
--- a/app/controllers/concerns/shingles_ab_testable.rb
+++ b/app/controllers/concerns/shingles_ab_testable.rb
@@ -18,7 +18,7 @@ module ShinglesABTestable
 
   def shingles_test
     @shingles_test ||= GovukAbTesting::AbTest.new(
-      "shingles_ab_test",
+      "ShinglesABTest",
       dimension: CUSTOM_DIMENSION,
       allowed_variants: %w(A B),
       control_variant: "A",

--- a/app/controllers/concerns/shingles_ab_testable.rb
+++ b/app/controllers/concerns/shingles_ab_testable.rb
@@ -1,0 +1,39 @@
+module ShinglesABTestable
+  CUSTOM_DIMENSION = 42
+
+  def self.included(base)
+    base.helper_method(
+      :shingles_variant,
+      :shingles_ab_test,
+      :in_shingles_ab_test_scope?,
+    )
+    base.after_action :set_shingles_response_header
+  end
+
+  def shingles_ab_test
+    return {} if shingles_variant.variant?("A")
+
+    { shingles: shingles_variant.variant_name }
+  end
+
+  def shingles_test
+    @shingles_test ||= GovukAbTesting::AbTest.new(
+      "shingles_ab_test",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A",
+    )
+  end
+
+  def shingles_variant
+    @shingles_variant ||= shingles_test.requested_variant(request.headers)
+  end
+
+  def set_shingles_response_header
+    shingles_variant.configure_response(response) if in_shingles_ab_test_scope?
+  end
+
+  def in_shingles_ab_test_scope?
+    content_item.is_finder?
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -115,7 +115,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: shingles_ab_test,
+      ab_params: ab_params,
     )
   end
 
@@ -175,6 +175,10 @@ private
       sort_presenter,
       i_am_a_topic_page_finder: i_am_a_topic_page_finder,
     )
+  end
+
+  def ab_params
+    popularity_ab_test.merge(shingles_ab_test)
   end
 
   def grouped_display?

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
+  include ShinglesABTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -114,7 +115,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: {},
+      ab_params: shingles_ab_test,
     )
   end
 

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -115,7 +115,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: ab_params,
+      ab_params: shingles_ab_test,
     )
   end
 
@@ -175,10 +175,6 @@ private
       sort_presenter,
       i_am_a_topic_page_finder: i_am_a_topic_page_finder,
     )
-  end
-
-  def ab_params
-    popularity_ab_test.merge(shingles_ab_test)
   end
 
   def grouped_display?

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -12,6 +12,7 @@
   <% end %>
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
+  <%= shingles_variant.analytics_meta_tag.html_safe if in_shingles_ab_test_scope? %>
 <% end %>
 
 <% content_for :meta_title, content_item.title %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 require "gds_api/test_helpers/content_store"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 
 describe FindersController, type: :controller do
   include GdsApi::TestHelpers::ContentStore
   include FixturesHelper
   include GovukContentSchemaExamples
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
   include GovukAbTesting::RspecHelpers
 
   render_views

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -250,6 +250,30 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "shingles A/B test" do
+    before do
+      content_store_has_item("/search/all", all_content_finder)
+    end
+
+    it "requests the B variant" do
+      request = search_api_request(query: { ab_tests: "shingles:B" })
+
+      with_variant shingles_ab_test: "B" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+
+    it "requests the non-shingles variant (A) by default" do
+      request = search_api_request
+
+      with_variant shingles_ab_test: "A" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+  end
+
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example("finder").to_hash.merge(

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -258,7 +258,7 @@ describe FindersController, type: :controller do
     it "requests the B variant" do
       request = search_api_request(query: { ab_tests: "shingles:B" })
 
-      with_variant shingles_ab_test: "B" do
+      with_variant ShinglesABTest: "B" do
         get :show, params: { slug: "search/all" }
         expect(request).to have_been_made.once
       end
@@ -267,7 +267,7 @@ describe FindersController, type: :controller do
     it "requests the non-shingles variant (A) by default" do
       request = search_api_request
 
-      with_variant shingles_ab_test: "A" do
+      with_variant ShinglesABTest: "A" do
         get :show, params: { slug: "search/all" }
         expect(request).to have_been_made.once
       end


### PR DESCRIPTION
## todo

* [x] Get a custom dimension number

---

This enables finder-frontend to use the shingles AB test request header
to request the shingles variant from search-api when appropriate.

This is part of https://docs.publishing.service.gov.uk/manual/run-ab-test.html#2-how-to-set-up-an-ab-test

Once this is deployed, the next step is to deploy a 100:0 AB test to the CDN.

Trello card: https://trello.com/c/Px5wOXil/1079-run-an-a-b-test-for-shingles.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1687.herokuapp.com/search/all
- http://finder-frontend-pr-1687.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1687.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1687.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1687.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1687.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1687.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1687.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1687.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1687.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)