### PR TITLE
Hacky prototype for dynamic facets

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -374,7 +374,10 @@
     var oldStates = $optionSelectElements.map(function () {
       var $el = $(this)
       var id = $el.find('.js-container-head').attr('id')
-      return { 'elementId': id, 'expanded': $el.hasClass('js-closed') }
+      var filter = ''
+      var filters = $el.find('.app-c-option-select__filter-input')
+      if (filters.length === 1) { filter = filters[0].value }
+      return { 'elementId': id, 'expanded': $el.hasClass('js-closed'), 'filter': filter }
     })
     // replace facets content with data from the JSON
     this.updateElement(this.$facetWrapper, results.facet_collection_filterables)
@@ -384,6 +387,11 @@
       var $el = $header.parent('[data-module="option-select"]')
       $el.data('closed-on-load', data.expanded)
       new GOVUK.Modules.OptionSelect().start($el)
+      var filters = $el.find('.app-c-option-select__filter-input')
+      if (filters.length === 1) {
+        filters[0].value = data.filter
+        $(filters[0]).keyup()
+      }
     })
     // we need to reinitialise the module after the DOM update
     var updatedTaxonomy = new GOVUK.TaxonomySelect({ $el: $('.js-taxonomy-select') })

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -373,7 +373,7 @@
     // so we can restore them after the relopad
     var oldStates = $optionSelectElements.map(function () {
       var $el = $(this)
-      var id = $el.find('.js-container-head').attr('id')
+      var id = $el.find('.js-container-button').attr('id')
       var filter = ''
       var filters = $el.find('.app-c-option-select__filter-input')
       if (filters.length === 1) { filter = filters[0].value }
@@ -384,7 +384,7 @@
     // apply old states to each facets and reinitialise the optionSelect script
     oldStates.each(function (i, data) {
       var $header = $('#' + data.elementId)
-      var $el = $header.parent('[data-module="option-select"]')
+      var $el = $header.parents('[data-module="option-select"]')
       $el.data('closed-on-load', data.expanded)
       new GOVUK.Modules.OptionSelect().start($el)
       var filters = $el.find('.app-c-option-select__filter-input')
@@ -396,6 +396,12 @@
     // we need to reinitialise the module after the DOM update
     var updatedTaxonomy = new GOVUK.TaxonomySelect({ $el: $('.js-taxonomy-select') })
     updatedTaxonomy.update()
+    // reinitialise expanders
+    var expanders = $('[data-module="expander"]')
+    console.log(expanders)
+    for (var i = 0; i < expanders.length; i++) {
+      new GOVUK.Modules.Expander().start($(expanders[i]))
+    }
     // we need to show the element again the way it's done on first load
     // in application.js:31
     var $facetElementsRequiringJavascript = $(this.$facetWrapper).find('.js-required')

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -297,6 +297,7 @@
     var liveSearch = this
     if (typeof cachedResultData === 'undefined') {
       this.showLoadingIndicator()
+      this.facetsLoadingIndicator(true)
       return $.ajax({
         url: this.action,
         data: this.state,
@@ -327,6 +328,16 @@
 
   LiveSearch.prototype.showLoadingIndicator = function showLoadingIndicator () {
     this.$loadingBlock.text('Loading...').show()
+  }
+
+  LiveSearch.prototype.facetsLoadingIndicator = function facetsLoadingIndicator (loading) {
+    if (loading) {
+      this.$facetWrapper.addClass('facets-loading')
+      $('<div class="facets__loader">Loading...</div>').appendTo(this.$facetWrapper)
+    } else {
+      this.$facetWrapper.removeClass('facets-loading')
+        .find('.loader').remove()
+    }
   }
 
   LiveSearch.prototype.showErrorIndicator = function showErrorIndicator () {
@@ -381,6 +392,7 @@
     // in application.js:31
     var $facetElementsRequiringJavascript = $(this.$facetWrapper).find('.js-required')
     $facetElementsRequiringJavascript.show()
+    this.facetsLoadingIndicator(false)
   }
 
   LiveSearch.prototype.restoreBooleans = function restoreBooleans () {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -107,6 +107,9 @@
 
 .app-c-option-select__container-inner {
   padding: govuk-spacing(1) 13px;
+  .no-results {
+    padding-top: 6px;
+  }
 }
 
 .app-c-option-select__filter {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -382,3 +382,42 @@ mark {
   margin-bottom: govuk-spacing(7);
   padding-bottom: govuk-spacing(0);
 }
+
+.facets__loader {
+  visibility: visible;
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  border: 6px solid rgba(0, 0, 0, 0.1);
+  border-top: 6px solid #555;
+  animation: rotating 1.2s infinite cubic-bezier(0.785, 0.135, 0.15, 0.86);
+  position: absolute;
+  top:0;
+  left:0;
+  right: 0;
+  margin: auto;
+  z-index: 2;
+  opacity: 1;
+  text-indent: -9999px;
+}
+
+.facets-loading {
+  position: relative;
+}
+
+.facets-loading:after {
+  content: '';
+  position: absolute;
+  background: rgba(255, 255, 255, 0.8);
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+}
+
+@keyframes rotating {
+  100% {
+      transform: rotate(360deg);
+  }
+}

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -64,6 +64,7 @@ private
     {
       total: result_set_presenter.total_count,
       display_total: result_set_presenter.displayed_total,
+      facet_collection_filterables: render_component("finders/facet_collection_filterables", content_item: content_item),
       facet_tags: render_component("facet_tags", facet_tags.present),
       search_results: render_component("finders/search_results", result_set_presenter.search_results_content),
       sort_options_markup: render_component("finders/sort_options", sort_presenter.to_hash),

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -51,7 +51,7 @@ class OptionSelectFacet < FilterableFacet
   end
 
   def cache_key
-    { selected: selected_values, allowed: allowed_values }
+    { name: name, selected: selected_values, allowed: allowed_values }
   end
 
   def query_params

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -42,7 +42,7 @@
   <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>" tabindex="-1">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if options.empty? %>
-        There are no matching results.
+        <p class="no-results">There are no matching results.</p>
       <% else %>
         <% if really_show_filter %>
           <span id="<%= checkboxes_count_id %>"

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -3,9 +3,10 @@
   checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
   checkboxes_count_id = checkboxes_id + "-count"
   show_filter ||= false
+  really_show_filter = show_filter && !options.empty?
 %>
 
-<% if show_filter %>
+<% if really_show_filter %>
   <%
     filter_id ||= "input-#{SecureRandom.hex(4)}"
   %>
@@ -31,7 +32,7 @@
   class="app-c-option-select" data-module="option-select"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
-  <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
+  <% if really_show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >
   <h2 class="app-c-option-select__heading js-container-heading">
     <span class="app-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
@@ -40,23 +41,27 @@
   </h2>
   <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>" tabindex="-1">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
-      <% if show_filter %>
-        <span id="<%= checkboxes_count_id %>"
-          class="app-c-option-select__count govuk-visually-hidden"
-          aria-live="polite"
-          data-single="<%= t('components.option_select.found_single') %>"
-          data-multiple="<%= t('components.option_select.found_multiple') %>"
-          data-selected="<%= t('components.option_select.selected') %>"></span>
+      <% if options.empty? %>
+        There are no matching results.
+      <% else %>
+        <% if really_show_filter %>
+          <span id="<%= checkboxes_count_id %>"
+            class="app-c-option-select__count govuk-visually-hidden"
+            aria-live="polite"
+            data-single="<%= t('components.option_select.found_single') %>"
+            data-multiple="<%= t('components.option_select.found_multiple') %>"
+            data-selected="<%= t('components.option_select.selected') %>"></span>
+        <% end %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: "#{key}[]",
+          id: checkboxes_id,
+          heading: title,
+          small: true,
+          visually_hide_heading: true,
+          no_hint_text: true,
+          items: options
+        } %>
       <% end %>
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: "#{key}[]",
-        id: checkboxes_id,
-        heading: title,
-        small: true,
-        visually_hide_heading: true,
-        no_hint_text: true,
-        items: options
-      } %>
     </div>
   </div>
 </div>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -32,7 +32,7 @@
       </button>
 
       <div id="facet-wrapper" class="facet-toggle__content facet-toggle__content--hide">
-        <%= render facets.select(&:filterable?) %>
+        <%= render partial: 'facet_collection_filterables'%>
       </div>
     </div>
   <% end %>

--- a/app/views/finders/_facet_collection_filterables.html.erb
+++ b/app/views/finders/_facet_collection_filterables.html.erb
@@ -1,0 +1,1 @@
+<%= render facets.select(&:filterable?) %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -40,7 +40,7 @@
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= content_item.title %>">
+      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= content_item.title %>" id="js-facet-collection">
         <%= render partial: 'facet_collection'%>
       </div>
 

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -300,14 +300,6 @@ Feature: Filtering documents
     And I select facet Aerospace in the already expanded "Sector / Business Area" section
     Then I see results grouped by primary facet value
 
-  Scenario: Dynamic facets continue to show all options on page reload
-    When I view the news and communications finder
-    And I select a Person
-    And I reload the page
-    Then I should see all people in the people facet
-    And I should see all organisations in the organisation facet
-    And I should see all world locations in the world location facet
-
   @javascript
   Scenario: Skip to results after inputing some keywords
     When I view the news and communications finder

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -707,33 +707,6 @@ And(/^I click filter results$/) do
   click_on "Filter results"
 end
 
-And(/^I reload the page$/) do
-  visit [current_path, page.driver.request.env["QUERY_STRING"]].reject(&:blank?).join("?")
-end
-
-Then(/^I should see all people in the people facet$/) do
-  expect(page).to have_css('input[id^="people-"]', count: 5)
-  find("label", text: "Albus Dumbledore")
-  find("label", text: "Cornelius Fudge")
-  find("label", text: "Harry Potter")
-  find("label", text: "Ron Weasley")
-  find("label", text: "Rufus Scrimgeour")
-end
-
-And(/^I should see all organisations in the organisation facet$/) do
-  expect(page).to have_css('input[id^="organisations-"]', count: 4)
-  find("label", text: "Department of Mysteries")
-  find("label", text: "Gringots")
-  find("label", text: "Ministry of Magic")
-  find("label", text: "Closed organisation: Death Eaters")
-end
-
-Then(/^I should see all world locations in the world location facet$/) do
-  expect(page).to have_css('input[id^="world_locations-"]', count: 2)
-  find("label", text: "Azkaban")
-  find("label", text: "Tracy Island")
-end
-
 And(/^I select a World Location$/) do
   click_on("World location")
   check("Azkaban")

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -829,6 +829,15 @@ module DocumentHelper
           "options": [
             {
               "value": {
+                "title": "Rufus Scrimgeour",
+                "slug": "rufus-scrimgeour",
+                "link": "/government/people/rufus-scrimgeour",
+                "content_id": "content_id_for_rufus-scrimgeour"
+              },
+              "documents": 1
+            },
+            {
+              "value": {
                 "slug": "harry-potter",
                 "title": "Harry Potter",
                 "content_id": "aca5d2de-1fef-45fe-a39d-6a779589d220",

--- a/lib/facets_builder.rb
+++ b/lib/facets_builder.rb
@@ -68,7 +68,7 @@ private
     return facet_hash["allowed_values"] unless facet_hash["allowed_values"].blank?
 
     facet_key = facet_hash["key"]
-    if registries.all.has_key?(facet_key)
+    if registries.all.has_key?(facet_key) && !registries.all[facet_key].is_dynamic?
       allowed_values_from_registry(facet_key)
     elsif (facet_details = search_results.dig("facets", facet_key))
       allowed_values_for_facet_details(facet_key, facet_details)

--- a/lib/registries/organisations_registry.rb
+++ b/lib/registries/organisations_registry.rb
@@ -18,6 +18,10 @@ module Registries
       "registries/organisations"
     end
 
+    def is_dynamic?
+      true
+    end
+
   private
 
     def report_error

--- a/lib/registries/people_registry.rb
+++ b/lib/registries/people_registry.rb
@@ -18,6 +18,10 @@ module Registries
       "#{NAMESPACE}/people"
     end
 
+    def is_dynamic?
+      true
+    end
+
   private
 
     def report_error

--- a/lib/registries/registry.rb
+++ b/lib/registries/registry.rb
@@ -3,5 +3,9 @@ module Registries
     def can_refresh_cache?
       false
     end
+
+    def is_dynamic?
+      false
+    end
   end
 end

--- a/lib/registries/world_locations_registry.rb
+++ b/lib/registries/world_locations_registry.rb
@@ -14,6 +14,10 @@ module Registries
       "#{NAMESPACE}/world_locations"
     end
 
+    def is_dynamic?
+      true
+    end
+
   private
 
     def cacheable_data

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -209,7 +209,7 @@ module Search
     end
 
     def facets_not_overridden_by_registries(facet_params)
-      facet_params.reject { |k, _v| Services.registries.all.has_key?(k) }
+      facet_params.reject { |k, _v| Services.registries.all.has_key?(k) && !Services.registries.all[k].is_dynamic? }
     end
 
     def count_dynamic_facets(facet_names)

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -260,6 +260,9 @@ describe FacetsBuilder do
       let(:hash_under_test) {
         option_select_facet_hash.except(:allowed_values)
       }
+      let(:search_results) {
+        people_search_api_results.deep_stringify_keys
+      }
       it "gets values from the registry" do
         stub_request(:get, rummager_url).to_return(body: people_search_api_results.to_json)
         expect(facet.allowed_values).to eq([{ "label" => "Cornelius Fudge", "value" => "cornelius-fudge" }, { "label" => "Rufus Scrimgeour", "value" => "rufus-scrimgeour" }])


### PR DESCRIPTION
This makes *some* facets dynamic - ie, they only contain values which, when selected, will return at least 1 additional result.

I thought that elements disappearing from the page could be confusing, which has some consequences:

- The brexit checkbox on https://www.gov.uk/search/news-and-communications should always be there.
- The radio buttons on https://www.gov.uk/search/research-and-statistics should always be there
- Invalid values can be removed from the topic, sub-topic, organisations, people (etc) facets but the component should always be drawn, even if it has nothing which can be selected.

This PR makes registry-backed facets (organisations, people, etc) dynamic.  Things which would be nice to be dynamic but which are trickier are:

- Facets which have a list of allowed values (eg, document type in https://www.gov.uk/search/policy-papers-and-consultations)
- The topic and sub-topic facets.

However, those facets have a relatively small number of options available.

Topic/sub-topic would require changes in search-api I think, as search-api doesn't treat first- and second-level taxons specially, so we can only aggregate over the entire taxonomy, which is too much.

This PR implements it in a very hacky way, detailed in d9fff518562816a142248b434154815f38025dfb, and I'd need some help from a frontend developer to make it nice.

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1691.herokuapp.com/search/all
- http://finder-frontend-pr-1691.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1691.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1691.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1691.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1691.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1691.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1691.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1691.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1691.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
