### PR TITLE
Change EU/UK funding question

### DIFF
--- a/lib/brexit_checker/criteria.yaml
+++ b/lib/brexit_checker/criteria.yaml
@@ -154,14 +154,10 @@ criteria:
   text: You use or rely on exhaustion of rights protection
 - key: do-not-ip
   text: You do not use or rely on intellectual property protection
-- key: eu-uk-funding
-  text: You receive EU or UK government funding
 - key: eu-funding
   text: You receive EU government funding
-- key: uk-funding
-  text: You receive UK government funding
-- key: do-not-eu-uk-funding
-  text: You do not receive EU or UK government funding
+- key: eu-funding-no
+  text: You receive EU government funding
 - key: sell-public-sector
   text: You sell products or services to the public sector
 - key: sell-public-sector-contracts

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -203,20 +203,14 @@ questions:
     criteria:
       - owns-operates-business-organisation
     type: "single_wrapped"
-    text: "Do you get EU or UK government funding?"
+    text: "Do you get funding from an EU programme?"
     description: |
-      <p>EU funding includes the Creative Europe Fund or Horizon 2020 scheme.</p>
+      <p>This includes funding like Erasmus+ and Horizon 2020.</p>
     options:
       - label: "Yes"
-        value: eu-uk-funding
-        options:
-          - label: EU funding
-            value: eu-funding
-          - label: UK government funding
-            value: uk-funding
+        value: eu-funding
       - label: "No"
-        value: do-not-eu-uk-funding
-
+        value: eu-funding-no
   - key: public-sector-procurement
     criteria:
       - owns-operates-business-organisation


### PR DESCRIPTION
Relates to: [Trello Ticket](https://trello.com/c/Yvl6gb8v/139-eu-programme-funding-update-funding-question-on-checker)

UK funding question is effectively removed as we have no actions for them.
This simplifies this question into a straightforward EU funding question.
A yes answer now substitutes for a previous yes to funding + eu funding selection.
A no status gets a new criteria `no-eu-funding` not yet used.