### PR TITLE
Style tweaks to the results page

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -370,3 +370,12 @@ mark {
     }
   }
 }
+
+// remove separator and increase spacing between list items
+// later, propose both features as flags in the 
+// "document list" govuk-publishing component
+.gem-c-document-list__item {
+  border: 0;
+  margin-bottom: govuk-spacing(7);
+  padding-bottom: govuk-spacing(0);
+}

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -56,13 +56,10 @@
         >
         <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
+            <div class="govuk-grid-column-full">
               <h2 class="result-region-header__counter" id="js-result-count">
                 <%= result_set_presenter.displayed_total %>
               </h2>
-            </div>
-            <div class="govuk-grid-column-two-thirds">
-              <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
             </div>
           </div>
           <div id="js-facet-tag-wrapper" aria-live="assertive">
@@ -82,6 +79,10 @@
 
         <div id="js-pagination">
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
+        </div>
+
+        <div class="subscription-links">
+          <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Following on from the [prototype work on mobile ui changes](#1338), we're bringing changes in across all breakpoints.

In this pull request we've:

<details>
<summary>Updated padding and remove border separator</summary>

**Before**
<img width="662" alt="Screenshot 2019-10-30 at 11 50 26" src="https://user-images.githubusercontent.com/3758555/67856049-9f757d80-fb0b-11e9-9889-c46679bf6f48.png">

**After**
<img width="665" alt="Screenshot 2019-10-30 at 11 50 52" src="https://user-images.githubusercontent.com/3758555/67856050-9f757d80-fb0b-11e9-9b57-44c969248f9e.png">

</details>

<details>
<summary>Moved subscription links to the end of results</summary>

**Before**

<img width="658" alt="Screenshot 2019-10-30 at 11 45 01" src="https://user-images.githubusercontent.com/3758555/67855668-caab9d00-fb0a-11e9-8ef5-96b8ebc54b8d.png">

**After**
Beginning of results list
<img width="668" alt="Screenshot 2019-10-30 at 11 57 50" src="https://user-images.githubusercontent.com/3758555/67856501-976a0d80-fb0c-11e9-99d0-58a02f0adf95.png">
End of results list
<img width="669" alt="Screenshot 2019-10-30 at 11 58 09" src="https://user-images.githubusercontent.com/3758555/67856502-976a0d80-fb0c-11e9-8867-001e59f6caaa.png">
</details>

## Search page examples to sanity check:

- http://finder-frontend-pr-1701.herokuapp.com/search/all
- http://finder-frontend-pr-1701.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1701.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1701.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1701.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1701.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1701.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1701.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1701.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1701.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

Trello ticket: https://trello.com/c/85fpNfId/1053-restyle-search-results-section
