### PR TITLE
Fix spelling suggestions analytics

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -38,11 +38,6 @@
       window.ga('set', 'transport', 'beacon')
     }
 
-    // track impressions of spelling suggestions
-    if (this.$suggestionsBlock) {
-      this.trackSpellingSuggestionsImpressions(this.$suggestionsBlock)
-    }
-
     if (GOVUK.support.history()) {
       this.saveState()
 
@@ -151,9 +146,11 @@
   }
 
   LiveSearch.prototype.trackSpellingSuggestionsImpressions = function trackSpellingSuggestionsImpressions ($suggestions) {
-    $($suggestions).find('a').each(function () {
-      GOVUK.SearchAnalytics.setDimension(81, $(this).data('track-options').dimension81)
-    })
+    var $spellingSuggestionMetaTag = $("meta[name='govuk:spelling-suggestion']")
+    // currently there's ever only one suggestion
+    var spellingSuggestionAvailable = this.$suggestionsBlock.find('a').length > 0
+    var suggestion = spellingSuggestionAvailable ? this.$suggestionsBlock.find('a').data('track-options').dimension81 : ''
+    $spellingSuggestionMetaTag.attr('content', suggestion)
   }
 
   /**

--- a/app/views/finders/_spelling_suggestion.html.erb
+++ b/app/views/finders/_spelling_suggestion.html.erb
@@ -1,3 +1,5 @@
+<% # we want an empty string if there are no suggestions on page load %> 
+<% _spelling_suggestion = '' %>
 <% if @spelling_suggestion_presenter.suggestions.any? %>
 <p class="govuk-body">Did you mean
   <% @spelling_suggestion_presenter.suggestions.each do |suggestion| %>
@@ -5,6 +7,10 @@
       class: "govuk-link govuk-!-font-weight-bold",
       :data => suggestion[:data_attributes]
     %>
+    <% _spelling_suggestion = suggestion[:keywords] %>
   <% end %>
 </p>
+<% end %>
+<% content_for :head do %>
+  <meta name="govuk:spelling-suggestion" content="<%= _spelling_suggestion %>">
 <% end %>


### PR DESCRIPTION
Depends on alphagov/static#1927

For finders where we show spelling suggestions, we want to track their page view impressions.
First part of the work is in static alphagov/static#1927

Here we insert the meta tag into the document head for analytics script to pick up.

As we're adding a meta tag for GA tracking, we now need to only update the meta tag content where there is and isn't a spelling suggestion.

[Trello ticket](https://trello.com/c/7eVLdKvd/1110-fix-spelling-suggestion-tracking)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1710.herokuapp.com/search/all
- http://finder-frontend-pr-1710.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1710.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1710.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1710.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1710.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1710.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1710.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1710.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1710.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
