### PR TITLE
Add missing **assistance** dog from brexit question

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -106,7 +106,7 @@ questions:
     options:
       - label: Drive
         value: visiting-driving
-      - label: Take your pet
+      - label: Take your pet or an assistance dog
         value: visiting-bring-pet
 
   - key: returning


### PR DESCRIPTION
Trello: https://trello.com/c/PejHpkfN/79-assistance-dogs-defra-daera-ni-relates-to-s032-chased-10-oct

---

Realised in this ticket, looks like we updated this action, but not the question.
I suspect this goes back to recent conversations we've had about needed acceptance criteria before this hits the devs?
