### PR TITLE
Reverse actions array, so business actions come first

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -6,15 +6,21 @@ module BrexitCheckerHelper
   end
 
   def format_action_audiences(actions)
-    action_groups = actions.group_by(&:audience)
+    business, citizen = actions.partition { |action| action.audience == "business" }
+    business_results = {
+      heading: I18n.t("brexit_checker.results.audiences.business.heading"),
+      actions: order_actions_by_priority(business),
+    }
+    citizen_results = {
+      heading: I18n.t("brexit_checker.results.audiences.citizen.heading"),
+      actions: order_actions_by_priority(citizen),
+    }
+    [business_results, citizen_results]
+  end
 
-    action_groups.map do |key, action_group|
-      {
-        heading: I18n.t("brexit_checker.results.audiences.#{key}.heading"),
-        actions: action_group.sort_by.with_index do |action, index|
-          [-action.priority, index]
-        end,
-      }
+  def order_actions_by_priority(action_group)
+    action_group.sort_by.with_index do |action, index|
+      [-action.priority, index]
     end
   end
 

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -26,12 +26,12 @@ describe BrexitCheckerHelper, type: :helper do
       it "return actions grouped by audience and sorted by priority" do
         expect(subject).to eq([
           {
-            heading: I18n.t("brexit_checker.results.audiences.citizen.heading"),
-            actions: [action2, action1],
-          },
-          {
             heading: I18n.t("brexit_checker.results.audiences.business.heading"),
             actions: [action3, action4],
+          },
+          {
+            heading: I18n.t("brexit_checker.results.audiences.citizen.heading"),
+            actions: [action2, action1],
           },
         ])
       end


### PR DESCRIPTION
Quick request by Mark and Stephen.
Would need to go live before PEP starts

~I'm unsure if using `.reverse` like that is a terrible hack (currently there are only two audiences, not impossible there are more in future!).~  

Turns out the linter doesn't like me chaining `end.reverse`, gone for a slightly more verbose method though I'm _still_ not sure if that's a terrible hack. A proper sort method would make sense, but I'm wondering if it's overkill?