### PR TITLE
Update expander component

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -11,6 +11,9 @@
 
 .app-c-expander__content {
   padding: govuk-spacing(2) 13px;
+  .govuk-form-group:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .js-enabled {
@@ -34,7 +37,7 @@
   top: 0;
   left: 6px;
   width: 30px;
-  height: 100%;
+  height: 40px;
   fill: govuk-colour("black");
 }
 
@@ -44,6 +47,7 @@
   background: none;
   text-align: left;
   cursor: pointer;
+  padding: 0;
   color: $govuk-link-colour;
 
   &:hover {
@@ -66,6 +70,12 @@
     left: 0;
     z-index: 2;
   }
+}
+
+.app-c-expander__selected-counter {
+  @include govuk-font($size: 14);
+  color: $govuk-text-colour;
+  margin-top: 3px;
 }
 
 .js-enabled {

--- a/app/views/components/_date-filter.html.erb
+++ b/app/views/components/_date-filter.html.erb
@@ -8,29 +8,33 @@
   date_errors_to ||= nil
 %>
 <% if key && name %>
-  <div class="app-c-date-filter" id="<%= key %>" <% if aria_controls_id %> data-module="enable-aria-controls"<% end %>>
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: name + " after"
-      },
-      name: key + "[from]",
-      id: key + "[from]",
-      value: from_value,
-      controls: aria_controls_id,
-      hint: "For example, 2005 or 21/11/2014",
-      error_message: date_errors_from
-    } %>
-
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: name + " before"
-      },
-      name: key + "[to]",
-      id: key + "[to]",
-      value: to_value,
-      controls: aria_controls_id,
-      hint: "For example, 2005 or 21/11/2014",
-      error_message: date_errors_to
-    } %>
-  </div>
+  <%= render "components/expander", {
+      title: "Date"
+    } do %>
+    <div class="app-c-date-filter govuk-!-margin-bottom-0" id="<%= key %>" <% if aria_controls_id %> data-module="enable-aria-controls"<% end %>>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: name + " after"
+        },
+        name: key + "[from]",
+        id: key + "[from]",
+        value: from_value,
+        controls: aria_controls_id,
+        hint: "For example, 2005 or 21/11/2014",
+        error_message: date_errors_from
+      } %>
+  
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: name + " before"
+        },
+        name: key + "[to]",
+        id: key + "[to]",
+        value: to_value,
+        controls: aria_controls_id,
+        hint: "For example, 2005 or 21/11/2014",
+        error_message: date_errors_to
+      } %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,20 +1,24 @@
 <% unless i_am_a_topic_page_finder %>
-<div class="js-taxonomy-select">
-  <%= render "govuk_publishing_components/components/select", {
-    id: 'level_one_taxon',
-    label: "Topic",
-    full_width: true,
-    options: taxon_facet.topics
-  }
-  %>
-  <div class="js-required govuk-form-group gem-c-select">
-    <%= render "govuk_publishing_components/components/select", {
-      id: 'level_two_taxon',
-      label: "Sub-topic",
-      full_width: true,
-      options: taxon_facet.sub_topics
-    }
-    %>
-  </div>
-</div>
+  <%= render "components/expander", {
+    title: "Topic"
+  } do %>
+    <div class="js-taxonomy-select">
+      <%= render "govuk_publishing_components/components/select", {
+        id: 'level_one_taxon',
+        label: "Topic",
+        full_width: true,
+        options: taxon_facet.topics
+      }
+      %>
+      <div class="js-required govuk-form-group gem-c-select">
+        <%= render "govuk_publishing_components/components/select", {
+          id: 'level_two_taxon',
+          label: "Sub-topic",
+          full_width: true,
+          options: taxon_facet.sub_topics
+        }
+        %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -80,4 +80,51 @@ describe('An expander module', function () {
       expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
     })
   })
+
+  describe('with user selected items', function () {
+    /* eslint-disable */
+    var html = '\
+      <div class="app-c-expander" data-module="expander">\
+        <h2 class="app-c-expander__heading">\
+          <span class="app-c-expander__title js-toggle">Topic</span>\
+          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>\
+          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>\
+        </h2>\
+        <div class="app-c-expander__content js-content" id="expander-content-2386afad">\
+          <select>\
+            <option value="">All topics</option>\
+            <option value="e48ab80a-de80-4e83-bf59-26316856a5f9" selected>Government</option>\
+          </select>\
+          <select>\
+            <option value="">All sub topics</option>\
+            <option value="a">Department A</option>\
+            <option value="b" selected>Department B</option>\
+          </select>\
+          <input name="public_timestamp[from]" value="" type="text">\
+          <input name="public_timestamp[to]" value="november" type="text">\
+        </div>\
+      </div>'
+    /* eslint-enable */
+    beforeEach(function () {
+      expander = new GOVUK.Modules.Expander()
+      $element = $(html)
+      expander.start($element)
+    })
+
+    afterEach(function () {
+      $(document).off()
+    })
+
+    it('shows the number of selecteed items when select options or text inputs have a value', function () {
+      expect($element.find('.js-selected-counter').html()).toBe('3 selected')
+    })
+
+    it('expands the content on page load', function () {
+      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
+    })
+
+    it('sets correct aria attributes on the button', function () {
+      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
+    })
+  })
 })


### PR DESCRIPTION
Following on from the [prototype work on mobile ui changes](#1338), we're updating the expander component and wrapping the Topic selection and Date filters in it.

Updates to the component include:
 - visual styling tweaks
- displaying the number of user selected items, be it select options (in the case of topics) or text inputs (in the case of date filter)
- expanding the content of the component if any items are selected (to match the OptionSelect component behaviour)
- adding javascript test

**Before**
<img width="333" alt="Screenshot 2019-11-07 at 10 20 29" src="https://user-images.githubusercontent.com/3758555/68381501-c0f8e980-0149-11ea-9be9-22576c7c65cc.png">

**After**
<img width="319" alt="Screenshot 2019-11-07 at 10 24 26" src="https://user-images.githubusercontent.com/3758555/68381516-c9e9bb00-0149-11ea-88f0-7d671e800c4b.png">


[Trello ticket](https://trello.com/c/HLhFrEWp/1101-show-number-of-selected-options-for-date-and-topics-filter)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1722.herokuapp.com/search/all
- http://finder-frontend-pr-1722.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1722.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1722.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1722.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1722.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1722.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1722.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1722.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1722.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
