### PR TITLE
Add tracking to details component in checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "google-api-client"
 gem "govuk_ab_testing", "~> 2.4.1"
 gem "govuk_app_config", "~> 2.0.1"
 gem "govuk_document_types", "~> 0.9.2"
-gem "govuk_publishing_components", "~> 21.9.0"
+gem "govuk_publishing_components", "~> 21.10.0"
 gem "rails", "~> 6.0.0"
 gem "slimmer", "~> 13.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
     govuk_document_types (0.9.2)
-    govuk_publishing_components (21.9.0)
+    govuk_publishing_components (21.10.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -443,7 +443,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 2.0.1)
   govuk_document_types (~> 0.9.2)
-  govuk_publishing_components (~> 21.9.0)
+  govuk_publishing_components (~> 21.10.0)
   govuk_schemas (~> 4.0)
   govuk_test
   jasmine-rails

--- a/app/views/brexit_checker/_detail_text.html.erb
+++ b/app/views/brexit_checker/_detail_text.html.erb
@@ -1,6 +1,10 @@
 <% unless detail_text.nil? %>
   <%= render "govuk_publishing_components/components/details", {
-    title: detail_title  || "Why am I being asked this question?"
+    title: detail_title  || "Why am I being asked this question?",
+    data_attributes: {
+      track_category: "brexit-checker-qa",
+      track_action: question_key,
+    }
   } do %>
     <%= detail_text.html_safe %>
   <% end %>

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -67,7 +67,8 @@
         %>
         <%= render 'detail_text', {
             detail_text: @current_question.detail_text,
-            detail_title: @current_question.detail_title
+            detail_title: @current_question.detail_title,
+            question_key: @current_question.key
           }
         %>
         <div class="govuk-form-footer">


### PR DESCRIPTION
## What
Add tracking to the details component in the Brexit checker.

Tracking is set as:

track-category: brexit-checker-qa
track-label: "open" or "closed" depending on the status of the component
track-action: [the question the user is on, e.g: "travelling"]

## Why
We need tracking so we can tell if users are clicking on this component.

Pages to test:

- https://finder-frontend-pr-1724.herokuapp.com/get-ready-brexit-check/questions?c%5B%5D=living-uk&c%5B%5D=nationality-uk&page=3
- https://finder-frontend-pr-1724.herokuapp.com/get-ready-brexit-check/questions?c%5B%5D=living-uk&c%5B%5D=nationality-uk&page=4
- https://finder-frontend-pr-1724.herokuapp.com/get-ready-brexit-check/questions?c%5B%5D=living-uk&c%5B%5D=nationality-uk&page=6
