### PR TITLE
Re-enable Popularity AC test

### DIFF
--- a/app/controllers/concerns/finder_popularity_ab_testable.rb
+++ b/app/controllers/concerns/finder_popularity_ab_testable.rb
@@ -1,0 +1,41 @@
+module FinderPopularityAbTestable
+  CUSTOM_DIMENSION = 43
+
+  def self.included(base)
+    base.helper_method(
+      :popularity_variant,
+      :popularity_ab_test,
+      :in_popularity_ab_test_scope?,
+    )
+    base.after_action :set_popularity_response_header
+  end
+
+  def popularity_ab_test
+    if popularity_variant.variant?("A")
+      {}
+    else
+      { popularity: popularity_variant.variant_name }
+    end
+  end
+
+  def popularity_test
+    @popularity_test ||= GovukAbTesting::AbTest.new(
+      "FinderPopularityABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A C),
+      control_variant: "A",
+    )
+  end
+
+  def popularity_variant
+    @popularity_variant ||= popularity_test.requested_variant(request.headers)
+  end
+
+  def set_popularity_response_header
+    popularity_variant.configure_response(response) if in_popularity_ab_test_scope?
+  end
+
+  def in_popularity_ab_test_scope?
+    content_item.is_finder?
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,6 +1,7 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
   include ShinglesABTestable
+  include FinderPopularityAbTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -115,7 +116,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: shingles_ab_test,
+      ab_params: shingles_ab_test.merge(popularity_ab_test),
     )
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -13,6 +13,7 @@
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
   <%= shingles_variant.analytics_meta_tag.html_safe if in_shingles_ab_test_scope? %>
+  <%= popularity_variant.analytics_meta_tag.html_safe if in_popularity_ab_test_scope? %>
 <% end %>
 
 <% content_for :meta_title, content_item.title %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -274,6 +274,29 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "popularity A/B test" do
+    before do
+      content_store_has_item("/search/all", all_content_finder)
+    end
+
+    it "should request the B popularity variant from search api" do
+      request = search_api_request(query: { ab_tests: "popularity:C" })
+
+      with_variant FinderPopularityABTest: "C" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+
+    it "should not specify a popularity variant from search api by default" do
+      request = search_api_request
+      with_variant FinderPopularityABTest: "A" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+  end
+
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example("finder").to_hash.merge(


### PR DESCRIPTION
This will allow us to test the C variant of popularity further.

The B variant is disabled because it didn't show good enough performance (click-through rate, abandonment rate).

Trello: https://trello.com/c/rmqWpfin/1123-restart-popularity-ab-test

This reverts commit fb8f289c41a36b6f6ed7441644497d40b7424f91.


---

## Search page examples to sanity check:

- http://finder-frontend-pr-1727.herokuapp.com/search/all
