### PR TITLE
add styling for placement of subscription links

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -354,6 +354,12 @@ mark {
   }
 }
 
+.subscription-links--desktop {
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+}
+
 // show spelling suggestion container only if suggestions are available
 .spelling-suggestions {
   margin-top: -(govuk-spacing(1));
@@ -363,7 +369,7 @@ mark {
     margin-top: -(govuk-spacing(2));
     margin-bottom: govuk-spacing(7);
 
-    // We need to keep font size consistently 16 pixels 
+    // We need to keep font size consistently 16 pixels
     // when above the tablet breakpoint
     .govuk-body {
       font-size: 16px;
@@ -372,7 +378,7 @@ mark {
 }
 
 // remove separator and increase spacing between list items
-// later, propose both features as flags in the 
+// later, propose both features as flags in the
 // "document list" govuk-publishing component
 .gem-c-document-list__item {
   border: 0;

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -57,10 +57,13 @@
         >
         <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-one-third">
               <h2 class="result-region-header__counter" id="js-result-count">
                 <%= result_set_presenter.displayed_total %>
               </h2>
+            </div>
+            <div class="govuk-grid-column-two-thirds subscription-links subscription-links--desktop">
+              <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
             </div>
           </div>
           <div id="js-facet-tag-wrapper" aria-live="assertive">
@@ -82,7 +85,7 @@
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
         </div>
 
-        <div class="subscription-links">
+        <div class="subscription-links" id="subscription-links-footer">
           <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
         </div>
       </div>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -368,6 +368,11 @@ Feature: Filtering documents
     Then I see email and feed sign up links with filters and order applied
 
   @javascript
+  Scenario: Email links while on mobile
+    When I view the news and communications finder
+    Then I see only one email and feed sign up link on mobile
+
+  @javascript
   Scenario: Policy papers should have three options
     When I view the policy papers and consultations finder
     And I select some document types

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -69,6 +69,15 @@ And("I see email and feed sign up links") do
   expect(page).to have_css('a[href="/search/news-and-communications.atom"]')
 end
 
+And("I see only one email and feed sign up link on mobile") do
+  width = page.driver.browser.manage.window.size.width
+  height = page.driver.browser.manage.window.size.height
+  page.driver.browser.manage.window.resize_to(375, 812)
+  expect(page).to have_css('a[href="/search/news-and-communications/email-signup"]', count: 1)
+  expect(page).to have_css('a[href="/search/news-and-communications.atom"]', count: 1)
+  page.driver.browser.manage.window.resize_to(width, height)
+end
+
 And("I see email and feed sign up links with filters applied") do
   expect(page).to have_css('a[href="/search/news-and-communications/email-signup?people%5B%5D=rufus-scrimgeour"]')
   expect(page).to have_css('a[href="/search/news-and-communications.atom?people%5B%5D=rufus-scrimgeour"]')
@@ -431,7 +440,9 @@ Then(/^I browse to a huge page number and get an appropriate error$/) do
 end
 
 And("I click on the atom feed link") do
-  click_on "Subscribe to feed"
+  within("#subscription-links-footer") do
+    click_on "Subscribe to feed"
+  end
 end
 
 And("there is machine readable information") do
@@ -788,7 +799,9 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
 
   content_store_has_item("/cma-cases/email-signup", signup_content_item)
 
-  click_link("Get email alerts")
+  within "#subscription-links-footer" do
+    click_link("Get email alerts")
+  end
 
   begin
     click_on("Create subscription")
@@ -799,7 +812,9 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
 end
 
 When("I create an email subscription") do
-  click_link("Get email alerts")
+  within "#subscription-links-footer" do
+    click_link("Get email alerts")
+  end
 end
 
 Then("I see the email subscription page") do


### PR DESCRIPTION
This change brings back the subscription links to the top of the search results, but for desktop only. On mobile, the subscription links are shown at the bottom of the page. 

[Trello card](https://trello.com/c/DTSIoSVp/1129-moving-subscription-links-on-desktop)

---

## Search page examples to sanity check:

- http://finder-frontend-pr-1728.herokuapp.com/search/all
- http://finder-frontend-pr-1728.herokuapp.com/search/research-and-statistics
- http://finder-frontend-pr-1728.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- http://finder-frontend-pr-1728.herokuapp.com/get-ready-brexit-check/questions
- http://finder-frontend-pr-1728.herokuapp.com/drug-device-alerts
- http://finder-frontend-pr-1728.herokuapp.com/find-eu-exit-guidance-business
- http://finder-frontend-pr-1728.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- http://finder-frontend-pr-1728.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- http://finder-frontend-pr-1728.herokuapp.com/uk-nationals-living-eu
- http://finder-frontend-pr-1728.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
