### PR TITLE
Only embolden the corrected part of a spelling suggestion

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -151,7 +151,7 @@ private
     suggested_queries = search_results.fetch("suggested_queries", [])
     SpellingSuggestionPresenter.new(
       suggested_queries,
-      finder_url_builder.url(keywords: suggested_queries.first),
+      finder_url_builder.url(keywords: (suggested_queries.first || {}).dig("text")),
       # Search api is set to always return an array with one item
       content_item.as_hash["content_id"],
     )

--- a/app/presenters/spelling_suggestion_presenter.rb
+++ b/app/presenters/spelling_suggestion_presenter.rb
@@ -6,15 +6,16 @@ class SpellingSuggestionPresenter
   end
 
   def suggestions
-    @suggested_queries.map do |keywords|
+    @suggested_queries.map do |suggestion|
       {
-        keywords: keywords,
+        keywords: suggestion["text"],
+        highlighted: suggestion["highlighted"],
         link: @url,
         data_attributes: {
           ecommerce_content_id: @content_item_id,
           ecommerce_row: 1,
           track_options: {
-            dimension81: keywords,
+            dimension81: suggestion["text"],
           },
         },
       }

--- a/app/views/finders/_spelling_suggestion.html.erb
+++ b/app/views/finders/_spelling_suggestion.html.erb
@@ -3,8 +3,8 @@
 <% if @spelling_suggestion_presenter.suggestions.any? %>
 <p class="govuk-body">Did you mean
   <% @spelling_suggestion_presenter.suggestions.each do |suggestion| %>
-    <%= link_to suggestion[:keywords], suggestion[:link],
-      class: "govuk-link govuk-!-font-weight-bold",
+    <%= link_to sanitize(suggestion[:highlighted]), suggestion[:link],
+      class: "govuk-link",
       :data => suggestion[:data_attributes]
     %>
     <% _spelling_suggestion = suggestion[:keywords] %>

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -685,7 +685,7 @@ module DocumentHelper
       "total": 20,
       "start": 0,
       "facets": {},
-      "suggested_queries": ["driving"]
+      "suggested_queries": [{ "text": "driving", "highlighted": "<mark>driving</mark>" }]
     }|
   end
 

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -85,7 +85,7 @@ module RummagerUrlHelper
     {
       "count" => "1500",
       "start" => "0",
-      "suggest" => "spelling",
+      "suggest" => "spelling_with_highlighting",
     }
   end
 

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -235,7 +235,7 @@ module Search
     end
 
     def suggest_query
-      { "suggest" => "spelling" }
+      { "suggest" => "spelling_with_highlighting" }
     end
 
     def stopwords

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -56,7 +56,7 @@ describe FindersController, type: :controller do
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
-              suggest: "spelling",
+              suggest: "spelling_with_highlighting",
             },
           )
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -115,7 +115,7 @@ describe FindersController, type: :controller do
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
-              suggest: "spelling",
+              suggest: "spelling_with_highlighting",
             },
           )
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -232,7 +232,7 @@ describe FindersController, type: :controller do
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
-              suggest: "spelling",
+              suggest: "spelling_with_highlighting",
             },
           )
           .to_return(status: 200, body: rummager_response, headers: {})
@@ -317,7 +317,7 @@ describe FindersController, type: :controller do
         "total": 0,
         "start": 0,
         "facets": {},
-        "suggested_queries": ["cereal"]
+        "suggested_queries": [{ "text": "cereal", "highlighted": "<mark>cereal</mark>" }]
       }|
       stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
     end
@@ -341,7 +341,7 @@ describe FindersController, type: :controller do
           filter_document_type: "mosw_report",
           order: "-public_timestamp",
           start: 0,
-          suggest: "spelling",
+          suggest: "spelling_with_highlighting",
         }.merge(query),
       )
       .to_return(status: 200, body: rummager_response, headers: {})

--- a/spec/presenters/spelling_suggestion_presenter_spec.rb
+++ b/spec/presenters/spelling_suggestion_presenter_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe SpellingSuggestionPresenter do
   describe "#suggestions" do
     it "presents spelling suggestions" do
-      suggested_queries = ["full english"]
+      suggested_queries = [{ "text" => "full english", "highlighted" => "<mark>full</mark> english" }]
       url = "/breakfast-finder?keywords=full+english"
       content_item_id = "123AAA"
 
@@ -20,6 +20,7 @@ RSpec.describe SpellingSuggestionPresenter do
           },
         },
         keywords: "full english",
+        highlighted: "<mark>full</mark> english",
         link: "/breakfast-finder?keywords=full+english" }]
 
       expect(presenter.suggestions).to eq(expected)


### PR DESCRIPTION
<img width="309" alt="Screenshot 2019-11-12 at 15 55 27" src="https://user-images.githubusercontent.com/75235/68687340-f09e5c00-0564-11ea-9570-f3f9b49a5bed.png">

[Trello card](https://trello.com/c/J0OF5keV/1134-bold-only-the-corrected-words-in-spelling-suggestions)


---

## Search page examples to sanity check:

- https://finder-frontend-pr-1734.herokuapp.com/search/all
- https://finder-frontend-pr-1734.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1734.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1734.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1734.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1734.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1734.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1734.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1734.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1734.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
