### PR TITLE
Ab test hide keyword facet tags

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -125,6 +125,7 @@
           this.trackingInit()
           this.setRelevantResultCustomDimension()
           this.trackPageView()
+          this.displayKeywordTags(e)
         }.bind(this)
       )
     }
@@ -436,6 +437,13 @@
       $input.siblings('.gem-c-error-message').remove()
       $input.parent('.govuk-form-group').removeClass('govuk-form-group--error')
       $input.attr('aria-describedby', '')
+    }
+  }
+
+  LiveSearch.prototype.displayKeywordTags = function displayKeywordTags (e) {
+    // only display them when user interacted with the filters
+    if (e.currentTarget.id !== 'finder-keyword-search') {
+      this.$form.find('.facet-tags__group--keywords').addClass('show')
     }
   }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -379,3 +379,14 @@ mark {
   margin-bottom: govuk-spacing(7);
   padding-bottom: govuk-spacing(0);
 }
+
+
+// A/B test: hiding keywords until user has interacted with a filter
+.js-enabled .keywords-hide-ab-test {
+  .facet-tags__group--keywords {
+    display: none;
+    &.show {
+      display: block;
+    }
+  }
+}

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -6,9 +6,10 @@
 <% end %>
 
 <% if local_assigns[:applied_filters] %>
-  <div class="facet-tags" data-module="track-click">
+  <div class="facet-tags keywords-hide-ab-test" data-module="track-click">
     <% local_assigns[:applied_filters].each do |applied_filter| %>
-      <div class="facet-tags__group">
+      <% # apply type of facet tag as class to the group to be a be able to target it  %> 
+      <div class="facet-tags__group facet-tags__group--<%= applied_filter.first[:data_facet].strip.downcase %>">
         <% applied_filter.each do |filter| %>
           <div class="facet-tags__wrapper">
             <p class="facet-tags__preposition"><%= filter[:preposition] %></p>


### PR DESCRIPTION
[Trello card](https://trello.com/c/BB54xdeT/1112-test-hiding-keyword-facets-on-main-site-search)

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1735.herokuapp.com/search/all
- https://finder-frontend-pr-1735.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1735.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1735.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1735.herokuapp.com/drug-device-alerts

[Other finders](https://live-stuff.herokuapp.com/finders)
