### PR TITLE
Enable A/B test: Hide keyword facets tags

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -25,6 +25,7 @@
     this.$resultsCountMetaTag = $("meta[name='govuk:search-result-count']")
     this.$emailLink = $('a[href*="email-signup"]')
     this.previousSearchTerm = ''
+    this.isHideKeywordFacetTagsTestBVariant = $("meta[name='govuk:ab-test']").attr('content') === 'HideKeywordFacetTagsABTest:B'
 
     this.emailSignupHref = this.$emailLink.attr('href')
     this.$atomLink = $('a[href*=".atom"]')
@@ -39,6 +40,9 @@
     }
 
     this.focusErrorMessagesOnLoad(this.$form)
+
+    // hide keyword facet tags on load
+    this.toggleKeywordTags()
 
     if (GOVUK.support.history()) {
       this.saveState()
@@ -125,6 +129,7 @@
           this.trackingInit()
           this.setRelevantResultCustomDimension()
           this.trackPageView()
+          this.toggleKeywordTags()
         }.bind(this)
       )
     }
@@ -436,6 +441,19 @@
       $input.siblings('.gem-c-error-message').remove()
       $input.parent('.govuk-form-group').removeClass('govuk-form-group--error')
       $input.attr('aria-describedby', '')
+    }
+  }
+
+  LiveSearch.prototype.toggleKeywordTags = function toggleKeywordTags () {
+    if (this.isHideKeywordFacetTagsTestBVariant) {
+      var $facetTagsContainer = this.$form.find('.facet-tags')
+      var $facetTagsGroups = $facetTagsContainer.find('.facet-tags__group')
+      var $facetTagsKeyword = $facetTagsContainer.find('.facet-tags__group--keywords')
+      var isFacetTagKeyword = $facetTagsGroups.hasClass('facet-tags__group--keywords')
+
+      if ($facetTagsGroups.length === 1 && isFacetTagKeyword) {
+        $facetTagsKeyword.hide()
+      }
     }
   }
 

--- a/app/controllers/concerns/hide_keyword_facet_tags_ab_testable.rb
+++ b/app/controllers/concerns/hide_keyword_facet_tags_ab_testable.rb
@@ -1,0 +1,39 @@
+module HideKeywordFacetTagsABTestable
+  CUSTOM_DIMENSION = 43
+
+  def self.included(base)
+    base.helper_method(
+      :hide_keyword_facet_tags_variant,
+      :hide_keyword_facet_tags_ab_test,
+      :in_hide_keyword_facet_tags_ab_test_scope?,
+    )
+    base.after_action :set_hide_keyword_facet_tags_response_header
+  end
+
+  def hide_keyword_facet_tags_ab_test
+    return {} if hide_keyword_facet_tags_variant.variant?("A")
+
+    { hide_keyword_facet_tags: hide_keyword_facet_tags_variant.variant_name }
+  end
+
+  def hide_keyword_facet_tags_test
+    @hide_keyword_facet_tags_test ||= GovukAbTesting::AbTest.new(
+      "HideKeywordFacetTagsABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A",
+    )
+  end
+
+  def hide_keyword_facet_tags_variant
+    @hide_keyword_facet_tags_variant ||= hide_keyword_facet_tags_test.requested_variant(request.headers)
+  end
+
+  def set_hide_keyword_facet_tags_response_header
+    hide_keyword_facet_tags_variant.configure_response(response) if in_hide_keyword_facet_tags_ab_test_scope?
+  end
+
+  def in_hide_keyword_facet_tags_ab_test_scope?
+    content_item.is_finder?
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,6 +1,7 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
   include SpellingSuggestionsABTestable
+  include HideKeywordFacetTagsABTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -116,7 +117,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: spelling_suggestions_ab_test,
+      ab_params: spelling_suggestions_ab_test.merge(hide_keyword_facet_tags_ab_test),
     )
   end
 

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -8,7 +8,8 @@
 <% if local_assigns[:applied_filters] %>
   <div class="facet-tags" data-module="track-click">
     <% local_assigns[:applied_filters].each do |applied_filter| %>
-      <div class="facet-tags__group">
+      <% # apply type of facet tag as class to the group to be a be able to target it  %> 
+      <div class="facet-tags__group facet-tags__group--<%= applied_filter.first[:data_facet].strip.downcase %>">
         <% applied_filter.each do |filter| %>
           <div class="facet-tags__wrapper">
             <p class="facet-tags__preposition"><%= filter[:preposition] %></p>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -13,6 +13,7 @@
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
   <%= spelling_suggestions_variant.analytics_meta_tag.html_safe if in_spelling_suggestions_ab_test_scope? %>
+  <%= hide_keyword_facet_tags_variant.analytics_meta_tag.html_safe if in_hide_keyword_facet_tags_ab_test_scope? %>
 <% end %>
 
 <% content_for :meta_title, content_item.title %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -274,6 +274,30 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "hide keyword facet tag A/B test" do
+    before do
+      content_store_has_item("/search/all", all_content_finder)
+    end
+
+    it "requests the B (hide keyword facet tags) variant" do
+      request = search_api_request(query: { ab_tests: "hide_keyword_facet_tags:B" })
+
+      with_variant HideKeywordFacetTagsABTest: "B" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+
+    it "requests the control variant (A) by default" do
+      request = search_api_request
+
+      with_variant HideKeywordFacetTagsABTest: "A" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+  end
+
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example("finder").to_hash.merge(


### PR DESCRIPTION
We want to hide the keyword facet tags from users when they perform a text search until they've interacted with a filter and have it selected.

Once they have no more filters selected, we hide the tags again.

This sets up the HideKeywordFacets controller with all the logic and imports it into the finders_controller.

We attach a CSS class to the groups of facet tags based on their `[:data_facet]` value, so that we can target keywords group.

We use javascript to check for the A/B test meta tag value. If the user is in the B variant, we hide the keyword tags in they're the only tags present (which meant users hasn't used any of the filters)

[Trello card](https://trello.com/c/BB54xdeT/1112-test-hiding-keyword-facets-on-main-site-search)

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1736.herokuapp.com/search/all
- https://finder-frontend-pr-1736.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1736.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1736.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1736.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1736.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1736.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance

[Other finders](https://live-stuff.herokuapp.com/finders)
