### PR TITLE
Enable AB testing for Levenshtein algorithm for suggestions

### DIFF
--- a/app/controllers/concerns/spelling_suggestions_ab_testable.rb
+++ b/app/controllers/concerns/spelling_suggestions_ab_testable.rb
@@ -1,0 +1,39 @@
+module SpellingSuggestionsABTestable
+  CUSTOM_DIMENSION = 42
+
+  def self.included(base)
+    base.helper_method(
+      :spelling_suggestions_variant,
+      :spelling_suggestions_ab_test,
+      :in_spelling_suggestions_ab_test_scope?,
+    )
+    base.after_action :set_spelling_suggestions_response_header
+  end
+
+  def spelling_suggestions_ab_test
+    return {} if spelling_suggestions_variant.variant?("A")
+
+    { spelling_suggestions: spelling_suggestions_variant.variant_name }
+  end
+
+  def spelling_suggestions_test
+    @spelling_suggestions_test ||= GovukAbTesting::AbTest.new(
+      "SpellingSuggestionsABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: %w(A B),
+      control_variant: "A",
+    )
+  end
+
+  def spelling_suggestions_variant
+    @spelling_suggestions_variant ||= spelling_suggestions_test.requested_variant(request.headers)
+  end
+
+  def set_spelling_suggestions_response_header
+    spelling_suggestions_variant.configure_response(response) if in_spelling_suggestions_ab_test_scope?
+  end
+
+  def in_spelling_suggestions_ab_test_scope?
+    content_item.is_finder?
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -2,6 +2,7 @@ class FindersController < ApplicationController
   include FinderTopResultAbTestable
   include ShinglesABTestable
   include FinderPopularityAbTestable
+  include SpellingSuggestionsABTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -117,7 +118,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: shingles_ab_test.merge(popularity_ab_test),
+      ab_params: shingles_ab_test.merge(popularity_ab_test).merge(spelling_suggestions_ab_test),
     )
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -12,7 +12,6 @@
   <% end %>
 
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
-  <%= shingles_variant.analytics_meta_tag.html_safe if in_shingles_ab_test_scope? %>
   <%= popularity_variant.analytics_meta_tag.html_safe if in_popularity_ab_test_scope? %>
   <%= spelling_suggestions_variant.analytics_meta_tag.html_safe if in_spelling_suggestions_ab_test_scope? %>
 <% end %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,6 +14,7 @@
   <%= finder_top_result_variant.analytics_meta_tag.html_safe if content_item.eu_exit_finder? %>
   <%= shingles_variant.analytics_meta_tag.html_safe if in_shingles_ab_test_scope? %>
   <%= popularity_variant.analytics_meta_tag.html_safe if in_popularity_ab_test_scope? %>
+  <%= spelling_suggestions_variant.analytics_meta_tag.html_safe if in_spelling_suggestions_ab_test_scope? %>
 <% end %>
 
 <% content_for :meta_title, content_item.title %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -250,30 +250,6 @@ describe FindersController, type: :controller do
     end
   end
 
-  describe "shingles A/B test" do
-    before do
-      content_store_has_item("/search/all", all_content_finder)
-    end
-
-    it "requests the B variant" do
-      request = search_api_request(query: { ab_tests: "shingles:B" })
-
-      with_variant ShinglesABTest: "B" do
-        get :show, params: { slug: "search/all" }
-        expect(request).to have_been_made.once
-      end
-    end
-
-    it "requests the non-shingles variant (A) by default" do
-      request = search_api_request
-
-      with_variant ShinglesABTest: "A" do
-        get :show, params: { slug: "search/all" }
-        expect(request).to have_been_made.once
-      end
-    end
-  end
-
   describe "popularity A/B test" do
     before do
       content_store_has_item("/search/all", all_content_finder)

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -297,6 +297,30 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "suggestions A/B test" do
+    before do
+      content_store_has_item("/search/all", all_content_finder)
+    end
+
+    it "requests the B (levenshtein) variant" do
+      request = search_api_request(query: { ab_tests: "spelling_suggestions:B" })
+
+      with_variant SpellingSuggestionsABTest: "B" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+
+    it "requests the non-levenshtein variant (A) by default" do
+      request = search_api_request
+
+      with_variant SpellingSuggestionsABTest: "A" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+  end
+
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example("finder").to_hash.merge(


### PR DESCRIPTION
This PR allows us to use the Levenshtein algorithm for search
suggestions over the default Elasticsearch algorithm, which relies on
an "optimised" system that may not be too accurate for our purposes.

Trello card: https://trello.com/c/c2YUDVg3/1117-try-different-ways-of-doing-spelling-suggestions