### PR TITLE
Fix tracking on new results page

### DIFF
--- a/app/views/brexit_checker/_action_audiences.html.erb
+++ b/app/views/brexit_checker/_action_audiences.html.erb
@@ -8,13 +8,14 @@
               <%= audience[:heading] %>
             </h2>
           </header>
-          <% audience[:groups].each do |group| %>
+          <% audience[:groups].each.with_index do |group, group_index| %>
             <section class="brexit-checker-actions__group">
               <div class="govuk-grid-row">
                 <%= render 'results_criteria', criteria: group[:criteria], heading: group[:heading] %>
                 <div class="govuk-grid-column-two-thirds">
+                  <% analytics_group = "#{audience[:heading]} #{" - #{group[:heading]} - " if !group[:heading].nil?}#{group_index + 1}." %>
                   <%= render "action_list", {
-                    heading: group[:heading],
+                    analytics_group: analytics_group,
                     priority: group[:priority],
                     actions: group[:actions]
                   } %>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -1,5 +1,4 @@
 <% actions.each.with_index do | action, index | %>
-  <% index = "#{priority}.#{'%02d' % (index + 1)}"%>
   <div class="govuk-grid-row brexit-checker__action">
     <div class="brexit-checker__content-wrapper">
       <p class="govuk-body govuk-!-font-weight-bold">
@@ -8,7 +7,7 @@
             class="govuk-link"
             href="<%= action.title_url %>"
             data-module="track-click"
-            data-track-action="<%= heading %> <%= index %> - Action"
+            data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
           ><%= action.title %></a>
@@ -45,7 +44,7 @@
               href="<%= action.guidance_url %>"
               class="govuk-link"
               data-module="track-click"
-              data-track-action="<%= heading %> <%= index %> - Guidance"
+              data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"
             ><%= action.guidance_link_text %></a>


### PR DESCRIPTION
Trello: https://trello.com/c/q7N706kM/261-fix-tracking-links-on-results-page

---

Fixes Tracking links on new results page:

Fills out the `data-track-action` attribute with an appropriate tracking string.
Fills out data for both kinds of links that turn up under actions

Eg. Links under "More Information" Return:
`data-track-action="Your business or organisation -  1.1 - Guidance"`

Eg. Links on titles Return:
`data-track-action="Your business or organisation -  1.6 - Action"`

Individual / Citizen results are nested one further level into groups and so get some further information:

Eg. Links under "More Information" Return:
`data-track-action="You and your family  - Visiting the EU - 1.4 - Guidance"`

Eg. Links on titles Return:
`data-track-action="You and your family  - Visiting the EU - 1.4 - Action"`

The index on groups reference an actions position within a group:
ie. 1.4 = The first group within an audience, and the 4th action.
