### PR TITLE
Fix selected count on facet tag removal

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -31,6 +31,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
       this.$toggleButton.click()
     }
 
+    // listen for the change event
+    $module.on('change', 'select, input[type="text"]', this.updateSelectedCount.bind(this))
+
     // Attach listener function to update selected count
     var boundChangeEvents = this.bindChangeEvents.bind(this)
     boundChangeEvents()
@@ -39,10 +42,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
   Expander.prototype.bindChangeEvents = function (e) {
     for (var i = 0; i < this.$allInteractiveElements.length; i++) {
       var $el = this.$allInteractiveElements[i]
-      // for selects we only need to listen to the change event
-      if ($el.tagName === 'SELECT') {
-        $el.addEventListener('change', this.updateSelectedCount.bind(this))
-      }
       // but for inputs we need both change and enter key event
       if ($el.tagName === 'INPUT') {
         $el.addEventListener('change', this.handleInputEvent.bind(this))


### PR DESCRIPTION
This fixes a bug where if a topic/subtopic or date filter was used and the facet tag was removed, the count in the sidebar facet didn't update properly

This PR moves the change event listener to the container

**Before**
![tag-before](https://user-images.githubusercontent.com/3758555/68964408-3bbca700-07d1-11ea-89e6-3993c2a26aea.gif)

**After**
![tag-after](https://user-images.githubusercontent.com/3758555/68964438-4f680d80-07d1-11ea-884d-be59acd004e7.gif)

[Trello ticket](https://trello.com/c/vvXwB2FW/1149-fix-topic-date-selected-count-on-facet-tag-removal)

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1748.herokuapp.com/search/all
- https://finder-frontend-pr-1748.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1748.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1748.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1748.herokuapp.com/drug-device-alerts
