### PR TITLE
Removed errant parameter enabling shingling AB tests in the frontend

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -118,7 +118,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: shingles_ab_test.merge(popularity_ab_test).merge(spelling_suggestions_ab_test),
+      ab_params: popularity_ab_test.merge(spelling_suggestions_ab_test),
     )
   end
 


### PR DESCRIPTION
Left this behind when disabling Shingles AB testing and it's screwing up the data being received by GA. The rest of the shingles AB testing code will be removed after discussing with the involved developers.