### PR TITLE
[DO NOT MERGE] Add ecommerce tracking to the new results grouping checker actions

### DIFF
--- a/app/views/brexit_checker/_action_audiences.html.erb
+++ b/app/views/brexit_checker/_action_audiences.html.erb
@@ -9,7 +9,8 @@
             </h2>
           </header>
           <% audience[:groups].each.with_index do |group, group_index| %>
-            <section class="brexit-checker-actions__group">
+            <% ecommerce_list = group[:heading].nil? ? audience[:heading] : group[:heading] %>
+            <section class="brexit-checker-actions__group" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Brexit checker results: <%= ecommerce_list %>" data-search-query>
               <div class="govuk-grid-row">
                 <%= render 'results_criteria', criteria: group[:criteria], heading: group[:heading] %>
                 <div class="govuk-grid-column-two-thirds">

--- a/app/views/brexit_checker/_action_audiences.html.erb
+++ b/app/views/brexit_checker/_action_audiences.html.erb
@@ -8,13 +8,14 @@
               <%= audience[:heading] %>
             </h2>
           </header>
-          <% audience[:groups].each do |group| %>
+          <% audience[:groups].each.with_index do |group, group_index| %>
             <section class="brexit-checker-actions__group">
               <div class="govuk-grid-row">
                 <%= render 'results_criteria', criteria: group[:criteria], heading: group[:heading] %>
                 <div class="govuk-grid-column-two-thirds">
+                  <% analytics_group = "#{audience[:heading]} #{" - #{group[:heading]} - " if !group[:heading].nil?}#{group_index + 1}." %>
                   <%= render "action_list", {
-                    heading: group[:heading],
+                    analytics_group: analytics_group,
                     priority: group[:priority],
                     actions: group[:actions]
                   } %>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -11,7 +11,7 @@
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
             data-ecommerce-row
-            data-ecommerce-path="<%= action.title_url %>"
+            data-ecommerce-path="<%= action.title_path %>"
           ><%= action.title %></a>
         <% else %>
           <%= action.title %>
@@ -50,7 +50,7 @@
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"
               data-ecommerce-row
-              data-ecommerce-path="<%= action.guidance_url %>"
+              data-ecommerce-path="<%= action.guidance_path %>"
             ><%= action.guidance_link_text %></a>
           </p>
         </div>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -1,5 +1,4 @@
 <% actions.each.with_index do | action, index | %>
-  <% index = "#{priority}.#{'%02d' % (index + 1)}"%>
   <div class="govuk-grid-row brexit-checker__action">
     <div class="brexit-checker__content-wrapper">
       <p class="govuk-body govuk-!-font-weight-bold">
@@ -8,7 +7,7 @@
             class="govuk-link"
             href="<%= action.title_url %>"
             data-module="track-click"
-            data-track-action="<%= heading %> <%= index %> - Action"
+            data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
           ><%= action.title %></a>
@@ -45,7 +44,7 @@
               href="<%= action.guidance_url %>"
               class="govuk-link"
               data-module="track-click"
-              data-track-action="<%= heading %> <%= index %> - Guidance"
+              data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"
             ><%= action.guidance_link_text %></a>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -10,6 +10,8 @@
             data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
+            data-ecommerce-row
+            data-ecommerce-path="<%= action.title_url %>"
           ><%= action.title %></a>
         <% else %>
           <%= action.title %>
@@ -35,7 +37,7 @@
       <% end %>
 
       <% if action.guidance_url.present? %>
-        <div class="govuk-body govuk-!-font-size-16"> 
+        <div class="govuk-body govuk-!-font-size-16">
           <p>
             <%= action.guidance_prompt || t("brexit_checker.action_list.guidance_prompt") %>:
           </p>
@@ -47,6 +49,8 @@
               data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"
+              data-ecommerce-row
+              data-ecommerce-path="<%= action.guidance_url %>"
             ><%= action.guidance_link_text %></a>
           </p>
         </div>

--- a/lib/brexit_checker/action.rb
+++ b/lib/brexit_checker/action.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 class BrexitChecker::Action
   include ActiveModel::Validations
 
@@ -10,13 +12,15 @@ class BrexitChecker::Action
   validates_numericality_of :priority, only_integer: true
   validate :citizen_actions_must_have_groupings
 
-  attr_reader :id, :title, :consequence, :exception, :title_url,
+  attr_reader :id, :title, :consequence, :exception, :title_url, :title_path,
               :lead_time, :criteria, :audience, :guidance_link_text,
-              :guidance_url, :guidance_prompt, :priority, :result_groups,
+              :guidance_url, :guidance_path, :guidance_prompt, :priority, :result_groups,
               :groups
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    @title_path = path_from_url(title_url) if title_url
+    @guidance_path = path_from_url(guidance_url) if guidance_url
     validate!
     load_groups
   end
@@ -32,6 +36,15 @@ class BrexitChecker::Action
   def self.load_all
     @load_all = nil if Rails.env.development?
     @load_all ||= YAML.load_file(CONFIG_PATH)["actions"].map { |a| new(a) }
+  end
+
+  def path_from_url(full_url)
+    url = Addressable::URI.parse(full_url)
+    if url.host == "www.gov.uk"
+      url.path
+    else
+      full_url
+    end
   end
 
 private


### PR DESCRIPTION
Trello: https://trello.com/c/G8vx3tIU/275-do-not-deploy-adapt-ecommerce-tracking-for-new-results-grouping

## What
Adjust the ecommerce tracking (introduced in https://github.com/alphagov/finder-frontend/pull/1764) for the new groupings.

This is an example of what is sent to GA for an impression and a click:

```
ga("ec:addImpression", {position: 1, list: "Brexit checker results: Visiting the EU", dimension71: "", name: "https://www.gov.uk/guidance/foreign-travel-insurance"})
```

```
ga("ec:addProduct", {position: 2, list: "Brexit checker results: Visiting the EU", dimension71: "", name: "https://www.gov.uk/check-a-passport-for-travel-to-europe"})
```

```
ga("ec:setAction", "click", {list: "Brexit checker results: Visiting the EU"})
```

```
ga("send", {hitType: "event", eventCategory: "UX", eventAction: "click", eventLabel: "Results", dimension15: "200", dimension16: "unknown", dimension95: "1682487469.1574251572", dimension11: "2", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension5: "14", dimension12: "not withdrawn", dimension20: "FinderFrontend", dimension30: "none", dimension32: "none", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", dimension23: "unknown"})
```

**Link to test:**
https://finder-frontend-pr-1752.herokuapp.com/get-ready-brexit-check/results?c%5B%5D=pharma&c%5B%5D=do-not-ip&c%5B%5D=do-not-sell-to-public-sector&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=do-not-personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk