### PR TITLE
[DO NOT MERGE] Stop sending ecommerce tracking content id

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -25,7 +25,6 @@ class SearchResultPresenter
         description: sanitize(summary_text),
         data_attributes: {
           ecommerce_path: link,
-          ecommerce_content_id: document.content_id,
           ecommerce_row: 1,
           track_category: "navFinderLinkClicked",
           track_action: "#{content_item.title}.#{document.index}",

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -34,7 +34,6 @@ Then(/^the ecommerce tracking tags are present$/) do
   first_link = results.first
 
   expect(first_link["data-ecommerce-path"]).to eq("/restrictions-on-usage-of-spells-within-school-grounds")
-  expect(first_link["data-ecommerce-content-id"]).to eq("1234")
 end
 
 And "I search for lunch" do

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe ResultSetPresenter do
             description: "document_description",
             data_attributes: {
               ecommerce_path: "/path/to/doc",
-              ecommerce_content_id: "content_id",
               ecommerce_row: 1,
               track_category: "navFinderLinkClicked",
               track_action: "A finder.1",

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe SearchResultPresenter do
           description: "I am a document.",
           data_attributes: {
             ecommerce_path: link,
-            ecommerce_content_id: "content_id",
             ecommerce_row: 1,
             track_category: "navFinderLinkClicked",
             track_action: "finder-title.1",


### PR DESCRIPTION
Trello Card: https://trello.com/c/2iCWKnNV/274-adjust-existing-ecommerce-tracking-logic-to-handle-passing-page-path-as-name

## What
Follows on from this change: https://github.com/alphagov/static/pull/1941

We no longer send `id` with our ecommerce tracking on finders. Instead, the page path is sent as `name` (see linked static PR).

One exception are spelling suggestions: we continue to send `id` for these.