### PR TITLE
Enable non-modifiable email facet choices

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -35,7 +35,7 @@ class SignupPresenter
   end
 
   def can_modify_choices?
-    choices? && choices_formatted.any? && !(content_item["details"]["email_filter_by"] == "all_selected_facets")
+    choices? && choices_formatted.any? && content_item["details"]["email_filter_by"] != "all_selected_facets"
   end
 
   def hidden_choices

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -35,7 +35,7 @@ class SignupPresenter
   end
 
   def can_modify_choices?
-    choices? && choices_formatted.any?
+    choices? && choices_formatted.any? && !content_item["details"]["cannot_modify_choices"]
   end
 
   def hidden_choices

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -35,7 +35,7 @@ class SignupPresenter
   end
 
   def can_modify_choices?
-    choices? && choices_formatted.any? && !content_item["details"]["cannot_modify_choices"]
+    choices? && choices_formatted.any? && !(content_item["details"]["email_filter_by"] == "all_selected_facets")
   end
 
   def hidden_choices

--- a/app/presenters/subscriber_list_params_presenter.rb
+++ b/app/presenters/subscriber_list_params_presenter.rb
@@ -28,11 +28,21 @@ private
   end
 
   def facets
-    allowed_facets.reject { |facet| facet.key?("facet_choices") }
+    return allowed_facets if can_modify_choices?
+
+    email_filter_facets
+  end
+
+  def can_modify_choices?
+    !content_item["details"]["cannot_modify_choices"]
+  end
+
+  def email_filter_facets
+    content_item["details"].fetch("email_filter_facets", [])
   end
 
   def allowed_facets
-    content_item["details"].fetch("email_filter_facets", [])
+    email_filter_facets.reject { |facet| facet.key?("facet_choices") }
   end
 
   def hash_with_default_as_array

--- a/app/presenters/subscriber_list_params_presenter.rb
+++ b/app/presenters/subscriber_list_params_presenter.rb
@@ -34,7 +34,7 @@ private
   end
 
   def can_modify_choices?
-    !content_item["details"]["cannot_modify_choices"]
+    !content_item["details"]["email_filter_by"] == "all_selected_facets"
   end
 
   def email_filter_facets

--- a/docs/finder-email-alerts.md
+++ b/docs/finder-email-alerts.md
@@ -68,7 +68,7 @@ In this case, the user can modify the filters that they applied on the finder,
 to change what they will be subscribed to. Rather than using `email_filter_facets`,
 this uses an `email_signup_choice`.
 
-## How do I add or update an finder email signup?
+## How do I add or update a finder email alert signup?
 
 The `finder_email_signup` content items are published by [Search API](https://github.com/alphagov/search-api/blob/master/doc/publishing-finders.md).
 
@@ -87,6 +87,14 @@ a particular city, you might add the following to `email_filter_facets`:
   "facet_name": "city"
 },
 ```
+
+## How do I use selected search filters as email filter facets?
+
+If you would like to skip the email filter checkboxes and use the selected
+search filters as email filters, set the value of `email_filter` to `all_selected_facets`.
+
+**Note**: This is solution is in place until user email signup journeys are made consistent
+across all finders.
 
 You might also need to permit users to subscribe to this kind of tag.
 In this case, you would need to add `city` to [the list of allowed `tags`

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -185,7 +185,7 @@ describe EmailAlertTitleBuilder do
         { "facet_id" => "level_two_taxon", "filter_key" => "part_of_taxonomy_tree", "facet_name" => "topics" },
         { "facet_id" => "related_to_brexit", "filter_key" => "part_of_taxonomy_tree", "filter_value" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea", "facet_name" => "topics" },
         { "facet_id" => "document_type", "facet_name" => "document types" },
-    ]
+      ]
     end
     let(:filter) do
       {

--- a/spec/presenters/subscriber_list_params_presenter_spec.rb
+++ b/spec/presenters/subscriber_list_params_presenter_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe SubscriberListParamsPresenter do
       )
     end
 
+    it "returns hash with values if cannot modify choices" do
+      finder_content_item = business_readiness_signup_content_item
+
+      finder_content_item = finder_content_item.tap do |content_item|
+        content_item["details"]["cannot_modify_choices"] = true
+      end
+
+      params = { "sector_business_area" => %w(accommodation aerospace) }
+
+      presenter = described_class.new(finder_content_item, params)
+
+      expect(presenter.subscriber_list_params).to eql(params)
+    end
+
     it "returns empty hash if email_filter_facet includes facet_choices in the content_item" do
       signup_finder_content_item = signup_finder.tap do |content_item|
         content_item["details"]["email_filter_facets"] = [

--- a/spec/presenters/subscriber_list_params_presenter_spec.rb
+++ b/spec/presenters/subscriber_list_params_presenter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SubscriberListParamsPresenter do
       finder_content_item = business_readiness_signup_content_item
 
       finder_content_item = finder_content_item.tap do |content_item|
-        content_item["details"]["cannot_modify_choices"] = true
+        content_item["details"]["email_filter_by"] = "all_selected_facets"
       end
 
       params = { "sector_business_area" => %w(accommodation aerospace) }


### PR DESCRIPTION
For specialist finders using `email_filter_facets`, the default behaviour is currently to allow the user to modify email filters before subscribing to the alerts.

This PR introduces a flag in the schema that allows us to skip this intermediate step and go straight to sign up when that makes sense, e.g. when the list of facets is too long to display as checkboxes.

I am not a fan of the negatively phrased `cannot_modify_choices`; the intention here is to allow existing finders to keep their default behaviour without changing anything to their schemas. Naming suggestions / alternate solutions welcome. :)

**Update 26/11/2019**

I have replaced the `cannot_modify_choices` boolean flag with the ability to add `"all_selected_facets"` value to `email_filter_by`. This is a tactical solution too, but a better one, in that it avoids the negative flag and doesn't require an intrusive change to the email sign up content item schema.


--

### Card

https://trello.com/c/rTCRCbiM/930-fix-the-email-subscriptions-for-residential-property-tribunal-decisions-et-al-%F0%9F%8D%90

--

## Search page examples to sanity check:

- https://finder-frontend-pr-1757.herokuapp.com/search/all
- https://finder-frontend-pr-1757.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1757.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1757.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1757.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1757.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1757.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1757.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1757.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1757.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
