### PR TITLE
Replace deprecated govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ inherit_gem:
 AllCops:
   Exclude:
     - 'lib/tasks/cucumber.rake' # Automatically generated
+    - 'tmp/**/*'
 
 Lint/AmbiguousRegexpLiteral:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   Exclude:
     - 'lib/tasks/cucumber.rake' # Automatically generated
@@ -11,7 +15,3 @@ Metrics/BlockLength:
     - 'features/**/*.rb'
     - 'spec/**/*'
     - 'config/routes.rb'
-
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,7 @@ Metrics/BlockLength:
     - 'features/**/*.rb'
     - 'spec/**/*'
     - 'config/routes.rb'
+
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,12 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "dotenv-rails"
-  gem "govuk-lint", "~> 4.3.0"
   gem "govuk_schemas", "~> 4.0"
   gem "jasmine-rails"
   gem "listen"
   gem "pry-byebug"
   gem "rspec-rails", "~> 4.0.0.beta3"
+  gem "rubocop-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,11 +153,6 @@ GEM
       signet (~> 0.12)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_ab_testing (2.4.1)
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
@@ -239,7 +234,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
     os (1.0.1)
-    parallel (1.18.0)
+    parallel (1.19.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
@@ -333,6 +328,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -341,11 +340,6 @@ GEM
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -356,8 +350,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sdoc (1.0.0)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.6)
@@ -439,7 +431,6 @@ DEPENDENCIES
   gds-api-adapters (~> 61.0)
   google-api-client
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint (~> 4.3.0)
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 2.0.1)
   govuk_document_types (~> 0.9.2)
@@ -453,6 +444,7 @@ DEPENDENCIES
   rails (~> 6.0.1)
   rails-controller-testing
   rspec-rails (~> 4.0.0.beta3)
+  rubocop-govuk
   sass-rails (~> 6.0.0)
   sdoc
   simplecov (~> 0.17.1)

--- a/app/helpers/page_metadata_helper.rb
+++ b/app/helpers/page_metadata_helper.rb
@@ -5,7 +5,7 @@ module PageMetadataHelper
     end
 
     {}.tap do |metadata|
-      metadata[:from] = organisation_links unless organisation_links.blank?
+      metadata[:from] = organisation_links if organisation_links.present?
       metadata[:inverse] = true if topic_finder?(filter_params)
     end
   end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
 task default: :lint
 desc "Run govuk-lint and StandardJS with similar params to CI"
 task :lint do
-  sh "bundle exec govuk-lint-ruby --format clang app config features Gemfile lib spec"
+  sh "bundle exec rubocop"
   sh "yarn run lint"
 end


### PR DESCRIPTION
Replace deprecated govuk-lint with rubocop-govuk https://github.com/alphagov/rubocop-govuk.
