### PR TITLE
Add ecommerce tracking

### DIFF
--- a/app/views/brexit_checker/_action_audiences.html.erb
+++ b/app/views/brexit_checker/_action_audiences.html.erb
@@ -5,7 +5,7 @@
         <div class="govuk-grid-column-full">
           <h2 class="govuk-heading-l action-audience__heading"><%= audience[:heading] %></h2>
         </div>
-        <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-full" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Brexit checker results: <%= audience[:heading] %>" data-search-query>
           <%= render "action_list", {
             audience_heading: audience[:heading],
             audience_index: index + 1,

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -11,6 +11,8 @@
             data-track-action="<%= audience_heading %> <%= action_index %> - Action"
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
+            data-ecommerce-row
+            data-ecommerce-path="<%= action.title_path %>"
           ><%= action.title %></a>
         <% else %>
           <%= action.title %>
@@ -39,6 +41,8 @@
               data-track-action="<%= audience_heading %> <%= action_index %> - Guidance"
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"
+              data-ecommerce-row
+              data-ecommerce-path="<%= action.guidance_path %>"
             ><%= action.guidance_link_text %></a>
         </p>
       <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/mfthS6Ov/276-add-ecommerce-tracking-to-the-checker-results

## What
Adds logic to convert a full action URL into a path to match our standard GOV.UK tracking.

Add ecommerce tracking to the Brexit checker results page. This is an example of what is sent to GA for an impression and a click:

```
ga("ec:addImpression", {position: 5, list: "Brexit checker results: Your business or organisation", dimension71: "", name: "/guidance/driving-in-the-eu-after-brexit"})
```

```
ga("ec:addProduct", {position: 1, list: "Brexit checker results: Your business or organisation", dimension71: "", name: "/guidance/prepare-to-use-the-ukca-mark-after-brexit"})
```

```
ga("ec:setAction", "click", {list: "Brexit checker results: Your business or organisation"})
```

```
ga("send", {hitType: "event", eventCategory: "UX", eventAction: "click", eventLabel: "Results", dimension15: "200", dimension16: "unknown", dimension95: "982887940.1574872074", dimension11: "2", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension5: "14", dimension12: "not withdrawn", dimension20: "FinderFrontend", dimension30: "none", dimension32: "none", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", dimension23: "unknown"})
```

**Link to test:**
https://finder-frontend-pr-1764.herokuapp.com/get-ready-brexit-check/results?c%5B%5D=pharma&c%5B%5D=do-not-ip&c%5B%5D=do-not-sell-to-public-sector&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=do-not-personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk