### PR TITLE
Next to continue

### DIFF
--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -73,7 +73,7 @@
         %>
         <div class="govuk-form-footer">
           <%= render "govuk_publishing_components/components/button", {
-            text: "Next"
+            text: "Continue"
           } %>
         </div>
       </form>

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -29,7 +29,7 @@ questions:
   - key: employment
     type: multiple_grouped
     text: 'Do you work or study?'
-    hint_text: 'Select all that apply. If you do something else, select next.'
+    hint_text: 'Select all that apply. If you do something else, select continue.'
     options:
       - label: Work
         options:
@@ -82,7 +82,7 @@ questions:
   - key: travelling
     type: multiple
     text: 'Where do you plan to travel for leisure and tourism?'
-    hint_text: Select all that apply. If you do not plan to travel, select next.
+    hint_text: Select all that apply. If you do not plan to travel, select continue.
     detail_text: |
       <p>After Brexit, the rules for travelling abroad will change.</p>
       <p>We need to know where you plan to go so we can show you what you need to do before you travel.</p>
@@ -109,7 +109,7 @@ questions:
         - travel-eu-business
     type: multiple
     text: 'Do you plan to do either of the following when travelling?'
-    hint_text: "Select all that apply. If neither apply, select next."
+    hint_text: "Select all that apply. If neither apply, select continue."
     detail_text: |
       <p>After Brexit, the rules for driving abroad and taking a pet will change.</p>
       <p>We need to know about your plans so we can show you what you need to do before you travel.</p>

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
   end
 
   def and_i_answer_travel_questions
-    3.times { click_on "Next" }
+    3.times { click_on "Continue" }
     answer_question("travelling", "To another EU country, or Switzerland, Norway, Iceland or Liechtenstein")
     answer_question("activities", "Take your pet")
   end

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -14,10 +14,10 @@ RSpec.feature "Filtering options based on criteria", type: :feature do
   end
 
   def and_i_choose_uk_for_the_living_question
-    click_on "Next"
+    click_on "Continue"
     answer_question("living", "UK")
-    click_on "Next"
-    click_on "Next"
+    click_on "Continue"
+    click_on "Continue"
   end
 
   def then_i_should_not_see_uk_as_an_option_for_the_travel_question

--- a/spec/support/brexit_checker_helper.rb
+++ b/spec/support/brexit_checker_helper.rb
@@ -3,6 +3,6 @@ module BrexitCheckerHelper
     question = BrexitChecker::Question.find_by_key(key)
     expect(page).to have_content(question.text)
     options.each { |o| find_field(o).click }
-    click_on "Next"
+    click_on "Continue"
   end
 end


### PR DESCRIPTION
Resurrected version of: #1763

---

Relates to: Trello (https://trello.com/c/Zut0LKKK/262-do-not-deploy-change-button-label-in-all-questions-of-the-checker-to-continue)

--- 

## What

Changes button copy and hints from "Next" -> "Continue", on the Brexit checker only.
Non standard "Next" buttons remain in finder-frontend questions/answers.

## Why
Because the design system says `Make sure your ‘Continue’ button is labelled ‘Continue’, not ‘Next’`

https://design-system.service.gov.uk/patterns/question-pages/

We should be using common components whenever possible to be consistent across GOV.UK. 