### PR TITLE
Add shared tracker pageviews for search

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -145,6 +145,7 @@
   LiveSearch.prototype.trackPageView = function trackPageView () {
     var newPath = window.location.pathname + '?' + $.param(this.state)
     GOVUK.SearchAnalytics.trackPageview(newPath)
+    GOVUK.SearchAnalytics.trackPageview(newPath, document.title, { 'trackerName': 'govuk' })
   }
 
   LiveSearch.prototype.trackSpellingSuggestionsImpressions = function trackSpellingSuggestionsImpressions ($suggestions) {

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -82,6 +82,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         action,
         { label: label }
       )
+
+      GOVUK.SearchAnalytics.trackEvent(
+        category,
+        action,
+        { label: label, trackerName: 'govuk' }
+      )
     }
 
     function decodeEntities (string) {


### PR DESCRIPTION
## What

Update JS so that any pageviews sent when search results pages are updated (when filters are changed and the page updates dynamically) are also sent to the cross domain analytics property.

Relies upon [this change to static](https://github.com/alphagov/static/pull/1951) (deployed).

## Why

We want the pageviews coming from GOV.UK to look the same in both properties.

Trello card: https://trello.com/c/FYntaHmw/92-send-virtual-pageviews-for-ajax-page-updates-on-search-finders-and-mainstream-browse

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1770.herokuapp.com/search/all
- https://finder-frontend-pr-1770.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1770.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1770.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1770.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1770.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1770.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1770.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1770.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1770.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
