### PR TITLE
Moves logic from checker results view to helper

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -70,4 +70,32 @@ module BrexitCheckerHelper
 
     url.to_s
   end
+
+  def brexit_results_email_link_label(actions)
+    if actions.any?
+      t("brexit_checker.results.email_sign_up_link")
+    else
+      t("brexit_checker.results.email_sign_up_link_no_actions")
+    end
+  end
+
+  def brexit_results_title(actions, criteria_keys)
+    if actions.any?
+      t("brexit_checker.results.title")
+    elsif criteria_keys.any?
+      t("brexit_checker.results.title_no_actions")
+    else
+      t("brexit_checker.results.title_no_answers")
+    end
+  end
+
+  def brexit_results_description(actions, criteria_keys)
+    if actions.any?
+      t("brexit_checker.results.description")
+    elsif criteria_keys.present?
+      t("brexit_checker.results.description_no_actions")
+    else
+      t("brexit_checker.results.description_no_answers")
+    end
+  end
 end

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -1,19 +1,7 @@
 <%
-  action_based_email_link_label = @actions.any? ? t('brexit_checker.results.email_sign_up_link') : t('brexit_checker.results.email_sign_up_link_no_actions')
-  action_based_title            = if @actions.any?
-                                    t('brexit_checker.results.title')
-                                  elsif criteria_keys.present?
-                                    t('brexit_checker.results.title_no_actions')
-                                  else
-                                    t('brexit_checker.results.title_no_answers')
-                                  end
-  action_based_description      = if @actions.any?
-                                    t('brexit_checker.results.description')
-                                  elsif criteria_keys.present?
-                                    t('brexit_checker.results.description_no_actions')
-                                  else
-                                    t('brexit_checker.results.description_no_answers')
-                                  end
+  action_based_email_link_label = brexit_results_email_link_label(@actions)
+  action_based_title = brexit_results_title(@actions, criteria_keys)
+  action_based_description = brexit_results_description(@actions, criteria_keys)
 %>
 
 <% content_for :title, action_based_title %>

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -199,4 +199,58 @@ describe BrexitCheckerHelper, type: :helper do
       expect(link).to match("http://www.gov.uk?")
     end
   end
+
+  describe "#brexit_results_email_link_label" do
+    let(:actions) { [FactoryBot.build(:brexit_checker_action)] }
+
+    it "returns the email link copy if there are actions" do
+      expect(brexit_results_email_link_label(actions)).to eq(t("brexit_checker.results.email_sign_up_link"))
+    end
+
+    it "returns the no results email link copy if there are no actions" do
+      expect(brexit_results_email_link_label([])).to eq(t("brexit_checker.results.email_sign_up_link_no_actions"))
+    end
+  end
+
+  describe "#brexit_results_title" do
+    let(:actions) { [FactoryBot.build(:brexit_checker_action)] }
+    let(:criteria_keys) { %w"nationality-eu" }
+
+    it "returns the title if there are actions and answers" do
+      expect(brexit_results_title(actions, criteria_keys)).to eq(t("brexit_checker.results.title"))
+    end
+
+    it "returns the meta title if there are actions and no answers" do
+      expect(brexit_results_title(actions, [])).to eq(t("brexit_checker.results.title"))
+    end
+
+    it "returns the no actions title if there are answers but no actions" do
+      expect(brexit_results_title([], criteria_keys)).to eq(t("brexit_checker.results.title_no_actions"))
+    end
+
+    it "returns the no answers title if there no answers and no actions" do
+      expect(brexit_results_title([], [])).to eq(t("brexit_checker.results.title_no_answers"))
+    end
+  end
+
+  describe "#brexit_results_description" do
+    let(:actions) { [FactoryBot.build(:brexit_checker_action, grouping_criteria: "visiting-eu")] }
+    let(:criteria_keys) { %w"nationality-eu" }
+
+    it "returns the desciption if there are actions and answers" do
+      expect(brexit_results_description(actions, criteria_keys)).to eq(t("brexit_checker.results.description"))
+    end
+
+    it "returns the desciption if there are actions and no answers" do
+      expect(brexit_results_description(actions, [])).to eq(t("brexit_checker.results.description"))
+    end
+
+    it "returns the no actions desciption if there are answers but no actions" do
+      expect(brexit_results_description([], criteria_keys)).to eq(t("brexit_checker.results.description_no_actions"))
+    end
+
+    it "returns the no answers desciption there no answers and no actions" do
+      expect(brexit_results_description([], [])).to eq(t("brexit_checker.results.description_no_answers"))
+    end
+  end
 end


### PR DESCRIPTION
A part of: https://trello.com/c/uLLaEVPV/186-dont-deploy-update-checker-results-page

---

## What

In advance of larger changes to the view, to help users parse large numbers of actions by grouping them, start by simplifying the view by moving logic to the helper. This gives a cleaner canvas to begin working on the subgrouping feature.

## Why
Attempts to [deliver all of the subgrouping](https://github.com/alphagov/finder-frontend/pull/1731) at once led to too much complexity at once. This is the first in a sequence of PRs that breaks out useful work that can be delivered in more manageable chunks.

This particular set of changes assumes that the sub-groupings will inevitably add complexity to the results page, and pre-emptively reduces complexity in the view layer by moving logic into a helper.

## When can it go live?
As soon as merged, this is just a refactor of existing code in live. No new copy, features or user facing changes. Can be merged into master before the rest of the grouping work begins.