### PR TITLE
Add SCSS linting

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,6 @@
+scss_files:
+  - 'app/assets/stylesheets/**/*.scss'
+exclude: 
+  - 'app/assets/stylesheets/_reset.scss'
+plugin_gems: ['scss_lint-govuk']
+

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails", "~> 4.0.0.beta3"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,11 @@ GEM
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -350,6 +355,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     sdoc (1.0.0)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.6)
@@ -446,6 +455,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.beta3)
   rubocop-govuk
   sass-rails (~> 6.0.0)
+  scss_lint-govuk
   sdoc
   simplecov (~> 0.17.1)
   slimmer (~> 13.2.0)

--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -11,6 +11,7 @@
 
 .app-c-expander__content {
   padding: govuk-spacing(2) 13px;
+
   .govuk-form-group:last-child {
     margin-bottom: 0;
   }
@@ -21,7 +22,7 @@
     position: relative;
     padding: 10px 8px 5px 40px;
   }
-  
+
   .app-c-expander__content {
     display: none;
   }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -59,12 +59,6 @@ mark {
   @include govuk-media-query($from: tablet) {
     max-width: (100% / 3) * 2;
   }
-
-  fieldset.invalid {
-    border-left: solid 4px $govuk-error-colour;
-    padding-left: govuk-spacing(3);
-    margin-left: -govuk-spacing(3) - 4;
-  }
 }
 
 .signup-choices__message {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -115,7 +115,7 @@ mark {
   }
 }
 
-#finder-frontend {
+.finder-frontend {
   margin-bottom: govuk-spacing(8);
 }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,3 +1,5 @@
+$app-colour-true-black: #000;
+
 .metadata-summary {
   @include govuk-font(19);
   margin-bottom: govuk-spacing(6);
@@ -42,7 +44,7 @@ mark {
 
 .filter-form {
   .js-enabled & .button__wrapper {
-    display:none;
+    display: none;
   }
 
   .js-required {
@@ -196,7 +198,7 @@ mark {
   @include govuk-font(16, $weight: bold);
   text-align: left;
   cursor: pointer;
-  color: #000;
+  color: $app-colour-true-black;
   text-decoration: none;
   background: none;
   border: 0;
@@ -204,6 +206,7 @@ mark {
   .js-enabled & {
     display: inline-block;
     border: 1px solid transparent;
+
     &:focus {
       -webkit-box-shadow: inset 0 0 0 2px;
       box-shadow: inset 0 0 0 2px;
@@ -315,7 +318,7 @@ mark {
 // scss-lint:enable IdSelector
 
 .topic-finder__taxon-link {
-    @include govuk-font(24, $weight: bold);
+  @include govuk-font(24, $weight: bold);
 }
 
 // NOTE: used to override govspeak component when it's used on an inverse header

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -24,18 +24,24 @@ header,
   margin-top: 20px;
   clear: both;
 
-  a, dl, ul, li {
+  a,
+  dl,
+  ul,
+  li {
     margin: 0;
   }
+
   ul {
     padding: 0;
   }
+
   .document {
     margin: 10px 0;
     padding-bottom: 10px;
     border-bottom: 1px solid $govuk-border-colour;
     list-style: none;
   }
+
   a {
     font-weight: bold;
     margin-bottom: 5px;

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -1,4 +1,4 @@
-main.search {
+.search-wrapper {
   padding-bottom: 30px;
 
   @include govuk-media-query($from: tablet) {
@@ -28,7 +28,7 @@ main.search {
   }
 }
 
-main.no-search-term {
+.search-wrapper--no-search-term {
   @include govuk-media-query($from: tablet) {
     h1 {
       @include govuk-font(48, $weight: bold);

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -17,7 +17,7 @@
   <body class="<%= yield :body_classes %>">
     <div id="wrapper">
       <main id="content" role="main" class="finder-frontend-content">
-        <div id="finder-frontend">
+        <div class="finder-frontend">
           <%= yield %>
         </div>
       </main>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -5,7 +5,7 @@
         content="Search GOV.UK." />
 <% end %>
 
-<main id="content" role="main" class="search no-search-term">
+<main id="content" role="main" class="search-wrapper search-wrapper--no-search-term">
   <form action="/search" method="get" accept-charset="utf-8" class="search-header" role="search">
     <%= render 'search_field' %>
   </form>


### PR DESCRIPTION
Happy to introduce linting of SCSS files with https://github.com/alphagov/scss-lint-govuk

This PR:
- adds the linting gem and configuration file
- fixes obvious lint errors
- removes unused styles
- updates markup to fit in with the linting rules

[Trello card](https://trello.com/c/OBvn4OCD/1194-add-linting-of-scss-files)

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1777.herokuapp.com/search/all
- https://finder-frontend-pr-1777.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1777.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1777.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1777.herokuapp.com/drug-device-alerts
[Other finders](https://live-stuff.herokuapp.com/finders)
