### PR TITLE
Relax authorized host domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Hostname for govuk-docker
-  config.hosts << "finder-frontend.dev.gov.uk"
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
 end


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/176

This changes the development configuration to allow requests from
any domain. While this will include *.dev.gov.uk, this reduces the
coupling to that specific domain without any extra effort, thus
supporting more use cases like Docker training.



---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)