### PR TITLE
Fix validator using symbolic keys

### DIFF
--- a/lib/brexit_checker/criteria/validator.rb
+++ b/lib/brexit_checker/criteria/validator.rb
@@ -34,7 +34,8 @@ private
     when Array
       object.flat_map { |element| extract_criteria(element) }
     when Hash
-      extract_criteria(object.fetch(:any_of, [])) + extract_criteria(object.fetch(:all_of, []))
+      extract_criteria(object.fetch("any_of", [])) +
+        extract_criteria(object.fetch("all_of", []))
     when String
       object
     end

--- a/spec/lib/brexit_checker/criteria/validator_spec.rb
+++ b/spec/lib/brexit_checker/criteria/validator_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe BrexitChecker::Criteria::Validator do
   end
 
   context "the criteria includes all the available criteria" do
-    let(:expression) { [{ any_of: %w(a b c) }] }
+    let(:expression) { [{ "any_of" => %w(a b c) }] }
     it { is_expected.to eq(true) }
   end
 
   context "the criteria references a non-existent criteria" do
-    let(:expression) { [{ any_of: %w(a b c) }, { all_of: %w(d) }] }
+    let(:expression) { [{ "any_of" => %w(a b c) }, { "all_of" => %w(d) }] }
     it { is_expected.to eq(false) }
   end
 end


### PR DESCRIPTION
This fixes the validator to use string keys, which reflect the parsed
action criteria we get from our config files



---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)