### PR TITLE
Fix validation of criteria separating extraction/validation

### DIFF
--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -1568,7 +1568,7 @@ actions:
   - any_of:
     - environment
     - import-from-eu
-    - export-from-eu
+    - export-to-eu
   audience: business
 - id: T097
   priority: 2
@@ -1582,7 +1582,7 @@ actions:
   criteria:
   - any_of:
     - import-from-eu
-    - export-from-eu
+    - export-to-eu
     - fish-inc-wholesale
     - forestry
     - animal-ex-food

--- a/lib/brexit_checker/criteria/extractor.rb
+++ b/lib/brexit_checker/criteria/extractor.rb
@@ -1,0 +1,21 @@
+class BrexitChecker::Criteria::Extractor
+  class << self
+    def expression_criteria(expression)
+      extract_criteria(expression).flatten.to_set
+    end
+
+  private
+
+    def extract_criteria(criteria)
+      case criteria
+      when Array
+        criteria.flat_map { |element| extract_criteria(element) }
+      when Hash
+        extract_criteria(criteria.symbolize_keys.fetch(:any_of, [])) +
+          extract_criteria(criteria.symbolize_keys.fetch(:all_of, []))
+      when String
+        [criteria]
+      end
+    end
+  end
+end

--- a/lib/brexit_checker/criteria/validator.rb
+++ b/lib/brexit_checker/criteria/validator.rb
@@ -8,7 +8,8 @@ class BrexitChecker::Criteria::Validator
   def validate
     return true if expression.nil?
 
-    expression_criteria.subset?(all_criteria)
+    criteria = BrexitChecker::Criteria::Extractor.expression_criteria(expression)
+    criteria.subset?(all_criteria)
   end
 
   def self.validate(*args)
@@ -23,20 +24,5 @@ private
 
   def all_criteria
     BrexitChecker::Criterion.load_all.map(&:key).to_set
-  end
-
-  def expression_criteria
-    extract_criteria(expression).to_set
-  end
-
-  def extract_criteria(object)
-    case object
-    when Array
-      object.flat_map { |element| extract_criteria(element) }
-    when Hash
-      extract_criteria(object.fetch(:any_of, [])) + extract_criteria(object.fetch(:all_of, []))
-    when String
-      object
-    end
   end
 end

--- a/spec/lib/brexit_checker/criteria/extractor_spec.rb
+++ b/spec/lib/brexit_checker/criteria/extractor_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe BrexitChecker::Criteria::Extractor do
+  describe "#expression_criteria" do
+    subject(:expression_criteria) { described_class.expression_criteria(expression) }
+
+    context "an empty criteria" do
+      let(:expression) { [] }
+      it { is_expected.to eq([].to_set) }
+    end
+
+    context "the criteira is an array of strings" do
+      let(:expression) { %w(a b c) }
+      it { is_expected.to eq(%w(a b c).to_set) }
+    end
+
+    context "the criteira holds an OR object" do
+      let(:expression) { [{ "any_of": %w(a b c) }] }
+      it { is_expected.to eq(%w(a b c).to_set) }
+    end
+
+    context "the criteira holds an AND object" do
+      let(:expression) { [{ "all_of": %w(a b c) }] }
+      it { is_expected.to eq(%w(a b c).to_set) }
+    end
+
+    context "the criteira holds an AND and OR object" do
+      let(:expression) { [{ "any_of": %w(a b c) }, { "all_of": %w(d e f) }] }
+      it { is_expected.to eq(%w(a b c d e f).to_set) }
+    end
+
+    context "the criteira holds an AND object and separate criteira" do
+      let(:expression) { ["a", { "all_of": %w(d e f) }] }
+      it { is_expected.to eq(%w(a d e f).to_set) }
+    end
+
+    context "the criteira holds an OR object and separate criteira" do
+      let(:expression) { ["a", { "any_of": %w(d e f) }] }
+      it { is_expected.to eq(%w(a d e f).to_set) }
+    end
+  end
+end


### PR DESCRIPTION
We import criteria from strings in a spreadsheet. As such they're untrusted data, that we should validate. However criteria that is embedded in a hash can vary between having symbolic keys and string based keys.

This has led to a bug where a non-existing criteria `export-from-eu` snuck in to two business results.

This PR both fixes that, and separates criteria extraction from validation so it can be properly unit tested. This also lays some useful groundwork for us to re-use this criteria extraction on the new citizens grouping feature.