### PR TITLE
[On hold until Post Election] - Subscription footer

### DIFF
--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -57,6 +57,8 @@
   }
 
   .stay-updated__heading {
+    border-top: 1px solid $govuk-border-colour;
+    padding-top: govuk-spacing(6);
     margin-top: govuk-spacing(6);
   }
 

--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -62,6 +62,11 @@
     margin-top: govuk-spacing(6);
   }
 
+  .stay-updated_description {
+    margin-bottom: govuk-spacing(4);
+    @include govuk-font(19);
+  }
+
   .brexit-checker__no-results {
     margin-top: govuk-spacing(6);
   }

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -1,10 +1,10 @@
-<h2 class="govuk-heading-l stay-updated__heading"><%= t("brexit_checker.stay_updated.heading") %></h2>
+<h2 class="govuk-heading-m stay-updated__heading">
+  <%= t("brexit_checker.stay_updated.heading") %>
+</h2>
 
-<div class="govuk-!-margin-top-4">
-  <%= render "govuk_publishing_components/components/govspeak", {
-    content: t("brexit_checker.stay_updated.description").html_safe
-  } %>
-</div>
+<p class="stay-updated_description" >
+  <%= t("brexit_checker.stay_updated.description") %>
+</p>
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("brexit_checker.stay_updated.sign_up"),

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -71,14 +71,6 @@
     <%= render 'results_citizen_actions', citizen_results_groups: @citizen_results_groups if @citizen_results_groups.any? %>
     <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-section-break--bold">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        &nbsp; <!-- without this space, it will push the two-thirds column to the left -->
-      </div>
-      <div class="govuk-grid-column-two-thirds">
-        <%= render 'stay_updated' %>
-      </div>
-    </div>
+    <%= render 'stay_updated' %>
   <% end %>
 </div>

--- a/config/locales/en/brexit_checker/stay_updated.yml
+++ b/config/locales/en/brexit_checker/stay_updated.yml
@@ -1,11 +1,6 @@
 en:
   brexit_checker:
     stay_updated:
-      heading: Get updates
-      description: >
-        <p>Sign up to receive:</p>
-        <ul>
-          <li>email alerts about changes to Brexit information that may affect you</li>
-          <li>a link to your results</li>
-        </ul>
+      heading: What you need to do may change
+      description: Subscribe to updates about changes that may affect you and get a link to your results.
       sign_up: Subscribe


### PR DESCRIPTION
Do not merge until post-election

---

A part of: A part of: https://trello.com/c/uLLaEVPV/186-dont-deploy-update-checker-results-page

---

## Includes
- Modifying the footer subscription prompt on the results page to:
  - Make it full width
  - Give it new copy
  - Change what was as govespeak insert to a simple description

## Before
- No Results ([current live](http://gov.uk/get-ready-brexit-check/results?c[]=nationality-uk))
- No Answers ([current live](http://gov.uk/get-ready-brexit-check/results))
- Lots of results([current live](https://gov.uk/get-ready-brexit-check/results?c%5B%5D=aero-space&c%5B%5D=install-service-repair&c%5B%5D=animal-ex-food&c%5B%5D=legal-service&c%5B%5D=voluntary&c%5B%5D=construction&c%5B%5D=defence&c%5B%5D=electricity&c%5B%5D=oil-gas-coal&c%5B%5D=media&c%5B%5D=sports&c%5B%5D=insurance&c%5B%5D=pharma&c%5B%5D=telecoms&c%5B%5D=consumer-goods&c%5B%5D=diamond&c%5B%5D=mining&c%5B%5D=justice-including-prisons&c%5B%5D=education&c%5B%5D=motor-trade&c%5B%5D=restaurants-catering&c%5B%5D=port-airports&c%5B%5D=postal-couriers&c%5B%5D=rail-passenger-freight&c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=provide-services-do-business-in-eu&c%5B%5D=haulage-goods-across-eu-borders&c%5B%5D=ip&c%5B%5D=ip-copyright&c%5B%5D=ip-trade-marks&c%5B%5D=ip-designs&c%5B%5D=ip-patents&c%5B%5D=ip-exhaustion-rights&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=sell-defence-contracts&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-use&c%5B%5D=personal-eu-org-provide&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=working-ie&c%5B%5D=working-eu&c%5B%5D=studying-uk&c%5B%5D=studying-ie&c%5B%5D=studying-eu&c%5B%5D=living-uk&c%5B%5D=nationality-uk))

<img width="475" alt="Screenshot 2019-12-10 at 10 05 37" src="https://user-images.githubusercontent.com/3694062/70519944-a644d680-1b34-11ea-8e4b-cc73909f1452.png">

<img width="1159" alt="Screenshot 2019-12-10 at 10 05 21" src="https://user-images.githubusercontent.com/3694062/70519948-a6dd6d00-1b34-11ea-8e89-542bea2a2bd9.png">

## After 
- No Results ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results?c[]=nationality-uk) | [heroku](https://finder-frontend-pr-1793.herokuapp.com/get-ready-brexit-check/results?c[]=nationality-uk))
- No Answers ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results) | [heroku](https://finder-frontend-pr-1793.herokuapp.com/get-ready-brexit-check/results))
- Lots of results ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results?c[]=aero-space&c[]=install-service-repair&c[]=animal-ex-food&c[]=legal-service&c[]=voluntary&c[]=construction&c[]=defence&c[]=electricity&c[]=oil-gas-coal&c[]=media&c[]=sports&c[]=insurance&c[]=pharma&c[]=telecoms&c[]=consumer-goods&c[]=diamond&c[]=mining&c[]=justice-including-prisons&c[]=education&c[]=motor-trade&c[]=restaurants-catering&c[]=port-airports&c[]=postal-couriers&c[]=rail-passenger-freight&c[]=import-from-eu&c[]=export-to-eu&c[]=provide-services-do-business-in-eu&c[]=haulage-goods-across-eu-borders&c[]=ip&c[]=ip-copyright&c[]=ip-trade-marks&c[]=ip-designs&c[]=ip-patents&c[]=ip-exhaustion-rights&c[]=sell-public-sector&c[]=sell-public-sector-contracts&c[]=sell-defence-contracts&c[]=eu-uk-funding&c[]=personal-eu-org&c[]=personal-eu-org-process&c[]=personal-eu-org-use&c[]=personal-eu-org-provide&c[]=employ-eu-citizens&c[]=owns-operates-business-organisation&c[]=visiting-driving&c[]=visiting-bring-pet&c[]=visiting-ie&c[]=visiting-eu&c[]=visiting-row&c[]=travel-eu-business&c[]=working-uk&c[]=working-ie&c[]=working-eu&c[]=studying-uk&c[]=studying-ie&c[]=studying-eu&c[]=living-uk&c[]=nationality-uk) | [heroku](https://finder-frontend-pr-1793.herokuapp.com/get-ready-brexit-check/results?c[]=aero-space&c[]=install-service-repair&c[]=animal-ex-food&c[]=legal-service&c[]=voluntary&c[]=construction&c[]=defence&c[]=electricity&c[]=oil-gas-coal&c[]=media&c[]=sports&c[]=insurance&c[]=pharma&c[]=telecoms&c[]=consumer-goods&c[]=diamond&c[]=mining&c[]=justice-including-prisons&c[]=education&c[]=motor-trade&c[]=restaurants-catering&c[]=port-airports&c[]=postal-couriers&c[]=rail-passenger-freight&c[]=import-from-eu&c[]=export-to-eu&c[]=provide-services-do-business-in-eu&c[]=haulage-goods-across-eu-borders&c[]=ip&c[]=ip-copyright&c[]=ip-trade-marks&c[]=ip-designs&c[]=ip-patents&c[]=ip-exhaustion-rights&c[]=sell-public-sector&c[]=sell-public-sector-contracts&c[]=sell-defence-contracts&c[]=eu-uk-funding&c[]=personal-eu-org&c[]=personal-eu-org-process&c[]=personal-eu-org-use&c[]=personal-eu-org-provide&c[]=employ-eu-citizens&c[]=owns-operates-business-organisation&c[]=visiting-driving&c[]=visiting-bring-pet&c[]=visiting-ie&c[]=visiting-eu&c[]=visiting-row&c[]=travel-eu-business&c[]=working-uk&c[]=working-ie&c[]=working-eu&c[]=studying-uk&c[]=studying-ie&c[]=studying-eu&c[]=living-uk&c[]=nationality-uk))

<img width="519" alt="Screenshot 2019-12-10 at 10 00 35" src="https://user-images.githubusercontent.com/3694062/70519523-fb341d00-1b33-11ea-9e58-dfe4ac9509b6.png">

<img width="1159" alt="Screenshot 2019-12-10 at 10 01 34" src="https://user-images.githubusercontent.com/3694062/70519796-71388400-1b34-11ea-8e56-5e3d89c30c3a.png">