### PR TITLE
[On hold until Post Election] - Change public sector question to clarifiy UK context

### DIFF
--- a/lib/brexit_checker/criteria.yaml
+++ b/lib/brexit_checker/criteria.yaml
@@ -159,13 +159,13 @@ criteria:
 - key: eu-uk-funding
   text: You receive EU or UK government funding
 - key: sell-public-sector
-  text: You sell products or services to the public sector
+  text: You sell products or services to the UK public sector
 - key: sell-public-sector-contracts
-  text: You have public sector contracts
+  text: You have UK public sector contracts
 - key: sell-defence-contracts
-  text: You have defence contracts
+  text: You have UK defence contracts
 - key: do-not-sell-to-public-sector
-  text: You do not sell products or services to the public sector
+  text: You do not sell products or services to the UK public sector
 - key: nationality-uk
   text: You are a British national
 - key: nationality-ie

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -228,7 +228,7 @@ questions:
     criteria:
       - owns-operates-business-organisation
     type: "single_wrapped"
-    text: "Do you sell your products or services to the public sector?"
+    text: "Do you sell your products or services to the UK public sector?"
     description: |
       <p>This includes non-government organisations, such as hospitals and schools, and central or local government organisations.</p>
     options:


### PR DESCRIPTION
Trello card: https://trello.com/c/hd8BwgsS/322-small-wording-change-to-public-sector-question-in-checker

---

Aims to clarify that public sector procurement is specific to the UK context.

Also updates relevant criteria.

Looks like this:
<img width="690" alt="Screenshot 2019-12-10 at 15 24 23" src="https://user-images.githubusercontent.com/3694062/70542759-30a32f80-1b61-11ea-9f14-059db47687b4.png">

<img width="481" alt="Screenshot 2019-12-10 at 15 24 11" src="https://user-images.githubusercontent.com/3694062/70542762-31d45c80-1b61-11ea-8d3a-32749ab7bbd3.png">

