### PR TITLE
Override subscriber list params with applied filters on signup page

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -44,12 +44,11 @@ private
   end
 
   def applied_filters
-    params
-      .permit("filter" => {})
-      .dig("filter")
-      .to_h
-      .merge(
-        filter_params.fetch("subscriber_list_params", {}),
+    filter_params.fetch("subscriber_list_params", {}).merge(
+      params
+        .permit("filter" => {})
+        .dig("filter")
+        .to_h,
       )
   end
 

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -80,6 +80,29 @@ describe EmailAlertSubscriptionsController, type: :controller do
         }
         expect(subject).to redirect_to("http://www.example.com")
       end
+
+      context "request params contain subscriber_list_params and filter" do
+        it "overrides any subscriber_list_params with filter params" do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "case_type" => { any: %w[overriding-case-type] },
+              "format" => { any: %w[cma_case] },
+            },
+            "subscription_url" => "http://www.example.com",
+          )
+
+          post :create, params: {
+            slug: "cma-cases",
+            filter: {
+              "case_type" => %w[overriding-case-type],
+            },
+            subscriber_list_params: {
+              "case_type" => %w[overriden-case-type],
+            },
+          }
+          expect(subject).to redirect_to("http://www.example.com")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently the filters on `/search/research-and-statistics/email-signup?content_store_document_type=upcoming_statistics` will not be overriden by the filters selected on the email signup page. So in this case the content_store_document_type would remain upcoming_statistics even if the options selected were research and/or published_statistics.

https://trello.com/c/XTAM883f/1221-bug-research-and-statistics-signup-page-filters-dont-have-an-effect-if-filters-already-selected-on-finder

This fixes that issue by overriding subscriber_list_params with filters applied
by the user on the signup page.


---

## Search page examples to sanity check:

- https://finder-frontend-pr-1806.herokuapp.com/search/all
- https://finder-frontend-pr-1806.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1806.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1806.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1806.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1806.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1806.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1806.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1806.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1806.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
