### PR TITLE
[WIP] Use topic_names_sentence for dynamic filters which have filter values

### DIFF
--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -49,7 +49,7 @@ private
 
   def multiple_facets_suffix
     grouped_facets.map { |facet_key, facet_group|
-      if dynamic_filter_option?(facet_key)
+      if dynamic_filter_option?(facet_key) && has_no_filter_values?(facet_group)
         dynamic_facet_sentence(facet_key, facet_group.first["facet_name"])
       else
         facet_group.map { |facet| facet["facet_name"] + " of " + topic_names_sentence(facet) }.to_sentence
@@ -63,7 +63,6 @@ private
 
   def choice_by_key(facet, key)
     chosen = facet.fetch("facet_choices", []).detect { |choice| choice["key"] == key }
-
     chosen["topic_name"] if chosen
   end
 
@@ -118,6 +117,11 @@ private
 
   def registries
     @registries ||= Registries::BaseRegistries.new
+  end
+
+  def has_no_filter_values?(facet_group)
+    facet_choices = facet_group.first.fetch("facet_choices", [])
+    facet_choices.none? { |choice| choice.fetch("filter_values", []).any? }
   end
 
   def dynamic_filter_option?(filter_key)

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -200,4 +200,31 @@ describe EmailAlertTitleBuilder do
       is_expected.to eq("News and communicatons with people of Harry Potter, Ron Weasley, Albus Dumbledore, Cornelius Fudge, and Rufus Scrimgeour, organisations of Ministry of Magic, Gringots, and 1 other organisation, topics of Magical Education, Brexit, and Herbology, and 2 document types")
     }
   end
+
+  context "when the finder is research and statistics" do
+    let(:subscription_list_title_prefix) { "Statistics" }
+    let(:facets) do
+      [
+        { "facet_id" => "content_store_document_type", "facet_name" => "document types", "facet_choices" => [{ "key" => "statistics_published", "filter_values" => %w[statistics national_statistics statistical_data_set official_statistics], "radio_button_name" => "Statistics (published)", "topic_name" => "Statistics (published)", "prechecked" => false }, { "key" => "research", "filter_values" => %w[dfid_research_output independent_report research], "radio_button_name" => "Research", "topic_name" => "Research", "prechecked" => false }] },
+        { "facet_id" => "organisations", "facet_name" => "organisations" },
+        { "facet_id" => "world_locations", "facet_name" => "world locations" },
+        { "facet_id" => "topic", "filter_key" => "all_part_of_taxonomy_tree", "facet_name" => "topics" },
+        { "facet_id" => "level_one_taxon", "filter_key" => "all_part_of_taxonomy_tree", "facet_name" => "topics" },
+        { "facet_id" => "level_two_taxon", "filter_key" => "all_part_of_taxonomy_tree", "facet_name" => "topics" },
+      ]
+    end
+
+    context "when published statistics are requested" do
+      let(:filter) do
+        {
+          "content_store_document_type" => %w[statistics_published research],
+          "organisations" => %w[fco hmrc],
+        }
+      end
+
+      it {
+        is_expected.to eq("Statistics with document types of Statistics (published) and Research and 2 organisations")
+      }
+    end
+  end
 end


### PR DESCRIPTION
When signing up to receive updates of research and statistics
we show users that their email subscription is called:
'Statistics with 2 Research and statistics' which looks odd.

This change should make this title:
'Statistics with document types of Statistics (published) and Research'
which looks a little better (still not great).

This is because the research and statistics finder email signup
content item [0] has facet_choices which have filter_values
and is also a dynamic filter type (content_store_document_type).

There's a fair amount of variation in the the email-signup
content items and schema, so it might be nice to do some
refactoring here.

https://trello.com/c/UX2Cd7vr/1211-research-and-stats-subscription-descriptions-are-weird


---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
