### PR TITLE
Aligns filter elements into a neat column

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -19,9 +19,9 @@
 .js-enabled {
   .app-c-expander__heading {
     position: relative;
-    padding: 10px 8px 5px 40px;
+    padding: 10px 8px 5px 43px;
   }
-  
+
   .app-c-expander__content {
     display: none;
   }
@@ -35,7 +35,7 @@
   display: none;
   position: absolute;
   top: 0;
-  left: 6px;
+  left: 9px;
   width: 30px;
   height: 40px;
   fill: govuk-colour("black");

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -87,7 +87,7 @@
   display: none;
   position: absolute;
   top: 0;
-  left: 6px;
+  left: 9px;
   width: 30px;
   height: 40px;
   fill: govuk-colour("black");
@@ -128,7 +128,7 @@
 .js-enabled {
   .app-c-option-select__heading {
     position: relative;
-    padding: 10px 8px 5px 40px;
+    padding: 10px 8px 5px 43px;
   }
 
   .app-c-option-select__icon--up {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -385,3 +385,8 @@ mark {
   margin-bottom: govuk-spacing(7);
   padding-bottom: govuk-spacing(0);
 }
+
+.facet-container {
+  padding-left: 13px;
+  padding-right: 13px;
+}

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,5 +1,7 @@
-<%= render "govuk_publishing_components/components/radio", {
-  name: radio_facet.key,
-  small: true,
-  items: radio_facet.options
-} %>
+<div class="facet-container">
+  <%= render "govuk_publishing_components/components/radio", {
+    name: radio_facet.key,
+    small: true,
+    items: radio_facet.options
+  } %>
+</div>


### PR DESCRIPTION
Change from this card https://trello.com/c/UiD3ey0z/1181-tweak-the-sidebar-design-of-the-research-and-statistics-type-page-template

Screenshot below shows the aligning of all the elements - I haven't been able to use govuk-spacing because its really specific pixel numbers. 

![image](https://user-images.githubusercontent.com/25597009/70997698-8d589a00-20cd-11ea-9ff7-98c833789e29.png)
