### PR TITLE
Analytics tests

### DIFF
--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -4,7 +4,7 @@
       <p class="govuk-body brexit-checker__action_title">
         <% if action.title_url.present? %>
           <a
-            class="govuk-link brexit-checker__action_link"
+            class="govuk-link"
             href="<%= action.title_url %>"
             data-module="track-click"
             data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
@@ -44,7 +44,7 @@
           <p>
             <a
               href="<%= action.guidance_url %>"
-              class="govuk-link brexit-checker__guidance_link"
+              class="govuk-link"
               data-module="track-click"
               data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -4,7 +4,7 @@
       <p class="govuk-body brexit-checker__action_title">
         <% if action.title_url.present? %>
           <a
-            class="govuk-link"
+            class="govuk-link brexit-checker__action_link"
             href="<%= action.title_url %>"
             data-module="track-click"
             data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
@@ -44,7 +44,7 @@
           <p>
             <a
               href="<%= action.guidance_url %>"
-              class="govuk-link"
+              class="govuk-link brexit-checker__guidance_link"
               data-module="track-click"
               data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -16,7 +16,7 @@
           <%= render 'results_criteria', criteria: business_results[:criteria] %>
           <div class="govuk-grid-column-two-thirds">
             <%= render "action_list", {
-              analytics_group: "#{t('brexit_checker.results.audiences.business.heading')}.",
+              analytics_group: "#{t('brexit_checker.results.audiences.business.heading')} - 1.",
               actions: business_results[:actions]
             } %>
           </div>

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -1,5 +1,5 @@
 <section
-  class="brexit-checker-actions brexit-checker-business-actions"
+  class="brexit-checker-actions"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
   data-list-title="Brexit checker results: <%= t('brexit_checker.results.audiences.business.heading') %>"

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -1,5 +1,5 @@
 <section
-  class="brexit-checker-actions"
+  class="brexit-checker-actions brexit-checker-business-actions"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
   data-list-title="Brexit checker results: <%= t('brexit_checker.results.audiences.business.heading') %>"

--- a/app/views/brexit_checker/_results_citizen_actions.html.erb
+++ b/app/views/brexit_checker/_results_citizen_actions.html.erb
@@ -4,12 +4,12 @@
       <%= t('brexit_checker.results.audiences.citizen.heading') %>
     </h2>
   </header>
-  <section class="brexit-checker-audience">
+  <section class="brexit-checker-audience brexit-checker-audience-citizen">
     <% citizen_results_groups.each.with_index do |group, group_index| %>
       <section
         class="brexit-checker-actions__group"
         data-analytics-ecommerce
-        data-ecommerce-start-index="1"
+        data-ecommerce-start-index=<%="#{group_index + 1}"%>
         data-list-title="Brexit checker results: <%= "#{t('brexit_checker.results.audiences.citizen.heading')} - #{group[:group].heading}" %>"
         data-search-query
       >

--- a/app/views/brexit_checker/_results_citizen_actions.html.erb
+++ b/app/views/brexit_checker/_results_citizen_actions.html.erb
@@ -5,20 +5,20 @@
     </h2>
   </header>
   <section class="brexit-checker-audience brexit-checker-audience-citizen">
-    <% citizen_results_groups.each.with_index do |group, group_index| %>
+    <% citizen_results_groups.each.with_index do |grouping, group_index| %>
       <section
         class="brexit-checker-actions__group"
         data-analytics-ecommerce
         data-ecommerce-start-index=<%="#{group_index + 1}"%>
-        data-list-title="Brexit checker results: <%= "#{t('brexit_checker.results.audiences.citizen.heading')} - #{group[:group].heading}" %>"
+        data-list-title="Brexit checker results: <%= "#{t('brexit_checker.results.audiences.citizen.heading')} - #{grouping[:group].heading}" %>"
         data-search-query
       >
         <div class="govuk-grid-row">
-          <%= render 'results_criteria', criteria: group[:criteria], heading: group[:group].heading %>
+          <%= render 'results_criteria', criteria: grouping[:criteria], heading: grouping[:group].heading %>
           <div class="govuk-grid-column-two-thirds">
             <%= render "action_list", {
-              analytics_group: "#{t('brexit_checker.results.audiences.citizen.heading')} - #{group[:heading]} - #{group_index + 1}.",
-              actions: group[:actions]
+              analytics_group: "#{t('brexit_checker.results.audiences.citizen.heading')} - #{grouping[:group].heading} - #{group_index + 1}.",
+              actions: grouping[:actions]
             } %>
           </div>
         </div>

--- a/app/views/brexit_checker/_results_citizen_actions.html.erb
+++ b/app/views/brexit_checker/_results_citizen_actions.html.erb
@@ -4,7 +4,7 @@
       <%= t('brexit_checker.results.audiences.citizen.heading') %>
     </h2>
   </header>
-  <section class="brexit-checker-audience brexit-checker-audience-citizen">
+  <section class="brexit-checker-audience">
     <% citizen_results_groups.each.with_index do |grouping, group_index| %>
       <section
         class="brexit-checker-actions__group"

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -170,6 +170,8 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 
   def and_the_ce_mark_link_should_have_tracking_analytics
@@ -177,6 +179,8 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 
   def and_the_pet_link_should_have_tracking_analytics
@@ -184,5 +188,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_the_business_action_header
     and_i_should_see_a_pet_action
     and_i_should_see_a_tourism_action
+    and_citizen_results_audience_analyitics_tracking_should_be_present
   end
 
   def then_i_see_business_results_only
@@ -53,6 +54,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
+    and_citizen_results_audience_analyitics_tracking_should_be_present
   end
 
   def and_i_should_see_the_citizens_action_header
@@ -72,6 +74,27 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
     find_all(".brexit-checker-audience-citizen section.brexit-checker-actions__group h3").each_with_index do |group_title, i|
       expect(group_title.text).to eq(group_titles_ordered[i])
+    end
+  end
+
+  def and_citizen_results_audience_analyitics_tracking_should_be_present
+    and_citizens_groups_section_has_ecommerce_tracking
+    and_citizens_groups_section_has_data_search_query_attributes
+  end
+
+  def and_citizens_groups_section_has_ecommerce_tracking
+    group_titles_ordered = ["Visiting the EU", "Visiting the UK", "Visiting Ireland"]
+
+    find_all('.brexit-checker-citizen-audience section.brexit-checker-actions__group', visible: false).each_with_index do |group, i|
+      expect(group['data-analytics-ecommerce']).to eq("")
+      expect(group['data-ecommerce-start-index']).to eq("#{i + 1}")
+      expect(group['data-list-title']).to eq("Brexit checker results: You and your family - #{group_titles_ordered[i]}")
+    end
+  end
+
+  def and_citizens_groups_section_has_data_search_query_attributes
+    find_all('.brexit-checker-citizen-audience section.brexit-checker-actions__group', visible: false).each do |group|
+      expect(group['data-search-query']).to eq("")
     end
   end
 

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.citizen.heading")
     and_i_should_see_the_business_action_header
     and_i_should_see_a_ce_mark_action
+    and_business_results_audience_analyitics_tracking_should_be_present
   end
 
   def then_i_see_citizens_results_only
@@ -75,6 +76,23 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     find_all(".brexit-checker-audience-citizen section.brexit-checker-actions__group h3").each_with_index do |group_title, i|
       expect(group_title.text).to eq(group_titles_ordered[i])
     end
+  end
+
+  def and_business_results_audience_analyitics_tracking_should_be_present
+    and_business_actions_section_has_ecommerce_tracking
+    and_business_actions_section_has_data_search_query_attributes
+  end
+
+  def and_business_actions_section_has_ecommerce_tracking
+    section = find('.brexit-checker-business-actions', visible: false)
+    expect(section['data-analytics-ecommerce']).to eq("")
+    expect(section['data-ecommerce-start-index']).to eq("1")
+    expect(section['data-list-title']).to eq("Brexit checker results: Your business or organisation")
+  end
+
+  def and_business_actions_section_has_data_search_query_attributes
+    section = find('.brexit-checker-business-actions', visible: false)
+    expect(section['data-search-query']).to eq("")
   end
 
   def and_citizen_results_audience_analyitics_tracking_should_be_present

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_a_pet_action
     and_i_should_see_a_tourism_action
     and_citizen_results_audience_analyitics_tracking_should_be_present
+    and_business_results_audience_analyitics_tracking_should_be_present
   end
 
   def then_i_see_business_results_only

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def then_i_see_business_results_only
     then_i_should_see_the_results_page
-    expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.citizen.heading")
+    and_i_should_not_see_the_business_action_header
     and_i_should_see_the_business_action_header
     and_i_should_see_a_ce_mark_action
     and_the_ce_mark_link_should_have_tracking_analyitics
@@ -51,7 +51,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def then_i_see_citizens_results_only
     then_i_should_see_the_results_page
     and_i_should_see_the_citizens_action_header
-    expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.business.heading")
+    and_i_should_not_see_the_citizens_action_header
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
@@ -64,6 +64,14 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def and_i_should_see_the_business_action_header
     expect(page).to have_content I18n.t!("brexit_checker.results.audiences.business.heading")
+  end
+
+  def and_i_should_not_see_the_citizens_action_header
+    expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.citizen.heading")
+  end
+
+  def and_i_should_not_see_the_business_action_header
+    expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.business.heading")
   end
 
   def when_i_visit_the_brexit_checker_flow

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -80,8 +80,8 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def and_all_business_actions_links_should_have_ecommerce_tracking
-    find_all('.brexit-checker-business-actions .brexit-checker__action a.govuk-link').each do |link|
-      expect(link['data-module']).to eq("track-click")
+    find_all(".brexit-checker-business-actions .brexit-checker__action a.govuk-link").each do |link|
+      expect(link["data-module"]).to eq("track-click")
     end
   end
 
@@ -92,32 +92,32 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def and_business_actions_section_has_ecommerce_tracking
-    section = find('.brexit-checker-business-actions', visible: false)
-    expect(section['data-analytics-ecommerce']).to eq("")
-    expect(section['data-ecommerce-start-index']).to eq("1")
-    expect(section['data-list-title']).to eq("Brexit checker results: Your business or organisation")
+    section = find(".brexit-checker-business-actions", visible: false)
+    expect(section["data-analytics-ecommerce"]).to eq("")
+    expect(section["data-ecommerce-start-index"]).to eq("1")
+    expect(section["data-list-title"]).to eq("Brexit checker results: Your business or organisation")
   end
 
   def all_business_action_links_have_ecommerce_tracking(link, action_index, link_type)
-    expect(link['data-module']).to eq("track-click")
-    expect(link['data-track-category']).to eq("brexit-checker-results")
-    expect(link['data-ecommerce-path']).to eq(link['href'].sub("https://www.gov.uk",""))
-    expect(link['data-ecommerce-row']).to eq("")
-    expect(link['data-track-label']).to eq(link['href'])
-    action_string = link['data-track-action'].split(" - ")
+    expect(link["data-module"]).to eq("track-click")
+    expect(link["data-track-category"]).to eq("brexit-checker-results")
+    expect(link["data-ecommerce-path"]).to eq(link["href"].sub("https://www.gov.uk", ""))
+    expect(link["data-ecommerce-row"]).to eq("")
+    expect(link["data-track-label"]).to eq(link["href"])
+    action_string = link["data-track-action"].split(" - ")
     expect(action_string[0]).to eql(I18n.t!("brexit_checker.results.audiences.business.heading"))
-    expect(action_string[1]).to eql(I18n.t!('brexit_checker.results.audiences.business.heading'))
+    expect(action_string[1]).to eql(I18n.t!("brexit_checker.results.audiences.business.heading"))
     expect(action_string[2]).to eql("1.#{action_index + 1}")
     expect(action_string[3]).to eql(link_type)
   end
 
   def all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, action_index, link_type)
-    expect(link['data-module']).to eq("track-click")
-    expect(link['data-track-category']).to eq("brexit-checker-results")
-    expect(link['data-ecommerce-path']).to eq(link['href'].sub("https://www.gov.uk",""))
-    expect(link['data-ecommerce-row']).to eq("")
-    expect(link['data-track-label']).to eq(link['href'])
-    action_string = link['data-track-action'].split(" - ")
+    expect(link["data-module"]).to eq("track-click")
+    expect(link["data-track-category"]).to eq("brexit-checker-results")
+    expect(link["data-ecommerce-path"]).to eq(link["href"].sub("https://www.gov.uk", ""))
+    expect(link["data-ecommerce-row"]).to eq("")
+    expect(link["data-track-label"]).to eq(link["href"])
+    action_string = link["data-track-action"].split(" - ")
     expect(action_string[0]).to eql(I18n.t!("brexit_checker.results.audiences.citizen.heading"))
     expect(action_string[1]).to eql(group_title)
     expect(action_string[2]).to eql("#{group_index}.#{action_index + 1}")
@@ -125,17 +125,17 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def and_all_business_actions_links_should_have_ecommerce_tracking
-    find_all('brexit-checker-business-actions .brexit-checker__action .brexit-checker__action_title a.govuk-link').each_with_index do |link, i|
-      all_business_action_links_have_ecommerce_tracking(link, i,"Action")
+    find_all("brexit-checker-business-actions .brexit-checker__action .brexit-checker__action_title a.govuk-link").each_with_index do |link, i|
+      all_business_action_links_have_ecommerce_tracking(link, i, "Action")
     end
-    find_all('brexit-checker-business-actions .brexit-checker__action .govuk-body a.govuk-link').each_with_index do |link, i|
-      all_business_action_links_have_ecommerce_tracking(link, i,"Guidance")
+    find_all("brexit-checker-business-actions .brexit-checker__action .govuk-body a.govuk-link").each_with_index do |link, i|
+      all_business_action_links_have_ecommerce_tracking(link, i, "Guidance")
     end
   end
 
   def and_business_actions_section_has_data_search_query_attributes
-    section = find('.brexit-checker-business-actions', visible: false)
-    expect(section['data-search-query']).to eq("")
+    section = find(".brexit-checker-business-actions", visible: false)
+    expect(section["data-search-query"]).to eq("")
   end
 
   def and_all_citizens_actions_links_should_have_ecommerce_tracking
@@ -143,13 +143,13 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
       group_index += 1
       group_title = group["data-list-title"].split(" - ").last
       within :xpath, group.path do
-        find_all('.brexit-checker__action', visible: false).each_with_index do |action, link_index|
+        find_all(".brexit-checker__action", visible: false).each_with_index do |action, link_index|
           within :xpath, action.path do
-            find_all('a.brexit-checker__action_link').each do |link|
+            find_all("a.brexit-checker__action_link").each do |link|
               all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, link_index, "Action")
             end
-            find_all('a.brexit-checker__guidance_link').each_with_index do |link|
-              all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, link_index,"Guidance")
+            find_all("a.brexit-checker__guidance_link").each do |link|
+              all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, link_index, "Guidance")
             end
           end
         end
@@ -166,16 +166,16 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def and_citizens_groups_section_has_ecommerce_tracking
     group_titles_ordered = ["Visiting the EU", "Visiting the UK", "Visiting Ireland"]
 
-    find_all('.brexit-checker-citizen-audience section.brexit-checker-actions__group', visible: false).each_with_index do |group, i|
-      expect(group['data-analytics-ecommerce']).to eq("")
-      expect(group['data-ecommerce-start-index']).to eq("#{i + 1}")
-      expect(group['data-list-title']).to eq("Brexit checker results: You and your family - #{group_titles_ordered[i]}")
+    find_all(".brexit-checker-citizen-audience section.brexit-checker-actions__group", visible: false).each_with_index do |group, i|
+      expect(group["data-analytics-ecommerce"]).to eq("")
+      expect(group["data-ecommerce-start-index"]).to eq((i + 1).to_s)
+      expect(group["data-list-title"]).to eq("Brexit checker results: You and your family - #{group_titles_ordered[i]}")
     end
   end
 
   def and_citizens_groups_section_has_data_search_query_attributes
-    find_all('.brexit-checker-citizen-audience section.brexit-checker-actions__group', visible: false).each do |group|
-      expect(group['data-search-query']).to eq("")
+    find_all(".brexit-checker-citizen-audience section.brexit-checker-actions__group", visible: false).each do |group|
+      expect(group["data-search-query"]).to eq("")
     end
   end
 

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 
@@ -179,7 +179,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 
@@ -188,7 +188,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_url.sub('https://www.gov.uk','')}']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
   end
 end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -168,7 +168,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def and_the_tourism_link_should_have_tracking_analytics
     action = BrexitChecker::Action.find_by_id("T063")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
-
   end
 
   def and_the_ce_mark_link_should_have_tracking_analytics

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -37,8 +37,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_the_business_action_header
     and_i_should_see_a_pet_action
     and_i_should_see_a_tourism_action
-    and_citizen_results_audience_analyitics_tracking_should_be_present
-    and_business_results_audience_analyitics_tracking_should_be_present
+    and_the_tourism_link_should_have_tracking_analyitics
   end
 
   def then_i_see_business_results_only
@@ -46,7 +45,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.citizen.heading")
     and_i_should_see_the_business_action_header
     and_i_should_see_a_ce_mark_action
-    and_business_results_audience_analyitics_tracking_should_be_present
+    and_the_ce_mark_link_should_have_tracking_analyitics
   end
 
   def then_i_see_citizens_results_only
@@ -56,7 +55,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
-    and_citizen_results_audience_analyitics_tracking_should_be_present
+    and_the_pet_link_should_have_tracking_analyitics
   end
 
   def and_i_should_see_the_citizens_action_header
@@ -76,106 +75,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
     find_all(".brexit-checker-audience-citizen section.brexit-checker-actions__group h3").each_with_index do |group_title, i|
       expect(group_title.text).to eq(group_titles_ordered[i])
-    end
-  end
-
-  def and_all_business_actions_links_should_have_ecommerce_tracking
-    find_all(".brexit-checker-business-actions .brexit-checker__action a.govuk-link").each do |link|
-      expect(link["data-module"]).to eq("track-click")
-    end
-  end
-
-  def and_business_results_audience_analyitics_tracking_should_be_present
-    and_business_actions_section_has_ecommerce_tracking
-    and_business_actions_section_has_data_search_query_attributes
-    and_all_business_actions_links_should_have_ecommerce_tracking
-  end
-
-  def and_business_actions_section_has_ecommerce_tracking
-    section = find(".brexit-checker-business-actions", visible: false)
-    expect(section["data-analytics-ecommerce"]).to eq("")
-    expect(section["data-ecommerce-start-index"]).to eq("1")
-    expect(section["data-list-title"]).to eq("Brexit checker results: Your business or organisation")
-  end
-
-  def all_business_action_links_have_ecommerce_tracking(link, action_index, link_type)
-    expect(link["data-module"]).to eq("track-click")
-    expect(link["data-track-category"]).to eq("brexit-checker-results")
-    expect(link["data-ecommerce-path"]).to eq(link["href"].sub("https://www.gov.uk", ""))
-    expect(link["data-ecommerce-row"]).to eq("")
-    expect(link["data-track-label"]).to eq(link["href"])
-    action_string = link["data-track-action"].split(" - ")
-    expect(action_string[0]).to eql(I18n.t!("brexit_checker.results.audiences.business.heading"))
-    expect(action_string[1]).to eql(I18n.t!("brexit_checker.results.audiences.business.heading"))
-    expect(action_string[2]).to eql("1.#{action_index + 1}")
-    expect(action_string[3]).to eql(link_type)
-  end
-
-  def all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, action_index, link_type)
-    expect(link["data-module"]).to eq("track-click")
-    expect(link["data-track-category"]).to eq("brexit-checker-results")
-    expect(link["data-ecommerce-path"]).to eq(link["href"].sub("https://www.gov.uk", ""))
-    expect(link["data-ecommerce-row"]).to eq("")
-    expect(link["data-track-label"]).to eq(link["href"])
-    action_string = link["data-track-action"].split(" - ")
-    expect(action_string[0]).to eql(I18n.t!("brexit_checker.results.audiences.citizen.heading"))
-    expect(action_string[1]).to eql(group_title)
-    expect(action_string[2]).to eql("#{group_index}.#{action_index + 1}")
-    expect(action_string[3]).to eql(link_type)
-  end
-
-  def and_all_business_actions_links_should_have_ecommerce_tracking
-    find_all("brexit-checker-business-actions .brexit-checker__action .brexit-checker__action_title a.govuk-link").each_with_index do |link, i|
-      all_business_action_links_have_ecommerce_tracking(link, i, "Action")
-    end
-    find_all("brexit-checker-business-actions .brexit-checker__action .govuk-body a.govuk-link").each_with_index do |link, i|
-      all_business_action_links_have_ecommerce_tracking(link, i, "Guidance")
-    end
-  end
-
-  def and_business_actions_section_has_data_search_query_attributes
-    section = find(".brexit-checker-business-actions", visible: false)
-    expect(section["data-search-query"]).to eq("")
-  end
-
-  def and_all_citizens_actions_links_should_have_ecommerce_tracking
-    find_all(".brexit-checker-audience-citizen section.brexit-checker-actions__group", visible: false).each_with_index do |group, group_index|
-      group_index += 1
-      group_title = group["data-list-title"].split(" - ").last
-      within :xpath, group.path do
-        find_all(".brexit-checker__action", visible: false).each_with_index do |action, link_index|
-          within :xpath, action.path do
-            find_all("a.brexit-checker__action_link").each do |link|
-              all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, link_index, "Action")
-            end
-            find_all("a.brexit-checker__guidance_link").each do |link|
-              all_citizen_action_links_have_ecommerce_tracking(link, group_index, group_title, link_index, "Guidance")
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def and_citizen_results_audience_analyitics_tracking_should_be_present
-    and_citizens_groups_section_has_ecommerce_tracking
-    and_citizens_groups_section_has_data_search_query_attributes
-    and_all_citizens_actions_links_should_have_ecommerce_tracking
-  end
-
-  def and_citizens_groups_section_has_ecommerce_tracking
-    group_titles_ordered = ["Visiting the EU", "Visiting the UK", "Visiting Ireland"]
-
-    find_all(".brexit-checker-citizen-audience section.brexit-checker-actions__group", visible: false).each_with_index do |group, i|
-      expect(group["data-analytics-ecommerce"]).to eq("")
-      expect(group["data-ecommerce-start-index"]).to eq((i + 1).to_s)
-      expect(group["data-list-title"]).to eq("Brexit checker results: You and your family - #{group_titles_ordered[i]}")
-    end
-  end
-
-  def and_citizens_groups_section_has_data_search_query_attributes
-    find_all(".brexit-checker-citizen-audience section.brexit-checker-actions__group", visible: false).each do |group|
-      expect(group["data-search-query"]).to eq("")
     end
   end
 
@@ -256,5 +155,21 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     if action.guidance_link_text
       expect(page).to have_link(action.guidance_link_text, href: action.guidance_url)
     end
+  end
+
+  def and_the_tourism_link_should_have_tracking_analyitics
+    action = BrexitChecker::Action.find_by_id("T063")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
+
+  end
+
+  def and_the_ce_mark_link_should_have_tracking_analyitics
+    action = BrexitChecker::Action.find_by_id("T001")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
+  end
+
+  def and_the_pet_link_should_have_tracking_analyitics
+    action = BrexitChecker::Action.find_by_id("S009")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
   end
 end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def then_i_see_citizen_and_business_results
     then_i_should_see_the_results_page
+    and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_the_citizens_action_header
     and_i_should_see_the_business_action_header
     and_i_should_see_a_pet_action
@@ -49,6 +50,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     then_i_should_see_the_results_page
     and_i_should_see_the_citizens_action_header
     expect(page).to_not have_content I18n.t!("brexit_checker.results.audiences.business.heading")
+    and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
   end
@@ -63,6 +65,14 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def when_i_visit_the_brexit_checker_flow
     visit brexit_checker_questions_path
+  end
+
+  def and_i_should_see_citizen_actions_are_grouped
+    group_titles_ordered = ["Visiting the EU", "Visiting the UK", "Visiting Ireland"]
+
+    find_all(".brexit-checker-audience-citizen section.brexit-checker-actions__group h3").each_with_index do |group_title, i|
+      expect(group_title.text).to eq(group_titles_ordered[i])
+    end
   end
 
   def and_i_do_not_answer_citizen_questions

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -42,8 +42,8 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def then_i_see_business_results_only
     then_i_should_see_the_results_page
-    and_i_should_not_see_the_business_action_header
     and_i_should_see_the_business_action_header
+    and_i_should_not_see_the_citizens_action_header
     and_i_should_see_a_ce_mark_action
     and_the_ce_mark_link_should_have_tracking_analytics
   end
@@ -51,7 +51,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def then_i_see_citizens_results_only
     then_i_should_see_the_results_page
     and_i_should_see_the_citizens_action_header
-    and_i_should_not_see_the_citizens_action_header
+    and_i_should_not_see_the_business_action_header
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
@@ -168,15 +168,21 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def and_the_tourism_link_should_have_tracking_analytics
     action = BrexitChecker::Action.find_by_id("T063")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
   end
 
   def and_the_ce_mark_link_should_have_tracking_analytics
     action = BrexitChecker::Action.find_by_id("T001")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
   end
 
   def and_the_pet_link_should_have_tracking_analytics
     action = BrexitChecker::Action.find_by_id("S009")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
   end
 end


### PR DESCRIPTION
The new-results-page adds both new e-commerce tracking, (so we can compare impressions and clickthroughs when judging the engagement around actions), and a new layout including subgroupings for citizens results.

This can lead to a large number of different tracking outputs.

This PR adds more comprehensive tests for that tracking, whilst also fixing a couple of bugs identified during writing the tests and clarifying variable names where possible.