### PR TITLE
Add share links to brexit checker results

### DIFF
--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -13,6 +13,12 @@
     margin-bottom: govuk-spacing(6);
   }
 
+  .brexit-checker__share {
+    border-top: 3px solid $govuk-brand-colour;
+    margin: govuk-spacing(8) 0;
+    padding: govuk-spacing(4) 0;
+  }
+
   .brexit-checker__action {
     margin: 0 0 govuk-spacing(6);
 

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -1,6 +1,10 @@
 require "addressable/uri"
 
 module BrexitCheckerHelper
+  def encoded_results_url
+    CGI.escape(request.original_url)
+  end
+
   def format_criterion(criteria_key)
     BrexitChecker::Criterion.load_by(criteria_key).first.text
   end

--- a/app/views/brexit_checker/_share_links.html.erb
+++ b/app/views/brexit_checker/_share_links.html.erb
@@ -1,0 +1,38 @@
+<section class="brexit-checker__share">
+  <% hidden_text = capture do %>
+    <span class="govuk-visually-hidden">Share on</span>
+  <% end %>
+  <h4 class="govuk-heading-m">
+    <%= I18n.t("brexit_checker.results.share_link_title") %>
+  </h4>
+  <%= render "govuk_publishing_components/components/share_links", {
+    columns: true,
+    links: [
+      {
+        href: "https://www.facebook.com/sharer/sharer.php?u=#{encoded_results_url}",
+        text: hidden_text + "Facebook",
+        icon: "facebook"
+      },
+      {
+        href: "https://twitter.com/share?url=#{encoded_results_url}",
+        text: hidden_text + "Twitter",
+        icon: "twitter"
+      },
+      {
+        href: "https://api.whatsapp.com/send?text=#{encoded_results_url}",
+        text: hidden_text + "WhatsApp",
+        icon: "whatsapp"
+      },
+      {
+        href: "mailto:?body=#{encoded_results_url}&subject=#{I18n.t("brexit_checker.results.title")}",
+        text: hidden_text + "Email",
+        icon: "email"
+      },
+      {
+        href: "http://www.linkedin.com/shareArticle?url=#{encoded_results_url}",
+        text: hidden_text + "LinkedIn",
+        icon: "linkedin"
+      },
+    ]
+  } %>
+</section>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -69,5 +69,6 @@
     <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
 
     <%= render 'stay_updated' %>
+    <%= render 'share_links' %>
   <% end %>
 </div>

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -15,6 +15,7 @@ en:
         Subscribe to updates about changes that may affect you and get a link to your results
       email_sign_up_link_no_actions: |
         This may change. Subscribe to email alerts about changes to Brexit information that may affect you.
+      share_link_title: Share your results
       social_media_meta:
         title: "Brexit: check what you need to do if there is no deal"
         description: |


### PR DESCRIPTION
Trello card: https://trello.com/c/fB9KKRrJ/242-add-share-your-results-component

---

Adds social share links that pass on your results URL onto various social media platforms.

## Desktop
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal(2)](https://user-images.githubusercontent.com/3694062/71256134-d73cbc80-2327-11ea-9def-1de3fe507f58.png)

## Intermediate
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal](https://user-images.githubusercontent.com/3694062/71256126-cee48180-2327-11ea-88da-6349baf1358c.png)

## Tiny Mobile
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal(1)](https://user-images.githubusercontent.com/3694062/71256131-d3109f00-2327-11ea-8b45-713e3138f68b.png)
