### PR TITLE
Change sizing of brexit checker results notification window

### DIFF
--- a/app/assets/stylesheets/components/_email-link.scss
+++ b/app/assets/stylesheets/components/_email-link.scss
@@ -3,6 +3,10 @@
   padding: govuk-spacing(4);
   background: govuk-colour('grey-4');
 
+  .govuk-heading-m {
+    margin-bottom: govuk-spacing(2);
+  }
+
   .app-c-email-link__title {
     font-weight: bold;
   }
@@ -14,6 +18,7 @@
   }
 
   .app-c-email-link__link {
+    @include govuk-font(19);
 
     &:visited .app-c-email-link__icon {
       fill: $govuk-link-visited-colour;

--- a/app/views/components/_email_link.html.erb
+++ b/app/views/components/_email_link.html.erb
@@ -4,10 +4,10 @@
 %>
 <div class="app-c-email-link">
   <% if link_title %>
-    <p class="app-c-email-link__title"><%= link_title %></p>
+    <p class="govuk-heading-m"><%= link_title %></p>
   <% end %>
-  <svg class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
-    <path d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"></path>
+  <svg class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="21" width="18" viewBox="0 0 18 21">
+    <path d="M7.05,19.01C7.05,20.11,7.92,21,9,21c1.08,0,1.95-0.89,1.95-1.99H7.05z M15.73,14.82V9c0-3.25-2.2-5.97-5.18-6.69V1.59C10.56,0.71,9.86,0,9,0C8.14,0,7.44,0.71,7.44,1.59v0.72C4.47,3.03,2.27,5.75,2.27,9v5.82l-2.08,2.12V18h17.62v-1.06L15.73,14.82z"></path>
   </svg>
   <%= tag.a href: link_href, class:"app-c-email-link__link govuk-link", data: data_attributes do %>
     <%= link_text %>


### PR DESCRIPTION
Cross referenced with the prototype here https://govuk-dynamic-list.herokuapp.com/get-ready-for-brexit/results/uk-national-and-business-mvp

The notification promps were larger and more prominent.

### Before
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal(3)](https://user-images.githubusercontent.com/3694062/71257722-59c77b00-232c-11ea-84d8-96cbd738c0b5.png)

### After 
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal(4)](https://user-images.githubusercontent.com/3694062/71257749-6fd53b80-232c-11ea-9ab4-32bbdcd02c8c.png)

### After (mobile)
![Screenshot_2019-12-20 Brexit check what you need to do if there is no deal(5)](https://user-images.githubusercontent.com/3694062/71257742-6b108780-232c-11ea-997c-7409b6457588.png)