### PR TITLE
Results accessibility audit

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -5,6 +5,12 @@ module BrexitCheckerHelper
     CGI.escape(request.original_url)
   end
 
+  def criteria_aside_label(heading = nil)
+    return "you-and-your-family-actions-group-#{heading.downcase.gsub(' ', '-')}-criteria" if !heading.nil?
+
+    "business-actions-criteria"
+  end
+
   def format_criterion(criteria_key)
     BrexitChecker::Criterion.load_by(criteria_key).first.text
   end

--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -1,5 +1,8 @@
 <% if criteria.present? %>
-  <aside class="govuk-grid-column-one-third">
+  <aside
+    class="govuk-grid-column-one-third"
+    aria-label=<%="#{criteria_aside_label(local_assigns[:heading])}"%>
+  >
     <% if local_assigns[:heading] %>
       <h3 class="govuk-heading-m"><%= heading %></h3>
     <% end %>

--- a/app/views/brexit_checker/_share_links.html.erb
+++ b/app/views/brexit_checker/_share_links.html.erb
@@ -2,9 +2,9 @@
   <% hidden_text = capture do %>
     <span class="govuk-visually-hidden">Share on</span>
   <% end %>
-  <h4 class="govuk-heading-m">
+  <h2 class="govuk-heading-m">
     <%= I18n.t("brexit_checker.results.share_link_title") %>
-  </h4>
+  </h2>
   <%= render "govuk_publishing_components/components/share_links", {
     columns: true,
     links: [

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -16,7 +16,7 @@
 
   <body class="<%= yield :body_classes %>">
     <div id="wrapper">
-      <main id="content" role="main" class="finder-frontend-content">
+      <main id="content" class="finder-frontend-content">
         <div class="finder-frontend">
           <%= yield %>
         </div>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -5,7 +5,7 @@
         content="Search GOV.UK." />
 <% end %>
 
-<main id="content" role="main" class="search-wrapper search-wrapper--no-search-term">
+<main id="content" class="search-wrapper search-wrapper--no-search-term">
   <form action="/search" method="get" accept-charset="utf-8" class="search-header" role="search">
     <%= render 'search_field' %>
   </form>

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -253,4 +253,14 @@ describe BrexitCheckerHelper, type: :helper do
       expect(brexit_results_description([], [])).to eq(t("brexit_checker.results.description_no_answers"))
     end
   end
+
+  describe "#criteria_aside_label" do
+    it "returns string 'buisness-criteira' if not provided with a group heading" do
+      expect(criteria_aside_label).to eql("business-actions-criteria")
+    end
+
+    it "returns an identifying string for citizen group criteria if provided with a group heading" do
+      expect(criteria_aside_label("I am an Official Group heading")).to eq("you-and-your-family-actions-group-i-am-an-official-group-heading-criteria")
+    end
+  end
 end


### PR DESCRIPTION
Trello: [A part of](https://trello.com/c/Kmp4WW27/339-accessibility-audit-of-checker-results-page)

Small accessibility tweaks, including:
- Adding aria labels to repeating 'aside' elements that hold criteria, uses group heading or business string as a label. Uses a new helper plus tests.
- Removes role from main elements. Those are now redundant with proper adoption of HTML5 in all major browsers
- Promotes the heading of the share buttons from h4 to h2, as it's really a higher heading level.