### PR TITLE
Add print button to brexit checker results

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -47,3 +47,8 @@ header,
     margin-bottom: 5px;
   }
 }
+
+.brexit-checker__print-link,
+.brexit-checker__share {
+  display: none;
+}

--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -15,7 +15,7 @@
 
   .brexit-checker__share {
     border-top: 3px solid $govuk-brand-colour;
-    margin: govuk-spacing(8) 0;
+    margin-top: govuk-spacing(8);
     padding: govuk-spacing(4) 0;
   }
 
@@ -82,5 +82,31 @@
     border-bottom: 1px solid $govuk-border-colour;
     padding: govuk-spacing(4) 0;
     margin-bottom: 0;
+  }
+
+  .brexit-checker__print-link {
+    @include govuk-font(19);
+    background: image-url("govuk_publishing_components/icon-print.png") no-repeat 10px 50%;
+    padding: 0.5em 0.5em 0.5em 38px;
+    margin-left: -10px;
+    margin-top: govuk-spacing(3);
+    outline: 0;
+    border: 0;
+    cursor: pointer;
+    text-decoration: underline;
+    color: $govuk-link-colour;
+
+    @include govuk-device-pixel-ratio($ratio: 2) {
+      background-image: image-url("govuk_publishing_components/icon-print-2x.png");
+      background-size: 16px 18px;
+    }
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:focus {
+      @include govuk-focused-text;
+    }
   }
 }

--- a/app/views/brexit_checker/_print_link.html.erb
+++ b/app/views/brexit_checker/_print_link.html.erb
@@ -1,0 +1,7 @@
+<button
+  class="brexit-checker__print-link govuk-link"
+  rel="alternate"
+  onclick="window.print();return false;"
+>
+   <%= t("brexit_checker.results.print_link") %>
+</button>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -70,5 +70,6 @@
 
     <%= render 'stay_updated' %>
     <%= render 'share_links' %>
+    <%= render 'print_link' if @business_results.any? || @citizen_results_groups.any? %>
   <% end %>
 </div>

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -31,3 +31,4 @@ en:
           heading: You and your family
         business:
           heading: Your business or organisation
+      print_link: Print your results

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_answer_citizen_questions
     and_i_answer_business_questions
     then_i_see_citizen_and_business_results
+    and_i_should_see_a_print_link
   end
 
   scenario "business questions only" do
@@ -15,6 +16,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_do_not_answer_citizen_questions
     and_i_answer_business_questions
     then_i_see_business_results_only
+    and_i_should_see_a_print_link
   end
 
   scenario "citizen questions only" do
@@ -22,6 +24,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_answer_citizen_questions
     and_i_do_not_answer_business_questions
     then_i_see_citizens_results_only
+    and_i_should_see_a_print_link
   end
 
   scenario "skip all questions" do
@@ -53,6 +56,14 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
+  end
+
+  def and_i_should_see_a_print_link
+    expect(page).to have_css(".brexit-checker__print-link", text: "Print your results")
+  end
+
+  def and_i_should_not_see_a_print_link
+    expect(page).to_not have_css(".brexit-checker__print-link", text: "Print your results")
   end
 
   def and_i_should_see_the_citizens_action_header

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_answer_business_questions
     then_i_see_citizen_and_business_results
     and_i_should_see_a_print_link
+    and_i_should_see_share_links
   end
 
   scenario "business questions only" do
@@ -17,6 +18,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_answer_business_questions
     then_i_see_business_results_only
     and_i_should_see_a_print_link
+    and_i_should_see_share_links
   end
 
   scenario "citizen questions only" do
@@ -25,6 +27,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_do_not_answer_business_questions
     then_i_see_citizens_results_only
     and_i_should_see_a_print_link
+    and_i_should_see_share_links
   end
 
   scenario "skip all questions" do
@@ -58,12 +61,25 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_not_see_a_tourism_action
   end
 
+  def and_i_should_see_share_links
+    current_url = CGI.escape(page.current_url)
+    expect(page).to have_css("a[href='https://www.facebook.com/sharer/sharer.php?u=#{current_url}']")
+    expect(page).to have_css("a[href='https://twitter.com/share?url=#{current_url}']")
+    expect(page).to have_css("a[href='https://api.whatsapp.com/send?text=#{current_url}']")
+    expect(page).to have_css("a[href='mailto:?body=#{current_url}&subject=Get%20ready%20for%20a%20no-deal%20Brexit:%20Your%20results']")
+    expect(page).to have_css("a[href='http://www.linkedin.com/shareArticle?url=#{current_url}']")
+  end
+
   def and_i_should_see_a_print_link
     expect(page).to have_css(".brexit-checker__print-link", text: "Print your results")
   end
 
   def and_i_should_not_see_a_print_link
     expect(page).to_not have_css(".brexit-checker__print-link", text: "Print your results")
+  end
+
+  def and_i_should_not_see_share_links
+    expect(page).to_not have_css(".gem-c-share-links")
   end
 
   def and_i_should_see_the_citizens_action_header


### PR DESCRIPTION
Trello card: https://trello.com/c/Gu5XqQxM/243-add-print-your-results-link

---

Adds a print button to results page (unlike share and email subscription - which both offer opportunities to return to updated results this only shows if there are any actions).

## How it looks

- Lots of results ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results?c[]=aero-space&c[]=install-service-repair&c[]=animal-ex-food&c[]=legal-service&c[]=voluntary&c[]=construction&c[]=defence&c[]=electricity&c[]=oil-gas-coal&c[]=media&c[]=sports&c[]=insurance&c[]=pharma&c[]=telecoms&c[]=consumer-goods&c[]=diamond&c[]=mining&c[]=justice-including-prisons&c[]=education&c[]=motor-trade&c[]=restaurants-catering&c[]=port-airports&c[]=postal-couriers&c[]=rail-passenger-freight&c[]=import-from-eu&c[]=export-to-eu&c[]=provide-services-do-business-in-eu&c[]=haulage-goods-across-eu-borders&c[]=ip&c[]=ip-copyright&c[]=ip-trade-marks&c[]=ip-designs&c[]=ip-patents&c[]=ip-exhaustion-rights&c[]=sell-public-sector&c[]=sell-public-sector-contracts&c[]=sell-defence-contracts&c[]=eu-uk-funding&c[]=personal-eu-org&c[]=personal-eu-org-process&c[]=personal-eu-org-use&c[]=personal-eu-org-provide&c[]=employ-eu-citizens&c[]=owns-operates-business-organisation&c[]=visiting-driving&c[]=visiting-bring-pet&c[]=visiting-ie&c[]=visiting-eu&c[]=visiting-row&c[]=travel-eu-business&c[]=working-uk&c[]=working-ie&c[]=working-eu&c[]=studying-uk&c[]=studying-ie&c[]=studying-eu&c[]=living-uk&c[]=nationality-uk) | [heroku](https://finder-frontend-pr-1829.herokuapp.com/get-ready-brexit-check/results?c[]=aero-space&c[]=install-service-repair&c[]=animal-ex-food&c[]=legal-service&c[]=voluntary&c[]=construction&c[]=defence&c[]=electricity&c[]=oil-gas-coal&c[]=media&c[]=sports&c[]=insurance&c[]=pharma&c[]=telecoms&c[]=consumer-goods&c[]=diamond&c[]=mining&c[]=justice-including-prisons&c[]=education&c[]=motor-trade&c[]=restaurants-catering&c[]=port-airports&c[]=postal-couriers&c[]=rail-passenger-freight&c[]=import-from-eu&c[]=export-to-eu&c[]=provide-services-do-business-in-eu&c[]=haulage-goods-across-eu-borders&c[]=ip&c[]=ip-copyright&c[]=ip-trade-marks&c[]=ip-designs&c[]=ip-patents&c[]=ip-exhaustion-rights&c[]=sell-public-sector&c[]=sell-public-sector-contracts&c[]=sell-defence-contracts&c[]=eu-uk-funding&c[]=personal-eu-org&c[]=personal-eu-org-process&c[]=personal-eu-org-use&c[]=personal-eu-org-provide&c[]=employ-eu-citizens&c[]=owns-operates-business-organisation&c[]=visiting-driving&c[]=visiting-bring-pet&c[]=visiting-ie&c[]=visiting-eu&c[]=visiting-row&c[]=travel-eu-business&c[]=working-uk&c[]=working-ie&c[]=working-eu&c[]=studying-uk&c[]=studying-ie&c[]=studying-eu&c[]=living-uk&c[]=nationality-uk))
![Screenshot_2019-12-24 Brexit check what you need to do if there is no deal](https://user-images.githubusercontent.com/3694062/71416531-b8f0fc80-2658-11ea-9dc4-6b2c3e73bb1c.png)

- No Results ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results?c[]=nationality-uk) | [heroku](https://finder-frontend-pr-1829.herokuapp.com/get-ready-brexit-check/results?c[]=nationality-uk))
NB. Print link should not appear
![Screenshot_2019-12-24 Brexit check what you need to do if there is no deal(2)](https://user-images.githubusercontent.com/3694062/71416645-3caae900-2659-11ea-9025-5dcc3f70d412.png)

- No Answers ([local dev](http://finder-frontend.dev.gov.uk/get-ready-brexit-check/results) | [heroku](https://finder-frontend-pr-1829.herokuapp.com/get-ready-brexit-check/results))
NB. Print link should not appear
![Screenshot_2019-12-24 Brexit check what you need to do if there is no deal(1)](https://user-images.githubusercontent.com/3694062/71416633-2f8dfa00-2659-11ea-95dd-04e059267ecb.png)