### PR TITLE
Align checkbox facet

### DIFF
--- a/app/views/finders/_checkbox_facet.html.erb
+++ b/app/views/finders/_checkbox_facet.html.erb
@@ -1,17 +1,19 @@
-<div id="<%= checkbox_facet.key %>">
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    name: checkbox_facet.key,
-    margin_bottom: true,
-    small: true,
-    items: [
-      {
-        label: checkbox_facet.name,
-        value: checkbox_facet.value,
-        id: checkbox_facet.id,
-        checked: checkbox_facet.is_checked?,
-        data_attributes: checkbox_facet.data,
-        controls: "js-search-results-info"
-      }
-    ]
-  } %>
+<div class="facet-container">
+  <div id="<%= checkbox_facet.key %>">
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: checkbox_facet.key,
+      margin_bottom: true,
+      small: true,
+      items: [
+        {
+          label: checkbox_facet.name,
+          value: checkbox_facet.value,
+          id: checkbox_facet.id,
+          checked: checkbox_facet.is_checked?,
+          data_attributes: checkbox_facet.data,
+          controls: "js-search-results-info"
+        }
+      ]
+    } %>
+  </div>
 </div>


### PR DESCRIPTION
## What
Align the checkbox facet with other filters

## Why
Visually it looks nicer when it's aligned with the filter toggle and inner checkboxes, but more importantly when #1804 lands, it will make it look much better, as that view has no search box above for alignment reference.

## Visual change
<details>
<summary>Before</summary>
<img width="323" alt="Screenshot 2019-12-26 at 18 27 58" src="https://user-images.githubusercontent.com/3758555/71486544-d23ba980-280e-11ea-9bfc-f2390317e63c.png">

<img width="323" alt="Screenshot 2019-12-26 at 18 28 12" src="https://user-images.githubusercontent.com/3758555/71486545-d23ba980-280e-11ea-8dbf-da81f374cbdf.png">
</details>

<details>
<summary>After</summary>
<img width="324" alt="Screenshot 2019-12-26 at 18 27 37" src="https://user-images.githubusercontent.com/3758555/71486533-bafcbc00-280e-11ea-969c-dc495cefe896.png">

<img width="324" alt="Screenshot 2019-12-26 at 18 28 42" src="https://user-images.githubusercontent.com/3758555/71486534-bb955280-280e-11ea-8efd-1e2cef9d7465.png">
</details>

<details>
<summary>With PR #1804</summary>

### Before

<img width="426" alt="Screenshot 2019-12-26 at 18 45 09" src="https://user-images.githubusercontent.com/3758555/71486801-0794c700-2810-11ea-9fda-6570c06becb0.png">

### After

<img width="426" alt="Screenshot 2019-12-26 at 18 45 37" src="https://user-images.githubusercontent.com/3758555/71486802-0794c700-2810-11ea-9a1b-223206f55134.png">
</details>



## Examples page:
- https://finder-frontend-pr-1830.herokuapp.com/search/news-and-communications

[Trello ticket](https://trello.com/c/eMDR5beW/1244-align-checkbox-facet)
