### PR TITLE
Refactor email signup presenter

### DIFF
--- a/app/helpers/eu_exit_finder_helper.rb
+++ b/app/helpers/eu_exit_finder_helper.rb
@@ -2,8 +2,4 @@ module EuExitFinderHelper
   def self.eu_exit_finder?(content_id)
     content_id == "42ce66de-04f3-4192-bf31-8394538e0734"
   end
-
-  def self.eu_exit_finder_email_signup?(content_id)
-    content_id == "2818d67a-029a-4899-a438-a543d5c6a20d"
-  end
 end

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -25,11 +25,11 @@ class SignupPresenter
   end
 
   def email_filter_by
-    content_item["details"].fetch("email_filter_by", nil)
+    content_item.dig("details", "email_filter_by")
   end
 
   def can_modify_choices?
-    choices? && choices_formatted.any? && content_item["details"]["email_filter_by"] != "all_selected_facets"
+    choices? && choices_formatted.any? && email_filter_by != "all_selected_facets"
   end
 
   def hidden_choices
@@ -47,12 +47,12 @@ class SignupPresenter
   end
 
   def choices?
-    multiple_facet_choice_data.present? || single_facet_choice_data.dig(0, "facet_choices").present?
+    email_filter_facets.present? || single_facet_choice_data.dig(0, "facet_choices").present?
   end
 
   def choices
-    if multiple_facet_choice_data.present? && multiple_facet_choice_data.any?
-      return multiple_facet_choice_data
+    if email_filter_facets.present? && email_filter_facets.any?
+      return email_filter_facets
     end
 
     single_facet_choice_data
@@ -76,10 +76,6 @@ class SignupPresenter
     }.compact
   end
 
-  def target
-    "#"
-  end
-
 private
 
   def facets_with_choices
@@ -96,21 +92,19 @@ private
   end
 
   def single_facet_choice_data
-    facet_id = content_item.dig("details", "email_filter_by")
-
-    return [] if facet_id.nil?
+    return [] if email_filter_by.nil?
 
     [
       {
-        "facet_id" => facet_id,
+        "facet_id" => email_filter_by,
         "facet_name" => single_facet_name,
         "facet_choices" => content_item["details"]["email_signup_choice"],
       },
     ]
   end
 
-  def multiple_facet_choice_data
-    content_item["details"]["email_filter_facets"]
+  def email_filter_facets
+    content_item.dig("details", "email_filter_facets")
   end
 
   def single_facet_name

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -47,15 +47,11 @@ class SignupPresenter
   end
 
   def choices?
-    email_filter_facets.present? || single_facet_choice_data.dig(0, "facet_choices").present?
+    email_filter_facets.present?
   end
 
   def choices
-    if email_filter_facets.present? && email_filter_facets.any?
-      return email_filter_facets
-    end
-
-    single_facet_choice_data
+    email_filter_facets
   end
 
   def choices_formatted
@@ -91,27 +87,8 @@ private
     params.permit(facets_ids).to_h
   end
 
-  def single_facet_choice_data
-    return [] if email_filter_by.nil?
-
-    [
-      {
-        "facet_id" => email_filter_by,
-        "facet_name" => single_facet_name,
-        "facet_choices" => content_item["details"]["email_signup_choice"],
-      },
-    ]
-  end
-
   def email_filter_facets
-    content_item.dig("details", "email_filter_facets")
-  end
-
-  def single_facet_name
-    email_filter_name = content_item["details"]["email_filter_name"]
-    return nil unless email_filter_name
-
-    (email_filter_name["plural"] || email_filter_name).capitalize
+    content_item["details"].fetch("email_filter_facets", [])
   end
 
   def ignore_facet?(facet_id)

--- a/docs/finder-email-alerts.md
+++ b/docs/finder-email-alerts.md
@@ -65,8 +65,7 @@ subscription' page:
 ![](/docs/assets/cma-alerts.png)
 
 In this case, the user can modify the filters that they applied on the finder,
-to change what they will be subscribed to. Rather than using `email_filter_facets`,
-this uses an `email_signup_choice`.
+to change what they will be subscribed to.
 
 ## How do I add or update a finder email alert signup?
 

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -91,56 +91,63 @@
   "description": "You'll get an email each time a case is updated or a new case is published.",
   "details": {
     "beta": false,
-    "email_signup_choice": [
+    "email_filter_facets": [
       {
-        "key": "ca98-and-civil-cartels",
-        "radio_button_name": "CA98 and civil cartels",
-        "topic_name": "CA98 and civil cartels",
-        "prechecked": false
-      },
-      {
-        "key": "competition-disqualification",
-        "radio_button_name": "Competition disqualification",
-        "topic_name": "competition disqualification",
-        "prechecked": false
-      },
-      {
-        "key": "criminal-cartels",
-        "radio_button_name": "Criminal cartels",
-        "topic_name": "criminal cartels",
-        "prechecked": false
-      },
-      {
-        "key": "markets",
-        "radio_button_name": "Markets",
-        "topic_name": "markets",
-        "prechecked": false
-      },
-      {
-        "key": "mergers",
-        "radio_button_name": "Mergers",
-        "topic_name": "mergers",
-        "prechecked": false
-      },
-      {
-        "key": "consumer-enforcement",
-        "radio_button_name": "Consumer enforcement",
-        "topic_name": "consumer enforcement",
-        "prechecked": false
-      },
-      {
-        "key": "regulatory-references-and-appeals",
-        "radio_button_name": "Regulatory references and appeals",
-        "topic_name": "regulatory references and appeals",
-        "prechecked": false
-      },
-      {
-        "key": "review-of-orders-and-undertakings",
-        "radio_button_name": "Reviews of orders and undertakings",
-        "topic_name": "reviews of orders and undertakings",
-        "prechecked": false
+        "facet_id": "case_type",
+        "facet_name": "Case type",
+        "facet_choices": [
+          {
+            "key": "ca98-and-civil-cartels",
+            "radio_button_name": "CA98 and civil cartels",
+            "topic_name": "CA98 and civil cartels",
+            "prechecked": false
+          },
+          {
+            "key": "competition-disqualification",
+            "radio_button_name": "Competition disqualification",
+            "topic_name": "competition disqualification",
+            "prechecked": false
+          },
+          {
+            "key": "criminal-cartels",
+            "radio_button_name": "Criminal cartels",
+            "topic_name": "criminal cartels",
+            "prechecked": false
+          },
+          {
+            "key": "markets",
+            "radio_button_name": "Markets",
+            "topic_name": "markets",
+            "prechecked": false
+          },
+          {
+            "key": "mergers",
+            "radio_button_name": "Mergers",
+            "topic_name": "mergers",
+            "prechecked": false
+          },
+          {
+            "key": "consumer-enforcement",
+            "radio_button_name": "Consumer enforcement",
+            "topic_name": "consumer enforcement",
+            "prechecked": false
+          },
+          {
+            "key": "regulatory-references-and-appeals",
+            "radio_button_name": "Regulatory references and appeals",
+            "topic_name": "regulatory references and appeals",
+            "prechecked": false
+          },
+          {
+            "key": "review-of-orders-and-undertakings",
+            "radio_button_name": "Reviews of orders and undertakings",
+            "topic_name": "reviews of orders and undertakings",
+            "prechecked": false
+          }
+        ]
       }
     ],
+    "email_signup_choice": [],
     "email_filter_by": "case_type",
     "email_filter_name": {
       "singular": "case type",

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -148,10 +148,6 @@
       }
     ],
     "email_filter_by": "case_type",
-    "email_filter_name": {
-      "singular": "case type",
-      "plural": "case types"
-    },
     "subscription_list_title_prefix": {
       "singular": "CMA cases with the following case type: ",
       "plural": "CMA cases with the following case types: ",

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -147,7 +147,6 @@
         ]
       }
     ],
-    "email_signup_choice": [],
     "email_filter_by": "case_type",
     "email_filter_name": {
       "singular": "case type",

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -9,7 +9,6 @@
       "content_purpose_subgroup": ["news", "speeches_and_statements"]
     },
     "email_filter_by": null,
-    "email_filter_name": null,
     "subscription_list_title_prefix": "News and communications ",
     "email_filter_facets": [
       {

--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -9,15 +9,25 @@ describe SignupPresenter do
   describe "single facet" do
     let(:content_item) {
       {
-        "details" =>
-          { "beta" => false,
-           "email_signup_choice" =>
-             [{ "key" => "devices",
-               "radio_button_name" => "Medical device alerts" },
-              { "key" => "drugs",
-                "radio_button_name" => "Drug alerts" }],
-           "email_filter_by" => "alert_type",
-           "email_filter_name" => "Alert Type" },
+        "details" => {
+          "beta" => false,
+          "email_filter_facets" => [
+            {
+              "facet_id" => "alert_type",
+              "facet_name" => "Alert type",
+              "facet_choices" => [
+                {
+                  "key" => "devices",
+                  "radio_button_name" => "Medical device alerts",
+                },
+                {
+                  "key" => "drugs",
+                  "radio_button_name" => "Drug alerts",
+                },
+              ],
+            },
+          ],
+        },
       }
     }
     describe "#choices" do
@@ -58,6 +68,18 @@ describe SignupPresenter do
               "facet_id" => "organisations",
               "facet_name" => "organisations",
             },
+            {
+              "facet_id" => "custom_facet",
+              "facet_name" => "Custom facet",
+              "facet_choices" => [
+                {
+                  "key" => "custom-facet-key-one",
+                  "radio_button_name" => "this is the custom facet",
+                  "topic_name" => "This is the custom facet",
+                  "prechecked" => false,
+                },
+              ],
+            },
           ],
         },
       }
@@ -65,16 +87,30 @@ describe SignupPresenter do
     describe "#choices" do
       it "returns an array of signup facets" do
         expect(SignupPresenter.new(content_item, params).choices).
-          to eq([
+          to eq(
+            [
+              {
+                "facet_id" => "people",
+                "facet_name" => "people",
+              },
+              {
+                "facet_id" => "organisations",
+                "facet_name" => "organisations",
+              },
+              {
+                "facet_id" => "custom_facet",
+                "facet_name" => "Custom facet",
+                "facet_choices" => [
                   {
-                    "facet_id" => "people",
-                    "facet_name" => "people",
+                    "key" => "custom-facet-key-one",
+                    "prechecked" => false,
+                    "radio_button_name" => "this is the custom facet",
+                    "topic_name" => "This is the custom facet",
                   },
-                  {
-                    "facet_id" => "organisations",
-                    "facet_name" => "organisations",
-                  },
-])
+                ],
+              },
+            ],
+          )
       end
     end
     describe "#choices?" do
@@ -83,8 +119,8 @@ describe SignupPresenter do
       end
     end
     describe "#can_modify_choices?" do
-      it "returns false" do
-        expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be false
+      it "returns true" do
+        expect(SignupPresenter.new(content_item, params).can_modify_choices?).to be true
       end
     end
   end
@@ -93,7 +129,7 @@ describe SignupPresenter do
     let(:content_item) {
       {
         "details" => {
-          "email_signup_choice" => [],
+          "email_filter_facets" => [],
         },
       }
     }


### PR DESCRIPTION
This change refactors finder-frontend to reflect changes to specialist publisher (https://github.com/alphagov/specialist-publisher/pull/1555) and content schemas (https://github.com/alphagov/govuk-content-schemas/pull/948).

Those changes make the email signup content items published by Specialist Publisher consistent with those published by Search API.

Making the content items consistent will help us make the signup flow for email subscriptions consistent. It'll also make working with the email signup flow in finder-frontend a bit easier.

Users shouldn't see any differences as a result of this change.

This should be merged and deployed after https://github.com/alphagov/specialist-publisher/pull/1555 is deployed and the content-items republished.

https://trello.com/c/otcTG22f/1246-email-alert-signup-tech-debt

More details about the changes in specialist publisher:

Specialist Publisher used to use other keys for email signup page facets. E.g. it put facets into `details.email_signup_choice` while search api would use `email_filter_facets`. The only reason for this is that we didn't get round to making them consistent.

Two keys are being removed from the finder email signup schema (https://github.com/alphagov/govuk-content-schemas/pull/948): `email_signup_choice` and `email_filter_name`. More could be deleted, like `email_filter_by`, but we can do it later.