### PR TITLE
Fix Capybara warning about 'nil matcher'

### DIFF
--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   def action_is_shown(key)
     action = BrexitChecker::Action.find_by_id(key)
     expect(page).to have_content action.title
-    expect(page).to have_content action.lead_time
+    expect(page).to have_content action.lead_time if action.lead_time
     expect(page).to have_content action.consequence
 
     if action.guidance_link_text

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -37,7 +37,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_the_business_action_header
     and_i_should_see_a_pet_action
     and_i_should_see_a_tourism_action
-    and_the_tourism_link_should_have_tracking_analytics
   end
 
   def then_i_see_business_results_only
@@ -45,7 +44,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_the_business_action_header
     and_i_should_not_see_the_citizens_action_header
     and_i_should_see_a_ce_mark_action
-    and_the_ce_mark_link_should_have_tracking_analytics
   end
 
   def then_i_see_citizens_results_only
@@ -55,7 +53,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_a_pet_action
     and_i_should_not_see_a_tourism_action
-    and_the_pet_link_should_have_tracking_analytics
   end
 
   def and_i_should_see_the_citizens_action_header
@@ -134,7 +131,10 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def and_i_should_see_a_pet_action
-    action_is_shown("S009")
+    action = BrexitChecker::Action.find_by_id("S009")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
+    action_is_shown(action)
+    action_has_analytics(action)
   end
 
   def and_i_should_not_see_a_tourism_action
@@ -142,11 +142,17 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def and_i_should_see_a_tourism_action
-    action_is_shown("T063")
+    action = BrexitChecker::Action.find_by_id("T063")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
+    action_is_shown(action)
+    action_has_analytics(action)
   end
 
   def and_i_should_see_a_ce_mark_action
-    action_is_shown("T001")
+    action = BrexitChecker::Action.find_by_id("T001")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
+    action_is_shown(action)
+    action_has_analytics(action)
   end
 
   def action_not_shown(key)
@@ -154,8 +160,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to_not have_link(action.title, href: action.title_url)
   end
 
-  def action_is_shown(key)
-    action = BrexitChecker::Action.find_by_id(key)
+  def action_is_shown(action)
     expect(page).to have_content action.title
     expect(page).to have_content action.lead_time if action.lead_time
     expect(page).to have_content action.consequence
@@ -165,27 +170,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     end
   end
 
-  def and_the_tourism_link_should_have_tracking_analytics
-    action = BrexitChecker::Action.find_by_id("T063")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.2 - Guidance']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
-  end
-
-  def and_the_ce_mark_link_should_have_tracking_analytics
-    action = BrexitChecker::Action.find_by_id("T001")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-row]")
-  end
-
-  def and_the_pet_link_should_have_tracking_analytics
-    action = BrexitChecker::Action.find_by_id("S009")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.2 - Guidance']")
+  def action_has_analytics(action)
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-category='brexit-checker-results']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-label='#{action.guidance_url}']")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-ecommerce-path='#{action.guidance_path}']")


### PR DESCRIPTION
Previously we were getting a warning due to checking the presence of a nil
lead_time on a page where none was expected.

   warn 'Checking for expected text of nil is confusing and/or pointless
since it will always match. '\
       'Please specify a string or regexp instead.'

---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)