### PR TITLE
Disable popularity option if keywords are given 

### DIFF
--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -37,6 +37,8 @@ private
 
   RELEVANCE_OPTION_TYPES = %w(relevance -relevance).freeze
 
+  POPULARITY_OPTION_TYPES = %w(popularity -popularity).freeze
+
   def has_options?
     content_item_sort_options.any?
   end
@@ -67,7 +69,11 @@ private
   end
 
   def disabled_option_value
-    keywords.blank? && relevance_option.present? ? option_value(relevance_option) : ""
+    if keywords.blank?
+      relevance_option.present? ? option_value(relevance_option) : ""
+    else
+      popularity_option.present? ? option_value(popularity_option) : ""
+    end
   end
 
   def raw_default_option
@@ -76,6 +82,10 @@ private
 
   def relevance_option
     sort_options.find { |option| RELEVANCE_OPTION_TYPES.include?(option["key"]) }
+  end
+
+  def popularity_option
+    sort_options.find { |option| POPULARITY_OPTION_TYPES.include?(option["key"]) }
   end
 
   def option_value(option)

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -20,29 +20,29 @@ RSpec.describe SortPresenter do
 
   let(:sort_options_without_relevance) {
     [
-      { "name" => "Most viewed" },
-      { "name" => "Updated (newest)" },
+      { "name" => "Most viewed", "key" => "-popularity" },
+      { "name" => "Updated (newest)", "key" => "-public_timestamp" },
     ]
   }
 
   let(:sort_options_with_relevance) {
     [
-      { "name" => "Most viewed" },
-      { "name" => "Updated (newest)" },
+      { "name" => "Most viewed", "key" => "-popularity" },
+      { "name" => "Updated (newest)", "key" => "-public_timestamp" },
       { "name" => "Relevance", "key" => "relevance" },
     ]
   }
 
   let(:sort_options_with_default) {
     [
-      { "name" => "Most viewed" },
-      { "name" => "Updated (oldest)", "default" => true },
+      { "name" => "Most viewed", "key" => "-popularity" },
+      { "name" => "Updated (oldest)", "key" => "-public_timestamp", "default" => true },
     ]
   }
 
   let(:sort_options_with_public_timestamp_default) {
     [
-      { "name" => "Most viewed" },
+      { "name" => "Most viewed", "key" => "-popularity" },
       { "name" => "Updated (newest)", "key" => "-public_timestamp", "default" => true },
     ]
   }
@@ -170,7 +170,7 @@ RSpec.describe SortPresenter do
     context "no option is selected by the user" do
       it "returns a default content item sort option" do
         expect(presenter_with_default.selected_option).to eq(
-          "default" => true, "name" => "Updated (oldest)",
+          "default" => true, "name" => "Updated (oldest)", "key" => "-public_timestamp",
         )
       end
     end

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe SortPresenter do
       }[:disabled]).to be true
     end
 
+    it "should enable the popularity option if keywords are not present" do
+      expect(presenter_with_relevance.to_hash[:options].find { |o|
+        o[:value] == "most-viewed"
+      }[:disabled]).to be false
+    end
+
     context "keywords are not blank" do
       let(:values) { { "keywords" => "something not blank" } }
 
@@ -109,6 +115,12 @@ RSpec.describe SortPresenter do
         expect(presenter_with_relevance.to_hash[:options].find { |o|
           o[:value] == "relevance"
         }[:disabled]).to be false
+      end
+
+      it "should disable popularity" do
+        expect(presenter_with_relevance.to_hash[:options].find { |o|
+          o[:value] == "most-viewed"
+        }[:disabled]).to be true
       end
     end
 


### PR DESCRIPTION
We think this is confusing to users, as you can end up on a page which
returns seemingly useless search results despite entering a query.

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1835.herokuapp.com/search/all
- https://finder-frontend-pr-1835.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1835.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1835.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1835.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1835.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1835.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1835.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1835.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1835.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/RaXrl815/1212-kill-the-most-viewed-sort-option)
