### PR TITLE
Allowlist for email alert filters

### DIFF
--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -3,7 +3,7 @@ module Filters
     def call
       [
         {
-          "value" => "published_statistics",
+          "value" => "statistics_published",
           "label" => "Statistics (published)",
           "filter" => {
             "content_store_document_type" => %w(statistics national_statistics statistical_data_set official_statistics),

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -81,10 +81,12 @@ private
   end
 
   def selected_choices
-    facets_ids = choices.each_with_object({}) do |choice, hash|
-      hash[choice["facet_id"].to_sym] = []
+    choices.each_with_object({}) do |choice, hash|
+      key = choice["facet_id"]
+      next unless params.key?(key)
+
+      hash[choice["facet_id"]] = Array(params[key])
     end
-    params.permit(facets_ids).to_h
   end
 
   def email_filter_facets

--- a/app/presenters/statistics_sort_presenter.rb
+++ b/app/presenters/statistics_sort_presenter.rb
@@ -61,7 +61,7 @@ private
     case doc_type
     when "upcoming_statistics"
       :upcoming
-    when "published_statistics"
+    when "statistics_published"
       :public
     when "cancelled_statistics"
       :any

--- a/app/validators/email_alert_params_validator.rb
+++ b/app/validators/email_alert_params_validator.rb
@@ -1,0 +1,25 @@
+class EmailAlertParamsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, filter)
+    unless filter.is_a? Hash
+      record.errors[attribute] << "is not a Hash"
+      return
+    end
+
+    if invalidly_formatted(filter.keys).any?
+      record.errors[attribute] << "has some unprocessable filter keys"
+    end
+
+    if invalidly_formatted(filter.values.flatten).any?
+      record.errors[attribute] << "has some unprocessable filter values"
+    end
+  end
+
+private
+
+  def invalidly_formatted(values)
+    # Allow alphanumerics, hyphens, and some legacy special characters.
+    values.reject { |val|
+      val.to_s.match?(/\A[a-zA-Z0-9\-_]*\z/)
+    }
+  end
+end

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -22,9 +22,9 @@
         items: @signup_presenter.choices_formatted,
         visually_hide_heading: true
       } %>
-      <% if @error_message.present? %>
-        <p class="signup-choices__message"><%= @error_message %></p>
-      <% end %>
+    <% end %>
+    <% if @error_message.present? %>
+      <p class="signup-choices__message"><%= @error_message %></p>
     <% end %>
 
     <% @signup_presenter.hidden_choices.each do |hidden_choice| %>

--- a/features/fixtures/bad_input_email_signup.json
+++ b/features/fixtures/bad_input_email_signup.json
@@ -1,0 +1,77 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/cma-cases/email-signup",
+  "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
+  "document_type": "finder_email_signup",
+  "first_published_at": "2015-08-17T13:28:37.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-12-30T11:14:06.000+00:00",
+  "publishing_app": "specialist-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
+  "title": "Bad input signup page",
+  "updated_at": "2019-12-30T11:21:05.768Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "24198-1577704672.422-10.13.3.248-531",
+  "links": {},
+  "description": "This is for bad inputs.",
+  "details": {
+    "beta": false,
+    "email_filter_facets": [
+      {
+        "facet_id": "evil_value",
+        "facet_name": "Case type",
+        "facet_choices": [
+          {
+            "key": "'><script>alert(1)</script>",
+            "radio_button_name": "Script",
+            "topic_name": "script",
+            "prechecked": false
+          },
+          {
+            "key": "good_value",
+            "radio_button_name": "Script",
+            "topic_name": "script",
+            "prechecked": false
+          }
+        ]
+      },
+      {
+        "facet_id": "evil_key'><script>alert(1)</script>",
+        "facet_name": "Case type",
+        "facet_choices": [
+          {
+            "key": "'><script>alert(1)</script>",
+            "radio_button_name": "Script",
+            "topic_name": "script",
+            "prechecked": false
+          },
+          {
+            "key": "markets",
+            "radio_button_name": "Markets",
+            "topic_name": "markets",
+            "prechecked": false
+          },
+          {
+            "key": "mergers",
+            "radio_button_name": "Mergers",
+            "topic_name": "mergers",
+            "prechecked": false
+          }
+        ]
+      }
+    ],
+    "email_filter_by": "case_type",
+    "filter": {
+      "document_type": "cma_case"
+    },
+    "subscription_list_title_prefix": {
+      "singular": "CMA cases with the following case type: ",
+      "plural": "CMA cases with the following case types: ",
+      "many": "Competition and Markets Authority (CMA) cases: "
+    }
+  }
+}

--- a/features/fixtures/business_readiness_email_signup.json
+++ b/features/fixtures/business_readiness_email_signup.json
@@ -1,9 +1,40 @@
 {
+  "analytics_identifier": null,
   "base_path": "/find-eu-exit-guidance-business/email-signup",
   "content_id": "2818d67a-029a-4899-a438-a543d5c6a20d",
   "document_type": "finder_email_signup",
-  "title": "Find EU Exit guidance for your business",
-  "description": "You'll get an email each time EU Exit guidance is published.",
+  "title": "Find Brexit guidance for your business",
+  "description": "Sign up for email alerts to Brexit guidance for businesses.",
+  "first_published_at": "2018-12-19T14:34:00.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-08-07T15:28:24.000+00:00",
+  "publishing_app": "search-api",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
+  "updated_at": "2019-08-07T15:28:26.211Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "29327-1565191705.320-10.3.3.1-390",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Find Brexit guidance for your business",
+        "public_updated_at": "2019-08-07T15:28:24Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/find-eu-exit-guidance-business/email-signup",
+        "api_path": "/api/content/find-eu-exit-guidance-business/email-signup",
+        "withdrawn": false,
+        "content_id": "2818d67a-029a-4899-a438-a543d5c6a20d",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/find-eu-exit-guidance-business/email-signup",
+        "web_url": "https://www.gov.uk/find-eu-exit-guidance-business/email-signup",
+        "links": {}
+      }
+    ]
+  },
   "details": {
     "email_filter_by": "facet_values",
     "email_filter_facets": [
@@ -21,15 +52,15 @@
           {
             "key": "aerospace",
             "content_id": "24fd50fa-6619-46ca-96cd-8ce90fa076ce",
-            "radio_button_name": "Aerospace",
-            "topic_name": "Aerospace",
+            "radio_button_name": "Aerospace and space",
+            "topic_name": "Aerospace and space",
             "prechecked": false
           },
           {
-            "key": "agriculture",
-            "content_id": "94b3cfe2-af89-4744-b8d7-7fc79edcbc85",
-            "radio_button_name": "Agriculture and forestry (including wholesale)",
-            "topic_name": "Agriculture and forestry (including wholesale)",
+            "key": "agriculture-and-farming",
+            "content_id": "9d54c591-f5ca-4d0c-a484-12d5591987cb",
+            "radio_button_name": "Agriculture and farming",
+            "topic_name": "Agriculture and farming",
             "prechecked": false
           },
           {
@@ -37,6 +68,13 @@
             "content_id": "43d328b3-59ee-4d5d-bda0-7c7d4bb301be",
             "radio_button_name": "Air freight and air passenger services",
             "topic_name": "Air freight and air passenger services",
+            "prechecked": false
+          },
+          {
+            "key": "animals-and-animal-products",
+            "content_id": "769b6a0c-9d64-45a4-850a-a8f7cfd5b60e",
+            "radio_button_name": "Animals and animal products (excluding food)",
+            "topic_name": "Animals and animal products (excluding food)",
             "prechecked": false
           },
           {
@@ -54,13 +92,6 @@
             "prechecked": false
           },
           {
-            "key": "auxiliary-activities",
-            "content_id": "5faa1741-fc55-4110-b342-de92f6324118",
-            "radio_button_name": "Auxiliary activities",
-            "topic_name": "Auxiliary activities",
-            "prechecked": false
-          },
-          {
             "key": "charities",
             "content_id": "05334231-9be3-4670-a2f5-84bef7e3badd",
             "radio_button_name": "Charities",
@@ -69,30 +100,9 @@
           },
           {
             "key": "chemicals",
-            "content_id": "7620da7a-0427-4b3c-9498-db9dc25209b",
+            "content_id": "7620da7a-0427-4b3c-9498-db9dc25209b0",
             "radio_button_name": "Chemicals",
             "topic_name": "Chemicals",
-            "prechecked": false
-          },
-          {
-            "key": "clothing-consumer-goods",
-            "content_id": "1e3e8abd-135d-4844-afa8-5c51df3d3c57",
-            "radio_button_name": "Clothing and consumer goods",
-            "topic_name": "Clothing and consumer goods",
-            "prechecked": false
-          },
-          {
-            "key": "clothing-consumer-goods-manufacturing",
-            "content_id": "a7263c3b-7ade-4a91-9f51-40ebc57b3f98",
-            "radio_button_name": "Clothing and consumer goods manufacture",
-            "topic_name": "Clothing and consumer goods manufacture",
-            "prechecked": false
-          },
-          {
-            "key": "computer-services",
-            "content_id": "70e6087f-714e-4922-8e06-72cfff997785",
-            "radio_button_name": "Digital, technology and computer services",
-            "topic_name": "Digital, technology and computer services",
             "prechecked": false
           },
           {
@@ -114,6 +124,20 @@
             "content_id": "77764805-73e6-4d47-9f20-aedd6de7dab9",
             "radio_button_name": "Defence",
             "topic_name": "Defence",
+            "prechecked": false
+          },
+          {
+            "key": "diamonds",
+            "content_id": "a68e08f2-6728-4f1d-bb90-514e733db8de",
+            "radio_button_name": "Diamonds",
+            "topic_name": "Diamonds",
+            "prechecked": false
+          },
+          {
+            "key": "computer-services",
+            "content_id": "70e6087f-714e-4922-8e06-72cfff997785",
+            "radio_button_name": "Digital, technology and computer services",
+            "topic_name": "Digital, technology and computer services",
             "prechecked": false
           },
           {
@@ -161,22 +185,8 @@
           {
             "key": "food-and-drink",
             "content_id": "53f9ce4c-7cbb-447f-bdf1-a9b022896d3a",
-            "radio_button_name": "Food, drink and tobacco (retail and wholesale)",
-            "topic_name": "Food, drink and tobacco (retail and wholesale)",
-            "prechecked": false
-          },
-          {
-            "key": "food-drink-tobacco",
-            "content_id": "9f3476e1-8ff0-455d-a14e-003236b2797c",
-            "radio_button_name": "Food, drink and tobacco (processing)",
-            "topic_name": "Food, drink and tobacco (processing)",
-            "prechecked": false
-          },
-          {
-            "key": "furniture-manufacture",
-            "content_id": "040649fc-4e2c-4028-b846-77fe3eebd1f7",
-            "radio_button_name": "Furniture manufacture",
-            "topic_name": "Furniture manufacture",
+            "radio_button_name": "Food, drink and tobacco",
+            "topic_name": "Food, drink and tobacco",
             "prechecked": false
           },
           {
@@ -215,17 +225,17 @@
             "prechecked": false
           },
           {
-            "key": "marine",
-            "content_id": "18c3892e-8a0e-4884-906e-5938380eceee",
-            "radio_button_name": "Marine",
-            "topic_name": "Marine",
+            "key": "clothing-consumer-goods-manufacturing",
+            "content_id": "a7263c3b-7ade-4a91-9f51-40ebc57b3f98",
+            "radio_button_name": "Manufacturing of consumer goods",
+            "topic_name": "Manufacturing of consumer goods",
             "prechecked": false
           },
           {
-            "key": "marine-transport",
-            "content_id": "356f46a0-17d3-4ba4-8952-8c02244f904",
-            "radio_button_name": "Marine transport",
-            "topic_name": "Marine transport",
+            "key": "marine",
+            "content_id": "18c3892e-8a0e-4884-906e-5938380eceee",
+            "radio_button_name": "Marine and marine transport",
+            "topic_name": "Marine and marine transport",
             "prechecked": false
           },
           {
@@ -278,31 +288,10 @@
             "prechecked": false
           },
           {
-            "key": "other-advanced-manufacturing",
-            "content_id": "14cf2a68-3297-44d3-ba01-a4426845b1b8",
-            "radio_button_name": "Other advanced manufacturing",
-            "topic_name": "Other advanced manufacturing",
-            "prechecked": false
-          },
-          {
             "key": "oil-gas-coal",
             "content_id": "46ad5a1d-fc2d-4065-a34f-3f7b2fea8e81",
             "radio_button_name": "Oil, gas and coal",
             "topic_name": "Oil, gas and coal",
-            "prechecked": false
-          },
-          {
-            "key": "other-energy",
-            "content_id": "2c562ab5-7891-4a00-8510-a5ebdb4001c8",
-            "radio_button_name": "Other energy",
-            "topic_name": "Other energy",
-            "prechecked": false
-          },
-          {
-            "key": "other-manufacturing",
-            "content_id": "7536c0c4-fb41-43f4-a2c4-08f4fa9f5427",
-            "radio_button_name": "Other manufacturing",
-            "topic_name": "Other manufacturing",
             "prechecked": false
           },
           {
@@ -315,8 +304,15 @@
           {
             "key": "pharmaceuticals",
             "content_id": "93f5c156-2449-4e52-9e92-aefc73586ffd",
-            "radio_button_name": "Pharmaceuticals",
-            "topic_name": "Pharmaceuticals",
+            "radio_button_name": "Pharmaceuticals and clinical trials",
+            "topic_name": "Pharmaceuticals and clinical trials",
+            "prechecked": false
+          },
+          {
+            "key": "plants-and-forestry",
+            "content_id": "afd45eef-743a-417d-9245-3eab8322116d",
+            "radio_button_name": "Plants and forestry",
+            "topic_name": "Plants and forestry",
             "prechecked": false
           },
           {
@@ -336,8 +332,8 @@
           {
             "key": "professional-and-business-services",
             "content_id": "f07527f1-e6de-4fe8-b7d9-b197769e1f1f",
-            "radio_button_name": "Professional and business services",
-            "topic_name": "Professional and business services",
+            "radio_button_name": "Professional, legal and business services",
+            "topic_name": "Professional, legal and business services",
             "prechecked": false
           },
           {
@@ -350,8 +346,8 @@
           {
             "key": "rail",
             "content_id": "53bcfcf0-e22a-416d-91ac-2661e1d6ed04",
-            "radio_button_name": "Rail",
-            "topic_name": "Rail",
+            "radio_button_name": "Rail (manufacture)",
+            "topic_name": "Rail (manufacture)",
             "prechecked": false
           },
           {
@@ -369,10 +365,10 @@
             "prechecked": false
           },
           {
-            "key": "repair-of-computers-consumer-goods",
-            "content_id": "c1d8057c-76bf-431c-9ac8-6281a4b7b9ca",
-            "radio_button_name": "Repair of computers and consumer goods",
-            "topic_name": "Repair of computers and consumer goods",
+            "key": "other-energy",
+            "content_id": "2c562ab5-7891-4a00-8510-a5ebdb4001c8",
+            "radio_button_name": "Renewable energy",
+            "topic_name": "Renewable energy",
             "prechecked": false
           },
           {
@@ -392,8 +388,8 @@
           {
             "key": "retail",
             "content_id": "34a6edd0-46ea-4a76-ae80-8c96709d4f59",
-            "radio_button_name": "Retail and wholesale (excluding motor trade, food and drink)",
-            "topic_name": "Retail and wholesale (excluding motor trade, food and drink)",
+            "radio_button_name": "Retail and wholesale (excluding food, drink and motors)",
+            "topic_name": "Retail and wholesale (excluding food, drink and motors)",
             "prechecked": false
           },
           {
@@ -401,13 +397,6 @@
             "content_id": "6f5f8dbb-3cd3-475d-8f3a-ed6e22d370be",
             "radio_button_name": "Road (passengers and freight)",
             "topic_name": "Road (passengers and freight)",
-            "prechecked": false
-          },
-          {
-            "key": "space",
-            "content_id": "b4e507df-f067-4749-9468-3de120775216",
-            "radio_button_name": "Space",
-            "topic_name": "Space",
             "prechecked": false
           },
           {
@@ -441,8 +430,8 @@
           {
             "key": "voluntary-community-organisations",
             "content_id": "c66d8196-977f-47a5-806f-885c9cf01412",
-            "radio_button_name": "Voluntary and community organistions",
-            "topic_name": "Voluntary and community organistions",
+            "radio_button_name": "Voluntary and community organisations",
+            "topic_name": "Voluntary and community organisations",
             "prechecked": false
           },
           {
@@ -461,8 +450,8 @@
           {
             "key": "products-or-goods",
             "content_id": "a55f04df-3877-4c73-bbfe-ad7339cdfccf",
-            "radio_button_name": "Sell goods or provide services in the UK ",
-            "topic_name": "Sell goods or provide services in the UK ",
+            "radio_button_name": "Sell goods or provide services in the UK",
+            "topic_name": "Sell goods or provide services in the UK",
             "prechecked": false
           },
           {
@@ -492,6 +481,13 @@
             "radio_button_name": "Haulage of goods across EU borders",
             "topic_name": "Haulage of goods across EU borders",
             "prechecked": false
+          },
+          {
+            "key": "none-of-these",
+            "content_id": "c35c2e8c-f88e-42e0-83ed-62e896aafd92",
+            "radio_button_name": "None of these",
+            "topic_name": "None of these",
+            "prechecked": false
           }
         ]
       },
@@ -502,15 +498,15 @@
           {
             "key": "yes",
             "content_id": "5476f0c7-d029-459b-8a17-196374ae3366",
-            "radio_button_name": "EU citizens",
-            "topic_name": "EU citizens",
+            "radio_button_name": "EU or EEA citizens",
+            "topic_name": "EU or EEA citizens",
             "prechecked": false
           },
           {
             "key": "no",
             "content_id": "bbdbda71-b1ec-46b8-a5b8-931d933288e9",
-            "radio_button_name": "Non-EU citizens",
-            "topic_name": "No EU citizens",
+            "radio_button_name": "No EU or EEA citizens",
+            "topic_name": "No EU or EEA citizens",
             "prechecked": false
           }
         ]
@@ -610,8 +606,8 @@
           {
             "key": "civil-government-contracts",
             "content_id": "f165dc7c-7cef-446a-bdfd-8a1ca685d091",
-            "radio_button_name": "Civil government contracts",
-            "topic_name": "Civil government contracts",
+            "radio_button_name": "Public sector contracts",
+            "topic_name": "Public sector contracts",
             "prechecked": false
           },
           {
@@ -624,6 +620,6 @@
         ]
       }
     ],
-    "subscription_list_title_prefix": "EU Exit guidance for your business"
+    "subscription_list_title_prefix": "Find Brexit guidance for your business"
   }
 }

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -6,30 +6,27 @@
   "first_published_at": "2015-08-17T13:28:37.000+00:00",
   "locale": "en",
   "phase": "live",
-  "public_updated_at": "2019-06-26T13:50:02.000+00:00",
+  "public_updated_at": "2019-12-30T11:14:06.000+00:00",
   "publishing_app": "specialist-publisher",
   "publishing_scheduled_at": null,
   "rendering_app": "finder-frontend",
   "scheduled_publishing_delay_seconds": null,
   "schema_name": "finder_email_signup",
   "title": "Competition and Markets Authority cases",
-  "updated_at": "2019-07-19T11:59:45.822Z",
-  "withdrawn_notice": {
-
-  },
-  "publishing_request_id": "18907-1561557105.583-10.3.3.1-400",
+  "updated_at": "2019-12-30T11:21:05.768Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "24198-1577704672.422-10.13.3.248-531",
   "links": {
     "organisations": [
       {
+        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
+        "title": "Competition and Markets Authority",
+        "locale": "en",
         "analytics_identifier": "D550",
         "api_path": "/api/content/government/organisations/competition-and-markets-authority",
         "base_path": "/government/organisations/competition-and-markets-authority",
-        "content_id": "957eb4ec-089b-4f71-ba2a-dc69ac8919ea",
-        "description": "We work to promote competition for the benefit of consumers, both within and outside the UK. We have staff in London, Edinburgh, Belfast and Cardiff. CMA is a non-ministerial department.",
         "document_type": "organisation",
-        "locale": "en",
         "schema_name": "organisation",
-        "title": "Competition and Markets Authority",
         "withdrawn": false,
         "details": {
           "logo": {
@@ -42,28 +39,23 @@
           "brand": "department-for-business-innovation-skills",
           "default_news_image": null
         },
-        "links": {
-
-        },
+        "links": {},
         "api_url": "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
         "web_url": "https://www.gov.uk/government/organisations/competition-and-markets-authority"
       }
     ],
     "related": [
       {
+        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
+        "title": "Competition and Markets Authority cases",
+        "locale": "en",
         "api_path": "/api/content/cma-cases",
         "base_path": "/cma-cases",
-        "content_id": "fef4ac7c-024a-4943-9f19-e85a8369a1f3",
-        "description": "Find reports and updates on current and historical CMA investigations",
         "document_type": "finder",
-        "locale": "en",
-        "public_updated_at": "2019-06-26T13:50:02Z",
+        "public_updated_at": "2019-12-30T11:14:06Z",
         "schema_name": "finder",
-        "title": "Competition and Markets Authority cases",
         "withdrawn": false,
-        "links": {
-
-        },
+        "links": {},
         "api_url": "https://www.gov.uk/api/content/cma-cases",
         "web_url": "https://www.gov.uk/cma-cases"
       }
@@ -71,20 +63,17 @@
     "available_translations": [
       {
         "title": "Competition and Markets Authority cases",
-        "public_updated_at": "2019-06-26T13:50:02Z",
+        "public_updated_at": "2019-12-30T11:14:06Z",
         "document_type": "finder_email_signup",
         "schema_name": "finder_email_signup",
         "base_path": "/cma-cases/email-signup",
-        "description": "You'll get an email each time a case is updated or a new case is published.",
         "api_path": "/api/content/cma-cases/email-signup",
         "withdrawn": false,
         "content_id": "43dd2b13-93ec-4ca6-a7a4-e2eb5f5d485a",
         "locale": "en",
         "api_url": "https://www.gov.uk/api/content/cma-cases/email-signup",
         "web_url": "https://www.gov.uk/cma-cases/email-signup",
-        "links": {
-
-        }
+        "links": {}
       }
     ]
   },
@@ -148,6 +137,9 @@
       }
     ],
     "email_filter_by": "case_type",
+    "filter": {
+      "document_type": "cma_case"
+    },
     "subscription_list_title_prefix": {
       "singular": "CMA cases with the following case type: ",
       "plural": "CMA cases with the following case types: ",

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -1,14 +1,49 @@
 {
+  "analytics_identifier": null,
   "base_path": "/search/news-and-communications/email-signup",
   "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
   "document_type": "finder_email_signup",
+  "first_published_at": "2019-02-05T11:50:59.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-08-06T12:01:40.000+00:00",
+  "publishing_app": "search-api",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
   "title": "News and communications",
+  "updated_at": "2019-08-06T12:01:42.473Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "868-1565092901.450-10.3.3.1-390",
+  "links": {
+    "available_translations": [
+      {
+        "title": "News and communications",
+        "public_updated_at": "2019-08-06T12:01:40Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/search/news-and-communications/email-signup",
+        "api_path": "/api/content/search/news-and-communications/email-signup",
+        "withdrawn": false,
+        "content_id": "54fa4dca-4dfb-40a5-b860-127716f02e75",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/news-and-communications/email-signup",
+        "web_url": "https://www.gov.uk/search/news-and-communications/email-signup",
+        "links": {}
+      }
+    ]
+  },
   "description": "You'll get an email each time news or communications are published.",
   "details": {
     "filter": {
-      "content_purpose_subgroup": ["news", "speeches_and_statements"]
+      "content_purpose_subgroup": [
+        "news",
+        "speeches_and_statements"
+      ]
     },
     "email_filter_by": null,
+    "email_filter_name": null,
     "subscription_list_title_prefix": "News and communications ",
     "email_filter_facets": [
       {
@@ -20,12 +55,13 @@
         "facet_name": "organisations"
       },
       {
-        "facet_id": "document_type",
-        "facet_name": "document types"
-      },
-      {
         "facet_id": "world_locations",
         "facet_name": "world locations"
+      },
+      {
+        "facet_id": "topic",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
       },
       {
         "facet_id": "level_one_taxon",

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -1,28 +1,22 @@
 {
-  "analytics_identifier":null,
-  "base_path":"/search/policy-papers-and-consultations",
-  "content_id":"622e9691-4b4f-4e9c-bce1-098b0c4f5ee2",
-  "content_purpose_document_supertype":"navigation",
-  "document_type":"finder",
-  "email_document_supertype":"other",
-  "first_published_at":"2018-11-07T14:47:48.000+00:00",
-  "government_document_supertype":"other",
-  "locale":"en",
-  "navigation_document_supertype":"other",
-  "phase":"alpha",
-  "public_updated_at":"2018-11-07T14:47:48.000+00:00",
-  "publishing_app":"finder-frontend",
-  "rendering_app":"finder-frontend",
-  "schema_name":"finder",
-  "search_user_need_document_supertype":"government",
-  "title":"Policy papers and consultations",
-  "updated_at":"2018-11-07T14:47:48.000+00:00",
-  "user_journey_document_supertype":"finding",
-  "withdrawn_notice":{
-
-  },
-  "publishing_request_id":"",
-  "links":{
+  "analytics_identifier": null,
+  "base_path": "/search/policy-papers-and-consultations",
+  "content_id": "45bb9f22-096a-4e4c-a39e-04a65ff82da7",
+  "document_type": "finder",
+  "first_published_at": "2019-03-13T11:59:20.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-08-06T12:01:43.000+00:00",
+  "publishing_app": "search-api",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder",
+  "title": "Policy papers and consultations",
+  "updated_at": "2019-08-06T13:56:49.039Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "20171-1565092905.023-10.3.3.1-390",
+  "links": {
     "email_alert_signup": [
       {
         "api_path": "/api/content/search/policy-papers-and-consultations/email-signup",
@@ -30,24 +24,42 @@
         "content_id": "5a4dc517-57cf-4dd6-873f-f1d29f6d540c",
         "document_type": "finder_email_signup",
         "locale": "en",
-        "public_updated_at": "2019-03-06T10:22:17Z",
+        "public_updated_at": "2019-08-06T12:01:43Z",
         "schema_name": "finder_email_signup",
         "title": "Policy papers and consultations",
         "withdrawn": false,
         "links": {},
-        "api_url": "https://www.gov.uk/api/content/policy-papers-and-consultations/email-signup",
-        "web_url": "/search/policy-papers-and-consultations/email-signup"
+        "api_url": "https://www.gov.uk/api/content/search/policy-papers-and-consultations/email-signup",
+        "web_url": "https://www.gov.uk/search/policy-papers-and-consultations/email-signup"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Policy papers and consultations",
+        "public_updated_at": "2019-08-06T12:01:43Z",
+        "document_type": "finder",
+        "schema_name": "finder",
+        "base_path": "/search/policy-papers-and-consultations",
+        "api_path": "/api/content/search/policy-papers-and-consultations",
+        "withdrawn": false,
+        "content_id": "45bb9f22-096a-4e4c-a39e-04a65ff82da7",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/policy-papers-and-consultations",
+        "web_url": "https://www.gov.uk/search/policy-papers-and-consultations",
+        "links": {}
       }
     ]
   },
-  "description":"Find policy papers and consultations from government",
-  "details":{
-    "document_noun":"result",
-    "filter":{
-      "content_purpose_supergroup":"policy_and_engagement"
+  "description": "Find policy papers and consultations from government",
+  "details": {
+    "document_noun": "result",
+    "filter": {
+      "content_purpose_supergroup": [
+        "policy_and_engagement"
+      ]
     },
-    "format_name":"document",
-    "show_summaries":true,
+    "format_name": "document",
+    "show_summaries": true,
     "sort": [
       {
         "name": "Most viewed",
@@ -67,10 +79,14 @@
         "key": "public_timestamp"
       }
     ],
-    "facets":[
+    "facets": [
       {
+        "key": "_unused",
         "filter_key": "all_part_of_taxonomy_tree",
-        "keys": ["level_one_taxon", "level_two_taxon"],
+        "keys": [
+          "level_one_taxon",
+          "level_two_taxon"
+        ],
         "name": "topic",
         "short_name": "topic",
         "type": "taxon",
@@ -79,26 +95,35 @@
         "preposition": "about"
       },
       {
-        "filter_key": "all_part_of_taxonomy_tree",
         "key": "topic",
+        "filter_key": "all_part_of_taxonomy_tree",
         "name": "topic",
         "short_name": "topic",
         "type": "hidden",
         "display_as_result_metadata": false,
-        "filterable":true,
-        "hide_facet_tag":true
+        "hide_facet_tag": true,
+        "filterable": true
       },
       {
         "key": "content_store_document_type",
         "name": "Document type",
         "preposition": "of type",
-        "type":"text",
+        "type": "text",
         "display_as_result_metadata": false,
         "filterable": true,
         "option_lookup": {
-          "policy_papers": ["impact_assessment", "case_study", "policy_paper"],
-          "open_consultations": ["open_consultation"],
-          "closed_consultations": ["closed_consultation", "consultation_outcome"]
+          "policy_papers": [
+            "impact_assessment",
+            "case_study",
+            "policy_paper"
+          ],
+          "open_consultations": [
+            "open_consultation"
+          ],
+          "closed_consultations": [
+            "closed_consultation",
+            "consultation_outcome"
+          ]
         },
         "allowed_values": [
           {
@@ -142,8 +167,19 @@
         "type": "date",
         "display_as_result_metadata": true,
         "filterable": true
+      },
+      {
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "topical_events",
+        "name": "Topical event",
+        "preposition": "about",
+        "short_name": "about",
+        "type": "hidden",
+        "show_option_select_filter": false,
+        "allowed_values": []
       }
     ],
-    "default_documents_per_page":20
+    "default_documents_per_page": 20
   }
 }

--- a/features/fixtures/policy_papers_and_consultations_email_signup.json
+++ b/features/fixtures/policy_papers_and_consultations_email_signup.json
@@ -1,0 +1,93 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/search/policy-papers-and-consultations/email-signup",
+  "content_id": "5a4dc517-57cf-4dd6-873f-f1d29f6d540c",
+  "document_type": "finder_email_signup",
+  "first_published_at": "2019-03-13T11:59:19.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-08-06T12:01:43.000+00:00",
+  "publishing_app": "search-api",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
+  "title": "Policy papers and consultations",
+  "updated_at": "2019-08-06T12:01:45.488Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "20169-1565092904.286-10.3.3.1-390",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Policy papers and consultations",
+        "public_updated_at": "2019-08-06T12:01:43Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/search/policy-papers-and-consultations/email-signup",
+        "api_path": "/api/content/search/policy-papers-and-consultations/email-signup",
+        "withdrawn": false,
+        "content_id": "5a4dc517-57cf-4dd6-873f-f1d29f6d540c",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/policy-papers-and-consultations/email-signup",
+        "web_url": "https://www.gov.uk/search/policy-papers-and-consultations/email-signup",
+        "links": {}
+      }
+    ]
+  },
+  "description": "You'll get an email each time content is published.",
+  "details": {
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Policy papers and consultations",
+    "filter": {
+      "content_purpose_supergroup": "policy_and_engagement"
+    },
+    "email_filter_facets": [
+      {
+        "facet_id": "people",
+        "facet_name": "people"
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "content_store_document_type",
+        "facet_name": "document types",
+        "option_lookup": {
+          "policy_papers": [
+            "impact_assessment",
+            "case_study",
+            "policy_paper"
+          ],
+          "open_consultations": [
+            "open_consultation"
+          ],
+          "closed_consultations": [
+            "closed_consultation",
+            "consultation_outcome"
+          ]
+        }
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "topic",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/features/fixtures/research_and_statistics_email_signup.json
+++ b/features/fixtures/research_and_statistics_email_signup.json
@@ -1,0 +1,98 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/search/research-and-statistics/email-signup",
+  "content_id": "119db584-0ae7-45e4-8f3a-fd79316c6921",
+  "document_type": "finder_email_signup",
+  "first_published_at": "2019-03-18T15:41:25.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2019-08-06T12:01:45.000+00:00",
+  "publishing_app": "search-api",
+  "publishing_scheduled_at": null,
+  "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "finder_email_signup",
+  "title": "Research and statistics",
+  "updated_at": "2019-08-06T12:01:46.728Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "16215-1565092905.674-10.3.3.1-390",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Research and statistics",
+        "public_updated_at": "2019-08-06T12:01:45Z",
+        "document_type": "finder_email_signup",
+        "schema_name": "finder_email_signup",
+        "base_path": "/search/research-and-statistics/email-signup",
+        "api_path": "/api/content/search/research-and-statistics/email-signup",
+        "withdrawn": false,
+        "content_id": "119db584-0ae7-45e4-8f3a-fd79316c6921",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/search/research-and-statistics/email-signup",
+        "web_url": "https://www.gov.uk/search/research-and-statistics/email-signup",
+        "links": {}
+      }
+    ]
+  },
+  "description": "<p>You can't subscribe to get email notifications about upcoming statistics.</p><p>Subscribe to published statistics to get an email every time statistics are published or updated.</p>",
+  "details": {
+    "email_filter_by": null,
+    "email_filter_name": null,
+    "subscription_list_title_prefix": "Statistics",
+    "filter": {},
+    "email_filter_facets": [
+      {
+        "facet_id": "content_store_document_type",
+        "facet_name": "Research and statistics",
+        "facet_choices": [
+          {
+            "key": "statistics_published",
+            "filter_values": [
+              "statistics",
+              "national_statistics",
+              "statistical_data_set",
+              "official_statistics"
+            ],
+            "radio_button_name": "Statistics (published)",
+            "topic_name": "Statistics (published)",
+            "prechecked": false
+          },
+          {
+            "key": "research",
+            "filter_values": [
+              "dfid_research_output",
+              "independent_report",
+              "research"
+            ],
+            "radio_button_name": "Research",
+            "topic_name": "Research",
+            "prechecked": false
+          }
+        ]
+      },
+      {
+        "facet_id": "organisations",
+        "facet_name": "organisations"
+      },
+      {
+        "facet_id": "world_locations",
+        "facet_name": "world locations"
+      },
+      {
+        "facet_id": "topic",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_one_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      },
+      {
+        "facet_id": "level_two_taxon",
+        "filter_key": "all_part_of_taxonomy_tree",
+        "facet_name": "topics"
+      }
+    ]
+  }
+}

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -40,7 +40,7 @@ module RummagerUrlHelper
 
   def policy_papers_params
     base_search_params.merge(
-      "filter_content_purpose_supergroup" => "policy_and_engagement",
+      "filter_content_purpose_supergroup" => %w(policy_and_engagement),
       "count" => "20",
       "order" => "-public_timestamp",
     )

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -48,6 +48,7 @@ private
   end
 
   def link_based_subscriber_list?
+    # TODO: move this logic into schema
     content_types = %w[organisations people world_locations part_of_taxonomy_tree]
     keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, "") }
     (keys & content_types).present?
@@ -57,7 +58,11 @@ private
     selected_keys = applied_filters.keys.map(&:to_s) & facet_filter_keys
     filter_links = selected_keys.each_with_object({}) do |full_key, result|
       operator, key = split_key(full_key)
-      values = Array.wrap(applied_filters[full_key.to_sym])
+      applied_values = Array.wrap(applied_filters[full_key.to_sym])
+      facet = facet_by_key(key) || {}
+      facet_choice_values = facet_choice_filter_values(facet, applied_values)
+      values = facet_choice_values.any? ? facet_choice_values : applied_values
+
       result[key] ||= {}
       result[key][operator] = to_content_ids(key, values)
     end

--- a/lib/parameter_parser/email_alert_parameter_parser.rb
+++ b/lib/parameter_parser/email_alert_parameter_parser.rb
@@ -1,0 +1,98 @@
+# Ensures that email alert filter keys and values provided by users
+# and that Finder Frontend sends to Email Alert API are within the
+# set of permitted keys and values provided in the content item or
+# registries of people, organisations, taxons, and world locations.
+module ParameterParser
+  class EmailAlertParameterParser
+    include ActiveModel::Validations
+
+    validates :applied_filters, email_alert_params: true
+
+    def initialize(content_item, filter_params, params)
+      @content_item = content_item
+      @filter_params = parsed_params(filter_params, params).deep_stringify_keys
+    end
+
+    def applied_filters
+      @applied_filters ||= begin
+        permitted_filter_keys.each_with_object({}) { |key, filter_hash|
+          filter_hash[key] = permitted_values_for_filter_key(key)
+        }.compact
+      end
+    end
+
+  private
+
+    attr_reader :filter_params, :content_item
+
+    def permitted_facets
+      content_item.dig("details", "email_filter_facets") || []
+    end
+
+    def permitted_filter_keys
+      allowed = permitted_facets.map { |facet| key_for_facet(facet) }
+      given = filter_params.keys
+      allowed & given
+    end
+
+    def permitted_values_for_filter_key(key)
+      facet = find_facet_by_key(key)
+      return if facet.blank?
+
+      given_values = Array(filter_params[key])
+      allowed_values = allowed_values_for_facet(facet)
+      permitted = allowed_values & given_values
+      permitted if permitted.any?
+    end
+
+    def find_facet_by_key(key)
+      permitted_facets.find { |facet| key_for_facet(facet) == key }
+    end
+
+    def key_for_facet(facet)
+      facet["filter_key"] || facet["facet_id"]
+    end
+
+    # TODO: this could be improved upon
+    def allowed_values_for_facet(facet)
+      # Facet choices used by /cma-cases/email-signup
+      facet_choices = facet.fetch("facet_choices", [])
+      facet_choice_values = facet_choices
+        .map { |choice| choice["content_id"] || choice["key"] }
+        .uniq
+        .compact
+
+      return facet_choice_values if facet_choice_values.any?
+
+      # Option lookup used by /search/policy-papers-and-consultations/email-signup
+      # TODO: remove option_lookup and make it consistent with other finders.
+      option_lookup = facet.dig("option_lookup")
+      return option_lookup.values.flatten if option_lookup.present?
+
+      # Dynamic facets, such as people or organisations, used by
+      # /search/news-and-communications/email-signup
+      # TODO: Put is_a_dynamic_facet: bool into the content item schema
+      key = key_for_facet(facet)
+      if facet_choices.none? && could_be_a_dynamic_facet?(key)
+        registry = Registries::BaseRegistries.new.all[key]
+        return registry.values.keys if registry
+      end
+
+      []
+    end
+
+    def could_be_a_dynamic_facet?(key)
+      %w(organisations people world_locations all_part_of_taxonomy_tree part_of_taxonomy_tree).include? key
+    end
+
+    def parsed_params(filter_params, params)
+      # TODO: There are 3 params hashes here for the email-alert-api tags/links
+      filter_params.fetch("subscriber_list_params", {}).merge(
+        params
+          .permit("filter" => {})
+          .dig("filter")
+          .to_h,
+        )
+    end
+  end
+end

--- a/lib/parameter_parser/email_alert_parameter_parser.rb
+++ b/lib/parameter_parser/email_alert_parameter_parser.rb
@@ -37,8 +37,6 @@ module ParameterParser
 
     def permitted_values_for_filter_key(key)
       facet = find_facet_by_key(key)
-      return if facet.blank?
-
       given_values = Array(filter_params[key])
       allowed_values = allowed_values_for_facet(facet)
       permitted = allowed_values & given_values

--- a/lib/registries/topic_taxonomy_registry.rb
+++ b/lib/registries/topic_taxonomy_registry.rb
@@ -10,6 +10,10 @@ module Registries
       @taxonomy_tree ||= fetch_from_cache
     end
 
+    def values
+      taxonomy_tree
+    end
+
     def cache_key
       "#{NAMESPACE}/topic_taxonomy"
     end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -13,22 +13,26 @@ describe EmailAlertSubscriptionsController, type: :controller do
   render_views
 
   let(:signup_finder) { cma_cases_signup_content_item }
-  let(:content_id_one) { "magical-education" }
-  let(:content_id_two) { "herbology" }
-  let(:top_level_taxon_one_title) { "Magical Education" }
-  let(:top_level_taxon_two_title) { "Herbology" }
+  let(:taxon_content_id_one) { "magical-education" }
+  let(:taxon_content_id_two) { "herbology" }
+  let(:brexit_taxon_id) { "d6c2de5d-ef90-45d1-82d4-5f2438369eea" }
+  let(:org_slug_one) { "department-of-mysteries" }
+  let(:org_slug_two) { "gringots" }
 
-  before { Rails.cache.clear }
-  after { Rails.cache.clear }
-
-  before :each do
+  before do
+    Rails.cache.clear
     topic_taxonomy_has_taxons([
-      FactoryBot.build(:level_one_taxon_hash, content_id: content_id_one, title: top_level_taxon_one_title),
-      FactoryBot.build(:level_one_taxon_hash, content_id: content_id_two, title: top_level_taxon_two_title),
+      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_one, title: "Magical Education"),
+      FactoryBot.build(:level_one_taxon_hash, content_id: brexit_taxon_id, title: "Brexit"),
+      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_two, title: "Herbology"),
     ])
 
     stub_people_registry_request
     stub_organisations_registry_request
+  end
+
+  after :each do
+    Rails.cache.clear
   end
 
   describe "GET #new" do
@@ -41,8 +45,10 @@ describe EmailAlertSubscriptionsController, type: :controller do
     end
 
     describe "finder email signup item does exist" do
-      it "returns a success" do
+      before do
         content_store_has_item("/does-exist/email-signup", signup_finder)
+      end
+      it "returns a success" do
         get :new, params: { slug: "does-exist" }
 
         expect(response).to be_successful
@@ -50,13 +56,23 @@ describe EmailAlertSubscriptionsController, type: :controller do
     end
   end
 
-  describe 'POST "#create"' do
-    before do
-      content_store_has_item("/cma-cases", cma_cases_content_item)
-      content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+  describe "POST #create" do
+    context "when finder email signup item doesn't exist" do
+      before do
+        content_store_does_not_have_item("/does-not-exist/email-signup")
+      end
+      it "returns a 404" do
+        get :new, params: { slug: "does-not-exist" }
+        expect(response.status).to eq(404)
+      end
     end
 
     context "when Email Alert API returns a 422 error" do
+      before do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+      end
+
       it "returns a 200 and displays the signup page" do
         stub_any_email_alert_api_call.to_return(status: 422)
         post :create, params: {
@@ -68,141 +84,291 @@ describe EmailAlertSubscriptionsController, type: :controller do
       end
     end
 
-    context "finder has default filters" do
-      it "fails if the relevant filters are not provided" do
-        post :create, params: { slug: "cma-cases" }
-        expect(response).to be_successful
-        expect(response).to render_template("new")
+    context "when the finder signup page has filters (CMA Cases)" do
+      before do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
       end
 
-      it "redirects to the correct email subscription url" do
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "case_type" => { any: %w[ca98-and-civil-cartels] },
-            "format" => { any: %w[cma_case] },
-          },
-          "subscription_url" => "http://www.example.com",
-        )
-
-        post :create, params: {
-          slug: "cma-cases",
-          filter: {
-            "case_type" => %w[ca98-and-civil-cartels],
-          },
-        }
-        expect(subject).to redirect_to("http://www.example.com")
-      end
-
-      context "request params contain subscriber_list_params and filter" do
-        it "overrides any subscriber_list_params with filter params" do
+      context "when no filters are provided" do
+        it "redirects to the subscription url" do
           email_alert_api_has_subscriber_list(
             "tags" => {
-              "case_type" => { any: %w[overriding-case-type] },
               "format" => { any: %w[cma_case] },
+              "document_type" => { any: %w[cma_case] },
             },
-            "subscription_url" => "http://www.example.com",
+            "subscription_url" => "http://www.gov.uk/default-subscription-to-cma-cases",
+          )
+
+          post :create, params: { slug: "cma-cases" }
+          expect(subject).to redirect_to("http://www.gov.uk/default-subscription-to-cma-cases")
+        end
+      end
+
+      context "when at least one required filter is provided" do
+        it "redirects to the subscription url" do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "case_type" => { any: %w[consumer-enforcement] },
+              "format" => { any: %w[cma_case] },
+              "document_type" => { any: %w[cma_case] },
+            },
+            "subscription_url" => "http://www.gov.uk/subscription-to-cma-cases",
           )
 
           post :create, params: {
             slug: "cma-cases",
             filter: {
-              "case_type" => %w[overriding-case-type],
-            },
-            subscriber_list_params: {
-              "case_type" => %w[overriden-case-type],
+              "case_type" => %w[consumer-enforcement],
             },
           }
-          expect(subject).to redirect_to("http://www.example.com")
+          expect(subject).to redirect_to("http://www.gov.uk/subscription-to-cma-cases")
         end
       end
     end
-  end
 
-  context "with a multi facet signup" do
-    describe 'POST "#create"' do
-      it "redirects to the correct email subscription url" do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", cma_cases_with_multi_facets_signup_content_item)
-
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "case_type" => { any: %w[ca98-and-civil-cartels] },
-            "case_state" => { any: %w(open) },
-            "format" => { any: %w[cma_case] },
-          },
-          "subscription_url" => "http://www.example.com",
-        )
-
-        post :create, params: {
-          slug: "cma-cases",
-          filter: {
-            "case_type" => %w[ca98-and-civil-cartels],
-            "case_state" => %w(open),
-          },
-        }
-
-        expect(subject).to redirect_to("http://www.example.com")
+    context "when the signup page has 'dynamic' filters (News and Communications)" do
+      before do
+        content_store_has_item("/news-and-communications", news_and_communications_content_item)
+        content_store_has_item("/news-and-communications/email-signup", news_and_communications_signup_content_item)
       end
 
       it "redirects to the correct email subscription url with subscriber_list_params" do
-        content_store_has_item("/news-and-communications", news_and_communications_content_item)
-        content_store_has_item("/news-and-communications/email-signup", news_and_communications_signup_content_item)
-
         email_alert_api_has_subscriber_list(
           "links" => {
-            "content_purpose_subgroup" =>
-              {
-                "any" => %w[news speeches_and_statements],
-              },
+            "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
+            "taxon_tree" => { "all" => [brexit_taxon_id, taxon_content_id_two, taxon_content_id_one] },
+            "content_purpose_subgroup" => { "any" => %w(news speeches_and_statements) },
           },
-          "subscription_url" => "http://www.example.com",
+          "subscription_url" => "http://www.gov.uk/subscription/news",
         )
 
         post :create, params: {
           slug: "news-and-communications",
-          subscriber_list_params: {},
+          subscriber_list_params: {
+            "all_part_of_taxonomy_tree" => [taxon_content_id_one, taxon_content_id_two, brexit_taxon_id, "junk-content-id"],
+            "organisations" => [org_slug_one, org_slug_two, "junk-organisation"],
+            "junk_key" => %w(junk-values),
+            "another_junk_key" => "single-junk-value",
+          },
         }
-        expect(subject).to redirect_to("http://www.example.com")
+        expect(subject).to redirect_to("http://www.gov.uk/subscription/news")
       end
 
-
-      it "will not include a facet that is not in the signup content item in the redirect" do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+      it "without allowed filters it redirects to the default email subscription url" do
         email_alert_api_has_subscriber_list(
-          "tags" => {
-            "case_type" => { any: %w[ca98-and-civil-cartels] },
-            "format" => { any: %w[cma_case] },
-          },
-          "subscription_url" => "http://www.example.com",
+          "links" => { "content_purpose_subgroup" => { "any" => %w(news speeches_and_statements) } },
+          "subscription_url" => "http://www.gov.uk/subscription/default-news",
         )
 
         post :create, params: {
-          slug: "cma-cases",
-          subscriber_list_params: { part_of_taxonomy_tree: %w(some-taxon) },
-          filter: {
-            "case_type" => %w[ca98-and-civil-cartels],
-            "case_state" => %w(open),
+          slug: "news-and-communications",
+          subscriber_list_params: {
+            "organisations" => %w(junk-org),
+            "junk_key" => %w(junk-values),
+            "another_junk_key" => "single-junk-value",
           },
         }
-        expect(subject).to redirect_to("http://www.example.com")
+        expect(subject).to redirect_to("http://www.gov.uk/subscription/default-news")
       end
     end
-  end
 
-  context "with email_filter_by set to 'facet_values'" do
-    describe 'POST "#create"' do
+    context "when the signup page has 'option lookup' filters (Policy Papers and Consultations)" do
       before do
-        content_store_has_item("/find-eu-exit-guidance-business", business_readiness_content_item)
-        content_store_has_item("/find-eu-exit-guidance-business/email-signup", business_readiness_signup_content_item)
+        content_store_has_item("/search/policy-papers-and-consultations", policy_papers_finder_content_item)
+        content_store_has_item("/search/policy-papers-and-consultations/email-signup", policy_papers_finder_signup_content_item)
       end
 
-      it "should call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
+      it "redirects to the correct email subscription URL" do
         email_alert_api_has_subscriber_list(
           "links" => {
-            "facet_values" => { any: %w(aerospace) },
+            "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
+            "content_store_document_type" => { "any" => %w(impact_assessment case_study policy_paper) },
+            "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+            "content_purpose_supergroup" => { "any" => %w(policy_and_engagement) },
           },
-          "subscription_url" => "http://www.itstartshear.com",
+          "subscription_url" => "http://www.gov.uk/subscription/policy-papers-and-consultations",
+        )
+
+        post :create, params: {
+          slug: "search/policy-papers-and-consultations",
+          subscriber_list_params: {
+            "all_part_of_taxonomy_tree" => [taxon_content_id_one, taxon_content_id_two, "junk-content-id"],
+            "content_store_document_type" => %w(impact_assessment case_study policy_paper junk-doc-type),
+            "organisations" => [org_slug_one, org_slug_two, "junk-organisation"],
+          },
+        }
+        expect(subject).to redirect_to("http://www.gov.uk/subscription/policy-papers-and-consultations")
+      end
+    end
+
+    context "when facet choices contain filter_values (Research and Statistics)" do
+      before do
+        content_store_has_item("/search/research-and-statistics", research_and_stats_finder_content_item)
+        content_store_has_item("/search/research-and-statistics/email-signup", research_and_stats_finder_signup_content_item)
+      end
+
+      it "will redirect the user to the subscription URL" do
+        email_alert_api_has_subscriber_list(
+          "links" => {
+            "content_store_document_type" => {
+              "any" => %w(
+                statistics national_statistics statistical_data_set official_statistics
+                dfid_research_output independent_report research
+              ),
+            },
+            "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
+            "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+          },
+          "subscription_url" => "http://www.gov.uk/subscription/research-and-stats",
+        )
+
+        post :create, params: {
+          slug: "search/research-and-statistics",
+          filter: {
+            "content_store_document_type" => %w[statistics_published research junk-doc-type],
+          },
+          subscriber_list_params: {
+            "content_store_document_type" => %w(statistics_published research junk-doc-type),
+            "organisations" => [org_slug_one, org_slug_two, "junk-organisation"],
+            "all_part_of_taxonomy_tree" => [taxon_content_id_one, taxon_content_id_two, "junk-content-id"],
+          },
+        }
+        expect(subject).to redirect_to("http://www.gov.uk/subscription/research-and-stats")
+      end
+
+      context "when filter and subscriber_list_params params are empty" do
+        it "will render the signup page URL again" do
+          post :create, params: {
+            slug: "search/research-and-statistics",
+            filter: {},
+            subscriber_list_params: {},
+          }
+          expect(response).to be_successful
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context "when the filter params are not provided" do
+        it "will redirect the user to the subscription URL" do
+          email_alert_api_has_subscriber_list(
+            "links" => {
+              "content_store_document_type" => {
+                "any" => %w(
+                  statistics national_statistics statistical_data_set official_statistics
+                  dfid_research_output independent_report research
+                ),
+              },
+              "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+            },
+            "subscription_url" => "http://www.gov.uk/subscription/research-and-stats",
+          )
+
+          post :create, params: {
+            slug: "search/research-and-statistics",
+            filter: {},
+            subscriber_list_params: {
+              "content_store_document_type" => %w(statistics_published research junk-doc-type),
+              "all_part_of_taxonomy_tree" => [taxon_content_id_one, taxon_content_id_two, "junk-content-id"],
+            },
+          }
+          expect(subject).to redirect_to("http://www.gov.uk/subscription/research-and-stats")
+        end
+      end
+
+      context "when the subscriber_list_params params are not provided" do
+        it "will redirect the user to the subscription URL" do
+          email_alert_api_has_subscriber_list(
+            "links" => {
+              "content_store_document_type" => {
+                "any" => %w(
+                  statistics national_statistics statistical_data_set official_statistics
+                  dfid_research_output independent_report research
+                ),
+              },
+            },
+            "subscription_url" => "http://www.gov.uk/subscription/research-and-stats",
+          )
+
+          post :create, params: {
+            slug: "search/research-and-statistics",
+            filter: {
+              "content_store_document_type" => %w[statistics_published research junk-doc-type],
+            },
+            subscriber_list_params: {},
+          }
+          expect(subject).to redirect_to("http://www.gov.uk/subscription/research-and-stats")
+        end
+      end
+    end
+
+    context "when additional keys or values are provided by the user" do
+      before do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+      end
+      it "will strip surplus keys or values" do
+        email_alert_api_has_subscriber_list(
+          "tags" => {
+            "case_type" => { any: %w[consumer-enforcement] },
+            "format" => { any: %w[cma_case] },
+            "document_type" => { any: %w[cma_case] },
+          },
+          "subscription_url" => "http://www.gov.uk/subscription-to-cma-cases",
+        )
+        post :create, params: {
+          slug: "cma-cases",
+          filter: { "case_type" => %w[consumer-enforcement foo], "foo" => %w(mergers) },
+          subscriber_list_params: { "case_type" => %w[foo ca98-and-civil-cartels], "foo" => %w(markets) },
+          foo: { "filter" => %w[regulatory-references-and-appeals] },
+          bar: [{ "case_type" => %w[criminal-cartels] }],
+          blah: "criminal-cartels",
+          mergers: %w[competition-disqualification],
+        }
+        expect(subject).to redirect_to("http://www.gov.uk/subscription-to-cma-cases")
+      end
+    end
+
+    context "when unprocessable keys are provided by the user" do
+      before do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
+      end
+      it "will redirect the user to the signup page" do
+        post :create, params: {
+          slug: "cma-cases",
+          filter: { "evil_key'><script>alert(1)</script>" => %w(mergers) },
+        }
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context "when unprocessable keys are provided by the user" do
+      before do
+        content_store_has_item("/cma-cases", cma_cases_content_item)
+        content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
+      end
+      it "will redirect the user to the signup page" do
+        post :create, params: {
+          slug: "cma-cases",
+          filter: { "evil_value" => %w('><script>alert(1)</script>) },
+        }
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+
+    # TODO: Remove email_filter_by key
+    context "with email_filter_by set to 'facet_values'" do
+      it "should call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
+        content_store_has_item("/find-eu-exit-guidance-business", business_readiness_content_item)
+        content_store_has_item("/find-eu-exit-guidance-business/email-signup", business_readiness_signup_content_item)
+        email_alert_api_has_subscriber_list(
+          "links" => {
+            "facet_values" => { any: %w(24fd50fa-6619-46ca-96cd-8ce90fa076ce) },
+          },
+          "subscription_url" => "http://www.gov.uk/subscription/find-eu-exit-guidance-business",
           "email_filter_by" => "facet_values",
         )
 
@@ -211,39 +377,40 @@ describe EmailAlertSubscriptionsController, type: :controller do
         post :create, params: {
           slug: "find-eu-exit-guidance-business",
           filter: {
-            "sector_business_area" => %w(aerospace),
+            "sector_business_area" => %w(24fd50fa-6619-46ca-96cd-8ce90fa076ce),
           },
         }
 
         expect(EmailAlertListTitleBuilder).to have_received(:call)
       end
-    end
-  end
 
-  context "with blank email_filter_by" do
-    describe 'POST "#create"' do
-      it "should not call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
-        content_store_has_item("/cma_cases", cma_cases_content_item)
-        content_store_has_item("/cma_cases/email-signup", cma_cases_signup_content_item)
+      context "with blank email_filter_by" do
+        before do
+          content_store_has_item("/cma_cases", cma_cases_content_item)
+          content_store_has_item("/cma_cases/email-signup", cma_cases_signup_content_item)
+        end
 
-        email_alert_api_has_subscriber_list(
-          "tags" => {
-            "format" => { any: %w[cma_case] },
-            "case_type" => { any: %w[markets] },
-          },
-          "subscription_url" => "http://www.gov.uk",
-        )
+        it "should not call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "format" => { any: %w[cma_case] },
+              "case_type" => { any: %w[markets] },
+              "document_type" => { any: %w[cma_case] },
+            },
+            "subscription_url" => "http://www.gov.uk/subscription/cma-markets",
+          )
 
-        allow(EmailAlertTitleBuilder).to receive(:call)
+          allow(EmailAlertTitleBuilder).to receive(:call)
 
-        post :create, params: {
-          slug: "cma_cases",
-          filter: {
-            "case_type" => %w[markets],
-          },
-        }
+          post :create, params: {
+            slug: "cma_cases",
+            filter: {
+              "case_type" => %w[markets],
+            },
+          }
 
-        expect(EmailAlertTitleBuilder).to have_received(:call)
+          expect(EmailAlertTitleBuilder).to have_received(:call)
+        end
       end
     end
   end

--- a/spec/lib/email_alert_list_title_builder_spec.rb
+++ b/spec/lib/email_alert_list_title_builder_spec.rb
@@ -19,25 +19,25 @@ describe EmailAlertListTitleBuilder do
   context "one choice for one facet selected" do
     let(:filter) do
       {
-        "sector_business_area" => %w(94b3cfe2-af89-4744-b8d7-7fc79edcbc85),
+        "sector_business_area" => %w(894a7c88-40bb-4ba6-a234-b7e15d8a0c21),
       }
     end
 
     it "will join one choices from one facets in a list" do
-      is_expected.to eq("EU Exit guidance in the following category: 'Agriculture and forestry (including wholesale)'")
+      is_expected.to eq("EU Exit guidance in the following category: 'Accommodation'")
     end
   end
 
   context "one choice for multiple facets selected" do
     let(:filter) do
       {
-        "sector_business_area" => %w(94b3cfe2-af89-4744-b8d7-7fc79edcbc85),
+        "sector_business_area" => %w(894a7c88-40bb-4ba6-a234-b7e15d8a0c21),
         "business_activity" => %w(d422aa2e-59ad-4986-8ef0-973959878912),
       }
     end
 
     it "will join one choice from multiple facets in a list, separated with commas" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Import from the EU'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Accommodation', 'Import from the EU'")
     end
   end
 
@@ -45,26 +45,26 @@ describe EmailAlertListTitleBuilder do
   context "a selected facet with one overridden facet_choice is overwritten" do
     let(:filter) do
       {
-        "sector_business_area" => %w(94b3cfe2-af89-4744-b8d7-7fc79edcbc85),
+        "sector_business_area" => %w(894a7c88-40bb-4ba6-a234-b7e15d8a0c21),
         "public_sector_procurement" => %w(33fc20d7-6a45-40c9-b31f-e4678f962ff1),
       }
     end
 
     it "will include the overwritten facet_choice" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Public sector procurement - defence contracts'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Accommodation', 'Public sector procurement - defence contracts'")
     end
   end
 
   context "multiple selected facets with multiple facet_choice overrides are overwritten" do
     let(:filter) do
       {
-        "sector_business_area" => %w(94b3cfe2-af89-4744-b8d7-7fc79edcbc85),
+        "sector_business_area" => %w(894a7c88-40bb-4ba6-a234-b7e15d8a0c21),
         "public_sector_procurement" => %w(33fc20d7-6a45-40c9-b31f-e4678f962ff1 f165dc7c-7cef-446a-bdfd-8a1ca685d091),
       }
     end
 
     it "will include the overwritten facet_choices" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Public sector procurement - defence contracts', 'Public sector procurement - civil government contracts'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Accommodation', 'Public sector procurement - defence contracts', 'Public sector procurement - civil government contracts'")
     end
   end
 
@@ -72,13 +72,13 @@ describe EmailAlertListTitleBuilder do
   context "multiple choices for multiple facets selected" do
     let(:filter) do
       {
-        "sector_business_area" => %w(94b3cfe2-af89-4744-b8d7-7fc79edcbc85 01b51981-1ad6-4e45-9b14-b8a57fcb4204),
+        "sector_business_area" => %w(894a7c88-40bb-4ba6-a234-b7e15d8a0c21 01b51981-1ad6-4e45-9b14-b8a57fcb4204),
         "business_activity" => %w(d422aa2e-59ad-4986-8ef0-973959878912 7283b8e1-840f-49da-967f-c0a512a3f531),
       }
     end
 
     it "will join multiple choices from multiple facets in a list, separated with commas" do
-      is_expected.to eq("EU Exit guidance in the following categories: 'Agriculture and forestry (including wholesale)', 'Electronics, parts and machinery', 'Import from the EU', 'Export to the EU'")
+      is_expected.to eq("EU Exit guidance in the following categories: 'Accommodation', 'Electronics, parts and machinery', 'Import from the EU', 'Export to the EU'")
     end
   end
 end

--- a/spec/lib/parameter_parser/email_alert_parameter_parser_spec.rb
+++ b/spec/lib/parameter_parser/email_alert_parameter_parser_spec.rb
@@ -1,0 +1,240 @@
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+
+describe ParameterParser::EmailAlertParameterParser do
+  include GdsApi::TestHelpers::ContentStore
+  include FixturesHelper
+  include TaxonomySpecHelper
+  include RegistrySpecHelper
+
+  subject(:parser) { described_class.new(content_item, filter_params, user_params) }
+  let(:content_item) { { "details" => {} } }
+  let(:filter_params) { {} }
+  let(:user_params) { ActionController::Parameters.new(params) }
+  let(:params) { {} }
+  let(:signup_finder) { cma_cases_signup_content_item }
+  let(:taxon_content_id_one) { "magical-education" }
+  let(:taxon_content_id_two) { "herbology" }
+  let(:brexit_taxon_id) { "d6c2de5d-ef90-45d1-82d4-5f2438369eea" }
+
+  before do
+    Rails.cache.clear
+    topic_taxonomy_has_taxons([
+      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_one, title: "Magical Education"),
+      FactoryBot.build(:level_one_taxon_hash, content_id: brexit_taxon_id, title: "Brexit"),
+      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_two, title: "Herbology"),
+    ])
+
+    stub_people_registry_request
+    stub_organisations_registry_request
+  end
+
+  describe "#valid?" do
+    subject(:valid) { parser.valid? }
+    let(:error_messages) { parser.errors.full_messages }
+
+    context "when there are no permitted facets" do
+      context "with no user params provided" do
+        it { is_expected.to be true }
+      end
+
+      context "with good params provided" do
+        let(:params) { { "filter" => { foo: "bar", bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+
+      context "with bad params provided" do
+        let(:params) { { "filter" => { "foo": %w('><script>alert(1)</script>), bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when there are permitted facets (CMA cases)" do
+      let(:content_item) { cma_cases_signup_content_item }
+
+      context "with no user params provided" do
+        it { is_expected.to be true }
+      end
+
+      context "with good params provided" do
+        let(:params) do
+          {
+            "filter" => { "case_type" => %w(ca98-and-civil-cartels consumer-enforcement) },
+          }
+        end
+        it { is_expected.to be true }
+      end
+
+      context "with unpermitted params provided" do
+        let(:params) { { "filter" => { "foo": "bar", bar: %w(foo) } } }
+        let(:filter_params) { { "subscriber_list_params" => { foo: "bar", bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+
+      context "with bad keys provided in params" do
+        let(:params) { { "filter" => { "'><script>alert(1)</script>": %w(foo), bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+
+      context "with bad values provided in params" do
+        let(:params) { { "filter" => { "foo": %w('><script>alert(1)</script>), bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when there are bad facets in the content item" do
+      let(:content_item) { bad_input_finder_signup_content_item }
+
+      context "with no user params provided" do
+        it { is_expected.to be true }
+      end
+
+      context "with good params provided" do
+        let(:params) { { "filter" => { "good_value": %w(competition-disqualification), bar: %w(foo) } } }
+        it { is_expected.to be true }
+      end
+
+      context "with bad keys provided in params" do
+        let(:params) { { "filter" => { "evil_key'><script>alert(1)</script>": %w(markets) } } }
+        it { is_expected.to be false }
+      end
+
+      context "with bad values provided in params" do
+        let(:params) { { "filter" => { "evil_value": %w('><script>alert(1)</script>) } } }
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe "#applied_filters" do
+    subject(:applied_filters) { parser.applied_filters }
+
+    context "when there are no permitted facets" do
+      context "with no user params provided" do
+        it { is_expected.to eq({}) }
+      end
+
+      context "with user params provided" do
+        let(:params) { { "filter" => { foo: "bar", bar: %w(foo) } } }
+        it { is_expected.to eq({}) }
+      end
+
+      context "with filter params provided" do
+        let(:filter_params) { { "subscriber_list_params" => { foo: "bar", bar: %w(foo) } } }
+        it { is_expected.to eq({}) }
+      end
+    end
+
+    context "when there are permitted facets (CMA Cases)" do
+      let(:content_item) { cma_cases_signup_content_item }
+
+      context "with no user params provided" do
+        it { is_expected.to eq({}) }
+      end
+
+      context "with good params provided" do
+        let(:params) do
+          {
+            "filter" => { "case_type" => %w(ca98-and-civil-cartels consumer-enforcement) },
+          }
+        end
+        it { is_expected.to eq("case_type" => %w[ca98-and-civil-cartels consumer-enforcement]) }
+      end
+
+      context "with unpermitted params provided" do
+        let(:params) {
+          {
+            "filter" => {
+              "foo" => "bar",
+              "bar" => %w(foo),
+              "case_type" => %w(ca98-and-civil-cartels consumer-enforcement bad-value),
+            },
+          }
+        }
+        it { is_expected.to eq("case_type" => %w[ca98-and-civil-cartels consumer-enforcement]) }
+      end
+    end
+
+    context "when there are 'dynamic' facets (News and Communications)" do
+      let(:content_item) { news_and_communications_signup_content_item }
+
+      context "with no user params provided" do
+        it { is_expected.to eq({}) }
+      end
+
+      context "with filter params provided" do
+        let(:params) do
+          {
+            "filter" => { "people" => %w(albus-dumbledore foo bar) },
+          }
+        end
+        it { is_expected.to eq("people" => %w[albus-dumbledore]) }
+      end
+
+      context "with subscriber_list_params params provided" do
+        let(:filter_params) do
+          {
+            "subscriber_list_params" => {
+              "people" => %w(albus-dumbledore foo bar),
+              "organisations" => %w(department-of-mysteries gringots junk-organisation),
+              "junk_key" => %w(junk-values),
+              "another_junk_key" => "single-junk-value",
+            },
+          }
+        end
+        it { is_expected.to eq("organisations" => %w[department-of-mysteries gringots], "people" => %w[albus-dumbledore]) }
+      end
+
+      context "with both subscriber_list_params and params provided" do
+        let(:params) do
+          {
+            "filter" => { "people" => %w(albus-dumbledore harry-potter foo bar) },
+          }
+        end
+        let(:filter_params) do
+          {
+            "subscriber_list_params" => {
+              "people" => %w(cornelius-fudge foo bar),
+              "organisations" => %w(department-of-mysteries gringots junk-organisation),
+              "junk_key" => %w(junk-values),
+              "another_junk_key" => "single-junk-value",
+            },
+          }
+        end
+        it { is_expected.to eq("organisations" => %w[department-of-mysteries gringots], "people" => %w[albus-dumbledore harry-potter]) }
+      end
+    end
+
+    context "when there are 'option lookup' facets (Policy Papers and Consultations)" do
+      let(:content_item) { policy_papers_finder_signup_content_item }
+      let(:filter_params) do
+        {
+          "subscriber_list_params" => {
+            "people" => %w(cornelius-fudge foo bar),
+            "organisations" => %w(department-of-mysteries gringots junk-organisation),
+            "junk_key" => %w(junk-values),
+            "another_junk_key" => "single-junk-value",
+          },
+        }
+      end
+
+      it { is_expected.to eq("organisations" => %w[department-of-mysteries gringots], "people" => %w[cornelius-fudge]) }
+    end
+
+    context "when there are facets containing filter_values (Research and Statistics)" do
+      let(:content_item) { research_and_stats_finder_signup_content_item }
+      let(:filter_params) do
+        {
+          "subscriber_list_params" => {
+            "content_store_document_type" => %w(statistics_published junk-doc-type),
+            "organisations" => %w(department-of-mysteries junk-organisation),
+            "junk_key" => %w(junk-values),
+            "another_junk_key" => "single-junk-value",
+          },
+        }
+      end
+
+      it { is_expected.to eq("content_store_document_type" => %w[statistics_published], "organisations" => %w[department-of-mysteries]) }
+    end
+  end
+end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -54,4 +54,24 @@ module FixturesHelper
   def criteria_csv_to_convert_to_yaml
     fixtures_path + "/criteria_csv_to_convert.csv"
   end
+
+  def policy_papers_finder_content_item
+    JSON.parse(File.read(fixtures_path + "/policy_and_engagement.json"))
+  end
+
+  def policy_papers_finder_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/policy_papers_and_consultations_email_signup.json"))
+  end
+
+  def research_and_stats_finder_content_item
+    JSON.parse(File.read(fixtures_path + "/statistics.json"))
+  end
+
+  def research_and_stats_finder_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/research_and_statistics_email_signup.json"))
+  end
+
+  def bad_input_finder_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/bad_input_email_signup.json"))
+  end
 end


### PR DESCRIPTION
This implements an allowlist for the filters that we permit users to use in their subscriber lists (on the finder frontend side).

Users shouldn't see a difference as a result of this change.

When signing up for email alerts, users can submit filters they'd like to sign up with:

```
{ "people": ["albus-dumbledore"], "organisations": ["hogwarts"] }
```

This change ensures that the keys and values submitted are correct and will result in a correctly working email subscription.

For now we'll show users a generic error if they've made an invalid request. I've also used a 200 rather than a 400 in the response, because we want to re-render the same signup page, and slimmer renders an error page if we respond with a bad request status. It would be awesome to improve on how we respond to errors in the future!

I'd recommend viewing by commit, since the first commit contains the bulk of the change (updating content item fixtures).

Should be merged after https://github.com/alphagov/search-api/pull/1884 is merged and deployed.

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1836.herokuapp.com/search/all
- https://finder-frontend-pr-1836.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1836.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1836.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1836.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1836.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1836.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1836.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1836.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1836.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

https://trello.com/c/LMsj6yPk/1247
https://trello.com/c/tIR0DvbN/1248-business-finder-email-signup-errors-if-no-facet-options-selected