### PR TITLE
Rescue date parsing errors

### DIFF
--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -3,7 +3,6 @@ class DateParser
     date_string = date_string.to_s.strip
 
     if date_string.present?
-
       date_string =
         contains_invalid_characters?(date_string) ? " " : date_string
 
@@ -17,7 +16,12 @@ class DateParser
     if could_be_month_name?(date_string)
       date = process_month_name_inputs(date_string)
     end
-    date ||= Chronic.parse(date_string, guess: :begin, endian_precedence: :little)
+    date ||=
+      begin
+        Chronic.parse(date_string, guess: :begin, endian_precedence: :little)
+      rescue StandardError
+        nil
+      end
     Date.new(date.year, date.month, date.day) if date
   end
 

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -43,6 +43,9 @@ describe DateParser do
             "1@" => nil,
             "20120" => nil,
             "1" => nil,
+            "randomwords" => nil,
+            "Britain First" => nil,
+            "6   april    2018 to april 2018" => nil,
 
             # Dates should be interpretted as UK not US
             "01/11/2014" => Date.new(2014, 11, 1),


### PR DESCRIPTION
Don't blow up if Chronic fails to parse a date string. Return nil and display our error message.

Fixes a couple of bugs: 
- https://sentry.io/organizations/govuk/issues/1335124209/?environment=staging&project=202224&query=is%3Aunresolved
- https://sentry.io/organizations/govuk/issues/1333642184/?environment=staging&project=202224&query=is%3Aunresolved

Before
<img width="790" alt="Screenshot 2020-01-06 at 13 12 41" src="https://user-images.githubusercontent.com/17908089/71820159-48010a00-3086-11ea-99c2-78b9bc23edbb.png">


After
<img width="798" alt="Screenshot 2020-01-06 at 13 12 12" src="https://user-images.githubusercontent.com/17908089/71820163-4c2d2780-3086-11ea-8e1c-18c473904b3f.png">


---

## Search page examples to sanity check:

- https://finder-frontend-pr-1839.herokuapp.com/search/all
- https://finder-frontend-pr-1839.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1839.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1839.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1839.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1839.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1839.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1839.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1839.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1839.herokuapp.com/prepare-business-uk-leaving-eu
