### PR TITLE
Escape special characters inside filter search

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -83,6 +83,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   OptionSelect.prototype.cleanString = function cleanString (text) {
     text = text.replace(/&/g, 'and')
     text = text.replace(/[’',:–-]/g, '') // remove punctuation characters
+    text = text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape special characters
     return text.trim().replace(/\s\s+/g, ' ').toLowerCase() // replace multiple spaces with one
   }
 


### PR DESCRIPTION
At the moment if users enter a special character inside a filter search box, for example `*` in "organisations filter, Javascript function will error.

<img width="1253" alt="Screenshot 2020-01-06 at 15 22 26" src="https://user-images.githubusercontent.com/3758555/71827585-81db0c00-3098-11ea-8ad1-4e4b6a45e4c5.png">

This amendment will escape these characters.

<img width="1148" alt="Screenshot 2020-01-06 at 15 22 54" src="https://user-images.githubusercontent.com/3758555/71827635-90292800-3098-11ea-99a6-755b977c7c84.png">


Borrowed from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping)




---

## Search page examples to sanity check:

- https://finder-frontend-pr-1840.herokuapp.com/search/all
- https://finder-frontend-pr-1840.herokuapp.com/search/research-and-statistics
