### PR TITLE
Handle 422 from email alert api

### DIFF
--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,6 +1,8 @@
 require "addressable/uri"
 
 class EmailAlertSignupAPI
+  class UnprocessableSubscriberListError < StandardError; end
+
   def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, email_filter_by: nil)
     @applied_filters = applied_filters.deep_symbolize_keys
     @default_filters = default_filters.deep_symbolize_keys
@@ -12,6 +14,8 @@ class EmailAlertSignupAPI
 
   def signup_url
     subscriber_list["subscription_url"]
+  rescue GdsApi::HTTPUnprocessableEntity
+    raise UnprocessableSubscriberListError
   end
 
 private

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -56,6 +56,18 @@ describe EmailAlertSubscriptionsController, type: :controller do
       content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
     end
 
+    context "when Email Alert API returns a 422 error" do
+      it "returns a 200 and displays the signup page" do
+        stub_any_email_alert_api_call.to_return(status: 422)
+        post :create, params: {
+          slug: "cma-cases",
+          filter: { "case_type" => %w[overriding-case-type] },
+        }
+        expect(response).to be_successful
+        expect(response).to render_template("new")
+      end
+    end
+
     context "finder has default filters" do
       it "fails if the relevant filters are not provided" do
         post :create, params: { slug: "cma-cases" }


### PR DESCRIPTION
Email Alert API can return a 422 (unprocessable) error. This adds more error handling to finder-frontend for this case.

Co-Authored-by: @MahmudH

Trello: https://trello.com/c/so20SdvH/808