### PR TITLE
Email alert signup filter bug fixes

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -36,7 +36,7 @@ private
   end
 
   def at_least_one_filter_chosen?
-    applied_filters.any?(&:present?)
+    final_filter_choices.any?
   end
 
   def has_default_filters?
@@ -44,12 +44,17 @@ private
   end
 
   def applied_filters
-    filter_params.fetch("subscriber_list_params", {}).merge(
-      params
-        .permit("filter" => {})
-        .dig("filter")
-        .to_h,
-      )
+    filter_params.fetch("subscriber_list_params", {}).merge(filter_params)
+      .keep_if { |key, _| final_filter_choices.include?(key) }
+  end
+
+  def final_filter_choices
+    subscriber_list_params = filter_params.fetch("subscriber_list_params", {})
+    subscriber_list_params.keys && filter_params.keys
+  end
+
+  def filter_params
+    params.permit("filter" => {}).dig("filter").to_h
   end
 
   def fetch_content_item(content_item_path)

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -102,6 +102,26 @@ describe EmailAlertSubscriptionsController, type: :controller do
           }
           expect(subject).to redirect_to("http://www.example.com")
         end
+
+        it "overrides any subscriber_list_params with filter params even if they are empty" do
+          email_alert_api_has_subscriber_list(
+            "tags" => {
+              "case_type" => { any: %w[overriding-case-type] },
+              "format" => { any: %w[cma_case] },
+            },
+            "subscription_url" => "http://www.example.com",
+          )
+
+          post :create, params: {
+            slug: "cma-cases",
+            filter: {},
+            subscriber_list_params: {
+              "case_type" => %w[overriden-case-type],
+            },
+          }
+          expect(response).to be_successful
+          expect(response).to render_template("new")
+        end
       end
     end
   end


### PR DESCRIPTION
## Bug on business readiness finder

If a user selects a filter, and signs up to email alerts, it is now be possible to remove those filters on the email sign up page without bad things happening. Instead of seeing a 500, they will see the error message prompting them to select a filter type, as is the intended behaviour. 

Trello card: https://trello.com/c/tIR0DvbN/1248-business-finder-email-signup-errors-if-no-facet-options-selected

Before: 
https://sentry.io/organizations/govuk/issues/1333513652/?environment=production&project=202224&query=is%3Aunresolved

After: 
<img width="742" alt="Screenshot 2020-01-06 at 19 02 40" src="https://user-images.githubusercontent.com/17908089/71841381-25d3b000-30b7-11ea-85f0-837ed0dcf415.png">

## Bug on cma-cases finder

Trello card: https://trello.com/c/BOUerRPp/1252-cma-cases-finder-email-signup-is-incorrect-if-no-facet-option-is-selected

Before:
<img width="642" alt="Screenshot 2020-01-06 at 19 15 18" src="https://user-images.githubusercontent.com/17908089/71842116-e4440480-30b8-11ea-8664-59dc71b60b66.png">

## Search page examples to sanity check:

- https://finder-frontend-pr-1843.herokuapp.com/search/all
- https://finder-frontend-pr-1843.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1843.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1843.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic

