### PR TITLE
Revert "Change crossorigin from 'anonymous' to 'use-credentials'"

### DIFF
--- a/app/views/layouts/development_layout.html.erb
+++ b/app/views/layouts/development_layout.html.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title><%= yield :title %> - GOV.UK</title>
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "use-credentials" %><!--<![endif]-->
-    <%= javascript_include_tag "application", integrity: true, crossorigin: "use-credentials" %>
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+    <%= javascript_include_tag "application", integrity: true, crossorigin: "anonymous" %>
     <meta name="robots" content="noindex">
   </head>
 

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <title><%= yield :title %> - GOV.UK</title>
-    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'use-credentials' %>
+    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
     <%= stylesheet_link_tag "print", media: "print" %>
-    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'use-credentials' %>
+    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
     <%= csrf_meta_tags %>
     <%= yield :head %>
 

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -3,9 +3,9 @@
   <head>
     <title><%= yield :title %> - GOV.UK</title>
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
-    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'use-credentials' %>
+    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
     <%= stylesheet_link_tag "print", media: "print" %>
-    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'use-credentials' %>
+    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
     <% if @content_item %>
       <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
     <% end %>


### PR DESCRIPTION
Reverts alphagov/finder-frontend#1844

`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at ‘https://assets.integration.publishing.service.gov.uk/frontend/frontend-7f9a59db277ec340f1dc70fbf02c886072883f9243a91384b2c6405ecf3be4a9.js’. (Reason: Credential is not supported if the CORS header ‘Access-Control-Allow-Origin’ is ‘*’).`

Need to investigate this issue first