### PR TITLE
Show document (guide, travel advice) parts in search results

### DIFF
--- a/app/assets/stylesheets/components/_document-list.scss
+++ b/app/assets/stylesheets/components/_document-list.scss
@@ -1,0 +1,58 @@
+.gem-c-document-list__children {
+  margin-bottom: 0;
+  margin-top: govuk-spacing(3);
+
+  @include govuk-media-query($from: tablet) {
+    margin-left: govuk-spacing(4);
+
+    @supports (display: grid) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      column-gap: 15px;
+    }
+  }
+}
+
+.gem-c-document-list-child {
+  @include govuk-font($size: 16);
+}
+
+.gem-c-document-list-child--dashed {
+  @include govuk-media-query($until: tablet) {
+    position: relative;
+    padding-left: govuk-spacing(5); //25px on mobile
+    padding-top: govuk-spacing(2);
+
+    &:before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      width: 20px;
+      overflow: hidden;
+    }
+  }
+}
+
+.gem-c-document-list-child__heading {
+  @include govuk-typography-weight-bold;
+}
+
+.gem-c-document-list-child__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.gem-c-document-list-child__description {
+  @include govuk-media-query($until: tablet) {
+    display: none;
+  }
+
+  @include govuk-text-colour;
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,7 +2,7 @@ class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
               :content_purpose_supergroup, :document_type, :organisations,
               :release_timestamp, :es_score, :format, :content_id, :index,
-              :facet_content_ids, :description
+              :parts, :facet_content_ids, :description
 
   def initialize(document_hash, index)
     document_hash = document_hash.with_indifferent_access
@@ -20,6 +20,7 @@ class Document
     @es_score = document_hash.fetch(:es_score, nil)
     @format = document_hash.fetch(:format, nil)
     @facet_content_ids = document_hash.fetch(:facet_values, [])
+    @parts = document_hash.fetch(:parts, [])
     @document_hash = document_hash
     @index = index
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -2,6 +2,7 @@ class SearchResultPresenter
   include ActionView::Helpers::SanitizeHelper
 
   delegate :title,
+           :parts,
            :is_historic,
            :government_name,
            :format,
@@ -40,10 +41,13 @@ class SearchResultPresenter
       subtext: subtext,
       highlight: @highlight,
       highlight_text: highlight_text,
+      parts: structure_parts,
     }
   end
 
 private
+
+  class MalformedPartError < StandardError; end
 
   def link
     document.path
@@ -75,6 +79,33 @@ private
       value = meta[:is_date] ? "<time datetime='#{meta[:machine_date]}'>#{meta[:human_date]}</time>" : meta[:value]
       component_metadata[meta[:label]] = sanitize("#{meta[:label]}: #{value}", tags: %w(time span))
     end
+  end
+
+  def structure_parts
+    structured_parts = parts.map.with_index(1) do |part, index|
+      has_required_data = %i[title slug body].all? { |key| part.key? key }
+      unless has_required_data
+        GovukError.notify(MalformedPartError.new, extra: { part: part, link: link })
+        next
+      end
+      {
+        link: {
+          text: part[:title],
+          path: "#{link}/#{part[:slug]}",
+          description: part[:body],
+          data_attributes: {
+            ecommerce_path: part[:slug],
+            track_category: "resultPart",
+            track_action: "Result part",
+            track_label: "Part #{index}",
+            track_options: {
+              dimension82: index,
+            },
+          },
+        },
+      }
+    end
+    structured_parts.compact
   end
 
 

--- a/app/views/components/_document_list.html.erb
+++ b/app/views/components/_document_list.html.erb
@@ -1,0 +1,80 @@
+<%
+  items ||= []
+
+  classes = "gem-c-document-list"
+  classes << " gem-c-document-list--top-margin" if local_assigns[:margin_top]
+  classes << " gem-c-document-list--bottom-margin" if local_assigns[:margin_bottom]
+  classes << " gem-c-document-list--no-underline" if local_assigns[:remove_underline]
+
+  within_multitype_list ||= false
+  within_multitype_list_class = " gem-c-document-list__multi-list" if within_multitype_list
+  title_with_context_class = " gem-c-document-list__item-title--context"
+
+  brand ||= false
+  brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
+%>
+<% if items.any? %>
+  <% unless within_multitype_list %>
+    <ol class="<%= classes %>">
+  <% end %>
+    <% items.each do |item| %>
+      <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
+
+      <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
+        <% if item[:highlight] && item[:highlight_text] %>
+          <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
+        <% end %>
+
+        <%=
+          item_classes = "gem-c-document-list__item-title #{brand_helper.color_class} #{title_with_context_class if item[:link][:context]}"
+
+          if item[:link][:path]
+            link_to(
+              item[:link][:text],
+              item[:link][:path],
+              data: item[:link][:data_attributes],
+              class: "#{item_classes} gem-c-document-list__item-link",
+            )
+          else
+            content_tag(
+              "span",
+              item[:link][:text],
+              data: item[:link][:data_attributes],
+              class: item_classes,
+            )
+          end
+        %>
+
+        <% if item[:link][:context] %>
+          <span class="gem-c-document-list__item-context"><%= item[:link][:context] %></span>
+        <% end %>
+
+        <% if item[:link][:description] %>
+          <p class="gem-c-document-list__item-description" ><%= item[:link][:description] %></p>
+        <% end %>
+
+        <% if item[:metadata] %>
+          <ul class="gem-c-document-list__item-metadata">
+            <% item[:metadata].compact.each do |item_metadata_key, item_metadata_value| %>
+              <li class="gem-c-document-list__attribute">
+                <% if item_metadata_key.to_s.eql?("public_updated_at") %>
+                  <time datetime="<%= item_metadata_value.iso8601 %>">
+                    <%= l(item_metadata_value, format: '%e %B %Y') %>
+                  </time>
+                <% else %>
+                  <%= item_metadata_value %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+
+        <% if item[:subtext] %>
+          <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
+        <% end %>
+      </li>
+    <% end %>
+  <% unless within_multitype_list %>
+    </ol>
+  <% end %>
+<% end %>

--- a/app/views/components/_document_list.html.erb
+++ b/app/views/components/_document_list.html.erb
@@ -19,7 +19,6 @@
   <% end %>
     <% items.each do |item| %>
       <% highlight_class = " gem-c-document-list__item--highlight" if item[:highlight] %>
-
       <li class="gem-c-document-list__item<%= within_multitype_list_class %> <%= brand_helper.brand_class %> <%= highlight_class %>">
         <% if item[:highlight] && item[:highlight_text] %>
           <p class='gem-c-document-list__highlight-text'><%= item[:highlight_text] %></p>
@@ -71,6 +70,38 @@
 
         <% if item[:subtext] %>
           <p class="gem-c-document-list__subtext"><%= item[:subtext] %></p>
+        <% end %>
+        
+        <% if item.include?(:parts) && item[:parts].any? %>
+          <ul class="gem-c-document-list__children govuk-list">
+            <% item[:parts].each do |part| %>
+              <li class="gem-c-document-list-child gem-c-document-list-child--dashed">
+                <%=
+                  if part[:link][:path]
+                    link_to(
+                      part[:link][:text],
+                      part[:link][:path],
+                      data: part[:link][:data_attributes],
+                      class: "gem-c-document-list-child__link",
+                    )
+                  else
+                    # there shouldn't be an instance that doesn't have a link
+                    # but if there is one, render the text
+                    content_tag(
+                      "span",
+                      part[:link][:text],
+                      class: "gem-c-document-list-child__heading",
+                    )
+                  end
+                %>
+                <% if part[:link][:description] %>
+                <p class="gem-c-document-list-child__description">
+                  <%= part[:link][:description] %>
+                </p>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
         <% end %>
       </li>
     <% end %>

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -8,7 +8,7 @@
         <% if group[:group_name] %>
           <h2 class="filtered-results__facet-heading"><%= group[:group_name] %></h2>
         <% end %>
-        <%= render "govuk_publishing_components/components/document_list", {
+        <%= render "components/document_list", {
           items: group[:documents],
           remove_underline: true
         } %>
@@ -17,7 +17,7 @@
   </ul>
 <% else %>
   <div class="finder-results js-finder-results" data-module="track-click">
-    <%= render "govuk_publishing_components/components/document_list", {
+    <%= render "components/document_list", {
       items: local_assigns[:document_list_component_data],
       remove_underline: true
     } %>

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -102,6 +102,7 @@ module RummagerUrlHelper
       is_historic
       government_name
       content_id
+      parts
     )
   end
 end

--- a/lib/search/query_builder.rb
+++ b/lib/search/query_builder.rb
@@ -87,6 +87,7 @@ module Search
         is_historic
         government_name
         content_id
+        parts
       )
     end
 

--- a/spec/components/document_list.spec.rb
+++ b/spec/components/document_list.spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+describe "Document list", type: :view do
+  def component_name
+    "document_list"
+  end
+
+  def render_component(component_arguments)
+    render partial: "components/#{component_name}", locals: component_arguments
+  end
+
+  def default
+    {
+      items: [
+        {
+          link: {
+            text: "School behaviour and attendance: parental responsibility measures",
+            path: "/government/publications/parental-responsibility-measures-for-behaviour-and-attendance",
+          },
+        },
+      ],
+    }
+  end
+
+  def with_parts
+    {
+      items: [
+        {
+          link: {
+            text: "Item title",
+            path: "/link",
+          },
+          parts: [
+            {
+              link: {
+                text: "Part title",
+                path: "part-link",
+                description: "Part description",
+              },
+            },
+          ],
+        },
+      ],
+    }
+  end
+
+  def with_parts_no_link
+    {
+      items: [
+        {
+          link: {
+            text: "Item title",
+            path: "/link",
+          },
+          parts: [
+            {
+              link: {
+                text: "Part title without link",
+                description: "Part description",
+              },
+            },
+          ],
+        },
+      ],
+    }
+  end
+
+  it "does not render parts if they are not available" do
+    render_component(default)
+    expect(rendered).not_to have_selector(".gem-c-document-list__children")
+  end
+
+  it "renders parts if they are available" do
+    render_component(with_parts)
+    expect(rendered).to have_selector(".gem-c-document-list__children")
+  end
+
+  it "part contains a title" do
+    render_component(with_parts)
+    expect(rendered).to have_selector(".gem-c-document-list-child__link", text: "Part title")
+  end
+
+  it "part link contains a valid url" do
+    render_component(with_parts)
+    expect(rendered).to have_link "Part title", href: "/link/part-link"
+  end
+
+  it "part contains a description" do
+    render_component(with_parts)
+    expect(rendered).to have_selector(".gem-c-document-list-child__description", text: "Part description")
+  end
+
+  it "part renders a heading span if no link is provided" do
+    render_component(with_parts_no_link)
+    expect(rendered).to have_selector(".gem-c-document-list-child__heading", text: "Part title without link")
+    expect(rendered).not_to have_selector(".gem-c-document-list-child__link")
+  end
+end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -53,7 +53,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
@@ -112,7 +112,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
@@ -229,7 +229,7 @@ describe FindersController, type: :controller do
           .with(
             query: {
               count: 10,
-              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
               filter_document_type: "mosw_report",
               order: "-public_timestamp",
               start: 0,
@@ -344,7 +344,7 @@ describe FindersController, type: :controller do
       .with(
         query: {
           count: 10,
-          fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,walk_type,place_of_origin,date_of_introduction,creator",
+          fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
           filter_document_type: "mosw_report",
           order: "-public_timestamp",
           start: 0,

--- a/spec/factories/document_hash.rb
+++ b/spec/factories/document_hash.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     es_score { nil }
     format { "answer" }
     facet_values { [] }
+    parts { [] }
 
     initialize_with { attributes.deep_stringify_keys }
   end

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -58,7 +58,7 @@ describe Search::QueryBuilder do
   context "without any facets" do
     it "should include base return fields" do
       expect(query).to include(
-        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id",
+        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts",
       )
     end
   end
@@ -85,7 +85,7 @@ describe Search::QueryBuilder do
 
     it "should include base and extra return fields" do
       expect(query).to include(
-        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,alpha,beta",
+        "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,alpha,beta",
       )
     end
 
@@ -102,7 +102,7 @@ describe Search::QueryBuilder do
 
       it "should use the filter value in fields" do
         expect(query).to include(
-          "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,zeta,beta",
+          "fields" => "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,zeta,beta",
         )
       end
     end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe ResultSetPresenter do
           subtext: nil,
           highlight: false,
           highlight_text: nil,
+          parts: [],
         }
 
         search_result_objects = subject.search_results_content[:document_list_component_data]

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe SearchResultPresenter do
         subtext: nil,
         highlight: false,
         highlight_text: nil,
+        parts: [],
       }
       expect(subject.document_list_component_data).to eql(expected_document)
     end

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SearchResultPresenter do
   let(:link) { "link-1" }
   let(:description) { "I am a document. I am full of words and that." }
 
-  describe "#govuk_component_data" do
+  describe "#document_list_component_data" do
     it "returns a hash of the data we need to show the document" do
       expected_document = {
         link: {
@@ -72,6 +72,70 @@ RSpec.describe SearchResultPresenter do
         parts: [],
       }
       expect(subject.document_list_component_data).to eql(expected_document)
+    end
+    context "has parts" do
+      let(:parts) {
+        [
+          {
+            title: "I am a part title",
+            slug: "part-path",
+            body: "Part description",
+          },
+          {
+            title: "I am a part title 2",
+            slug: "part-path2",
+          },
+        ]
+      }
+      let(:expected_parts) {
+        [
+          {
+            link: {
+              text: "I am a part title",
+              path: "#{link}/part-path",
+              description: "Part description",
+              data_attributes: {
+                ecommerce_path: "part-path",
+                track_category: "resultPart",
+                track_action: "Result part",
+                track_label: "Part 1",
+                track_options: {
+                  dimension82: 1,
+                },
+              },
+            },
+          },
+        ]
+      }
+
+      let(:document) {
+        FactoryBot.build(:document,
+                         title: title,
+                         link: link,
+                         description_with_highlighting: description,
+                         is_historic: is_historic,
+                         government_name: "Government!",
+                         format: "cake",
+                         es_score: 0.005,
+                         content_id: "content_id",
+                         filter_key: "filter_value",
+                         index: 1,
+                         parts: parts)
+      }
+      it "shows only parts with required data" do
+        expect(subject.document_list_component_data[:parts]).to eq(expected_parts)
+      end
+
+      it "notifies of a validation error for missing part data" do
+        expect(GovukError).to receive(:notify).with(
+          instance_of(described_class::MalformedPartError),
+          extra: {
+            part: { title: "I am a part title 2", slug: "part-path2" },
+            link: "link-1",
+          },
+        )
+        subject.document_list_component_data
+      end
     end
   end
 


### PR DESCRIPTION
## What
Enhance the [document-list component](https://components.publishing.service.gov.uk/component-guide/document_list) to be able to show document parts - pages that are a part of the same parent document (guide)

For now we have vendored-in and extended the component locally, with the aim to port the changes upstream if there is a need.

To style the 'parts' on larger viewports we use CSS Grid for side-by-side display
<img width="662" alt="Screenshot 2020-01-22 at 11 52 46" src="https://user-images.githubusercontent.com/3758555/72892193-d5429080-3d0d-11ea-9125-9a06431684c1.png">

**Mobile**
<img width="433" alt="Screenshot 2020-01-22 at 11 52 59" src="https://user-images.githubusercontent.com/3758555/72892212-df648f00-3d0d-11ea-9b53-fb265d35cd13.png">

## Why
Part of the effort to provide users more useful search results.
Externally, we already provide a page-specific machine-readable FAQ  schema, that search engines use to display parts - see below 

<img width="709" alt="Screenshot 2020-01-13 at 09 49 47" src="https://user-images.githubusercontent.com/3758555/72246175-150cc800-35ea-11ea-8f3c-16bd32520ad8.png">


## Example 
- https://finder-frontend-pr-1849.herokuapp.com/search/all?keywords=universal+credit

[Trello ticket](https://trello.com/c/LALh4pr3/1228-display-results-in-parts-fe-work)