### PR TITLE
Turn on new colours

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
-$govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import 'reset';
 @import 'govuk_publishing_components/all_components';

--- a/app/assets/stylesheets/components/_email-link.scss
+++ b/app/assets/stylesheets/components/_email-link.scss
@@ -1,7 +1,7 @@
 .app-c-email-link {
   display: block;
   padding: govuk-spacing(4);
-  background: govuk-colour('grey-4');
+  background: govuk-colour('light-grey');
 
   .govuk-heading-m {
     margin-bottom: govuk-spacing(2);

--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -1,7 +1,7 @@
 .app-c-expander {
   padding: 0 0 govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  border-bottom: 1px solid govuk-colour("light-grey", $legacy: "grey-3");
+  border-bottom: 1px solid govuk-colour("light-grey");
 }
 
 .app-c-expander__title {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -2,7 +2,7 @@
   position: relative;
   padding: 0 0 govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  border-bottom: 1px solid govuk-colour("light-grey", $legacy: "grey-3");
+  border-bottom: 1px solid govuk-colour("light-grey");
 
   @include govuk-media-query($from: desktop) {
     // Redefine scrollbars on desktop where these lists are scrollable

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -202,6 +202,7 @@ mark {
       -webkit-box-shadow: inset 0 0 0 2px;
       box-shadow: inset 0 0 0 2px;
       border: solid 1px govuk-colour("black");
+      outline: 3px solid $govuk-focus-colour;
     }
   }
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -82,7 +82,7 @@ mark {
 .published-by {
   @include govuk-font(14);
   display: block;
-  color: govuk-colour("dark-grey", $legacy: "grey-1");
+  color: govuk-colour("dark-grey");
 }
 
 .debug-results {
@@ -121,7 +121,7 @@ mark {
   padding: 5px;
 
   &:nth-child(odd) {
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
   }
 }
 
@@ -157,9 +157,9 @@ mark {
   display: block;
   position: relative;
   padding: 5px;
-  border: 1px solid govuk-colour("dark-grey", $legacy: "grey-1");
+  border: 1px solid govuk-colour("dark-grey");
   border-radius: 5px;
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
 
   .js-enabled & {
     padding: 8px 7px 7px 23px;

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -35,11 +35,8 @@ mark {
 
 .related-links__link {
   @include govuk-font(16, $weight: bold);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
+  @include govuk-link-common;
+  @include govuk-link-style-default;
 }
 
 .filter-form {

--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -48,7 +48,7 @@
 
   .brexit-checker-actions__description {
     padding: govuk-spacing(4);
-    background-color: govuk-colour('grey-4');
+    background-color: govuk-colour('light-grey');
   }
 
   .brexit-checker-actions__group {


### PR DESCRIPTION
## Why
Ongoing effort to update govuk apps with new improvements
[FE Accessibility team Trello ticket](https://trello.com/c/OzaySCtS/118-switch-to-new-colours-in-finder-frontend)
[Search team Trello ticket](https://trello.com/c/Z8hrCdzZ/1259-turn-on-new-colours)

## What
- Turn off `$govuk-use-legacy-palette` flag
- update colour variables
- remove legacy colour fallbacks
- fix some custom link styles

## Search page examples to sanity check:

- https://finder-frontend-pr-1850.herokuapp.com/search/all
- https://finder-frontend-pr-1850.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1850.herokuapp.com/search/business-finance-support
- https://finder-frontend-pr-1850.herokuapp.com/get-ready-brexit-check/questions

