### PR TITLE
Use full taxon registry for taxon validation

### DIFF
--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -5,7 +5,7 @@ module Registries
     def all
       @all ||= {
         "world_locations" => world_locations,
-        "all_part_of_taxonomy_tree" => topic_taxonomy,
+        "all_part_of_taxonomy_tree" => full_topic_taxonomy,
         "part_of_taxonomy_tree" => topic_taxonomy,
         "people" => people,
         "organisations" => organisations,

--- a/lib/registries/full_topic_taxonomy_registry.rb
+++ b/lib/registries/full_topic_taxonomy_registry.rb
@@ -14,6 +14,10 @@ module Registries
       "registries/full_topic_taxonomy"
     end
 
+    def values
+      taxonomy
+    end
+
   private
 
     def cacheable_data

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -39,7 +39,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
   describe "GET #new" do
     describe "finder email signup item doesn't exist" do
       it "returns a 404, rather than 5xx" do
-        content_store_does_not_have_item("/does-not-exist/email-signup")
+        stub_content_store_does_not_have_item("/does-not-exist/email-signup")
         get :new, params: { slug: "does-not-exist" }
         expect(response.status).to eq(404)
       end
@@ -47,7 +47,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     describe "finder email signup item does exist" do
       before do
-        content_store_has_item("/does-exist/email-signup", signup_finder)
+        stub_content_store_has_item("/does-exist/email-signup", signup_finder)
       end
       it "returns a success" do
         get :new, params: { slug: "does-exist" }
@@ -60,7 +60,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
   describe "POST #create" do
     context "when finder email signup item doesn't exist" do
       before do
-        content_store_does_not_have_item("/does-not-exist/email-signup")
+        stub_content_store_does_not_have_item("/does-not-exist/email-signup")
       end
       it "returns a 404" do
         get :new, params: { slug: "does-not-exist" }
@@ -70,8 +70,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when Email Alert API returns a 422 error" do
       before do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+        stub_content_store_has_item("/cma-cases", cma_cases_content_item)
+        stub_content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
       end
 
       it "returns a 200 and displays the signup page" do
@@ -87,8 +87,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when the finder signup page has filters (CMA Cases)" do
       before do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+        stub_content_store_has_item("/cma-cases", cma_cases_content_item)
+        stub_content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
       end
 
       context "when no filters are provided" do
@@ -130,8 +130,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when the signup page has 'dynamic' filters (News and Communications)" do
       before do
-        content_store_has_item("/news-and-communications", news_and_communications_content_item)
-        content_store_has_item("/news-and-communications/email-signup", news_and_communications_signup_content_item)
+        stub_content_store_has_item("/news-and-communications", news_and_communications_content_item)
+        stub_content_store_has_item("/news-and-communications/email-signup", news_and_communications_signup_content_item)
       end
 
       it "redirects to the correct email subscription url with subscriber_list_params" do
@@ -176,8 +176,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when the signup page has 'option lookup' filters (Policy Papers and Consultations)" do
       before do
-        content_store_has_item("/search/policy-papers-and-consultations", policy_papers_finder_content_item)
-        content_store_has_item("/search/policy-papers-and-consultations/email-signup", policy_papers_finder_signup_content_item)
+        stub_content_store_has_item("/search/policy-papers-and-consultations", policy_papers_finder_content_item)
+        stub_content_store_has_item("/search/policy-papers-and-consultations/email-signup", policy_papers_finder_signup_content_item)
       end
 
       it "redirects to the correct email subscription URL" do
@@ -205,8 +205,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when facet choices contain filter_values (Research and Statistics)" do
       before do
-        content_store_has_item("/search/research-and-statistics", research_and_stats_finder_content_item)
-        content_store_has_item("/search/research-and-statistics/email-signup", research_and_stats_finder_signup_content_item)
+        stub_content_store_has_item("/search/research-and-statistics", research_and_stats_finder_content_item)
+        stub_content_store_has_item("/search/research-and-statistics/email-signup", research_and_stats_finder_signup_content_item)
       end
 
       it "will redirect the user to the subscription URL" do
@@ -305,8 +305,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when additional keys or values are provided by the user" do
       before do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
+        stub_content_store_has_item("/cma-cases", cma_cases_content_item)
+        stub_content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
       end
       it "will strip surplus keys or values" do
         email_alert_api_has_subscriber_list(
@@ -332,8 +332,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when unprocessable keys are provided by the user" do
       before do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
+        stub_content_store_has_item("/cma-cases", cma_cases_content_item)
+        stub_content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
       end
       it "will redirect the user to the signup page" do
         post :create, params: {
@@ -347,8 +347,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
     context "when unprocessable keys are provided by the user" do
       before do
-        content_store_has_item("/cma-cases", cma_cases_content_item)
-        content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
+        stub_content_store_has_item("/cma-cases", cma_cases_content_item)
+        stub_content_store_has_item("/cma-cases/email-signup", bad_input_finder_signup_content_item)
       end
       it "will redirect the user to the signup page" do
         post :create, params: {
@@ -363,8 +363,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
     # TODO: Remove email_filter_by key
     context "with email_filter_by set to 'facet_values'" do
       it "should call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do
-        content_store_has_item("/find-eu-exit-guidance-business", business_readiness_content_item)
-        content_store_has_item("/find-eu-exit-guidance-business/email-signup", business_readiness_signup_content_item)
+        stub_content_store_has_item("/find-eu-exit-guidance-business", business_readiness_content_item)
+        stub_content_store_has_item("/find-eu-exit-guidance-business/email-signup", business_readiness_signup_content_item)
         email_alert_api_has_subscriber_list(
           "links" => {
             "facet_values" => { any: %w(24fd50fa-6619-46ca-96cd-8ce90fa076ce) },
@@ -387,8 +387,8 @@ describe EmailAlertSubscriptionsController, type: :controller do
 
       context "with blank email_filter_by" do
         before do
-          content_store_has_item("/cma_cases", cma_cases_content_item)
-          content_store_has_item("/cma_cases/email-signup", cma_cases_signup_content_item)
+          stub_content_store_has_item("/cma_cases", cma_cases_content_item)
+          stub_content_store_has_item("/cma_cases/email-signup", cma_cases_signup_content_item)
         end
 
         it "should not call EmailAlertListTitleBuilder instead of EmailAlertTitleBuilder" do

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -22,9 +22,10 @@ describe EmailAlertSubscriptionsController, type: :controller do
   before do
     Rails.cache.clear
     topic_taxonomy_has_taxons([
-      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_one, title: "Magical Education"),
+      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_one, title: "Magical Education", child_taxons: [
+        FactoryBot.build(:taxon_hash, content_id: taxon_content_id_two, title: "Herbology"),
+      ]),
       FactoryBot.build(:level_one_taxon_hash, content_id: brexit_taxon_id, title: "Brexit"),
-      FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_two, title: "Herbology"),
     ])
 
     stub_people_registry_request
@@ -137,7 +138,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
         email_alert_api_has_subscriber_list(
           "links" => {
             "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
-            "taxon_tree" => { "all" => [brexit_taxon_id, taxon_content_id_two, taxon_content_id_one] },
+            "taxon_tree" => { "all" => [taxon_content_id_one, taxon_content_id_two, brexit_taxon_id] },
             "content_purpose_subgroup" => { "any" => %w(news speeches_and_statements) },
           },
           "subscription_url" => "http://www.gov.uk/subscription/news",
@@ -184,7 +185,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
           "links" => {
             "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
             "content_store_document_type" => { "any" => %w(impact_assessment case_study policy_paper) },
-            "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+            "taxon_tree" => { "all" => [taxon_content_id_one, taxon_content_id_two] },
             "content_purpose_supergroup" => { "any" => %w(policy_and_engagement) },
           },
           "subscription_url" => "http://www.gov.uk/subscription/policy-papers-and-consultations",
@@ -218,7 +219,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
               ),
             },
             "organisations" => { "any" => ["content_id_for_#{org_slug_one}", "content_id_for_#{org_slug_two}"] },
-            "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+            "taxon_tree" => { "all" => [taxon_content_id_one, taxon_content_id_two] },
           },
           "subscription_url" => "http://www.gov.uk/subscription/research-and-stats",
         )
@@ -259,7 +260,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
                   dfid_research_output independent_report research
                 ),
               },
-              "taxon_tree" => { "all" => [taxon_content_id_two, taxon_content_id_one] },
+              "taxon_tree" => { "all" => [taxon_content_id_one, taxon_content_id_two] },
             },
             "subscription_url" => "http://www.gov.uk/subscription/research-and-stats",
           )

--- a/spec/factories/level_one_taxon_hash.rb
+++ b/spec/factories/level_one_taxon_hash.rb
@@ -18,9 +18,15 @@ FactoryBot.define do
       number_of_children { 0 }
     end
 
+    transient do
+      child_taxons { [] }
+    end
+
     after(:build) do |taxon, evaluator|
       taxon[:links] =
-        if evaluator.number_of_children == 0
+        if evaluator.child_taxons.any?
+          { child_taxons: evaluator.child_taxons }
+        elsif evaluator.number_of_children == 0
           {}
         else
           { child_taxons: FactoryBot.build_list(:taxon_hash, evaluator.number_of_children) }

--- a/spec/support/taxonomy_helper.rb
+++ b/spec/support/taxonomy_helper.rb
@@ -17,14 +17,14 @@ private
 
   def has_root_taxon_with(level_one_taxon_hashes)
     root_taxon_hash = FactoryBot.build(:root_taxon_hash, level_one_taxon_hashes: level_one_taxon_hashes)
-    content_store_has_item("/", root_taxon_hash)
+    stub_content_store_has_item("/", root_taxon_hash)
   end
 
   def has_taxons(taxon_hashes)
     return if taxon_hashes.nil?
 
     taxon_hashes.each do |taxon_hash|
-      content_store_has_item(taxon_hash["base_path"], taxon_hash)
+      stub_content_store_has_item(taxon_hash["base_path"], taxon_hash)
       has_taxons(taxon_hash.dig("links", "child_taxons"))
     end
   end


### PR DESCRIPTION
Using the full taxonomy, rather than the taxonomy tree,
lets us validate taxons which are more than one level
deep in the tree.

This fixes a bug where one would attempt to subscribe
to emails filtered by a top level taxon and a child
taxon, but would be subscribed to a list filtered
only by the top level taxon.

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1851.herokuapp.com/search/all
- https://finder-frontend-pr-1851.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1851.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1851.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1851.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1851.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1851.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1851.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1851.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1851.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
