### PR TITLE
Enable Autocomplete in Frontend

### DIFF
--- a/app/presenters/autocomplete_suggestion_presenter.rb
+++ b/app/presenters/autocomplete_suggestion_presenter.rb
@@ -1,0 +1,19 @@
+class AutocompleteSuggestionPresenter
+  def initialize(autocomplete_results, content_item_id)
+    @autocomplete_results = autocomplete_results
+    @content_item_id = content_item_id
+  end
+
+  def autocompletions
+    @autocomplete_results.map
+    {
+      keywords: autocomplete_results,
+      data_attributes:
+      {
+        ecommerce_content_id: @content_item_id,
+        ecommerce_row: 1,
+        track_options: {},
+      },
+    }
+  end
+end

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -10,11 +10,12 @@ module Search
       ParamValidator.new(query).validate
     end
 
-    def initialize(content_item, filter_params, ab_params: {}, override_sort_for_feed: false)
+    def initialize(content_item, filter_params, ab_params: {}, override_sort_for_feed: false, autocomplete_query: false)
       @content_item = content_item
       @filter_params = filter_params
       @ab_params = ab_params
       @override_sort_for_feed = override_sort_for_feed
+      @autocomplete_query = autocomplete_query
       @order =
         if override_sort_for_feed
           "most-recent"
@@ -33,7 +34,7 @@ module Search
 
   private
 
-    attr_reader :ab_params, :override_sort_for_feed, :content_item
+    attr_reader :ab_params, :override_sort_for_feed, :content_item, :autocomplete_query
 
     def merge_and_deduplicate(search_response)
       results = search_response.fetch("results")
@@ -85,6 +86,7 @@ module Search
         params: filter_params,
         ab_params: ab_params,
         override_sort_for_feed: override_sort_for_feed,
+        autocomplete_query: autocomplete_query,
       ).call
 
       if queries.one?


### PR DESCRIPTION
WIP pull request for implementation comments. Modifies existing finder such that we can create searches that only return autocomplete results, and presents those results to the user on the front end.

Info in this trello card: https://trello.com/c/eRITjGeX/1253-implement-autocomplete