### PR TITLE
Hide print link if JS not available

### DIFF
--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -85,28 +85,33 @@
   }
 
   .brexit-checker__print-link {
-    @include govuk-font(19);
-    background: image-url("govuk_publishing_components/icon-print.png") no-repeat 10px 50%;
-    padding: 0.5em 0.5em 0.5em 38px;
-    margin-left: -10px;
-    margin-top: govuk-spacing(3);
-    outline: 0;
-    border: 0;
-    cursor: pointer;
-    text-decoration: underline;
-    color: $govuk-link-colour;
+    display: none;
 
-    @include govuk-device-pixel-ratio($ratio: 2) {
-      background-image: image-url("govuk_publishing_components/icon-print-2x.png");
-      background-size: 16px 18px;
-    }
+    .js-enabled & {
+      @include govuk-font(19);
+      display: inline-block;
+      background: image-url("govuk_publishing_components/icon-print.png") no-repeat 10px 50%;
+      padding: 0.5em 0.5em 0.5em 38px;
+      margin-left: -10px;
+      margin-top: govuk-spacing(3);
+      outline: 0;
+      border: 0;
+      cursor: pointer;
+      text-decoration: underline;
+      color: $govuk-link-colour;
 
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
+      @include govuk-device-pixel-ratio($ratio: 2) {
+        background-image: image-url("govuk_publishing_components/icon-print-2x.png");
+        background-size: 16px 18px;
+      }
 
-    &:focus {
-      @include govuk-focused-text;
+      &:hover {
+        color: $govuk-link-hover-colour;
+      }
+
+      &:focus {
+        @include govuk-focused-text;
+      }
     }
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/JcC2UeYw/354-hide-print-link-if-javascript-is-disabled

## What
Hide the print link when JS is disabled.

## Why
The print link relies on JS, so doesn't work if JS is not available.

[Example](https://finder-frontend-pr-1853.herokuapp.com/get-ready-brexit-check/results?c%5B%5D=pharma&c%5B%5D=do-not-ip&c%5B%5D=do-not-sell-to-public-sector&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=do-not-personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)