### PR TITLE
Update travel question description

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -55,6 +55,7 @@ questions:
       - living-uk
     description: |
       <p>This also includes Switzerland, Norway, Iceland and Liechtenstein.</p>
+      <p>It does not include travel to Ireland.</p>
       <p>Business travel includes activities such as travelling for meetings and conferences, providing services, and touring art or music.</p>
     detail_text: |
       <p>After Brexit, the rules for business travel to the EU will change.</p>


### PR DESCRIPTION
Trello: https://trello.com/c/61rMtp3A/352-update-business-travel-question-descriptive-text

Add some descriptive text to the business travel question to say that it doesn't include travel to Ireland. 

<img width="616" alt="Screenshot 2020-01-10 at 10 27 16" src="https://user-images.githubusercontent.com/29889908/72146154-cb2aa480-3393-11ea-826b-373359ebc99c.png">


[Example](https://finder-frontend-pr-1854.herokuapp.com/get-ready-brexit-check/questions?c%5B%5D=working-uk&c%5B%5D=working-ie&c%5B%5D=working-eu&c%5B%5D=studying-uk&c%5B%5D=studying-ie&c%5B%5D=studying-eu&c%5B%5D=living-uk&c%5B%5D=nationality-uk&page=3)