### PR TITLE
The brexit checker results page no longer displays all criteria

### DIFF
--- a/lib/brexit_checker/results_audiences.rb
+++ b/lib/brexit_checker/results_audiences.rb
@@ -5,7 +5,7 @@ class BrexitChecker::ResultsAudiences
 
       {
         actions: audience_actions,
-        criteria: audience_actions.flat_map(&:all_criteria).uniq,
+        criteria: audience_actions.flat_map(&:all_criteria).uniq & selected_criteria,
       }
     end
 
@@ -18,7 +18,7 @@ class BrexitChecker::ResultsAudiences
           result << {
             group: group,
             actions: selected_actions,
-            criteria: selected_actions.flat_map(&:all_criteria).uniq,
+            criteria: selected_actions.flat_map(&:all_criteria).uniq & selected_criteria,
           }
         end
         result


### PR DESCRIPTION
The Brexit checker results page previously displayed all criteria
defined in the displayed action. This needs to be limited by the
criteria the user actually selected.

Trello: https://trello.com/c/KKrTCJXU/357-bug-answers-in-checker-dont-match-the-criteria-listed-on-results-page
---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
