### PR TITLE
Make relevance the default sort if most-viewed is disabled

### DIFF
--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -49,15 +49,11 @@ private
         label: option["name"],
         value: option_value(option),
         key: option["key"],
-        default: is_default?(option),
+        default: option_value(option) == option_value(raw_default_option),
         selected: option_value(option) == option_value(selected_option),
         disabled: option_value(option) == disabled_option_value,
       )
     end
-  end
-
-  def is_default?(option)
-    option["default"]
   end
 
   def options_as_hashes
@@ -65,7 +61,12 @@ private
   end
 
   def user_selected_option
-    sort_options.find { |option| option_value(option) == user_selected_order }
+    selected = sort_options.find { |option| option_value(option) == user_selected_order }
+    if selected == popularity_option && !relevance_option.nil? && keywords.present?
+      relevance_option
+    else
+      selected
+    end
   end
 
   def disabled_option_value
@@ -77,7 +78,12 @@ private
   end
 
   def raw_default_option
-    sort_options.find { |option| option["default"] }
+    default = sort_options.find { |option| option["default"] }
+    if default == popularity_option && !relevance_option.nil? && keywords.present?
+      relevance_option
+    else
+      default
+    end
   end
 
   def relevance_option

--- a/lib/search/order_query_builder.rb
+++ b/lib/search/order_query_builder.rb
@@ -15,6 +15,8 @@ module Search
 
       return order_by_relevance_query if sort_option.present? && order_by_relevance?(sort_option)
 
+      return order_by_relevance_query if keywords.present? && sort_option.present? && order_by_popularity?(sort_option)
+
       return order_by_sort_option_query if sort_option.present?
 
       return order_by_relevance_query if keywords.present?
@@ -28,6 +30,10 @@ module Search
 
     def order_by_relevance?(sort_option)
       %w(relevance -relevance topic -topic).include?(sort_option.dig("key"))
+    end
+
+    def order_by_popularity?(sort_option)
+      %w(popularity -popularity).include?(sort_option.dig("key"))
     end
 
     def public_timestamp_unsupported

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SortPresenter do
   subject(:presenter_without_sort) { described_class.new(content_item(sort_options: no_sort_options), values) }
   subject(:presenter_with_sort) { described_class.new(content_item(sort_options: sort_options_without_relevance), values) }
   subject(:presenter_with_default) { described_class.new(content_item(sort_options: sort_options_with_default), values) }
+  subject(:presenter_with_popularity_default_and_relevance) { described_class.new(content_item(sort_options: sort_options_with_popularity_default_and_relevance), values) }
   subject(:presenter_with_relevance) { described_class.new(content_item(sort_options: sort_options_with_relevance), values) }
   subject(:presenter_with_relevance_selected) {
     described_class.new(
@@ -37,6 +38,13 @@ RSpec.describe SortPresenter do
     [
       { "name" => "Most viewed", "key" => "-popularity" },
       { "name" => "Updated (oldest)", "key" => "-public_timestamp", "default" => true },
+    ]
+  }
+
+  let(:sort_options_with_popularity_default_and_relevance) {
+    [
+      { "name" => "Most viewed", "key" => "-popularity", "default" => true },
+      { "name" => "Relevance", "key" => "relevance" },
     ]
   }
 
@@ -97,30 +105,46 @@ RSpec.describe SortPresenter do
     end
 
     it "should disable the relevance option if keywords are not present" do
-      expect(presenter_with_relevance.to_hash[:options].find { |o|
+      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
         o[:value] == "relevance"
       }[:disabled]).to be true
+
+      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
+        o[:value] == "relevance"
+      }[:selected]).to be false
     end
 
     it "should enable the popularity option if keywords are not present" do
-      expect(presenter_with_relevance.to_hash[:options].find { |o|
+      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
         o[:value] == "most-viewed"
       }[:disabled]).to be false
+
+      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
+        o[:value] == "most-viewed"
+      }[:selected]).to be true
     end
 
     context "keywords are not blank" do
       let(:values) { { "keywords" => "something not blank" } }
 
       it "should not disable relevance" do
-        expect(presenter_with_relevance.to_hash[:options].find { |o|
+        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
           o[:value] == "relevance"
         }[:disabled]).to be false
+
+        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
+          o[:value] == "relevance"
+        }[:selected]).to be true
       end
 
       it "should disable popularity" do
-        expect(presenter_with_relevance.to_hash[:options].find { |o|
+        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
           o[:value] == "most-viewed"
         }[:disabled]).to be true
+
+        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
+          o[:value] == "most-viewed"
+        }[:selected]).to be false
       end
     end
 


### PR DESCRIPTION
When keywords are given the most-viewed option is disabled in the
drop-down box, but still used to sort the results (as it's the default
sort).

See:

- https://finder-frontend-pr-1858.herokuapp.com/search/all?keywords=frogs
- https://finder-frontend-pr-1858.herokuapp.com/search/all?keywords=frogs&order=most-viewed
- https://finder-frontend-pr-1858.herokuapp.com/search/all?order=most-viewed

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1858.herokuapp.com/search/all
- https://finder-frontend-pr-1858.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1858.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1858.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1858.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1858.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1858.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1858.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1858.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1858.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
