### PR TITLE
Update the link for T058

### DIFF
--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -1048,7 +1048,7 @@ actions:
   lead_time: It takes up to 4 weeks
   guidance_prompt: More information
   guidance_link_text: Trading electricity if there’s no Brexit deal
-  guidance_url: https://www.gov.uk/government/publications/trading-electricity-if-theres-no-brexit-deal/trading-electricity-if-theres-no-brexit-deal
+  guidance_url: https://www.gov.uk/government/publications/trading-electricity-if-theres-no-brexit-deal
   criteria:
   - electricity
   audience: business


### PR DESCRIPTION
Trello: https://trello.com/c/Oj8u6tmL/366-t058-trading-wholesale-energy-change-of-url

The URL for this action went directly to the HTML document whereas it should have linked to the landing page above that document