### PR TITLE
Remove keyword facet tags

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -172,7 +172,6 @@ private
   def facet_tags
     @facet_tags ||= FacetTagsPresenter.new(
       facets.select(&:filterable?),
-      keywords,
       sort_presenter,
       i_am_a_topic_page_finder: i_am_a_topic_page_finder,
     )

--- a/app/presenters/facet_tags_presenter.rb
+++ b/app/presenters/facet_tags_presenter.rb
@@ -1,7 +1,6 @@
 class FacetTagsPresenter
-  def initialize(filters, keywords, sort_presenter, i_am_a_topic_page_finder: false)
+  def initialize(filters, sort_presenter, i_am_a_topic_page_finder: false)
     @filters = filters
-    @keywords = keywords
     @sort_option = sort_presenter.selected_option || {}
     @i_am_a_topic_page_finder = i_am_a_topic_page_finder
   end
@@ -25,9 +24,9 @@ class FacetTagsPresenter
 
 private
 
-  attr_reader :filters, :sort_option, :keywords, :i_am_a_topic_page_finder
+  attr_reader :filters, :sort_option, :i_am_a_topic_page_finder
 
   def selected_filters
-    (filters + [KeywordFacet.new(keywords)]).select(&:has_filters?)
+    filters.select(&:has_filters?)
   end
 end

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -71,8 +71,6 @@ Feature: Filtering documents
     Then I should see results and pagination
     When I fill in a keyword that should match no results
     Then the results and pagination should be removed
-    And I click the xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx remove control
-    Then I should see results and pagination
 
   Scenario: Visit a finder with metadata
     Given a finder with metadata exists
@@ -185,41 +183,12 @@ Feature: Filtering documents
       | Azkaban            | "World location" | world_locations-azkaban         |
 
   @javascript
-  Scenario: Removing keyword filter
-    When I view the news and communications finder
-    Then I see Updated (newest) order selected
-    And I fill in some keywords
-    Then I see Relevance order selected
-    And the page title contains both keywords
-    And I click the Keyword1 remove control
-    Then The keyword textbox only contains Keyword2
-    And I see Relevance order selected
-    And the page title contains only Keyword2
-    And I click the Keyword2 remove control
-    Then The keyword textbox is empty
-    And I see Updated (newest) order selected
-    And the page title contains no keywords
-
-  @javascript
   Scenario: Adding keyword filter
     When I view the news and communications finder
     Then I see Updated (newest) order selected
     And I fill in some keywords
     And I press tab key to navigate
     Then I see Relevance order selected
-
-  @javascript
-  Scenario: Removing keyword filter in business finder
-    When I view the business readiness finder
-    Then I see Topic order selected
-    And I fill in some keywords
-    Then I see Relevance order selected
-    And I click the Keyword1 remove control
-    Then The keyword textbox only contains Keyword2
-    And I see Relevance order selected
-    And I click the Keyword2 remove control
-    Then The keyword textbox is empty
-    And I see Topic order selected
 
   @javascript
   Scenario: Adding keyword filter in business finder

--- a/spec/presenters/atom_presenter_spec.rb
+++ b/spec/presenters/atom_presenter_spec.rb
@@ -12,17 +12,15 @@ RSpec.describe AtomPresenter do
                      title: "News and communications")
   }
 
-  let(:keywords) { "" }
-
   let(:filters) {
     [a_facet, another_facet, a_date_facet]
   }
 
   let(:facet_tags) {
-    FacetTagsPresenter.new(filters, keywords, sort_presenter)
+    FacetTagsPresenter.new(filters, sort_presenter)
   }
 
-  let(:filter_params) { double(:filter_params, keywords: "") }
+  let(:filter_params) { double(:filter_params) }
   let(:sort_presenter) { double(:sort_presenter, selected_option: nil) }
 
   let(:a_facet) do

--- a/spec/presenters/facet_tags_presenter_spec.rb
+++ b/spec/presenters/facet_tags_presenter_spec.rb
@@ -4,11 +4,9 @@ require_relative "./helpers/facets_helper"
 describe FacetTagsPresenter do
   include FacetsHelper
 
-  subject(:presenter) { described_class.new(filters, keywords, sort_presenter) }
+  subject(:presenter) { described_class.new(filters, sort_presenter) }
 
   let(:filters) { [a_facet, another_facet, a_date_facet] }
-
-  let(:keywords) { "" }
 
   let(:sort_presenter) {
     double(
@@ -30,28 +28,6 @@ describe FacetTagsPresenter do
 
       filters.reject { |filter| filter.sentence_fragment.nil? }.each do |fragment|
         expect(prepositions).to include(fragment.sentence_fragment["preposition"])
-      end
-    end
-
-    context "when keywords have been searched for" do
-      let(:keywords) { "my search term" }
-
-      it "includes the keywords" do
-        applied_filters = presenter.selected_filter_descriptions.flat_map { |filter| filter }
-        text_values = applied_filters.flat_map { |filter| filter[:text] }
-
-        expect(text_values).to include("my", "search", "term")
-      end
-    end
-
-    context "when XSS attack keywords have been searched for" do
-      let(:keywords) { '"><script>alert("hello")</script>' }
-
-      it "escapes keywords appropriately" do
-        applied_filters = presenter.selected_filter_descriptions.flat_map { |filter| filter }
-        text_values = applied_filters.flat_map { |filter| filter[:text] }
-
-        expect(["script", "alert", "&quot;hello&quot;"].any? { |word| text_values.join(" ").include?(word) })
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/4ZtFx1gc/1277-remove-keyword-facets-from-search)

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1863.herokuapp.com/search/all
- https://finder-frontend-pr-1863.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1863.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1863.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1863.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1863.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1863.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1863.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1863.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1863.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
