### PR TITLE
[DO NOT MERGE BEFORE alphagov/govuk-puppet#10054] Access Worldwide API via whitehall-frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem "chronic", "~> 0.10.2"
 gem "dalli"
-gem "gds-api-adapters", "~> 63.2"
+gem "gds-api-adapters", "~> 63.3"
 gem "google-api-client"
 gem "govuk_ab_testing", "~> 2.4.1"
 gem "govuk_app_config", "~> 2.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,8 @@ GEM
       activesupport (>= 4.2.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
-    gds-api-adapters (63.2.0)
+    ffi (1.11.3)
+    gds-api-adapters (63.3.0)
       addressable
       link_header
       null_logger
@@ -437,7 +437,7 @@ DEPENDENCIES
   dalli
   dotenv-rails
   factory_bot
-  gds-api-adapters (~> 63.2)
+  gds-api-adapters (~> 63.3)
   google-api-client
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_ab_testing (~> 2.4.1)

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -553,7 +553,7 @@ module DocumentHelper
   end
 
   def whitehall_admin_world_locations_api_url
-    "#{Plek.current.find('whitehall-admin')}/api/world-locations"
+    "#{Plek.current.find('whitehall-frontend')}/api/world-locations"
   end
 
   def rummager_business_readiness_url

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -24,7 +24,7 @@ module Services
   end
 
   def self.worldwide_api
-    GdsApi::Worldwide.new(Plek.find("whitehall-admin"))
+    GdsApi.worldwide
   end
 
   def self.registries

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -535,7 +535,7 @@ describe EmailAlertSignupAPI do
             },
           ],
         }
-        stub_request(:get, "#{Plek.current.find('whitehall-admin')}/api/world-locations")
+        stub_request(:get, "#{Plek.current.find('whitehall-frontend')}/api/world-locations")
           .with(query: hash_including({}))
           .to_return(body: world_locations.to_json)
       end


### PR DESCRIPTION
To simplify the migration of Whitehall to AWS, calls to the Worldwide
API should be directed to whitehall-frontend, not whitehall-admin.

Co-authored-by: Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk>


---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
