### PR TITLE
[WIP] Add "as you type" title suggestions to search/all

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ruby:2.6.5
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get upgrade -y
-RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN apt-get install -y build-essential nodejs yarn && apt-get clean
 RUN gem install foreman
 
 ENV GOVUK_APP_NAME finder-frontend
@@ -14,6 +17,10 @@ WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
 ADD .ruby-version $APP_HOME/
 RUN bundle install
+
+ADD package.json $APP_HOME/
+ADD yarn.lock $APP_HOME/
+RUN yarn install
 
 ADD . $APP_HOME
 

--- a/app.json
+++ b/app.json
@@ -40,7 +40,10 @@
   "image": "heroku/ruby",
   "buildpacks": [
     {
-      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
     }
   ],
   "addons": []

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -15,6 +15,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$label = this.$module.querySelector('label')
     this.$submitButton = this.$module.querySelector('button[type=submit]')
     this.$searchContainer = this.$module.querySelector('.gem-c-search')
+    // store user entered partial query for further use
+    this.userEnteredQuery = ''
     // use to store suggestions
     this.cachedSuggestions = []
 
@@ -128,12 +130,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     window.GOVUK.SearchAnalytics.trackEvent(
       'suggestionClicked',
-      trackingDataOptions.position
+      'click',
+      {
+        'dimension333': this.userEnteredQuery,
+        'dimension444': trackingDataOptions.text,
+        'dimension555': trackingDataOptions.position,
+        'dimension666': trackingDataOptions.numberOfSuggestions
+      }
     )
+    document.querySelector('meta[name="govuk:publishing-application"]').setAttribute('content', 'suggestion selected')
   }
 
   Autocomplete.prototype.handleSearchQuery = function (query, populateResults) {
     statusMessage = 'Searching...'
+    this.userEnteredQuery = query
 
     // check if current string exists in the cached array
     // if it does exists, return matching items

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -1,0 +1,181 @@
+/* global XMLHttpRequest */
+//= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  // message for the user when there are no suggestions
+  // or connection failed
+  var statusMessage = null
+  function Autocomplete () {}
+
+  Autocomplete.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$input = this.$module.querySelector('input')
+    this.$label = this.$module.querySelector('label')
+    this.$submitButton = this.$module.querySelector('button[type=submit]')
+    this.$searchContainer = this.$module.querySelector('.gem-c-search')
+    // use to store suggestions
+    this.cachedSuggestions = []
+
+    // prevent autocomplete from running in IE<10 and Android WebKit
+    // http://caniuse.com/#feat=pagevisibility
+    // autocomplete does support IE9 but we have an additional check for history mode
+    // in liveSearch and a fallback submit button that in combination with
+    // with accessible autocomplete submits the form and refreshes the page
+    var featuresNeeded = (
+      'visibilityState' in document
+    )
+
+    if (!featuresNeeded) {
+      return
+    }
+
+    this.initAutoCompleteSearchBox(this.$input, this.$label, this.$submitButton)
+
+    // we have a fallback filter button
+    // with accessible autocomplete suggestions we also allow keyword search
+    // unfortunately that triggers the form submit and refreshes the page
+    var $fallbackSubmitButton = document.querySelector('.js-live-search-fallback button')
+    $fallbackSubmitButton.addEventListener('click', function (e) {
+      e.preventDefault()
+    })
+  }
+
+  Autocomplete.prototype.initAutoCompleteSearchBox = function ($input, $label, $submitButton) {
+    // a higher helper function to that executes a named function at a specified delay
+    // it's used here to only hit the api 300ms after the user finishes typing
+    // as we don't need to get results for each character immediately
+    // https://web.archive.org/web/20190112051125/https://remysharp.com/2010/07/21/throttling-function-calls/
+    function debounce (fn, delay) {
+      var timer = null
+      return function () {
+        var context = this
+        var args = arguments
+        clearTimeout(timer)
+        timer = setTimeout(function () {
+          fn.apply(context, args)
+        }, delay)
+      }
+    }
+
+    new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
+      id: $input.id,
+      name: $input.name,
+      element: this.$module,
+      defaultValue: $input.value || '',
+      cssNamespace: 'app-autocomplete-search',
+      displayMenu: 'overlay',
+      confirmOnBlur: false,
+      placeholder: $label.innerText,
+      onConfirm: this.handleOnConfirm.bind(this),
+      minLength: 3,
+      source: debounce(this.handleSearchQuery, 300).bind(this),
+      tNoResults: function () { return statusMessage }
+    })
+
+    this.enhanceSearchBox(this.$label, $submitButton, this.$searchContainer)
+  }
+
+  Autocomplete.prototype.enhanceSearchBox = function ($label, $submitButton, $searchContainer) {
+    // as we're removing the old search element we want to keep the old label and text
+    // but hide it as we're using the placeholder
+    var $labelClone = $label.cloneNode(true)
+    $labelClone.className = 'govuk-visually-hidden'
+
+    // we'll place the submit button back so that users
+    // are assured this is a search box
+    var $submitButtonClone = $submitButton.cloneNode(true)
+
+    // remove the old search box and insert the copy of the label and submit button
+    this.$module.removeChild($searchContainer)
+    this.$module.insertAdjacentElement('beforebegin', $labelClone)
+    this.$module.querySelector('.app-autocomplete-search__wrapper')
+      .insertAdjacentElement('afterend', $submitButtonClone)
+  }
+
+  Autocomplete.prototype.handleOnConfirm = function (query) {
+    // if GA available trigger click event submission on selected suggestion
+    this.trackSelectedOption(query)
+
+    // update the form input with the suggestion value the user selected
+    var $enhancedInput = this.$module.querySelector('input')
+    $enhancedInput.value = query
+
+    // dispatch the custom form change event to trigger the livesearch functionality
+    var $form = document.querySelector('.js-live-search-form')
+    var customEvent = document.createEvent('HTMLEvents')
+    customEvent.initEvent('customFormChange', true, false)
+    $form.dispatchEvent(customEvent)
+  }
+
+  Autocomplete.prototype.trackSelectedOption = function (query) {
+    // built-in onConfirm method only provides acces to the query
+    // so we need to find our own index of the selected option
+    // by checking for matching query string
+    var $availableSuggestionsNodeArray = Array.prototype.slice.call(this.$module.querySelector('.app-autocomplete-search__menu').childNodes)
+    // get data from the node to use in tracking
+    var trackingDataOptions = {}
+    for (var i = 0; i < $availableSuggestionsNodeArray.length; i++) {
+      var node = $availableSuggestionsNodeArray[i]
+      if (node.innerText === query) {
+        trackingDataOptions.text = node.innerText
+        trackingDataOptions.position = node.getAttribute('aria-posinset')
+        trackingDataOptions.numberOfSuggestions = node.getAttribute('aria-setsize')
+        break
+      }
+    }
+
+    window.GOVUK.SearchAnalytics.trackEvent(
+      'suggestionClicked',
+      trackingDataOptions.position
+    )
+  }
+
+  Autocomplete.prototype.handleSearchQuery = function (query, populateResults) {
+    statusMessage = 'Searching...'
+
+    // check if current string exists in the cached array
+    // if it does exists, return matching items
+    var matchingCachedResults = this.cachedSuggestions.filter(function (suggestion) {
+      return suggestion.toLowerCase().indexOf(query.toLowerCase()) !== -1
+    })
+
+    // if there are no matches in the cached array
+    // fetch suggestions from API
+    // If source is a function, the arguments are: query: string, populateResults: Function
+    // https://github.com/alphagov/accessible-autocomplete#source
+    matchingCachedResults.length > 0
+      ? populateResults(matchingCachedResults)
+      : this.fetchSuggestions(query, populateResults)
+  }
+
+  Autocomplete.prototype.fetchSuggestions = function (query, populateResults) {
+    var request = new XMLHttpRequest()
+    request.open('GET', 'https://www.gov.uk/api/search.json?q=' + encodeURIComponent(query) + '&count=0&suggest=autocomplete', true)
+    // Time to wait before giving up fetching the search api
+    request.timeout = 5 * 1000
+    request.onreadystatechange = function () {
+      // XHR client readyState DONE
+      if (request.readyState === 4) {
+        if (request.status === 200) {
+          var response = JSON.parse(request.responseText)
+          var suggestions = response.suggested_autocomplete
+          statusMessage = 'No suggestions found'
+          cacheSuggestions(suggestions, populateResults)
+        } else {
+          statusMessage = 'Failed to load suggestions'
+        }
+      }
+    }
+    request.send()
+
+    // cache suggestions to minimise API calls
+    var cacheSuggestions = function (suggestions, populateResults) {
+      this.cachedSuggestions = suggestions
+      populateResults(suggestions)
+    }.bind(this)
+  }
+
+  Modules.Autocomplete = Autocomplete
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -154,7 +154,7 @@
       this.updateOrder()
       this.updateLinks()
       this.updateTitle()
-      this.trackAutocompleteSuggestions()
+      this.trackAutocompleteSuggestions(e)
       pageUpdated = this.updateResults()
       pageUpdated.done(
         function () {
@@ -194,21 +194,23 @@
     $spellingSuggestionMetaTag.attr('content', suggestion)
   }
 
-  LiveSearch.prototype.trackAutocompleteSuggestions = function trackAutocompleteSuggestions () {
+  LiveSearch.prototype.trackAutocompleteSuggestions = function trackAutocompleteSuggestions (e) {
     var $autocompleteSuggestions = this.$form.find('.app-autocomplete-search__menu').children()
+    // only fire if suggestion wasn't selected
+    if (e.type !== 'customFormChange') {
+      var suggestionsCount = $autocompleteSuggestions.length === 1 &&
+        $autocompleteSuggestions.hasClass('app-autocomplete-search__option--no-results')
+        ? 0 : $autocompleteSuggestions.length
 
-    var suggestionsCount = $autocompleteSuggestions.length === 1 &&
-      $autocompleteSuggestions.hasClass('app-autocomplete-search__option--no-results')
-      ? 0 : $autocompleteSuggestions.length
-
-    window.GOVUK.SearchAnalytics.trackEvent(
-      'noSuggestionClicked',
-      'click',
-      {
-        'dimension555': this.$form.find('.app-autocomplete-search__input').val(),
-        'dimension666': suggestionsCount
-      }
-    )
+      window.GOVUK.SearchAnalytics.trackEvent(
+        'noSuggestionClicked',
+        'click',
+        {
+          'dimension555': this.$form.find('.app-autocomplete-search__input').val(),
+          'dimension666': suggestionsCount
+        }
+      )
+    }
   }
 
   /**

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -154,6 +154,7 @@
       this.updateOrder()
       this.updateLinks()
       this.updateTitle()
+      this.trackAutocompleteSuggestions()
       pageUpdated = this.updateResults()
       pageUpdated.done(
         function () {
@@ -191,6 +192,23 @@
     var spellingSuggestionAvailable = this.$suggestionsBlock.find('a').length > 0
     var suggestion = spellingSuggestionAvailable ? this.$suggestionsBlock.find('a').data('track-options').dimension81 : ''
     $spellingSuggestionMetaTag.attr('content', suggestion)
+  }
+
+  LiveSearch.prototype.trackAutocompleteSuggestions = function trackAutocompleteSuggestions () {
+    var $autocompleteSuggestions = this.$form.find('.app-autocomplete-search__menu').children()
+
+    var suggestionsCount = $autocompleteSuggestions.length === 1 &&
+      $autocompleteSuggestions.hasClass('app-autocomplete-search__option--no-results')
+      ? 0 : $autocompleteSuggestions.length
+
+    window.GOVUK.SearchAnalytics.trackEvent(
+      'noSuggestionClicked',
+      'click',
+      {
+        'dimension555': this.$form.find('.app-autocomplete-search__input').val(),
+        'dimension666': suggestionsCount
+      }
+    )
   }
 
   /**

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -62,19 +62,35 @@
         }.bind(this)
       )
       // custom event listener on the form, that fires the update only once
-      // when we clear of filters
-      // fired from javascripts/modules/mobile-filters-modal.js:139
+      // when we clear of filters fired from javascripts/modules/mobile-filters-modal.js:139
+      // and when the user selects a suggestion: /javascripts/components/autocomplete.js:82
       this.$form.on('customFormChange', this.$form,
         function (e) {
           this.formChange(e)
         }.bind(this)
       )
-
-      this.$form.on('change keypress', 'input[type=text],input[type=search]',
+      // excluding .app-autocomplete-search__input as we do not wan't to trigger livesearch
+      // when the user navigates through suggestions with a keyword
+      this.$form.on('change keypress', 'input[type=text]:not(.app-autocomplete-search__input),input[type=search]',
         function (e) {
           var ENTER_KEY = 13
 
           if (e.keyCode === ENTER_KEY || e.type === 'change') {
+            if (e.currentTarget.value !== this.previousSearchTerm && !e.suppressAnalytics) {
+              LiveSearch.prototype.fireTextAnalyticsEvent(e)
+            }
+            this.formChange(e)
+            this.previousSearchTerm = e.currentTarget.value
+            e.preventDefault()
+          }
+        }.bind(this)
+      )
+
+      // but we do want to perform a livesearch if the users want to perform a keyword search
+      this.$form.on('keyup', '.app-autocomplete-search__input',
+        function (e) {
+          var ENTER_KEY = 13
+          if (e.keyCode === ENTER_KEY) {
             if (e.currentTarget.value !== this.previousSearchTerm && !e.suppressAnalytics) {
               LiveSearch.prototype.fireTextAnalyticsEvent(e)
             }

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,0 +1,168 @@
+$size: 40px;
+
+.app-autocomplete-search__wrapper {
+  display: inline-block;
+  position: relative;
+  z-index: 3; // prevents the focus outline overlapping the submit button
+  height: $size;
+  width: calc(100% - #{$size});
+}
+
+.app-autocomplete-search__wrapper + .gem-c-search__submit {
+  display: inline-block;
+  height: 40px;
+  vertical-align: bottom;
+  background-color: $govuk-brand-colour;
+  color: govuk-colour("white");
+}
+
+.app-autocomplete-search__hint,
+.app-autocomplete-search__input {
+  box-sizing: border-box;
+  width: 100%;
+  height: $size;
+  margin-bottom: 0; // BUG: Safari 10 on macOS seems to add an implicit margin.
+  padding: govuk-spacing(1) govuk-spacing(1) govuk-spacing(1) govuk-spacing(2);
+  border: $govuk-border-width-form-element solid govuk-colour("white");  
+  border-radius: 0; // Safari 10 on iOS adds implicit border rounding.
+  -webkit-appearance: none;
+}
+
+.app-autocomplete-search__hint {
+  position: absolute;
+  color: govuk-colour("mid-grey");
+}
+
+.app-autocomplete-search__input {
+  position: relative;
+  border-width: $govuk-border-width-form-element 0 $govuk-border-width-form-element $govuk-border-width-form-element;
+  border-style: solid;
+  border-color: $govuk-input-border-colour;
+
+  &:focus {
+    -webkit-box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+    outline: 3px solid $govuk-focus-colour;
+  }
+
+  &::placeholder {
+    color: govuk-colour("dark-grey");
+  }
+}
+
+.app-autocomplete-search__input--focused {
+  -webkit-box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  outline: 3px solid $govuk-focus-colour;
+}
+
+.app-autocomplete-search__input--show-all-values {
+  padding: govuk-spacing(1) 34px govuk-spacing(1) govuk-spacing(1);
+  cursor: pointer;
+}
+
+.app-autocomplete-search__dropdown-arrow-down {
+  display: inline-block;
+  position: absolute;
+  z-index: -1;
+  top: govuk-spacing(2);
+  right: 8px;
+  width: 24px;
+  height: 24px;
+}
+
+.app-autocomplete-search__menu {
+  width: 100%;
+  max-height: 342px;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+  border-top: 0;
+  color: govuk-colour("black");
+  background-color: govuk-colour("white");
+}
+
+.app-autocomplete-search__menu--visible {
+  display: block;
+}
+
+.app-autocomplete-search__menu--hidden {
+  display: none;
+}
+
+.app-autocomplete-search__menu--overlay {
+  position: absolute;
+  z-index: 100;
+  top: 100%;
+  left: 0;
+  box-shadow: rgba(govuk-colour("black"), .256863) 0 2px 6px;
+}
+
+.app-autocomplete-search__option {
+  display: block;
+  position: relative;
+  padding: govuk-spacing(2);
+  border-bottom: solid govuk-colour("mid-grey");
+  border-width: 1px 0;
+  cursor: pointer;
+}
+
+.app-autocomplete-search__option > * {
+  pointer-events: none;
+}
+
+.app-autocomplete-search__option:first-of-type {
+  border-top-width: 0;
+}
+
+.app-autocomplete-search__option:last-of-type {
+  border-bottom-width: 0;
+}
+
+.app-autocomplete-search__option--odd {
+  background-color: govuk-colour("light-grey");
+}
+
+.app-autocomplete-search__option--focused,
+.app-autocomplete-search__option:hover {
+  border-color: govuk-colour("blue");
+  // Add a transparent outline for when users change their colours.
+  outline: 3px solid transparent;
+  outline-offset: -3px;
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+
+  .app-autocomplete-search--section {
+    color: inherit;
+  }
+}
+
+.app-autocomplete-search__option--no-results {
+  color: govuk-colour("dark-grey");
+  background-color: govuk-colour("white");
+  cursor: not-allowed;
+  
+  &:empty {
+    display: none;
+  }
+}
+
+.app-autocomplete-search__hint,
+.app-autocomplete-search__input,
+.app-autocomplete-search__option {
+  @include govuk-font($size: 19);
+}
+
+.app-autocomplete-search__separator {
+  display: inline-block;
+  margin-right: govuk-spacing(1);
+  margin-left: govuk-spacing(1);
+}
+
+// adjust margin as the non-enhanced form group has a massive margin
+// with the autcomplete enhancement we're removing that, 
+// so we need to adjust it
+.app-patch--search-input-override ~ .spelling-suggestions {
+  margin-top: govuk-spacing(4);
+}

--- a/app/views/components/_autocomplete.erb
+++ b/app/views/components/_autocomplete.erb
@@ -1,0 +1,32 @@
+<%
+  id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  type ||= nil
+  hint ||= nil
+  data_attributes ||= {}
+  input ||= {}
+  search ||= false
+  search_with_label ||= false
+
+  root_classes = %w(app-autocomplete)
+  if search
+    root_classes << "app-autocomplete--search"
+  elsif search_with_label
+    root_classes << "app-autocomplete--search-with-label"
+  end
+%>
+
+<%= tag.div class: root_classes, data: data_attributes.merge(module: "autocomplete", "autocomplete-type": type) do %>
+  <%= render "govuk_publishing_components/components/label", {
+    html_for: id
+  }.merge(label.symbolize_keys) %>
+
+  <%= tag.span hint, class: "govuk-hint" if hint %>
+  <% options = Array(input[:options]) %>
+
+  <%= tag.input name: name,
+    value: input[:value],
+    class: "govuk-input",
+    id: id,
+    list: options.any? ? "#{id}-list" : nil,
+    type: search ? "search" : "text" %>
+<% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -1,0 +1,187 @@
+name: Autocomplete
+description: An autocomplete component, built to be accessible
+body: |
+  This component is build using [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete).
+
+  Typically it is used to enhance a select element with autocomplete options.
+part_of_admin_layout: true
+accessibility_criteria: |
+  [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
+examples:
+  default:
+    data:
+      id: autocomplete
+      name: autocomplete
+      label:
+        text: Select your country
+      select:
+        options:
+          -
+            -
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+
+  with_selected_value:
+    data:
+      id: autocomplete-selected
+      name: autocomplete-selected
+      label:
+        text: Select your country
+        bold: true
+      hint: Only a few countries are available
+      select:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+        selected: de
+
+  with_error:
+    data:
+      name: autocomplete-with-error
+      label:
+        text: Autocomplete with error
+      select:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+      error_items:
+        - text: There is a problem with this input
+  select_multiple:
+    data:
+      id: autocomplete-multiselect
+      name: autocomplete-multiselect
+      label:
+        text: Select your country
+      select:
+        multiple: true
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+        selected:
+            - fr
+            - de
+  autocomplete_narrow_width:
+    data:
+      id: autocomplete-narrow
+      name: autocomplete-narrow
+      label:
+        text: Status
+      width: narrow
+      select:
+        options:
+          -
+            - Draft
+          -
+            - Published
+          -
+            - Removed
+  autocomplete_input:
+    description: |
+      An enhancement to an input element. Options are provided via a datalist.
+      A user can enter a value outside the list of options.
+    data:
+      id: autocomplete-input
+      name: autocomplete-input
+      label:
+        text: Select your country
+      input:
+        value: France
+        options:
+          - France
+          - United Arab Emirates
+          - United Kingdom
+  autocomplete_without_narrowing_results:
+    description: |
+      An enhancement to an input element. All options (provided by a datalist)
+      are shown whenever the input is focused. A user can enter a value outside
+      the list of options.
+    data:
+      id: autocomplete-without-narrowing-results
+      name: autocomplete-without-narrowing-results
+      data_attributes:
+        autocomplete-without-narrowing-results: true
+      label:
+        text: Select your country
+        bold: true
+      hint: The full list will show when you interact with the input
+      input:
+        value: France
+        options:
+          - France
+          - United Arab Emirates
+          - United Kingdom
+
+  autocomplete_search:
+    description: |
+      This is used to style the autocomplete as a search. If applied to an
+      input element the underlying input is rendered with type "search" rather
+      than "text".
+    data:
+      id: autocomplete-search
+      name: autocomplete-search
+      label:
+        text: Search
+      search: true
+      input:
+        options:
+          - France
+          - Germany
+          - United Kingdom
+  autocomplete_search_with_visible_label:
+    description: |
+      The search option automatically hides the label visually. Use `search_with_label` instead of `search` if you want a visible label.
+    data:
+      id: autocomplete-search
+      name: autocomplete-search
+      label:
+        text: Search
+      search_with_label: true
+      input:
+        options:
+          - France
+          - Germany
+          - United Kingdom
+  autocomplete_js_only:
+    description: |
+      Shows an autocomplete component only if JavaScript is enabled.
+      This is used when the search input requires a JavaScript request to return results.
+    data:
+      id: autocomplete-jsonly
+      name: autocomplete-jsonly
+      label:
+        text: Search
+      search: true
+      jsonly: true
+      input:
+        options:
+          - France
+          - Germany
+          - United Kingdom

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -15,7 +15,7 @@
       } %>
     </div>
     <% if facets.select(&:filterable?).any? %>
-      <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
+      <button type="button" class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
         data-toggle="mobile-filters-modal" data-target="facet-wrapper"
         data-module="track-click" data-track-category="filterClicked" 
         data-track-action="mobile-filter-button" data-track-label="">

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -17,7 +17,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>
         <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
-        <div id="keywords" class="app-patch--search-input-override">
+        <div id="keywords" class="app-patch--search-input-override" data-module="autocomplete">
           <%= render "govuk_publishing_components/components/search", {
             aria_controls: "js-search-results-info",
             id: "finder-keyword-search",

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -35,7 +35,7 @@
           > 
           <%= render 'spelling_suggestion' %>
         </div>
-        <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
+        <button type="button" class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
           data-toggle="mobile-filters-modal" data-target="facet-wrapper"
           data-module="track-click" data-track-category="filterClicked" 
           data-track-action="mobile-filter-button" data-track-label="">

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -26,6 +26,9 @@
             value: result_set_presenter.user_supplied_keywords,
           } %>
         </div>
+        <% content_for :head do %>
+          <meta name="govuk:search-autocomplete-status" content="">
+        <% end %>
         <div id="js-spelling-suggestions" class="spelling-suggestions" 
           data-analytics-ecommerce
           data-ecommerce-start-index="1"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,8 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << "static"
+# Add Yarn node_modules folder to the asset load path.
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "standard": "^12.0.1"
+  },
+  "dependencies": {
+    "accessible-autocomplete": "^2.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+accessible-autocomplete@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.2.tgz#869d6b3b80a31e21614076b0ce47999f6b1802c8"
+  integrity sha512-cdA4O4u1xmefZuAdtL+0VBnDivdapgIZRQjm0E1bcekHnH5h67Vt1QL79NqPtlAn+6lyrR+H+pbnYVvUOJ1ULQ==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -991,6 +998,11 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## What

Enhance search on search/all with suggestions from titles that match the keywords user is entering. 
Uses [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) engine.

## Why 
Hypothesis: We think that users don’t always know what they’re looking for, so if we provide autocomplete suggestions, they will refine their search less often.

## Performance
<details>
    <summary>Strategies</summary>

- we make use of a debounce function, so that we only trigger the lookup once 300ms have elapsed between keystrokes

- we cache last shown suggestions, so if users and more characters that result in a matching query or if they delete characters, we serve those instead of fetching from the API

<img src="https://user-images.githubusercontent.com/3758555/73460312-30a8fa00-4370-11ea-95c6-80a5007d3845.gif">
</details>




[Trello card](https://trello.com/c/boqrYuXi/686-make-autocomplete-production-ready)

## Search page examples to sanity check:

- https://finder-front-add-autoco-jp2dlr.herokuapp.com/search/all

Thanks to @kevindew and @sihugh for helping with CSP and Docker yarn stuff.

