### PR TITLE
Show facets by default on tablet / desktop

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -401,11 +401,8 @@
   }
 
   LiveSearch.prototype.focusErrorMessagesOnLoad = function ($container) {
-    var $facetToggle = $container.find('.facet-toggle')
-    var facetsHidden = $facetToggle.attr('aria-expanded') === 'false'
     var $inputWithError = $container.find('input[class*=--error]')
-    if (facetsHidden && $inputWithError.length) {
-      $facetToggle.click()
+    if ($inputWithError.length) {
       $inputWithError.focus()
     }
   }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -223,56 +223,6 @@ mark {
   }
 }
 
-.facet-toggle {
-  display: none;
-  margin-bottom: govuk-spacing(4);
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(6);
-  }
-}
-
-.js-enabled {
-  .facet-toggle {
-    display: none;
-    @include govuk-media-query($from: tablet) {
-      display: inline-block;
-      margin-bottom: govuk-spacing(6);
-    }
-  }
-
-  // on mobile we have a modal hidden with Javascript
-  // so there styles should only apply from larger viewports
-  // if user closes the filter and then switches orientation to landscape
-  // we need to show the filters if they toggle them on, hence !important
-  //
-  // we are looking always show filters on table/desktop
-  // so once that decision is made, all of this can be removed 
-  @include govuk-media-query($from: tablet) {
-    .facet-toggle__content {
-      display: block !important;
-
-      &.facet-toggle__content--hide {
-        display: none !important;
-      }
-    }
-  }
-
-  .facet-toggle--only-on-mobile {
-    .facet-toggle {
-      @include govuk-media-query($from: tablet) {
-        display: none !important;
-      }
-    }
-
-    .facet-toggle__content.facet-toggle__content--hide {
-      @include govuk-media-query($from: tablet) {
-        display: block !important;
-      }
-    }
-  }
-}
-
 .finder-frontend-content {
   .app-c-search-page-heading {
     @include govuk-font(48, $weight: bold);

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -109,10 +109,6 @@ class ContentItem
     content_item_hash.dig("links", "email_alert_signup", 0)
   end
 
-  def hide_facets_by_default
-    content_item_hash["details"]["hide_facets_by_default"] || false
-  end
-
   def signup_link
     content_item_hash["details"]["signup_link"]
   end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -34,33 +34,27 @@
   </div>
 
   <% if facets.select(&:filterable?).any? %>
-    <div data-module="gem-toggle" data-toggle-class="facet-toggle__content--hide" <%= "class=facet-toggle--only-on-mobile" unless content_item.hide_facets_by_default %>>
-      <button type="button" class="facet-toggle app-c-button-as-link" data-controls="facet-wrapper" data-expanded="false" data-track-category="filterClicked" data-track-action="accordion" data-toggled-text="- <%= t("finders.facet_collection.facet_disclosure.fewer", default: "Show fewer search options") %>">
-        + <%= t("finders.facet_collection.facet_disclosure.more", default: "Show more search options") %>
-      </button>
-
-      <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets facet-toggle__content facet-toggle__content--hide">
-        <div class="facets__box">
-          <div class="facets__header">
-            <h1 class="gem-c-title__text">Filter</h1>
-            <button class="app-c-button-as-link facets__return-link js-close-filters" type="button">
-              Return to results
-            </button>
+    <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets">
+      <div class="facets__box">
+        <div class="facets__header">
+          <h1 class="gem-c-title__text">Filter</h1>
+          <button class="app-c-button-as-link facets__return-link js-close-filters" type="button">
+            Return to results
+          </button>
+        </div>
+        <div class="facets__content">
+          <%= render facets.select(&:filterable?) %>
+          <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
+            <%= render "facet_tags", facet_tags.present %>
           </div>
-          <div class="facets__content">
-            <%= render facets.select(&:filterable?) %>
-            <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
-              <%= render "facet_tags", facet_tags.present %>
-            </div>
-            <button class="app-c-button-as-link facets__clear-link js-clear-selected-filters" type="button">
-              Clear all filters
-            </button> 
-          </div>
-          <div class="facets__footer">
-              <button class="gem-c-button govuk-button js-close-filters js-show-results" type="button">
-                Show <span class="js-result-count"> <%= result_set_presenter.displayed_total %><span>
-              </button>
-            </div>
+          <button class="app-c-button-as-link facets__clear-link js-clear-selected-filters" type="button">
+            Clear all filters
+          </button> 
+        </div>
+        <div class="facets__footer">
+          <button class="gem-c-button govuk-button js-close-filters js-show-results" type="button">
+            Show <span class="js-result-count"> <%= result_set_presenter.displayed_total %><span>
+          </button>
         </div>
       </div>
     </div>

--- a/config/locales/en/finders/facet_collection.yml
+++ b/config/locales/en/finders/facet_collection.yml
@@ -1,5 +1,0 @@
-en:
-  facet_collection:
-    facet_disclosure:
-      more: "Show more search options"
-      fewer: "Show fewer search options"

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -287,27 +287,9 @@ Feature: Filtering documents
     And the page has results region
 
   @javascript
-  Scenario: Facets should not be hidden by default on finders except all content
-    When I view the research and statistics finder
-    And I should not see a "Show more search options" button
-    Then I view the all content finder
-    And I should see a "Show more search options" button
-
-  @javascript
   Scenario: A Blue Banner should be displayed when navigating from a topic page
     When I view the research and statistics finder with a topic param set
     Then I should see a blue banner
-
-  @javascript
-  Scenario: Facets should expand when clicking on the "Show more search options" button on all content
-    When I view the all content finder
-    And I should see a "Show more search options" button
-    And I should not see a "Show fewer search options" button
-    And Facets should be hidden
-    Then I click "Show more search options" to expand all facets
-    And I should see a "Show fewer search options" button
-    And I should not see a "Show more search options" button
-    And Facets should be visible
 
   Scenario: Results should be a landmark to allow screenreaders to jump to it quickly
     When I view the news and communications finder

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -7,7 +7,6 @@
   "details": {
     "default_documents_per_page": 20,
     "document_noun": "result",
-    "hide_facets_by_default": true,
     "facets": [
       {
         "display_as_result_metadata": false,

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -921,24 +921,6 @@ Then(/^I should (see|not see) a "Skip to results" link$/) do |can_be_seen|
   expect(page).to have_css('[href="#js-results"]', visible: visibility)
 end
 
-Then(/^I should see a "(Show .* search options)" button$/) do |link_text|
-  expect(page).to have_css(".facet-toggle", visible: true)
-  expect(page).to have_selector(:link_or_button, link_text)
-end
-
-Then(/^I should not see a "(Show .* search options)" button$/) do |link_text|
-  expect(page).to have_css(".facet-toggle", visible: false)
-  expect(page).to_not have_selector(:link_or_button, link_text)
-end
-
-Then(/^Facets should be visible$/) do
-  expect(page).to_not have_css(".facet-toggle__content--hide")
-end
-
-Then(/^Facets should be hidden/) do
-  expect(page).to have_css(".facet-toggle__content--hide", visible: false)
-end
-
 Then(/^the page has results region$/) do
   expect(page).to have_css('[id="js-results"]')
 end


### PR DESCRIPTION
## What
Always show facets (filters) on finders on tablet/desktop. This PR removes code associated with the facet toggle functionality.

## Why
Following on from the[ A/B test we ran ](https://github.com/alphagov/finder-frontend/pull/1736) where our hypothesis was 

> that users who wouldn't use any other filter options are being confused by the keyword facets and if it weren't there they would either use the search bar to refine their search or not at all. 

The results tell us that users who did not see Facets after removing a facet did not then amend their search more. (removing a facet does not trigger and refinement but removing a facet and retyping does)

> When analysing the test we noticed that Search click through rate in variant B had increased by quite a large factor. This proved to be worth investigating as it seems that removal of Facets allows users to see results more quickly and click. Specifically on mobile. 

In conclusion,

> we will be making this change permanently as the results show it had a positive impact on users including some unexpected but welcome impacts.

[Trello ticket](https://trello.com/c/PtSyQ5hi/1285-show-facets-by-default)

## Search page examples to sanity check:

- https://finder-frontend-pr-1870.herokuapp.com/search/all
- https://finder-frontend-pr-1870.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1870.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1870.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1870.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1870.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1870.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance

[Other finders](https://live-stuff.herokuapp.com/finders)
