### PR TITLE
Add a registry for roles

### DIFF
--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -8,6 +8,7 @@ module Registries
         "all_part_of_taxonomy_tree" => full_topic_taxonomy,
         "part_of_taxonomy_tree" => topic_taxonomy,
         "people" => people,
+        "roles" => roles,
         "organisations" => organisations,
         "manual" => manuals,
         "full_topic_taxonomy" => full_topic_taxonomy,
@@ -46,6 +47,10 @@ module Registries
 
     def people
       @people ||= PeopleRegistry.new
+    end
+
+    def roles
+      @roles ||= RolesRegistry.new
     end
 
     def organisations

--- a/lib/registries/roles_registry.rb
+++ b/lib/registries/roles_registry.rb
@@ -1,0 +1,50 @@
+module Registries
+  class RolesRegistry < Registry
+    include CacheableRegistry
+
+    def [](slug)
+      roles[slug]
+    end
+
+    def roles
+      @roles ||= fetch_from_cache
+    end
+
+    def values
+      roles
+    end
+
+    def cache_key
+      "#{NAMESPACE}/roles"
+    end
+
+  private
+
+    def report_error
+      GovukStatsd.increment("registries.roles_api_errors")
+    end
+
+    def cacheable_data
+      roles_as_hash
+    end
+
+    def roles_as_hash
+      GovukStatsd.time("registries.roles.request_time") do
+        (fetch_roles_from_rummager || {})
+          .reject { |result| result.dig("value", "slug").blank? || result.dig("value", "title").blank? }
+          .each_with_object({}) { |result, roles|
+            slug = result["value"]["slug"]
+            roles[slug] = result["value"].slice("title", "slug", "content_id")
+          }
+      end
+    end
+
+    def fetch_roles_from_rummager
+      params = {
+        aggregate_roles: "1500,examples:0,order:value.title",
+        count: 0,
+      }
+      Services.rummager.search(params).dig("aggregates", "roles", "options")
+    end
+  end
+end

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -39,7 +39,7 @@ describe "Healthcheck" do
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
-            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, organisations, manual, full_topic_taxonomy.",
+            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy.",
             "status" => "warning",
           },
         },

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Healthchecks::RegistriesCache do
       stub_worldwide_api_has_locations %w(hogwarts privet-drive diagon-alley)
       topic_taxonomy_has_taxons
       stub_people_registry_request
+      stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
 
@@ -36,7 +37,7 @@ RSpec.describe Healthchecks::RegistriesCache do
   context "Registries caches are empty" do
     it "has an OK status" do
       expect(check.status).to eq :warning
-      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, organisations, manual, full_topic_taxonomy."
+      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy."
     end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Registries::BaseRegistries do
       clear_cache
       topic_taxonomy_has_taxons(level_one_taxons)
       stub_people_registry_request
+      stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
     end
@@ -62,6 +63,7 @@ RSpec.describe Registries::BaseRegistries do
       clear_cache
       topic_taxonomy_has_taxons(level_one_taxons)
       stub_people_registry_request
+      stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
     end

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+RSpec.describe Registries::RolesRegistry do
+  let(:slug) { "prime-minister" }
+  let(:rummager_params) do
+    {
+      count: 0,
+      aggregate_roles: "1500,examples:0,order:value.title",
+    }
+  end
+  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+
+  describe "when rummager is available" do
+    before do
+      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      clear_cache
+    end
+
+    it "will fetch role information by slug" do
+      role = described_class.new[slug]
+      expect(role).to eq(
+        "title" => "Prime Minister",
+        "slug" => slug,
+      )
+    end
+
+    it "will return all roles associated with documents ascending by name" do
+      roles = described_class.new.values
+
+      expect(roles.length).to eql(2)
+      expect(roles.keys).to eql(%w(prime-minister chief-mouser))
+    end
+  end
+
+  describe "there is no slug or title" do
+    it "will remove those results" do
+      stub_request(:get, rummager_url).to_return(
+        body: {
+          "facets": {
+            "roles": {
+              "options": [{ "value": {} }],
+            },
+          },
+        }.to_json,
+      )
+      clear_cache
+      expect(described_class.new.values).to be_empty
+    end
+  end
+
+  describe "when rummager is unavailable" do
+    before do
+      rummager_is_unavailable
+      clear_cache
+    end
+
+    it "will return an (uncached) empty hash" do
+      role = described_class.new[slug]
+      expect(role).to be_nil
+      expect(Rails.cache.fetch(described_class.new.cache_key)).to be_nil
+    end
+  end
+
+  def rummager_is_unavailable
+    stub_request(:get, rummager_url).to_return(status: 500)
+  end
+
+  def clear_cache
+    Rails.cache.delete(described_class.new.cache_key)
+  end
+
+  def rummager_results
+    %|{
+      "results": [],
+      "total": 394075,
+      "start": 0,
+      "aggregates": {
+        "roles": {
+          "options": [{
+            "value": {
+              "title": "Prime Minister",
+              "slug": "prime-minister",
+              "_id": "a field that we're not using"
+            },
+            "documents": 5
+          },
+          {
+            "value": {
+              "title": "Chief Mouser",
+              "slug": "chief-mouser",
+              "_id": "/government/minister/chief-mouser"
+            },
+            "documents": 6
+          }]
+        }
+      },
+      "suggested_queries": []
+    }|
+  end
+end

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -57,6 +57,31 @@ module RegistrySpecHelper
         }.to_json)
   end
 
+  def stub_roles_registry_request
+    stub_request(:get, "http://search.dev.gov.uk/search.json")
+        .with(query: {
+            count: 0,
+            aggregate_roles: "1500,examples:0,order:value.title",
+        })
+        .to_return(body: {
+            results: [],
+            facets: {
+                roles: {
+                    options: [
+                        {
+                            value: {
+                                title: "Prime Minister",
+                                slug: "prime-minister",
+                                _id: "a field that we're not using",
+                                content_id: "content_id_for_prime-minister",
+                            },
+                        },
+                    ],
+                },
+            },
+        }.to_json)
+  end
+
   def stub_organisations_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {


### PR DESCRIPTION
This will be used to support filtering documents on the role.

Depends on https://github.com/alphagov/search-api/pull/1922 to include `title`s and `link`s in the registry.