### PR TITLE
Don't request finder content item in signup requests

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -26,11 +26,7 @@ private
   end
 
   def content
-    @content ||= fetch_content_item(request.path)
-  end
-
-  def finder_content_item
-    @finder_content_item ||= fetch_content_item(finder_base_path)
+    @content ||= ContentItem.from_content_store(request.path).as_hash
   end
 
   def signup_presenter
@@ -68,16 +64,11 @@ private
     @applied_filters ||= email_alert_filter_params.applied_filters
   end
 
-  def fetch_content_item(content_item_path)
-    ContentItem.from_content_store(content_item_path).as_hash
-  end
-
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       applied_filters: applied_filters,
       default_filters: default_filters,
       facets: signup_presenter.choices,
-      finder_format: finder_format,
       subscriber_list_title: subscriber_list_title,
       email_filter_by: signup_presenter.email_filter_by,
     )
@@ -94,9 +85,5 @@ private
 
   def default_filters
     content["details"].fetch("filter", {})
-  end
-
-  def finder_format
-    finder_content_item.dig("details", "filter", "document_type")
   end
 end

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -138,7 +138,7 @@
     ],
     "email_filter_by": "case_type",
     "filter": {
-      "document_type": "cma_case"
+      "format": "cma_case"
     },
     "subscription_list_title_prefix": {
       "singular": "CMA cases with the following case type: ",

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -3,12 +3,11 @@ require "addressable/uri"
 class EmailAlertSignupAPI
   class UnprocessableSubscriberListError < StandardError; end
 
-  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, finder_format:, email_filter_by: nil)
+  def initialize(applied_filters:, default_filters:, facets:, subscriber_list_title:, email_filter_by: nil)
     @applied_filters = applied_filters.deep_symbolize_keys
     @default_filters = default_filters.deep_symbolize_keys
     @facets = facets
     @subscriber_list_title = subscriber_list_title
-    @finder_format = finder_format
     @email_filter_by = email_filter_by
   end
 
@@ -20,7 +19,7 @@ class EmailAlertSignupAPI
 
 private
 
-  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :finder_format, :email_filter_by
+  attr_reader :applied_filters, :default_filters, :facets, :subscriber_list_title, :email_filter_by
 
   def add_url_param(url, param)
     # this method safely adds a URL parameter using the correct one of '?' or '&'
@@ -119,13 +118,7 @@ private
   end
 
   def tags
-    return filters_to_tags if finder_format.blank?
-
-    filters_to_tags.merge(format: { any: [finder_format] })
-  end
-
-  def filters_to_tags
-    @filters_to_tags ||= filter_keys.each_with_object({}) { |key, tags_hash|
+    @tags ||= filter_keys.each_with_object({}) { |key, tags_hash|
       values = values_for_key(key)
       any_or_all = is_all_field?(key) ? :all : :any
       tag = is_all_field?(key) ? key[4..-1] : key

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -96,7 +96,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
           email_alert_api_has_subscriber_list(
             "tags" => {
               "format" => { any: %w[cma_case] },
-              "document_type" => { any: %w[cma_case] },
             },
             "subscription_url" => "http://www.gov.uk/default-subscription-to-cma-cases",
           )
@@ -112,7 +111,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
             "tags" => {
               "case_type" => { any: %w[consumer-enforcement] },
               "format" => { any: %w[cma_case] },
-              "document_type" => { any: %w[cma_case] },
             },
             "subscription_url" => "http://www.gov.uk/subscription-to-cma-cases",
           )
@@ -313,7 +311,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
           "tags" => {
             "case_type" => { any: %w[consumer-enforcement] },
             "format" => { any: %w[cma_case] },
-            "document_type" => { any: %w[cma_case] },
           },
           "subscription_url" => "http://www.gov.uk/subscription-to-cma-cases",
         )
@@ -396,7 +393,6 @@ describe EmailAlertSubscriptionsController, type: :controller do
             "tags" => {
               "format" => { any: %w[cma_case] },
               "case_type" => { any: %w[markets] },
-              "document_type" => { any: %w[cma_case] },
             },
             "subscription_url" => "http://www.gov.uk/subscription/cma-markets",
           )

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -12,7 +12,6 @@ describe EmailAlertSignupAPI do
       default_filters: default_filters,
       facets: facets,
       subscriber_list_title: subscriber_list_title,
-      finder_format: finder_format,
     )
   end
 
@@ -20,7 +19,6 @@ describe EmailAlertSignupAPI do
   let(:applied_filters) { {} }
   let(:facets) { [] }
   let(:subscriber_list_title) { "Subscriber list title" }
-  let(:finder_format) {}
 
   def init_simple_email_alert_api(subscription_url)
     email_alert_api_has_subscriber_list(
@@ -64,7 +62,7 @@ describe EmailAlertSignupAPI do
   end
 
   context "with a single facet finder" do
-    let(:finder_format) { "test-reports" }
+    let(:default_filters) { { "format" => "test-reports" } }
     let(:applied_filters) do
       { "alert_type" => %w(first second) }
     end
@@ -124,14 +122,14 @@ describe EmailAlertSignupAPI do
       context "with one choice selected and a title prefix" do
         let(:applied_filters) do
           {
-            format: { any: %w(test-reports) },
+            format: %w(other-reports),
             alert_type: %w[first],
           }
         end
         it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
             "tags" => {
-              format: { any: %w(test-reports) },
+              format: { any: %w(other-reports test-reports) },
               alert_type: { any: %w[first] },
             },
             "subscription_url" => subscription_url,
@@ -159,7 +157,7 @@ describe EmailAlertSignupAPI do
 
       context "no options available" do
         let(:facets) { [] }
-        let(:finder_format) { "test-reports" }
+        let(:default_filters) { { "format" => "test-reports" } }
 
         it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(
@@ -177,7 +175,7 @@ describe EmailAlertSignupAPI do
   end
 
   context "with a multi facet finder" do
-    let(:finder_format) { "test-reports" }
+    let(:default_filters) { { "format" => "test-reports" } }
     let(:applied_filters) do
       {
         "alert_type" => %w(first second),
@@ -266,7 +264,7 @@ describe EmailAlertSignupAPI do
       end
 
       context "with one choice selected and a title prefix" do
-        let(:finder_format) { "test-reports" }
+        let(:default_filters) { { "format" => "test-reports" } }
         let(:applied_filters) do
           {
             "alert_type" => %w[first],
@@ -307,7 +305,7 @@ describe EmailAlertSignupAPI do
 
       context "no options available" do
         let(:facets) { [] }
-        let(:finder_format) { "test-reports" }
+        let(:default_filters) { { "format" => "test-reports" } }
 
         it "asks email-alert-api to find or create the subscriber list" do
           req = email_alert_api_has_subscriber_list(


### PR DESCRIPTION
The finder content item is requested when a user signs up for email alerts.

It's requested because we want to take the default filter from the finder content item, and re-use it as the default filter for the email signup content item.

That's not necessary, since we can just use the default filter field on the signup content item.

This should be merged after https://github.com/alphagov/specialist-publisher/pull/1563 is merged and deployed, since it adds the default filter to the email signup items.

https://trello.com/c/KOdPubpx/1295-dont-request-finder-content-items-during-email-alert-signup