### PR TITLE
Spike into querying for eligibility on knowledge graph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "govuk_publishing_components", "~> 21.20.0"
 gem "rails", "~> 6.0.2"
 gem "slimmer", "~> 13.2.0"
 
+gem "neo4j", "~> 9.6", ">= 9.6.1"
 gem "sass-rails", "~> 6.0.0"
 gem "uglifier", "~> 4.2"
 gem "whenever", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,11 +120,18 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    faraday_middleware-multi_json (0.0.6)
+      faraday_middleware
+      multi_json
     ffi (1.11.3)
     gds-api-adapters (63.3.0)
       addressable
@@ -228,11 +235,29 @@ GEM
     multi_json (1.14.1)
     multi_test (0.1.2)
     multipart-post (2.1.1)
+    neo4j (9.6.1)
+      activemodel (>= 4.0)
+      activesupport (>= 4.0)
+      i18n (!= 1.3.0)
+      neo4j-core (>= 9.0.0)
+      orm_adapter (~> 0.5.0)
+    neo4j-core (9.0.0)
+      activesupport (>= 4.0)
+      faraday (>= 0.9.0)
+      faraday_middleware (>= 0.10.0)
+      faraday_middleware-multi_json
+      httpclient
+      json
+      multi_json
+      net_tcp_client (>= 2.0.1)
+      typhoeus (>= 1.1.2)
+    net_tcp_client (2.2.0)
     netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
+    orm_adapter (0.5.0)
     os (1.0.1)
     parallel (1.19.1)
     parser (2.6.5.0)
@@ -396,6 +421,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.1)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -449,6 +476,7 @@ DEPENDENCIES
   jasmine-rails
   launchy (~> 2.4.2)
   listen
+  neo4j (~> 9.6, >= 9.6.1)
   pry-byebug
   rails (~> 6.0.2)
   rails-controller-testing

--- a/app/models/age_requirement.rb
+++ b/app/models/age_requirement.rb
@@ -1,0 +1,32 @@
+class AgeRequirement
+  include Neo4j::ActiveNode
+  has_many :out, :requirements, type: :HAS_REQUIREMENT, model_class: %i(OrRequirementGroup AndRequirementGroup)
+  property :min_age
+  property :max_age
+
+  def ineligible?(attributes)
+    return false if attributes[:age].blank?
+
+    met_requirements = requirements_present.map { |requirement| send(requirement, attributes) }
+    !met_requirements.all?
+  end
+
+private
+
+  def requirements_present
+    criteria = { min_age: "meets_min_age_requirement?", max_age: "meets_max_age_requirement?" }
+    %i(min_age max_age).each_with_object([]) do |requirement, requirements|
+      if read_attribute(requirement).present?
+        requirements << criteria[requirement]
+      end
+    end
+  end
+
+  def meets_min_age_requirement?(attributes)
+    attributes[:age] >= min_age
+  end
+
+  def meets_max_age_requirement?(attributes)
+    attributes[:age] <= max_age
+  end
+end

--- a/app/models/and_requirement_group.rb
+++ b/app/models/and_requirement_group.rb
@@ -1,0 +1,10 @@
+class AndRequirementGroup
+  include Neo4j::ActiveNode
+
+  has_many :in, :eligibilities, type: :HAS_REQUIREMENT, model_class: :Eligibility
+  has_many :out, :requirements, type: :HAS_REQUIREMENT, model_class: false
+
+  def ineligible?(attributes)
+    requirements.map { |requirement| requirement.ineligible?(attributes) }.any?
+  end
+end

--- a/app/models/cid.rb
+++ b/app/models/cid.rb
@@ -1,0 +1,21 @@
+class Cid
+  include Neo4j::ActiveNode
+
+  property :documentType
+  property :contentID
+  property :name
+  property :description
+  property :pagerank
+  property :title
+
+  has_many :out, :eligibilities, type: :HAS_ELIGIBILITY, model_class: :Eligibility
+
+  def self.where_not_ineligible(attributes)
+    Eligibility.
+      all.
+      reject { |eligibility| eligibility.ineligible?(attributes) }.
+      map(&:cids).
+      flatten.
+      compact
+  end
+end

--- a/app/models/eligibility.rb
+++ b/app/models/eligibility.rb
@@ -1,0 +1,9 @@
+class Eligibility
+  include Neo4j::ActiveNode
+  has_many :in, :cids, type: :HAS_ELIGIBILITY, model_class: :Cid
+  has_one :out, :requirement, type: :HAS_REQUIREMENT, model_class: %i(OrRequirementGroup AndRequirementGroup)
+
+  def ineligible?(attributes)
+    requirement.ineligible?(attributes)
+  end
+end

--- a/app/models/or_requirement_group.rb
+++ b/app/models/or_requirement_group.rb
@@ -1,0 +1,10 @@
+class OrRequirementGroup
+  include Neo4j::ActiveNode
+
+  has_many :in, :eligibilities, type: :HAS_REQUIREMENT, model_class: :Eligibility
+  has_many :out, :requirements, type: :HAS_REQUIREMENT, model_class: false
+
+  def ineligible?(attributes)
+    requirements.map { |requirement| requirement.ineligible?(attributes) }.all?
+  end
+end

--- a/app/models/residency_requirement.rb
+++ b/app/models/residency_requirement.rb
@@ -1,0 +1,11 @@
+class ResidencyRequirement
+  include Neo4j::ActiveNode
+  has_many :out, :requirements, type: :HAS_REQUIREMENT, model_class: %i(OrRequirementGroup AndRequirementGroup)
+  property :meet_residency_requirement
+
+  def ineligible?(attributes)
+    return false unless attributes.keys.include?(:meet_residency_requirement)
+
+    !attributes[:meet_residency_requirement]
+  end
+end

--- a/app/models/study_requirement.rb
+++ b/app/models/study_requirement.rb
@@ -1,0 +1,24 @@
+class StudyRequirement
+  include Neo4j::ActiveNode
+  has_many :out, :requirements, type: :HAS_REQUIREMENT, model_class: %i(OrRequirementGroup AndRequirementGroup)
+  property :at_publicly_funded_school
+  property :at_publicly_funded_college
+  property :on_unpaid_training_course
+
+  def ineligible?(attributes)
+    return false unless attributes.keys.select { |key| requirements_present.include?(key) }.any?
+
+    met_requirements = requirements_present.map { |requirement| attributes[requirement] }
+    !met_requirements.all?
+  end
+
+private
+
+  def study_requirement_types
+    %i(at_publicly_funded_school at_publicly_funded_college on_unpaid_training_course)
+  end
+
+  def requirements_present
+    study_requirement_types.select { |requirement| read_attribute(requirement).present? }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ require "action_view/railtie"
 # require "action_cable/engine"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require "neo4j/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -51,5 +52,8 @@ module FinderFrontend
 
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    config.neo4j.session_type = :bolt
+    config.neo4j.session_path = ENV["NEO4J_URL"] || "http://localhost:7475"
   end
 end

--- a/db/neo4j/migrate/20200120121741_force_create_eligibility_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120121741_force_create_eligibility_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateEligibilityUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :Eligibility, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :Eligibility, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120140101_force_create_cid_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120140101_force_create_cid_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateCidUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :Cid, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :Cid, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120143819_force_create_requirement_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120143819_force_create_requirement_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateRequirementUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :Requirement, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :Requirement, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120144250_force_create_and_requirement_group_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120144250_force_create_and_requirement_group_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateAndRequirementGroupUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :AndRequirementGroup, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :AndRequirementGroup, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120144301_force_create_or_requirement_group_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120144301_force_create_or_requirement_group_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateOrRequirementGroupUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :OrRequirementGroup, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :OrRequirementGroup, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120165805_force_create_study_requirement_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120165805_force_create_study_requirement_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateStudyRequirementUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :StudyRequirement, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :StudyRequirement, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120165808_force_create_age_requirement_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120165808_force_create_age_requirement_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateAgeRequirementUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :AgeRequirement, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :AgeRequirement, :uuid
+  end
+end

--- a/db/neo4j/migrate/20200120170024_force_create_residency_requirement_uuid_constraint.rb
+++ b/db/neo4j/migrate/20200120170024_force_create_residency_requirement_uuid_constraint.rb
@@ -1,0 +1,9 @@
+class ForceCreateResidencyRequirementUuidConstraint < Neo4j::Migrations::Base
+  def up
+    add_constraint :ResidencyRequirement, :uuid, force: true
+  end
+
+  def down
+    drop_constraint :ResidencyRequirement, :uuid
+  end
+end

--- a/db/neo4j/schema.yml
+++ b/db/neo4j/schema.yml
@@ -1,0 +1,45 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of ActiveNode to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.yml definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using neo4j:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+---
+:constraints:
+- CONSTRAINT ON ( `neo4j::migrations::schemamigration`:`Neo4j::Migrations::SchemaMigration`
+  ) ASSERT `neo4j::migrations::schemamigration`.migration_id IS UNIQUE
+- CONSTRAINT ON ( agerequirement:AgeRequirement ) ASSERT agerequirement.uuid IS UNIQUE
+- CONSTRAINT ON ( andrequirementgroup:AndRequirementGroup ) ASSERT andrequirementgroup.uuid
+  IS UNIQUE
+- CONSTRAINT ON ( cid:Cid ) ASSERT cid.contentID IS UNIQUE
+- CONSTRAINT ON ( cid:Cid ) ASSERT cid.uuid IS UNIQUE
+- CONSTRAINT ON ( eligibility:Eligibility ) ASSERT eligibility.uuid IS UNIQUE
+- CONSTRAINT ON ( organisation:Organisation ) ASSERT organisation.name IS UNIQUE
+- CONSTRAINT ON ( organisation:Organisation ) ASSERT organisation.orgID IS UNIQUE
+- CONSTRAINT ON ( orrequirementgroup:OrRequirementGroup ) ASSERT orrequirementgroup.uuid
+  IS UNIQUE
+- CONSTRAINT ON ( person:Person ) ASSERT person.personContentID IS UNIQUE
+- CONSTRAINT ON ( requirement:Requirement ) ASSERT requirement.uuid IS UNIQUE
+- CONSTRAINT ON ( residencyrequirement:ResidencyRequirement ) ASSERT residencyrequirement.uuid
+  IS UNIQUE
+- CONSTRAINT ON ( role:Role ) ASSERT role.roleContentID IS UNIQUE
+- CONSTRAINT ON ( step:Step ) ASSERT step.step_id IS UNIQUE
+- CONSTRAINT ON ( studyrequirement:StudyRequirement ) ASSERT studyrequirement.uuid
+  IS UNIQUE
+- CONSTRAINT ON ( taxon:Taxon ) ASSERT taxon.taxonContentID IS UNIQUE
+:indexes: []
+:versions:
+- '20200120121741'
+- '20200120140101'
+- '20200120143819'
+- '20200120144250'
+- '20200120144301'
+- '20200120165805'
+- '20200120165808'
+- '20200120170024'

--- a/spec/models/cid_spec.rb
+++ b/spec/models/cid_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+describe Cid do
+  describe "ineligible?" do
+    it "Works as expected" do
+      # TODO: Break this up!
+
+      Eligibility.delete_all
+      StudyRequirement.delete_all
+      AgeRequirement.delete_all
+      ResidencyRequirement.delete_all
+      OrRequirementGroup.delete_all
+      AndRequirementGroup.delete_all
+      Cid.find_by(contentID: "f4b96a38-5247-4afd-b554-8a258a0e8c93").eligibilities.delete_all
+      Cid.find_by(contentID: "33f9d8a1-2a3c-4b71-abda-b67b38bf0d67").eligibilities.delete_all
+
+      eligibility = Eligibility.create
+      content_page = Cid.find_by(contentID: "f4b96a38-5247-4afd-b554-8a258a0e8c93")
+      content_page.eligibilities << eligibility
+
+      base_requirement = AndRequirementGroup.create
+      eligibility.requirement = base_requirement
+
+      # be at least 16 and under 19 on 31 August 2019
+      age_requirement = AgeRequirement.create(min_age: 16, max_age: 18)
+      base_requirement.requirements << age_requirement
+
+      # study at a publicly funded school or college, or be on an unpaid training course
+      study_requirement = OrRequirementGroup.create
+      base_requirement.requirements << study_requirement
+      publicly_funded_school_requirement = StudyRequirement.create(at_publicly_funded_school: true)
+      publicly_funded_college_requirement = StudyRequirement.create(at_publicly_funded_college: true)
+      on_unpaid_training_course_requirement = StudyRequirement.create(on_unpaid_training_course: true)
+      study_requirement.requirements += [publicly_funded_school_requirement, publicly_funded_college_requirement, on_unpaid_training_course_requirement]
+
+      # meet the residency requirements
+      residency_requirement = ResidencyRequirement.create(meet_residency_requirement: true)
+      base_requirement.requirements << residency_requirement
+
+      # Let's do some testing of the OrRequirement
+      expect(study_requirement.ineligible?({})).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_school: true, at_publicly_funded_college: true, on_unpaid_training_course: true)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_school: true, at_publicly_funded_college: true, on_unpaid_training_course: false)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_school: true, at_publicly_funded_college: false, on_unpaid_training_course: false)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_school: false, at_publicly_funded_college: false)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_school: false)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_college: false, on_unpaid_training_course: false)).to eql(false)
+      expect(study_requirement.ineligible?(on_unpaid_training_course: false)).to eql(false)
+      expect(study_requirement.ineligible?(at_publicly_funded_college: false)).to eql(false)
+      # Someone is only ineligible if they are definitely not any of those things
+      expect(study_requirement.ineligible?(at_publicly_funded_school: false, at_publicly_funded_college: false, on_unpaid_training_course: false)).to eql(true)
+
+      # Let's do some testing of the AndRequirement
+      expect(base_requirement.ineligible?({})).to eql(false)
+      expect(base_requirement.ineligible?(age: 17, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(false)
+      expect(base_requirement.ineligible?(age: 17, at_publicly_funded_school: false, at_publicly_funded_college: false, on_unpaid_training_course: false, meet_residency_requirement: true)).to eql(true)
+      expect(base_requirement.ineligible?(age: 17, at_publicly_funded_school: true, meet_residency_requirement: false)).to eql(true)
+      expect(base_requirement.ineligible?(age: 15, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(true)
+      expect(base_requirement.ineligible?(age: 19, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(true)
+
+      # Let's do some testing of the Eligibilty (which is actually the same as the last)
+      expect(eligibility.ineligible?({})).to eql(false)
+      expect(eligibility.ineligible?(age: 17, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(false)
+      expect(eligibility.ineligible?(age: 17, at_publicly_funded_school: false, at_publicly_funded_college: false, on_unpaid_training_course: false, meet_residency_requirement: true)).to eql(true)
+      expect(eligibility.ineligible?(age: 17, at_publicly_funded_school: true, meet_residency_requirement: false)).to eql(true)
+      expect(eligibility.ineligible?(age: 15, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(true)
+      expect(eligibility.ineligible?(age: 19, at_publicly_funded_school: true, meet_residency_requirement: true)).to eql(true)
+
+
+      # Let's add another Cid with slightly different eligibility criteria
+      jelly_cups_content_page = Cid.find_by(contentID: "33f9d8a1-2a3c-4b71-abda-b67b38bf0d67")
+      jelly_cups_eligibility = Eligibility.create
+      jelly_cups_content_page.eligibilities << jelly_cups_eligibility
+
+      jelly_cups_base_requirement = AndRequirementGroup.create
+      jelly_cups_eligibility.requirement = jelly_cups_base_requirement
+
+      jelly_cups_age_requirement = AgeRequirement.create(min_age: 3, max_age: 17)
+      jelly_cups_base_requirement.requirements << jelly_cups_age_requirement
+      jelly_cups_publicly_funded_school_requirement = StudyRequirement.create(at_publicly_funded_school: true)
+      jelly_cups_base_requirement.requirements << jelly_cups_publicly_funded_school_requirement
+
+      # Let's do some testing of the Cid .where_not_ineligible method to see if it work with more than one
+      assert_cid_where_not_ineligibile_equals({}, [content_page, jelly_cups_content_page])
+      assert_cid_where_not_ineligibile_equals({ age: 17, at_publicly_funded_school: true, meet_residency_requirement: true }, [content_page, jelly_cups_content_page])
+      assert_cid_where_not_ineligibile_equals({ age: 17, at_publicly_funded_school: false, at_publicly_funded_college: false, on_unpaid_training_course: false, meet_residency_requirement: true }, [])
+      assert_cid_where_not_ineligibile_equals({ age: 17, at_publicly_funded_school: true, meet_residency_requirement: false }, [jelly_cups_content_page])
+      assert_cid_where_not_ineligibile_equals({ age: 17, at_publicly_funded_school: true, meet_residency_requirement: true }, [content_page, jelly_cups_content_page])
+      assert_cid_where_not_ineligibile_equals({ age: 10, at_publicly_funded_school: true, meet_residency_requirement: true }, [jelly_cups_content_page])
+      assert_cid_where_not_ineligibile_equals({ age: 19, at_publicly_funded_school: true, meet_residency_requirement: true }, [])
+      assert_cid_where_not_ineligibile_equals({ age: 2, at_publicly_funded_school: true, meet_residency_requirement: true }, [])
+    end
+  end
+end
+
+def assert_cid_where_not_ineligibile_equals(attributes, expected)
+  results = Cid.where_not_ineligible(attributes)
+  expected.map { |expect| expect(results.include?(expect)).to eql(true) }
+  expect(results.count).to eq(expected.count)
+end


### PR DESCRIPTION
This is a spike into querying the knowledge graph to find content for which a person might be eligible for.

What's interesting is that on starting I realised what we're actually finding is things that we're not _ineligible_ for - if someone has only entered their age it might filter some things out but we're not necessarily eligible for everything else because we haven't entered enough information yet. As users enter more information the number of results will fall. This does mean that occasionally we end up with a double negative like 'not_ineligible' which is slightly eggy. I think this is something that needs a little more thought and clarification, perhaps with a product steer

There are ways to make this faster - for example making a query to find things that we know we're ineligible for (eg AgeRequirement where age < min_age or age > max_age), instantiating the content item and then doing a full filter to see if we can be certain we're not ineligible for that service (as some filters contain OrGroupRequirements, being ineligible for one requirement does not guarantee that, although if all parents of a FooRequirement are AndRequirementGroups that does guarantee that the user is not eligible). For the time being, such approaches add a lot more complexity and as for the short to medium term we will only have a small number of content items with eligibility criteria, there will be precious little speed improvement in doing so and simply iterating over any Cids with eligibility will be ok.

NB: The neo4j gem is quite large so I haven't had a proper look into it as I felt this is something to do if/when we think this approach is worth persuing

### To try it out (with docker)

* Add an environment variable for the key NEO4J_URL with the URL to a remote instance of the knowledge graph (or leave it blank to use a local copy (untested)). This takes the form `http://neo4j:password@localhost:7474`. 
* Run this branch of Finder Frontend with a bash console
* run `rake neo4j:migrate` (this only has to be done once a day, it may be possible to not have to do this but I didn't want to get too bogged down in it)
and open a console. 
* Running `Cid.test_toy_example` will delete any existing eligibilities, insert some test data into the database and run a few tests to ensure everything works as expected. You can run the query `MATCH p=()-[r:HAS_REQUIREMENT|HAS_ELIGIBILITY]->() RETURN p LIMIT 25` in the database to see the things you just inserted.