### PR TITLE
Ensure required filters have values at email signup

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -43,21 +43,7 @@ private
 
   def validate_choices!
     raise UnprocessableFilterAlertParamsError unless email_alert_filter_params.valid?
-    raise MissingFiltersError unless valid_choices?
-  end
-
-  def valid_choices?
-    # TODO: implement explicit controls in the schema over validity of filters.
-    # E.g. is it acceptable to have no additional filters provided by the user?
-    !signup_presenter.choices? || at_least_one_filter_chosen? || has_default_filters?
-  end
-
-  def at_least_one_filter_chosen?
-    applied_filters.any?(&:present?)
-  end
-
-  def has_default_filters?
-    default_filters.present? && default_filters.any?
+    raise MissingFiltersError unless email_alert_filter_params.required_facets_selected?
   end
 
   def applied_filters
@@ -67,7 +53,7 @@ private
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       applied_filters: applied_filters,
-      default_filters: default_filters,
+      default_filters: content["details"].fetch("filter", {}),
       facets: signup_presenter.choices,
       subscriber_list_title: subscriber_list_title,
       email_filter_by: signup_presenter.email_filter_by,
@@ -81,9 +67,5 @@ private
       subscription_list_title_prefix: content.dig("details", "subscription_list_title_prefix"),
       facets: signup_presenter.choices,
     )
-  end
-
-  def default_filters
-    content["details"].fetch("filter", {})
   end
 end

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -84,6 +84,7 @@
       {
         "facet_id": "case_type",
         "facet_name": "Case type",
+        "required": true,
         "facet_choices": [
           {
             "key": "ca98-and-civil-cartels",

--- a/features/fixtures/cma_cases_with_multi_facets_signup_content_item.json
+++ b/features/fixtures/cma_cases_with_multi_facets_signup_content_item.json
@@ -9,6 +9,7 @@
       {
         "facet_id": "case_type",
         "facet_name": "Case Type",
+        "required": true,
         "facet_choices": [
           {
             "key": "ca98-and-civil-cartels",

--- a/features/fixtures/research_and_statistics_email_signup.json
+++ b/features/fixtures/research_and_statistics_email_signup.json
@@ -44,6 +44,7 @@
       {
         "facet_id": "content_store_document_type",
         "facet_name": "Research and statistics",
+        "required": true,
         "facet_choices": [
           {
             "key": "statistics_published",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -801,14 +801,11 @@ end
 
 Then(/^I can sign up to email alerts for allowed filters$/) do
   email_alert_api_has_subscriber_list(
-    "tags" => { "case_state" => { any: { "0" => "open" } }, "format" => { any: { "0" => "cma_case" } } },
+    "tags" => { "case_type" => { any: %w(ca98-and-civil-cartels) }, "format" => { any: %w(cma_case) } },
     "subscription_url" => "http://www.rathergood.com",
   )
 
-  signup_content_item = cma_cases_with_multi_facets_signup_content_item
-  signup_content_item["details"]["email_filter_facets"] = [{ "facet_id" => "case_state", "facet_name" => "case_state" }]
-
-  stub_content_store_has_item("/cma-cases/email-signup", signup_content_item)
+  stub_content_store_has_item("/cma-cases/email-signup", cma_cases_with_multi_facets_signup_content_item)
 
   within "#subscription-links-footer" do
     click_link("Get email alerts")

--- a/lib/parameter_parser/email_alert_parameter_parser.rb
+++ b/lib/parameter_parser/email_alert_parameter_parser.rb
@@ -21,9 +21,17 @@ module ParameterParser
       end
     end
 
+    def required_facets_selected?
+      required_facets.all? { |facet| applied_filters.key?(key_for_facet(facet)) }
+    end
+
   private
 
     attr_reader :filter_params, :content_item
+
+    def required_facets
+      permitted_facets.select { |facet| facet.dig("required") }
+    end
 
     def permitted_facets
       content_item.dig("details", "email_filter_facets") || []

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -91,21 +91,15 @@ describe EmailAlertSubscriptionsController, type: :controller do
         stub_content_store_has_item("/cma-cases/email-signup", cma_cases_signup_content_item)
       end
 
-      context "when no filters are provided" do
-        it "redirects to the subscription url" do
-          email_alert_api_has_subscriber_list(
-            "tags" => {
-              "format" => { any: %w[cma_case] },
-            },
-            "subscription_url" => "http://www.gov.uk/default-subscription-to-cma-cases",
-          )
-
+      context "when a required filter is not provided" do
+        it "returns the user to the signup page with an error" do
           post :create, params: { slug: "cma-cases" }
-          expect(subject).to redirect_to("http://www.gov.uk/default-subscription-to-cma-cases")
+          expect(response).to be_successful
+          expect(response).to render_template("new")
         end
       end
 
-      context "when at least one required filter is provided" do
+      context "when all required filters are provided" do
         it "redirects to the subscription url" do
           email_alert_api_has_subscriber_list(
             "tags" => {


### PR DESCRIPTION
This will enforce a requirement that required facets (such as case type on the CMA cases email signup) have a value.

It should be deployed once the finders using the required field have been republished.

Example: http://finder-frontend-pr-1874.herokuapp.com/cma-cases/email-signup

Related:
https://github.com/alphagov/search-api/pull/1926
https://github.com/alphagov/specialist-publisher/pull/1564
https://github.com/alphagov/govuk-content-schemas/pull/952

https://trello.com/c/BOUerRPp/1252
