### PR TITLE
Fix: checker results breadcrumb to match page title

### DIFF
--- a/config/locales/en/brexit_checker/breadcrumbs.yml
+++ b/config/locales/en/brexit_checker/breadcrumbs.yml
@@ -3,6 +3,6 @@ en:
     breadcrumbs:
       home: Home
       brexit-home: Brexit
-      brexit-check: "Get ready for a no-deal Brexit: Your results"
+      brexit-check: "Brexit: check what you need to do"
       questions: Questions
       results: Results


### PR DESCRIPTION
Trello: No trello card
Slack conversation for context: https://gds.slack.com/archives/CP4BSEJF7/p1579786721010300

At some point this breadcrumb had fallen out of sync ideally we want breadcrumbs to match page titles, so it's clear what you are navigating back to. In this case the full page title is a little long so we've taken a liberty with shortening it.