### PR TITLE
Show model score and original rank when using debug_score

### DIFF
--- a/app/controllers/concerns/learn_to_rank_feature_flag.rb
+++ b/app/controllers/concerns/learn_to_rank_feature_flag.rb
@@ -1,10 +1,12 @@
 module LearnToRankFeatureFlag
+  RANKER_HEADER_NAME = "Govuk-Use-Search-Reranker".freeze
+
   def ranker_ab_test_params
     ranker_enabled ? { relevance: "B" } : {}
   end
 
   def ranker_enabled
-    ranker_header = request.headers["Govuk-Use-Search-Reranker"]
+    ranker_header = request.headers[RANKER_HEADER_NAME] || params[RANKER_HEADER_NAME]
     ranker_header.present? && ranker_header == "true"
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,7 +2,7 @@ class Document
   attr_reader :title, :public_timestamp, :is_historic, :government_name,
               :content_purpose_supergroup, :document_type, :organisations,
               :release_timestamp, :es_score, :format, :content_id, :index,
-              :facet_content_ids, :description
+              :facet_content_ids, :description, :score, :original_rank
 
   def initialize(document_hash, index)
     document_hash = document_hash.with_indifferent_access
@@ -18,6 +18,8 @@ class Document
     @is_historic = document_hash.fetch(:is_historic, false)
     @government_name = document_hash.fetch(:government_name, nil)
     @es_score = document_hash.fetch(:es_score, nil)
+    @score = document_hash.fetch(:combined_score, nil) || @es_score
+    @original_rank = document_hash.fetch(:original_rank, nil)
     @format = document_hash.fetch(:format, nil)
     @facet_content_ids = document_hash.fetch(:facet_values, [])
     @document_hash = document_hash

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -5,7 +5,9 @@ class SearchResultPresenter
            :is_historic,
            :government_name,
            :format,
+           :score,
            :es_score,
+           :original_rank,
            to: :document
 
   def initialize(document:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, highlight:)
@@ -60,9 +62,10 @@ private
   def subtext
     published_text = "<span class='published-by'>#{I18n.t('finders.search_result_presenter.first_published_during')} #{government_name}</span>" if is_historic
     if @debug_score
-      debug_text = "<span class='debug-results debug-results--link'>#{link}</span>"\
-                   "<span class='debug-results debug-results--meta'>Score: #{es_score || 'no score (sort by relevance)'}</span>"\
-                   "<span class='debug-results debug-results--meta'>Format: #{format}</span>"
+      debug_text = "<span class='debug-results debug-results--link'>#{link}</span>"
+      debug_text += "<span class='debug-results debug-results--meta'>Score: #{score}</span>" if score
+      debug_text += "<span class='debug-results debug-results--meta'>Original score: #{es_score} (ranked ##{original_rank})</span>" if es_score && original_rank
+      debug_text += "<span class='debug-results debug-results--meta'>Format: #{format}</span>"
     end
 
     sanitize("#{published_text}#{debug_text}") if published_text || debug_text

--- a/lib/search/query.rb
+++ b/lib/search/query.rb
@@ -72,11 +72,11 @@ module Search
     def sort_by_relevance(raw_results)
       return raw_results unless relevance_scores_exist?(raw_results)
 
-      raw_results.sort_by { |hash| hash["es_score"] }.reverse
+      raw_results.sort_by { |hash| hash["combined_score"] || hash["es_score"] }.reverse
     end
 
     def relevance_scores_exist?(results)
-      results.all? { |result| result["es_score"].present? }
+      results.all? { |result| (result["combined_score"] || result["es_score"]).present? }
     end
 
     def fetch_search_response(content_item)

--- a/spec/factories/document_hash.rb
+++ b/spec/factories/document_hash.rb
@@ -24,6 +24,8 @@ FactoryBot.define do
     is_historic { false }
     government_name { "2015 Conservative government" }
     es_score { nil }
+    combined_score { nil }
+    original_rank { nil }
     format { "answer" }
     facet_values { [] }
 

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -35,10 +35,15 @@ RSpec.describe SearchResultPresenter do
                      government_name: "Government!",
                      format: "cake",
                      es_score: 0.005,
+                     combined_score: combined_score,
+                     original_rank: original_rank,
                      content_id: "content_id",
                      filter_key: "filter_value",
                      index: 1)
   }
+
+  let(:combined_score) { nil }
+  let(:original_rank) { nil }
 
   let(:is_historic) { false }
   let(:title) { "Investigation into the distribution of road fuels in parts of Scotland" }
@@ -142,6 +147,23 @@ RSpec.describe SearchResultPresenter do
       let(:debug_score) { true }
       it "returns 'Published by' and debug metadata together" do
         expect(subject.document_list_component_data[:subtext]).to eql("#{historic_subtext}#{debug_subtext}")
+      end
+    end
+
+    context "The document has been reranked" do
+      let(:combined_score) { 8 }
+      let(:original_rank) { 3 }
+      let(:debug_score) { true }
+
+      let(:debug_subtext) do
+        "<span class=\"debug-results debug-results--link\">link-1</span>"\
+        "<span class=\"debug-results debug-results--meta\">Score: #{combined_score}</span>"\
+        "<span class=\"debug-results debug-results--meta\">Original score: 0.005 (ranked ##{original_rank})</span>"\
+        "<span class=\"debug-results debug-results--meta\">Format: cake</span>"
+      end
+
+      it "gives the original score and rank in the debug text" do
+        expect(subject.document_list_component_data[:subtext]).to eql(debug_subtext)
       end
     end
   end


### PR DESCRIPTION
See: https://finder-front-msw-debug-uubdpwn.herokuapp.com/search/all?keywords=frogs&debug_score=1&Govuk-Use-Search-Reranker=true

[Trello card](https://trello.com/c/0LlEXZNl/1322-make-finder-frontend-show-the-model-score-if-reranked)

---

## Search page examples to sanity check:

- https://finder-front-msw-debug-uubdpwn.herokuapp.com/search/all
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/search/research-and-statistics
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/drug-device-alerts
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/uk-nationals-living-eu
- https://finder-front-msw-debug-uubdpwn.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
