### PR TITLE
Remove wrapper class from finder layout

### DIFF
--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -15,7 +15,7 @@
   </head>
 
   <body class="<%= yield :body_classes %>">
-    <div id="wrapper">
+    <div>
       <main id="content" class="finder-frontend-content">
         <div class="finder-frontend">
           <%= yield %>


### PR DESCRIPTION
---

## Search page examples to sanity check:

- https://finder-frontend-pr-1882.herokuapp.com/search/all
- https://finder-frontend-pr-1882.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1882.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1882.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1882.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1882.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1882.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1882.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1882.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1882.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
