### PR TITLE
Fix aria-controls parameter on search input

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -5,7 +5,7 @@
         Search <span class="govuk-visually-hidden"><%= content_item.title %></span>
       <% end %>
       <%= render "govuk_publishing_components/components/search", {
-        controls: "js-search-results-info",
+        aria_controls: "js-search-results-info",
         id: "finder-keyword-search",
         name: "keywords",
         type: 'search',

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -19,7 +19,7 @@
         <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
         <div id="keywords" class="app-patch--search-input-override">
           <%= render "govuk_publishing_components/components/search", {
-            controls: "js-search-results-info",
+            aria_controls: "js-search-results-info",
             id: "finder-keyword-search",
             name: "keywords",
             type: 'search',


### PR DESCRIPTION
We use aria-controls to denote which elements in a page an interactive element
or set of elements has control over and affects.

Documented in [govuk_publishing_components ](https://components.publishing.service.gov.uk/component-guide/search/with_aria_controls_attribute), but it had been missed in the implementation.

**Before**
<img width="380" alt="Screenshot 2020-01-27 at 16 09 00" src="https://user-images.githubusercontent.com/3758555/73191854-1547b000-4120-11ea-9682-58706c5cd35b.png">

**After**
<img width="386" alt="Screenshot 2020-01-27 at 16 10 53" src="https://user-images.githubusercontent.com/3758555/73191863-1c6ebe00-4120-11ea-8996-2f5fff6f2abe.png">


---

## Search page examples to sanity check:

- https://finder-front-fix-search-x0znd5.herokuapp.com/search/all
- https://finder-front-fix-search-x0znd5.herokuapp.com/search/research-and-statistics

