### PR TITLE
Prevent form submit on search button click

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -11,6 +11,7 @@
     this.resultCache = {}
 
     this.$form = options.$form
+    this.$searchSubmitButton = this.$form.find('.gem-c-search__submit')
     this.$resultsWrapper = this.$form.find('.js-live-search-results-block')
     this.$suggestionsBlock = this.$form.find('#js-spelling-suggestions')
     this.$resultsBlock = options.$results.find('#js-results')
@@ -42,6 +43,15 @@
     }
 
     this.focusErrorMessagesOnLoad(this.$form)
+
+    // prevent page refresh on search submit button click
+    // instead trigger the AJAX results fetch
+    this.$searchSubmitButton.on('click',
+      function (e) {
+        e.preventDefault()
+        this.formChange(e)
+      }.bind(this)
+    )
 
     if (GOVUK.support.history()) {
       this.saveState()


### PR DESCRIPTION
As we've replaced the text input with a search component
(input + submit button) we haven't implemented preventing the form submit on button click.

While it hasn't been raised as an issue with users, we still want to prevent the server-side form submission and use the  existing Ajax functionality for fetching results.

**see url changing**

**Before**
![page-refresh](https://user-images.githubusercontent.com/3758555/73268803-8300e400-41d3-11ea-9070-fc4fd2fe7569.gif)


**After**
![page-ajax](https://user-images.githubusercontent.com/3758555/73269282-6dd88500-41d4-11ea-9f28-092c87903f7a.gif)

alternatively compare llve vs heroku links below

---

## Search page examples to sanity check:

- https://finder-front-search-but-nyllgy.herokuapp.com/search/all
- https://finder-front-search-but-nyllgy.herokuapp.com/search/research-and-statistics

