### PR TITLE
Add routes to process /transition-check

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ FinderFrontend::Application.routes.draw do
   get "/get-ready-brexit-check/questions" => "brexit_checker#show", as: :brexit_checker_questions
   get "/get-ready-brexit-check/email-signup" => "brexit_checker#email_signup", as: :brexit_checker_email_signup
   post "/get-ready-brexit-check/email-signup" => "brexit_checker#confirm_email_signup", as: :brexit_checker_confirm_email_signup
+
+  get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
+  get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions
+  get "/transition-check/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup
+  post "/transition-check/email-signup" => "brexit_checker#confirm_email_signup", as: :transition_checker_confirm_email_signup
+
   get "/email/subscriptions/new", to: proc { [200, {}, [""]] }, as: :email_alert_frontend_signup
 
   get "/*slug/email-signup" => "email_alert_subscriptions#new", as: :new_email_alert_subscriptions


### PR DESCRIPTION
We are going to reslug get-ready-brexit-check to transition-check

This PR adds the routes for this.

https://trello.com/c/LllJV5JJ/409-reslug-the-brexit-checker

---

## Search page examples to sanity check:

- https://finder-frontend-pr-1888.herokuapp.com/search/all
- https://finder-frontend-pr-1888.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-1888.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-1888.herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-1888.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-1888.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-1888.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-1888.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-1888.herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-1888.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
