### PR TITLE
[WIP] Add method and rake task for unpublishing content_items

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -27,6 +27,10 @@ module Services
     GdsApi.worldwide
   end
 
+  def self.publishing_api
+    GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+  end
+
   def self.registries
     Registries::BaseRegistries.new
   end

--- a/lib/tasks/unpublish_brexit_content.rake
+++ b/lib/tasks/unpublish_brexit_content.rake
@@ -1,0 +1,11 @@
+desc "Unpublish and redirect a piece of content"
+task :unpublish_content, %i[content_item_id parameters] => :environment do |_, args|
+  id = args[:content_item_id]
+  params = args[:parameters]
+  puts "Calling unpublish for content id: #{id}"
+  puts "with the following params:"
+  params.each { |k, v| puts "#{k}: #{v}" }
+  response = Services.publishing_api.unpublish(id, params)
+  puts "Done" if response.code == 200
+  puts "Error" if !response.code == 200
+end

--- a/lib/tasks/unpublish_brexit_content.rake
+++ b/lib/tasks/unpublish_brexit_content.rake
@@ -1,11 +1,15 @@
-desc "Unpublish and redirect a piece of content"
-task :unpublish_content, %i[content_item_id parameters] => :environment do |_, args|
-  id = args[:content_item_id]
-  params = args[:parameters]
-  puts "Calling unpublish for content id: #{id}"
-  puts "with the following params:"
-  params.each { |k, v| puts "#{k}: #{v}" }
-  response = Services.publishing_api.unpublish(id, params)
-  puts "Done" if response.code == 200
-  puts "Error" if !response.code == 200
+desc "Unpublish business finder results and questions pages"
+task :unpublish_business_finder => :environment do |_, args|
+  content_ids = %w[b9ef4434-761f-49ae-af97-dc7a248499c4 42ce66de-04f3-4192-bf31-8394538e0734]
+  content_ids.each do |content_id|
+    Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/transition")
+  end
+end
+
+desc "Unpublish prepare eu exit campaign page"
+task :unpublish_brexit_campaign_page => :environment do |_, args|
+  content_ids = %w[ecb55f9d-0823-43bd-a116-dbfab2b76ef9]
+  content_ids.each do |content_id|
+    Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/transition")
+  end
 end

--- a/spec/lib/services/publising_api_spec.rb
+++ b/spec/lib/services/publising_api_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "gds_api/publishing_api"
+require "gds_api/test_helpers/publishing_api"
+
+describe Services do
+  include GdsApi::TestHelpers::PublishingApi
+
+  describe "#unpublish" do
+    subject(:service) do
+      Services.publishing_api.unpublish(content_item_id, unpublish_options)
+    end
+
+    let(:content_item_id) { "f3dd33bd-e88a-400a-8dbc-50e673e42a7a" }
+
+    let(:unpublish_options) do
+      {
+        "type" => "redirect",
+        "alternative_path" => "/transition",
+      }.symbolize_keys
+    end
+
+    it "unpublishes the item" do
+      stub_any_publishing_api_unpublish
+      expect(subject.code).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Trello:
- https://trello.com/c/CLw2wZSV/391-business-finder-unpublish-the-results-email-signup-page
- https://trello.com/c/Nnm7Drqb/390-business-finder-redirect-question-pages-to-brexit-landing-page
Hits the publishing API with an unpublish call.
Intended for use against the Brexit Business and other Brexit estate
URLs. So we can point them all to the `/transition` URL

@TODO test against integration