### PR TITLE
Brexit checker paths now use /transition-check

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -27,7 +27,7 @@ class BrexitCheckerController < ApplicationController
       current_question_index: page,
     )
 
-    redirect_to brexit_checker_results_path(c: criteria_keys) if @current_question.nil?
+    redirect_to transition_checker_results_path(c: criteria_keys) if @current_question.nil?
   end
 
   def results
@@ -51,7 +51,7 @@ class BrexitCheckerController < ApplicationController
 private
 
   def subscriber_list_options
-    path = brexit_checker_results_path(c: criteria_keys)
+    path = transition_checker_results_path(c: criteria_keys)
 
     {
       "title" => "How to prepare for a no deal Brexit",

--- a/app/views/brexit_checker/_change_answers_link.html.erb
+++ b/app/views/brexit_checker/_change_answers_link.html.erb
@@ -3,8 +3,8 @@
   data-module="track-click"
   data-track-action="ChangeAnswers"
   data-track-category="ChangeAnswersClicked"
-  data-track-label="<%= brexit_checker_questions_path %>"
-  href="<%= brexit_checker_questions_path %>"
+  data-track-label="<%= transition_checker_questions_path %>"
+  href="<%= transition_checker_questions_path %>"
 >
   <%= t("brexit_checker.change_answers_link.link_text") %>
 </a>

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -8,11 +8,11 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("brexit_checker.stay_updated.sign_up"),
-  href: brexit_checker_email_signup_path(c: criteria_keys),
+  href: transition_checker_email_signup_path(c: criteria_keys),
   data_attributes: {
     "module": "track-click",
     "track-action": t("brexit_checker.stay_updated.sign_up"),
     "track-category": "StayUpdated",
-    "track-label": brexit_checker_email_signup_path
+    "track-label": transition_checker_email_signup_path
   }
 } %>

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -21,7 +21,7 @@
     },
     {
       title: t('brexit_checker.breadcrumbs.results'),
-      url: brexit_checker_results_path(c: criteria_keys)
+      url: transition_checker_results_path(c: criteria_keys)
     }
   ] %>
 
@@ -34,7 +34,7 @@
           This will include: Information about Brexit including what you and your business can do to prepare.
         </p>
 
-        <%= form_tag brexit_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
+        <%= form_tag transition_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.email_signup.sign_up'),
             inline_layout: true

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -57,10 +57,10 @@
         "module": "track-click",
         "track-action": action_based_email_link_label,
         "track-category": "StayUpdated",
-        "track-label": brexit_checker_email_signup_path
+        "track-label": transition_checker_email_signup_path
       },
       link_text: action_based_email_link_label,
-      link_href: brexit_checker_email_signup_path(c: criteria_keys),
+      link_href: transition_checker_email_signup_path(c: criteria_keys),
       link_title: t("brexit_checker.results.email_sign_up_title"),
     } %>
 

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-width-container">
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
-      href: brexit_checker_questions_path(page: @previous_page, c: criteria_keys),
+      href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/back_link", {
@@ -26,7 +26,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form
-        action="<%= brexit_checker_questions_path %>"
+        action="<%= transition_checker_questions_path %>"
         method="get"
         id="finder-qa-facet-filter-selection"
         data-module="track-brexit-qa-choices"

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,7 +8,7 @@
   <p>The following pages are rendered by this application:</p>
 
   <ul>
-    <li><%= link_to "How to prepare for a no deal Brexit questions", brexit_checker_questions_path %></li>
+    <li><%= link_to "How to prepare for a no deal Brexit questions", transition_checker_questions_path %></li>
   <% @rendered_pages.each do |page| %>
     <li><%= link_to page.fetch("title"), page.fetch("link") %></li>
   <% end %>

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -9,9 +9,9 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     {
       "title" => "How to prepare for a no deal Brexit",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/get-ready-brexit-check/results?c%5B%5D=nationality-eu)",
+      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
-      "url" => "/get-ready-brexit-check/results?c%5B%5D=nationality-eu",
+      "url" => "/transition-check/results?c%5B%5D=nationality-eu",
       "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
     }
   end
@@ -33,7 +33,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   def given_im_on_the_results_page
-    visit brexit_checker_results_path(c: %w(nationality-eu))
+    visit transition_checker_results_path(c: %w(nationality-eu))
   end
 
   def and_email_alert_api_has_subscriber_list

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
     expect(page).to have_link("Back", href: "/get-ready-brexit-check")
   end
 

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Filtering options based on criteria", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
   end
 
   def and_i_choose_uk_for_the_living_question

--- a/spec/lib/services/email_alert_api_spec.rb
+++ b/spec/lib/services/email_alert_api_spec.rb
@@ -13,7 +13,7 @@ describe Services::EmailAlertApi do
 
     let(:subscriber_list_options) do
       {
-        "title" => "How to prepare for a no deal Brexit",
+        "title" => "Check what you need to do now",
         "slug" => subscriber_list_slug,
         "description" => "You can view a copy of your results on GOV.UK.",
         "tags" => { "brexit_checklist_criteria" => { "any" => %w(does-not-own-business eu-national) } },


### PR DESCRIPTION
Paths in the views have been updated so we no longer use redirects.

trello: https://trello.com/c/LllJV5JJ/409-reslug-the-brexit-checker
## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
