### PR TITLE
Baseline checker content

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ Rails/DynamicFindBy:
   Whitelist:
     - find_by_key
     - find_by_id
+
+Rails/OutputSafety:
+  Enabled: false

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -27,7 +27,7 @@ class BrexitCheckerController < ApplicationController
       current_question_index: page,
     )
 
-    redirect_to brexit_checker_results_path(c: criteria_keys) if @current_question.nil?
+    redirect_to transition_checker_results_path(c: criteria_keys) if @current_question.nil?
   end
 
   def results
@@ -51,7 +51,7 @@ class BrexitCheckerController < ApplicationController
 private
 
   def subscriber_list_options
-    path = brexit_checker_results_path(c: criteria_keys)
+    path = transition_checker_results_path(c: criteria_keys)
 
     {
       "title" => "How to prepare for a no deal Brexit",

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -71,6 +71,7 @@ private
       level_two_taxon: params["subtaxons"].try(:first),
       organisations: params["departments"] || params["organisations"],
       people: params["people"],
+      roles: params["roles"],
       world_locations: params["world_locations"],
       public_timestamp: { from: params["from_date"], to: params["to_date"] }.compact.presence }.compact
   end

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -109,7 +109,7 @@ module BrexitCheckerHelper
     elsif criteria_keys.present?
       t("brexit_checker.results.description_no_actions")
     else
-      t("brexit_checker.results.description_no_answers")
+      t("brexit_checker.results.description_no_answers").html_safe
     end
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -63,8 +63,9 @@ private
   attr_reader :metadata_presenter_class, :sort_presenter, :total, :documents, :facets, :content_item
 
   def document_list_component_data(documents_to_convert:)
-    documents_to_convert.map do |document|
+    documents_to_convert.map.with_index do |document, index|
       SearchResultPresenter.new(document: document,
+                                rank: index + 1,
                                 metadata_presenter_class: metadata_presenter_class,
                                 doc_count: documents.count,
                                 facets: facets,

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -10,8 +10,9 @@ class SearchResultPresenter
            :original_rank,
            to: :document
 
-  def initialize(document:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, highlight:)
+  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, highlight:)
     @document = document
+    @rank = rank
     @metadata = metadata_presenter_class.new(document.metadata(facets)).present
     @count = doc_count
     @debug_score = debug_score
@@ -63,7 +64,11 @@ private
     published_text = "<span class='published-by'>#{I18n.t('finders.search_result_presenter.first_published_during')} #{government_name}</span>" if is_historic
     if @debug_score
       debug_text = "<span class='debug-results debug-results--link'>#{link}</span>"
-      debug_text += "<span class='debug-results debug-results--meta'>Score: #{score}</span>" if score
+      debug_text += if score
+                      "<span class='debug-results debug-results--meta'>Score: #{score} (ranked ##{@rank})</span>"
+                    else
+                      "<span class='debug-results debug-results--meta'>Ranked: ##{@rank}</span>"
+                    end
       debug_text += "<span class='debug-results debug-results--meta'>Original score: #{es_score} (ranked ##{original_rank})</span>" if es_score && original_rank
       debug_text += "<span class='debug-results debug-results--meta'>Format: #{format}</span>"
     end

--- a/app/views/brexit_checker/_change_answers_link.html.erb
+++ b/app/views/brexit_checker/_change_answers_link.html.erb
@@ -3,8 +3,8 @@
   data-module="track-click"
   data-track-action="ChangeAnswers"
   data-track-category="ChangeAnswersClicked"
-  data-track-label="<%= brexit_checker_questions_path %>"
-  href="<%= brexit_checker_questions_path %>"
+  data-track-label="<%= transition_checker_questions_path %>"
+  href="<%= transition_checker_questions_path %>"
 >
   <%= t("brexit_checker.change_answers_link.link_text") %>
 </a>

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -8,11 +8,11 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("brexit_checker.stay_updated.sign_up"),
-  href: brexit_checker_email_signup_path(c: criteria_keys),
+  href: transition_checker_email_signup_path(c: criteria_keys),
   data_attributes: {
     "module": "track-click",
     "track-action": t("brexit_checker.stay_updated.sign_up"),
     "track-category": "StayUpdated",
-    "track-label": brexit_checker_email_signup_path
+    "track-label": transition_checker_email_signup_path
   }
 } %>

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -21,7 +21,7 @@
     },
     {
       title: t('brexit_checker.breadcrumbs.results'),
-      url: brexit_checker_results_path(c: criteria_keys)
+      url: transition_checker_results_path(c: criteria_keys)
     }
   ] %>
 
@@ -31,7 +31,7 @@
         <h1 class="govuk-heading-l"><%= t('brexit_checker.email_signup.sign_up_heading') %></h1>
         <%= t('brexit_checker.email_signup.sign_up_message').html_safe %>
 
-        <%= form_tag brexit_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
+        <%= form_tag transition_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.email_signup.sign_up_button'),
             inline_layout: true

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -28,15 +28,12 @@
   <main class="govuk-main-wrapper" role="mail">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Get email alerts</h1>
-        <p class="govuk-body">You are signing up for email alerts about: how to prepare for a no deal Brexit.
-        <p class="govuk-body">
-          This will include: Information about Brexit including what you and your business can do to prepare.
-        </p>
+        <h1 class="govuk-heading-l"><%= t('brexit_checker.email_signup.sign_up_heading') %></h1>
+        <%= t('brexit_checker.email_signup.sign_up_message').html_safe %>
 
         <%= form_tag brexit_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
-            text: t('brexit_checker.email_signup.sign_up'),
+            text: t('brexit_checker.email_signup.sign_up_button'),
             inline_layout: true
           } %>
         <% end %>

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -13,11 +13,11 @@
     },
     {
       title: t('brexit_checker.breadcrumbs.brexit-home'),
-      url: "/brexit"
+      url: "/transition"
     },
     {
       title: t('brexit_checker.breadcrumbs.brexit-check'),
-      url: "/get-ready-brexit-check"
+      url: "/transition-check"
     },
     {
       title: t('brexit_checker.breadcrumbs.results'),

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -26,11 +26,11 @@
     },
     {
       title: t('brexit_checker.breadcrumbs.brexit-home'),
-      url: "/brexit"
+      url: "/transition"
     },
     {
       title: t('brexit_checker.breadcrumbs.brexit-check'),
-      url: "/get-ready-brexit-check"
+      url: "/transition-check"
     }
   ] %>
   <div class="govuk-grid-row">

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -57,10 +57,10 @@
         "module": "track-click",
         "track-action": action_based_email_link_label,
         "track-category": "StayUpdated",
-        "track-label": brexit_checker_email_signup_path
+        "track-label": transition_checker_email_signup_path
       },
       link_text: action_based_email_link_label,
-      link_href: brexit_checker_email_signup_path(c: criteria_keys),
+      link_href: transition_checker_email_signup_path(c: criteria_keys),
       link_title: t("brexit_checker.results.email_sign_up_title"),
     } %>
 

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-width-container">
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
-      href: brexit_checker_questions_path(page: @previous_page, c: criteria_keys),
+      href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/back_link", {
@@ -26,7 +26,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form
-        action="<%= brexit_checker_questions_path %>"
+        action="<%= transition_checker_questions_path %>"
         method="get"
         id="finder-qa-facet-filter-selection"
         data-module="track-brexit-qa-choices"

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,7 +8,7 @@
   <p>The following pages are rendered by this application:</p>
 
   <ul>
-    <li><%= link_to "How to prepare for a no deal Brexit questions", brexit_checker_questions_path %></li>
+    <li><%= link_to "How to prepare for a no deal Brexit questions", transition_checker_questions_path %></li>
   <% @rendered_pages.each do |page| %>
     <li><%= link_to page.fetch("title"), page.fetch("link") %></li>
   <% end %>

--- a/config/locales/en/brexit_checker/action_audiences.yml
+++ b/config/locales/en/brexit_checker/action_audiences.yml
@@ -1,4 +1,4 @@
 en:
   brexit_checker:
     action_audiences:
-      no_results: This is a safe and secure service. We don't store any of your personal information.
+      no_results: There are no actions you need to take now.

--- a/config/locales/en/brexit_checker/breadcrumbs.yml
+++ b/config/locales/en/brexit_checker/breadcrumbs.yml
@@ -5,4 +5,4 @@ en:
       brexit-home: Brexit
       brexit-check: "Check how to get ready for new rules in 2021"
       questions: Questions
-      results: Results
+      results: Your results

--- a/config/locales/en/brexit_checker/breadcrumbs.yml
+++ b/config/locales/en/brexit_checker/breadcrumbs.yml
@@ -3,6 +3,6 @@ en:
     breadcrumbs:
       home: Home
       brexit-home: Brexit
-      brexit-check: "Brexit: check what you need to do"
+      brexit-check: "Check how to get ready for new rules in 2021"
       questions: Questions
       results: Results

--- a/config/locales/en/brexit_checker/breadcrumbs.yml
+++ b/config/locales/en/brexit_checker/breadcrumbs.yml
@@ -2,7 +2,7 @@ en:
   brexit_checker:
     breadcrumbs:
       home: Home
-      brexit-home: Brexit
+      brexit-home: Transition period
       brexit-check: "Check how to get ready for new rules in 2021"
       questions: Questions
       results: Your results

--- a/config/locales/en/brexit_checker/email_signup.yml
+++ b/config/locales/en/brexit_checker/email_signup.yml
@@ -2,4 +2,8 @@ en:
   brexit_checker:
     email_signup:
       title: "Brexit: check what you need to do if there is no deal"
-      sign_up: Subscribe
+      sign_up_heading: "Get email alerts"
+      sign_up_message: |
+        <p class="govuk-body">You are signing up for email updates about: how to prepare for new rules from 1 January 2021.</p>
+        <p class="govuk-body">This will include: Information about the transition period including what you, your family, or your business can do to prepare for new rules.</p>
+      sign_up_button: Subscribe

--- a/config/locales/en/brexit_checker/email_signup.yml
+++ b/config/locales/en/brexit_checker/email_signup.yml
@@ -1,9 +1,9 @@
 en:
   brexit_checker:
     email_signup:
-      title: "Brexit: check what you need to do if there is no deal"
+      title: "How to get ready for new rules in 2021"
       sign_up_heading: "Get email alerts"
       sign_up_message: |
-        <p class="govuk-body">You are signing up for email updates about: how to prepare for new rules from 1 January 2021.</p>
-        <p class="govuk-body">This will include: Information about the transition period including what you, your family, or your business can do to prepare for new rules.</p>
+        <p class="govuk-body">You are signing up for email updates about how to prepare for new rules from 1 January 2021.</p>
+        <p class="govuk-body">This will include information about the transition period including what you, your family, or your business can do to prepare for new rules.</p>
       sign_up_button: Subscribe

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -9,8 +9,8 @@ en:
       description_no_actions: |
         Based on your responses, you do not need to take any action to prepare for the new rules from 1 January 2021.
       description_no_answers: |
-        To change your answers, follow the link below.
-        This is a safe and secure service. We do not store any of your personal information.
+        <p class="govuk-body-l">To change your answers, follow the link below.</p>
+        <p class="govuk-body-l">This is a safe and secure service. We do not store any of your personal information.</p>
       email_sign_up_title: What you need to do may change
       email_sign_up_link: |
         Subscribe to email updates about changes that may affect you and get a link to your results

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -7,7 +7,7 @@ en:
       description: |
         You may not need to take all these actions now. Actions you need to take will depend on your own circumstances.
       description_no_actions: |
-        Based on your responses, you do not need to take any action to prepare for the new rules from 1 January 2021.
+        Based on your responses, you do not need to take any action to prepare for new rules from 1 January 2021.
       description_no_answers: |
         <p class="govuk-body-l">To change your answers, follow the link below.</p>
         <p class="govuk-body-l">This is a safe and secure service. We do not store any of your personal information.</p>
@@ -15,7 +15,7 @@ en:
       email_sign_up_link: |
         Subscribe to email updates about changes that may affect you and get a link to your results
       email_sign_up_link_no_actions: |
-        This may change. Subscribe to email alerts about changes to Brexit information that may affect you.
+        Subscribe to email updates about changes that may affect you and get a link to your results
       share_link_title: Share your results
       social_media_meta:
         title: "How to get ready for new rules in 2021: Your results"

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -8,7 +8,8 @@ en:
       description_no_actions: |
         Based on your responses, you do not need to take any action to prepare for the new rules from 1 January 2021.
       description_no_answers: |
-        To change your answers, follow the link below. This is a safe and secure service. We do not store any of your personal information.
+        To change your answers, follow the link below.
+        This is a safe and secure service. We do not store any of your personal information.
       email_sign_up_title: What you need to do may change
       email_sign_up_link: |
         Subscribe to updates about changes that may affect you and get a link to your results

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -1,6 +1,7 @@
 en:
   brexit_checker:
     results:
+      title: "How to get ready for new rules in 2021: Your results"
       title_no_actions: You do not need to take action now
       title_no_answers: You did not answer any of the questions
       description: |
@@ -12,14 +13,14 @@ en:
         This is a safe and secure service. We do not store any of your personal information.
       email_sign_up_title: What you need to do may change
       email_sign_up_link: |
-        Subscribe to updates about changes that may affect you and get a link to your results
+        Subscribe to email updates about changes that may affect you and get a link to your results
       email_sign_up_link_no_actions: |
         This may change. Subscribe to email alerts about changes to Brexit information that may affect you.
       share_link_title: Share your results
       social_media_meta:
-        title: "Brexit: check what you need to do if there is no deal"
+        title: "How to get ready for new rules in 2021: Your results"
         description: |
-          Check what you or your business need to do to prepare for a no-deal Brexit.
+          What you, your family, or your business can do now to prepare for new rules from 1 January 2021.
       criteria:
         list_context: "Because you said:"
         no_answers: |

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -1,13 +1,12 @@
 en:
   brexit_checker:
     results:
-      title: "Get ready for a no-deal Brexit: Your results"
-      title_no_actions: You do not need to take action
+      title_no_actions: You do not need to take action now
       title_no_answers: You did not answer any of the questions
       description: |
         You may not need to take all these actions now. Actions you need to take will depend on your own circumstances.
       description_no_actions: |
-        Based on your responses, you do not need to take any action to prepare for a no-deal Brexit.
+        Based on your responses, you do not need to take any action to prepare for the new rules from 1 January 2021.
       description_no_answers: |
         To change your answers, follow the link below. This is a safe and secure service. We do not store any of your personal information.
       email_sign_up_title: What you need to do may change

--- a/config/locales/en/brexit_checker/show.yml
+++ b/config/locales/en/brexit_checker/show.yml
@@ -1,4 +1,4 @@
 en:
   brexit_checker:
     show:
-      title: "Brexit: check what you need to do if there is no deal"
+      title: "How to get ready for new rules in 2021"

--- a/config/locales/en/brexit_checker_mailer/change_notification.yml
+++ b/config/locales/en/brexit_checker_mailer/change_notification.yml
@@ -2,6 +2,6 @@ en:
   brexit_checker_mailer:
     change_notification:
       guidance_prompt: Read the guidance
-      title: How to prepare for a no deal Brexit
+      title: Your transition period results
       addition: A new action has been added
       content_change: An action has been updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,11 +19,6 @@ FinderFrontend::Application.routes.draw do
   end
 
   # Routes for the for Brexit Checker
-  get "/get-ready-brexit-check/results" => "brexit_checker#results", as: :brexit_checker_results
-  get "/get-ready-brexit-check/questions" => "brexit_checker#show", as: :brexit_checker_questions
-  get "/get-ready-brexit-check/email-signup" => "brexit_checker#email_signup", as: :brexit_checker_email_signup
-  post "/get-ready-brexit-check/email-signup" => "brexit_checker#confirm_email_signup", as: :brexit_checker_confirm_email_signup
-
   get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
   get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions
   get "/transition-check/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup

--- a/lib/brexit_checker/actions.yaml
+++ b/lib/brexit_checker/actions.yaml
@@ -160,7 +160,7 @@ actions:
     has re-introduced roaming charges.
   guidance_prompt: More information
   guidance_link_text: Visit Europe after Brexit
-  guidance_url: https://www.gov.uk/visit-europe-brexit
+  guidance_url: https://www.gov.uk/visit-europe-1-january-2021
   criteria:
   - any_of:
     - all_of:
@@ -197,7 +197,7 @@ actions:
     immigration rules.
   guidance_prompt: More information
   guidance_link_text: Visit Europe after Brexit
-  guidance_url: https://www.gov.uk/visit-europe-brexit
+  guidance_url: https://www.gov.uk/visit-europe-1-january-2021
   criteria:
   - all_of:
     - nationality-uk
@@ -307,7 +307,7 @@ actions:
     or ferry.
   guidance_prompt: More information
   guidance_link_text: Visit Europe after Brexit
-  guidance_url: https://www.gov.uk/visit-europe-brexit
+  guidance_url: https://www.gov.uk/visit-europe-1-january-2021
   criteria:
   - any_of:
     - all_of:
@@ -447,7 +447,7 @@ actions:
     meet the requirements.
   guidance_prompt: More information
   guidance_link_text: 'Visit Europe after Brexit: Business travel'
-  guidance_url: https://www.gov.uk/visit-europe-brexit/business-travel
+  guidance_url: https://www.gov.uk/visit-europe-1-january-2021/business-travel-extra-requirements
   criteria:
   - travel-eu-business
   audience: citizen

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -58,9 +58,8 @@ questions:
       <p>It does not include travel to Ireland.</p>
       <p>Business travel includes activities such as travelling for meetings and conferences, providing services, and touring art or music.</p>
     detail_text: |
-      <p>After Brexit, the rules for business travel to the EU will change.</p>
+      <p>From 1 January 2021, the rules for business travel to the EU will change.</p>
       <p>We need to know if you travel to the EU for business so we can show you what you need to do before you travel.</p>
-
     options:
       - label: "Yes"
         value: travel-eu-business
@@ -85,7 +84,7 @@ questions:
     text: 'Where do you plan to travel for leisure and tourism?'
     hint_text: Select all that apply. If you do not plan to travel, select continue.
     detail_text: |
-      <p>After Brexit, the rules for travelling abroad will change.</p>
+      <p>From 1 January 2021, the rules for travelling abroad will change.</p>
       <p>We need to know where you plan to go so we can show you what you need to do before you travel.</p>
     options:
       - label: To the UK
@@ -112,7 +111,7 @@ questions:
     text: 'Do you plan to do either of the following when travelling?'
     hint_text: "Select all that apply. If neither apply, select continue."
     detail_text: |
-      <p>After Brexit, the rules for driving abroad and taking a pet will change.</p>
+      <p>From 1 January 2021, the rules for driving abroad and taking a pet will change.</p>
       <p>We need to know about your plans so we can show you what you need to do before you travel.</p>
     options:
       - label: Drive
@@ -171,13 +170,14 @@ questions:
     description: |
       <p>This includes sole traders (self-employed), limited companies, and small and medium enterprises.</p>
     detail_text: |
-      <p>After Brexit, rules for UK businesses and organisations will change.</p>
-      <p>We need to know if you own or help to run a UK business or organisation so we can show you what you need to do to prepare for Brexit.</p>
+      <p>From 1 January 2021, rules for UK businesses and organisations will change.</p>
+      <p>We need to know if you own or help to run a UK business or organisation so we can show you what you need to do to prepare for the new rules.</p>
     options:
       - label: "Yes"
         value: owns-operates-business-organisation
       - label: "No"
         value: does-not-own-operate-business-organisation
+
   - key: employ-eu-citizens
     criteria:
       - owns-operates-business-organisation

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -48,7 +48,7 @@ private
 
   def link_based_subscriber_list?
     # TODO: move this logic into schema
-    content_types = %w[organisations people world_locations part_of_taxonomy_tree]
+    content_types = %w[organisations people roles world_locations part_of_taxonomy_tree]
     keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, "") }
     (keys & content_types).present?
   end
@@ -80,7 +80,7 @@ private
   end
 
   def to_content_ids(key, values)
-    return values unless %w[organisations people world_locations].include?(key)
+    return values unless %w[organisations people roles world_locations].include?(key)
 
     registry = Registries::BaseRegistries.new.all[key]
     values.map { |value| registry[value]["content_id"] }

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -127,6 +127,7 @@ private
       world_locations
       organisations
       people
+      roles
       part_of_taxonomy_tree
       all_part_of_taxonomy_tree
       document_type

--- a/lib/parameter_parser/email_alert_parameter_parser.rb
+++ b/lib/parameter_parser/email_alert_parameter_parser.rb
@@ -88,7 +88,7 @@ module ParameterParser
     end
 
     def could_be_a_dynamic_facet?(key)
-      %w(organisations people world_locations all_part_of_taxonomy_tree part_of_taxonomy_tree).include? key
+      %w(organisations people roles world_locations all_part_of_taxonomy_tree part_of_taxonomy_tree).include? key
     end
 
     def parsed_params(filter_params, params)

--- a/lib/registries/roles_registry.rb
+++ b/lib/registries/roles_registry.rb
@@ -41,10 +41,10 @@ module Registries
 
     def fetch_roles_from_rummager
       params = {
-        aggregate_roles: "1500,examples:0,order:value.title",
+        facet_roles: "1500,examples:0,order:value.title",
         count: 0,
       }
-      Services.rummager.search(params).dig("aggregates", "roles", "options")
+      Services.rummager.search(params).dig("facets", "roles", "options")
     end
   end
 end

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -9,9 +9,9 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     {
       "title" => "How to prepare for a no deal Brexit",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/get-ready-brexit-check/results?c%5B%5D=nationality-eu)",
+      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
-      "url" => "/get-ready-brexit-check/results?c%5B%5D=nationality-eu",
+      "url" => "/transition-check/results?c%5B%5D=nationality-eu",
       "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
     }
   end
@@ -33,7 +33,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   def given_im_on_the_results_page
-    visit brexit_checker_results_path(c: %w(nationality-eu))
+    visit transition_checker_results_path(c: %w(nationality-eu))
   end
 
   def and_email_alert_api_has_subscriber_list

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
     expect(page).to have_link("Back", href: "/get-ready-brexit-check")
   end
 

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_css("a[href='https://www.facebook.com/sharer/sharer.php?u=#{current_url}']")
     expect(page).to have_css("a[href='https://twitter.com/share?url=#{current_url}']")
     expect(page).to have_css("a[href='https://api.whatsapp.com/send?text=#{current_url}']")
-    expect(page).to have_css("a[href='mailto:?body=#{current_url}&subject=Get%20ready%20for%20a%20no-deal%20Brexit:%20Your%20results']")
+    expect(page).to have_css("a[href='mailto:?body=#{current_url}&subject=How%20to%20get%20ready%20for%20new%20rules%20in%202021:%20Your%20results']")
     expect(page).to have_css("a[href='http://www.linkedin.com/shareArticle?url=#{current_url}']")
   end
 

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
   end
 
   def and_i_should_see_citizen_actions_are_grouped

--- a/spec/features/brexit_checker/travel_question_spec.rb
+++ b/spec/features/brexit_checker/travel_question_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Filtering options based on criteria", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
   end
 
   def and_i_choose_uk_for_the_living_question

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -250,7 +250,7 @@ describe BrexitCheckerHelper, type: :helper do
     end
 
     it "returns the no answers desciption there no answers and no actions" do
-      expect(brexit_results_description([], [])).to eq(t("brexit_checker.results.description_no_answers"))
+      expect(brexit_results_description([], [])).to eq(t("brexit_checker.results.description_no_answers").html_safe)
     end
   end
 

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -578,5 +578,36 @@ describe EmailAlertSignupAPI do
         assert_requested(req)
       end
     end
+
+    describe "roles facet" do
+      let(:applied_filters) do
+        { "roles" => %w(prime-minister) }
+      end
+
+      let(:facets) do
+        [
+          {
+            "facet_id" => "roles",
+            "facet_name" => "roles",
+          },
+        ]
+      end
+
+      before { stub_roles_registry_request }
+
+      it "asks email-alert-api to find or create the subscriber list" do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            roles: { any: %w(content_id_for_prime-minister) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+          },
+          "subscription_url" => subscription_url,
+        )
+
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
   end
 end

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Registries::RolesRegistry do
   let(:rummager_params) do
     {
       count: 0,
-      aggregate_roles: "1500,examples:0,order:value.title",
+      facet_roles: "1500,examples:0,order:value.title",
     }
   end
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -74,7 +74,7 @@ RSpec.describe Registries::RolesRegistry do
       "results": [],
       "total": 394075,
       "start": 0,
-      "aggregates": {
+      "facets": {
         "roles": {
           "options": [{
             "value": {

--- a/spec/lib/services/email_alert_api_spec.rb
+++ b/spec/lib/services/email_alert_api_spec.rb
@@ -13,7 +13,7 @@ describe Services::EmailAlertApi do
 
     let(:subscriber_list_options) do
       {
-        "title" => "How to prepare for a no deal Brexit",
+        "title" => "Check what you need to do now",
         "slug" => subscriber_list_slug,
         "description" => "You can view a copy of your results on GOV.UK.",
         "tags" => { "brexit_checklist_criteria" => { "any" => %w(does-not-own-business eu-national) } },

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe GroupedResultSetPresenter do
   describe "#grouped_documents" do
     def build_document_list_component(document, all_documents_count)
       SearchResultPresenter.new(document: document,
+                                rank: 1,
                                 metadata_presenter_class: metadata_presenter_class,
                                 doc_count: all_documents_count,
                                 content_item: content_item,

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ResultSetPresenter do
         [FactoryBot.build(:document_hash, is_historic: true, es_score: 0.005, link: "/path/to/doc")]
       }
       let(:expected_document_content_with_debug) do
-        "<span class=\"published-by\">First published during the 2015 Conservative government</span><span class=\"debug-results debug-results--link\">/path/to/doc</span><span class=\"debug-results debug-results--meta\">Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: answer</span>"
+        "<span class=\"published-by\">First published during the 2015 Conservative government</span><span class=\"debug-results debug-results--link\">/path/to/doc</span><span class=\"debug-results debug-results--meta\">Score: 0.005 (ranked #1)</span><span class=\"debug-results debug-results--meta\">Format: answer</span>"
       end
 
       it "shows debug metadata" do

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe SearchResultPresenter do
 
   let(:facets) { [] }
 
+  let(:rank) { 1 }
+
   subject(:presenter) {
     SearchResultPresenter.new(document: document,
+                              rank: rank,
                               metadata_presenter_class: MetadataPresenter,
                               doc_count: 10,
                               content_item: content_item,
@@ -122,7 +125,7 @@ RSpec.describe SearchResultPresenter do
     end
     let(:debug_subtext) do
       "<span class=\"debug-results debug-results--link\">link-1</span><span class=\"debug-results debug-results--meta\">"\
-      "Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: cake</span>"
+      "Score: 0.005 (ranked #1)</span><span class=\"debug-results debug-results--meta\">Format: cake</span>"
     end
     it "returns nothing unless the document is historic or debug_score is set to true" do
       expect(subject.document_list_component_data[:subtext]).to eql(nil)
@@ -157,7 +160,7 @@ RSpec.describe SearchResultPresenter do
 
       let(:debug_subtext) do
         "<span class=\"debug-results debug-results--link\">link-1</span>"\
-        "<span class=\"debug-results debug-results--meta\">Score: #{combined_score}</span>"\
+        "<span class=\"debug-results debug-results--meta\">Score: #{combined_score} (ranked #1)</span>"\
         "<span class=\"debug-results debug-results--meta\">Original score: 0.005 (ranked ##{original_rank})</span>"\
         "<span class=\"debug-results debug-results--meta\">Format: cake</span>"
       end

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -61,7 +61,7 @@ module RegistrySpecHelper
     stub_request(:get, "http://search.dev.gov.uk/search.json")
         .with(query: {
             count: 0,
-            aggregate_roles: "1500,examples:0,order:value.title",
+            facet_roles: "1500,examples:0,order:value.title",
         })
         .to_return(body: {
             results: [],


### PR DESCRIPTION
Trello: https://trello.com/c/kYj73KEh/433-deploy-baseline-checker

Updates the brexit checker results page, emails and questions (detail components) to use baseline content.