### PR TITLE
Remove redundant routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,11 +19,6 @@ FinderFrontend::Application.routes.draw do
   end
 
   # Routes for the for Brexit Checker
-  get "/get-ready-brexit-check/results" => "brexit_checker#results", as: :brexit_checker_results
-  get "/get-ready-brexit-check/questions" => "brexit_checker#show", as: :brexit_checker_questions
-  get "/get-ready-brexit-check/email-signup" => "brexit_checker#email_signup", as: :brexit_checker_email_signup
-  post "/get-ready-brexit-check/email-signup" => "brexit_checker#confirm_email_signup", as: :brexit_checker_confirm_email_signup
-
   get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
   get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions
   get "/transition-check/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
   end
 
   def when_i_visit_the_brexit_checker_flow
-    visit brexit_checker_questions_path
+    visit transition_checker_questions_path
   end
 
   def and_i_should_see_citizen_actions_are_grouped


### PR DESCRIPTION
We reslugged the brexit checker from to checker-results and
put redirects in for the old routes.

These routes are no longer necessary and can be removed

Also fixed a route in one of the tests.

Trello: https://trello.com/c/LllJV5JJ/409-reslug-the-brexit-checker


---

## Search page examples to sanity check:

- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/all
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/get-ready-brexit-check/questions
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/uk-nationals-living-eu
- https://finder-frontend-pr-[THIS PR NUMBER].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
