### PR TITLE
Display rank in debug_score output

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -63,8 +63,9 @@ private
   attr_reader :metadata_presenter_class, :sort_presenter, :total, :documents, :facets, :content_item
 
   def document_list_component_data(documents_to_convert:)
-    documents_to_convert.map do |document|
+    documents_to_convert.map.with_index do |document, index|
       SearchResultPresenter.new(document: document,
+                                rank: index + 1,
                                 metadata_presenter_class: metadata_presenter_class,
                                 doc_count: documents.count,
                                 facets: facets,

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -10,8 +10,9 @@ class SearchResultPresenter
            :original_rank,
            to: :document
 
-  def initialize(document:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, highlight:)
+  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, highlight:)
     @document = document
+    @rank = rank
     @metadata = metadata_presenter_class.new(document.metadata(facets)).present
     @count = doc_count
     @debug_score = debug_score
@@ -63,7 +64,11 @@ private
     published_text = "<span class='published-by'>#{I18n.t('finders.search_result_presenter.first_published_during')} #{government_name}</span>" if is_historic
     if @debug_score
       debug_text = "<span class='debug-results debug-results--link'>#{link}</span>"
-      debug_text += "<span class='debug-results debug-results--meta'>Score: #{score}</span>" if score
+      debug_text += if score
+                      "<span class='debug-results debug-results--meta'>Score: #{score} (ranked ##{@rank})</span>"
+                    else
+                      "<span class='debug-results debug-results--meta'>Ranked: ##{@rank}</span>"
+                    end
       debug_text += "<span class='debug-results debug-results--meta'>Original score: #{es_score} (ranked ##{original_rank})</span>" if es_score && original_rank
       debug_text += "<span class='debug-results debug-results--meta'>Format: #{format}</span>"
     end

--- a/spec/presenters/grouped_result_set_presenter_spec.rb
+++ b/spec/presenters/grouped_result_set_presenter_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe GroupedResultSetPresenter do
   describe "#grouped_documents" do
     def build_document_list_component(document, all_documents_count)
       SearchResultPresenter.new(document: document,
+                                rank: 1,
                                 metadata_presenter_class: metadata_presenter_class,
                                 doc_count: all_documents_count,
                                 content_item: content_item,

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ResultSetPresenter do
         [FactoryBot.build(:document_hash, is_historic: true, es_score: 0.005, link: "/path/to/doc")]
       }
       let(:expected_document_content_with_debug) do
-        "<span class=\"published-by\">First published during the 2015 Conservative government</span><span class=\"debug-results debug-results--link\">/path/to/doc</span><span class=\"debug-results debug-results--meta\">Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: answer</span>"
+        "<span class=\"published-by\">First published during the 2015 Conservative government</span><span class=\"debug-results debug-results--link\">/path/to/doc</span><span class=\"debug-results debug-results--meta\">Score: 0.005 (ranked #1)</span><span class=\"debug-results debug-results--meta\">Format: answer</span>"
       end
 
       it "shows debug metadata" do

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe SearchResultPresenter do
 
   let(:facets) { [] }
 
+  let(:rank) { 1 }
+
   subject(:presenter) {
     SearchResultPresenter.new(document: document,
+                              rank: rank,
                               metadata_presenter_class: MetadataPresenter,
                               doc_count: 10,
                               content_item: content_item,
@@ -122,7 +125,7 @@ RSpec.describe SearchResultPresenter do
     end
     let(:debug_subtext) do
       "<span class=\"debug-results debug-results--link\">link-1</span><span class=\"debug-results debug-results--meta\">"\
-      "Score: 0.005</span><span class=\"debug-results debug-results--meta\">Format: cake</span>"
+      "Score: 0.005 (ranked #1)</span><span class=\"debug-results debug-results--meta\">Format: cake</span>"
     end
     it "returns nothing unless the document is historic or debug_score is set to true" do
       expect(subject.document_list_component_data[:subtext]).to eql(nil)
@@ -157,7 +160,7 @@ RSpec.describe SearchResultPresenter do
 
       let(:debug_subtext) do
         "<span class=\"debug-results debug-results--link\">link-1</span>"\
-        "<span class=\"debug-results debug-results--meta\">Score: #{combined_score}</span>"\
+        "<span class=\"debug-results debug-results--meta\">Score: #{combined_score} (ranked #1)</span>"\
         "<span class=\"debug-results debug-results--meta\">Original score: 0.005 (ranked ##{original_rank})</span>"\
         "<span class=\"debug-results debug-results--meta\">Format: cake</span>"
       end


### PR DESCRIPTION
With relevance: https://finder-front-msw-debug-laihwxt.herokuapp.com/search/all?q=frogs&debug_score=1

Without relevance: https://finder-front-msw-debug-laihwxt.herokuapp.com/search/all?debug_score=1

---

## Search page examples to sanity check:

- https://finder-front-msw-debug-laihwxt.herokuapp.com/search/all
- https://finder-front-msw-debug-laihwxt.herokuapp.com/search/research-and-statistics
- https://finder-front-msw-debug-laihwxt.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-msw-debug-laihwxt.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-msw-debug-laihwxt.herokuapp.com/drug-device-alerts
- https://finder-front-msw-debug-laihwxt.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-msw-debug-laihwxt.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-msw-debug-laihwxt.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-msw-debug-laihwxt.herokuapp.com/uk-nationals-living-eu
- https://finder-front-msw-debug-laihwxt.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
