### PR TITLE
Add further support for roles

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -71,6 +71,7 @@ private
       level_two_taxon: params["subtaxons"].try(:first),
       organisations: params["departments"] || params["organisations"],
       people: params["people"],
+      roles: params["roles"],
       world_locations: params["world_locations"],
       public_timestamp: { from: params["from_date"], to: params["to_date"] }.compact.presence }.compact
   end

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -48,7 +48,7 @@ private
 
   def link_based_subscriber_list?
     # TODO: move this logic into schema
-    content_types = %w[organisations people world_locations part_of_taxonomy_tree]
+    content_types = %w[organisations people roles world_locations part_of_taxonomy_tree]
     keys = facet_filter_keys.map { |key| key.gsub(/^(all_|any_)/, "") }
     (keys & content_types).present?
   end
@@ -80,7 +80,7 @@ private
   end
 
   def to_content_ids(key, values)
-    return values unless %w[organisations people world_locations].include?(key)
+    return values unless %w[organisations people roles world_locations].include?(key)
 
     registry = Registries::BaseRegistries.new.all[key]
     values.map { |value| registry[value]["content_id"] }

--- a/lib/email_alert_title_builder.rb
+++ b/lib/email_alert_title_builder.rb
@@ -127,6 +127,7 @@ private
       world_locations
       organisations
       people
+      roles
       part_of_taxonomy_tree
       all_part_of_taxonomy_tree
       document_type

--- a/lib/parameter_parser/email_alert_parameter_parser.rb
+++ b/lib/parameter_parser/email_alert_parameter_parser.rb
@@ -88,7 +88,7 @@ module ParameterParser
     end
 
     def could_be_a_dynamic_facet?(key)
-      %w(organisations people world_locations all_part_of_taxonomy_tree part_of_taxonomy_tree).include? key
+      %w(organisations people roles world_locations all_part_of_taxonomy_tree part_of_taxonomy_tree).include? key
     end
 
     def parsed_params(filter_params, params)

--- a/lib/registries/roles_registry.rb
+++ b/lib/registries/roles_registry.rb
@@ -41,10 +41,10 @@ module Registries
 
     def fetch_roles_from_rummager
       params = {
-        aggregate_roles: "1500,examples:0,order:value.title",
+        facet_roles: "1500,examples:0,order:value.title",
         count: 0,
       }
-      Services.rummager.search(params).dig("aggregates", "roles", "options")
+      Services.rummager.search(params).dig("facets", "roles", "options")
     end
   end
 end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -578,5 +578,36 @@ describe EmailAlertSignupAPI do
         assert_requested(req)
       end
     end
+
+    describe "roles facet" do
+      let(:applied_filters) do
+        { "roles" => %w(prime-minister) }
+      end
+
+      let(:facets) do
+        [
+          {
+            "facet_id" => "roles",
+            "facet_name" => "roles",
+          },
+        ]
+      end
+
+      before { stub_roles_registry_request }
+
+      it "asks email-alert-api to find or create the subscriber list" do
+        req = email_alert_api_has_subscriber_list(
+          "links" => {
+            roles: { any: %w(content_id_for_prime-minister) },
+            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+          },
+          "subscription_url" => subscription_url,
+        )
+
+        expect(subject.signup_url).to eql subscription_url
+
+        assert_requested(req)
+      end
+    end
   end
 end

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Registries::RolesRegistry do
   let(:rummager_params) do
     {
       count: 0,
-      aggregate_roles: "1500,examples:0,order:value.title",
+      facet_roles: "1500,examples:0,order:value.title",
     }
   end
   let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
@@ -74,7 +74,7 @@ RSpec.describe Registries::RolesRegistry do
       "results": [],
       "total": 394075,
       "start": 0,
-      "aggregates": {
+      "facets": {
         "roles": {
           "options": [{
             "value": {

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -61,7 +61,7 @@ module RegistrySpecHelper
     stub_request(:get, "http://search.dev.gov.uk/search.json")
         .with(query: {
             count: 0,
-            aggregate_roles: "1500,examples:0,order:value.title",
+            facet_roles: "1500,examples:0,order:value.title",
         })
         .to_return(body: {
             results: [],


### PR DESCRIPTION
This adds the ability for finder-frontend to get subscriber lists when filtering on roles and fixes the query to use `facet_roles` rather than the deprecated `aggregate_roles`.

[Trello Card](https://trello.com/c/yTYIqjiA/1699-5-support-searching-for-documents-tagged-to-roles)