### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/development_layout.html.erb
+++ b/app/views/layouts/development_layout.html.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title><%= yield :title %> - GOV.UK</title>
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
-    <%= javascript_include_tag "application", integrity: true, crossorigin: "anonymous" %>
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: false %><!--<![endif]-->
+    <%= javascript_include_tag "application", integrity: false %>
     <meta name="robots" content="noindex">
   </head>
 

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <title><%= yield :title %> - GOV.UK</title>
-    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "application", integrity: false %>
     <%= stylesheet_link_tag "print", media: "print" %>
-    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
+    <%= javascript_include_tag 'application', integrity: false %>
     <%= csrf_meta_tags %>
     <%= yield :head %>
 

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -3,9 +3,9 @@
   <head>
     <title><%= yield :title %> - GOV.UK</title>
     <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
-    <%= stylesheet_link_tag "application", integrity: true, crossorigin: 'anonymous' %>
+    <%= stylesheet_link_tag "application", integrity: false %>
     <%= stylesheet_link_tag "print", media: "print" %>
-    <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
+    <%= javascript_include_tag 'application', integrity: false %>
     <% if @content_item %>
       <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
     <% end %>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)