### PR TITLE
Show detailed error message in development

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,11 +9,13 @@ class ApplicationController < ActionController::Base
   helper :application
 
   # rescue_from precedence is bottom up - https://stackoverflow.com/a/9121054/170864
-  rescue_from GdsApi::BaseError, with: :error_503
-  rescue_from GdsApi::InvalidUrl, with: :unprocessable_entity
-  rescue_from GdsApi::HTTPNotFound, with: :error_not_found
-  rescue_from GdsApi::HTTPForbidden, with: :forbidden
-  rescue_from GdsApi::HTTPUnprocessableEntity, with: :unprocessable_entity
+  unless Rails.env.development?
+    rescue_from GdsApi::BaseError, with: :error_503
+    rescue_from GdsApi::InvalidUrl, with: :unprocessable_entity
+    rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+    rescue_from GdsApi::HTTPForbidden, with: :forbidden
+    rescue_from GdsApi::HTTPUnprocessableEntity, with: :unprocessable_entity
+  end
 
   if ENV["REQUIRE_BASIC_AUTH"]
     http_basic_authenticate_with(


### PR DESCRIPTION
This should help with debugging. Now in development the Better Errors gem (already in the gemfile) will render error pages rather than the generic 'sorry theres a problem' error message.


---

## Search page examples to sanity check:

- https://finder-front-no-slimmer-cioreh.herokuapp.com/search/all
- https://finder-front-no-slimmer-cioreh.herokuapp.com/search/research-and-statistics
- https://finder-front-no-slimmer-cioreh.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-no-slimmer-cioreh.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-no-slimmer-cioreh.herokuapp.com/drug-device-alerts
- https://finder-front-no-slimmer-cioreh.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-no-slimmer-cioreh.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-no-slimmer-cioreh.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-no-slimmer-cioreh.herokuapp.com/uk-nationals-living-eu
- https://finder-front-no-slimmer-cioreh.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
