### PR TITLE
Fix Whitehall URI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ if Rails.env.development? && ENV["LIVE"]
   ENV["PLEK_SERVICE_SEARCH_URI"] = "https://www.gov.uk/api"
   ENV["PLEK_SERVICE_CONTENT_STORE_URI"] = "https://www.gov.uk/api"
   ENV["PLEK_SERVICE_STATIC_URI"] = "assets.publishing.service.gov.uk"
-  ENV["PLEK_SERVICE_WHITEHALL_ADMIN_URI"] = "https://www.gov.uk"
+  ENV["PLEK_SERVICE_WHITEHALL_FRONTEND_URI"] = "https://www.gov.uk"
 end
 
 FinderFrontend::Application.load_tasks

--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     "PLEK_SERVICE_SEARCH_URI": {
       "value": "https://www.gov.uk/api"
     },
-    "PLEK_SERVICE_WHITEHALL_ADMIN_URI": {
+    "PLEK_SERVICE_WHITEHALL_FRONTEND_URI": {
       "value": "https://www.gov.uk"
     },
     "RAILS_SERVE_STATIC_ASSETS": {

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk \
+  PLEK_SERVICE_WHITEHALL_FRONTEND_URI=https://www.gov.uk \
   bundle exec rails s -p 3062
 else
   GOVUK_WEBSITE_ROOT=localhost:3062 \


### PR DESCRIPTION
Following bb43ad7 we need to set the whitehall uri to be the frontend url in development.

---

## Search page examples to sanity check:

https://finder-front-fix-whiteh-yl06au.herokuapp.com/search/all
https://finder-front-fix-whiteh-yl06au.herokuapp.com/search/research-and-statistics
https://finder-front-fix-whiteh-yl06au.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
https://finder-front-fix-whiteh-yl06au.herokuapp.com/get-ready-brexit-check/questions
https://finder-front-fix-whiteh-yl06au.herokuapp.com/drug-device-alerts
https://finder-front-fix-whiteh-yl06au.herokuapp.com/find-eu-exit-guidance-business
https://finder-front-fix-whiteh-yl06au.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
https://finder-front-fix-whiteh-yl06au.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
https://finder-front-fix-whiteh-yl06au.herokuapp.com/uk-nationals-living-eu
https://finder-front-fix-whiteh-yl06au.herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
