### PR TITLE
Update brexit checker subscription title

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -54,7 +54,7 @@ private
     path = transition_checker_results_path(c: criteria_keys)
 
     {
-      "title" => "How to prepare for a no deal Brexit",
+      "title" => "Get ready for 2021",
       "description" => "[You can view a copy of your results on GOV.UK.](#{Plek.new.website_root}#{path})",
       "group_id" => SUBSCRIBER_LIST_GROUP_ID,
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
 
   let(:subscriber_list) do
     {
-      "title" => "How to prepare for a no deal Brexit",
+      "title" => "Get ready for 2021",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
       "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },


### PR DESCRIPTION
We need to update the title to reflect the new situation

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu
- https://[HEROKU-APP-ID].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
