### PR TITLE
Research and stats email

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -54,7 +54,7 @@ private
     EmailAlertSignupAPI.new(
       applied_filters: applied_filters,
       default_filters: content["details"].fetch("filter", {}),
-      facets: signup_presenter.choices,
+      facets: content["details"].fetch("email_filter_facets", []),
       subscriber_list_title: subscriber_list_title,
       email_filter_by: signup_presenter.email_filter_by,
     )
@@ -65,7 +65,7 @@ private
     title_builder.call(
       filter: applied_filters,
       subscription_list_title_prefix: content.dig("details", "subscription_list_title_prefix"),
-      facets: signup_presenter.choices,
+      facets: content["details"].fetch("email_filter_facets", []),
     )
   end
 end

--- a/app/presenters/signup_links_presenter.rb
+++ b/app/presenters/signup_links_presenter.rb
@@ -22,7 +22,7 @@ private
     signup_link = content_item.signup_link
     return signup_link if signup_link.present?
 
-    "#{content_item.email_alert_signup['web_url']}#{query_string(alert_query_params)}" if content_item.email_alert_signup
+    "#{content_item.email_alert_signup['base_path']}#{query_string(alert_query_params)}" if content_item.email_alert_signup
   end
 
   def feed_link

--- a/features/fixtures/research_and_statistics_email_signup.json
+++ b/features/fixtures/research_and_statistics_email_signup.json
@@ -38,12 +38,13 @@
   "details": {
     "email_filter_by": null,
     "email_filter_name": null,
-    "subscription_list_title_prefix": "Statistics",
+    "subscription_list_title_prefix": "",
     "filter": {},
     "email_filter_facets": [
       {
         "facet_id": "content_store_document_type",
-        "facet_name": "Research and statistics",
+        "facet_name": "All documents",
+        "facet_connector": "filtered by",
         "required": true,
         "facet_choices": [
           {

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -4,6 +4,7 @@ require "email_alert_title_builder"
 describe EmailAlertTitleBuilder do
   include TaxonomySpecHelper
   include RegistrySpecHelper
+  include FixturesHelper
 
   subject do
     described_class.call(
@@ -198,6 +199,16 @@ describe EmailAlertTitleBuilder do
 
     it {
       is_expected.to eq("News and communicatons with people of Harry Potter, Ron Weasley, Albus Dumbledore, Cornelius Fudge, and Rufus Scrimgeour, organisations of Ministry of Magic, Gringots, and 1 other organisation, topics of Magical Education, Brexit, and Herbology, and 2 document types")
+    }
+  end
+
+  context "when a facet_connector is provided" do
+    let(:content_item) { research_and_stats_finder_signup_content_item }
+    let(:filter) { { "content_store_document_type" => %w(statistics_published research) } }
+    let(:subscription_list_title_prefix) { content_item.dig("details", "subscription_list_title_prefix") }
+    let(:facets) { content_item["details"].fetch("email_filter_facets", []) }
+    it {
+      is_expected.to eq("All documents filtered by Statistics (published) and Research")
     }
   end
 end

--- a/spec/presenters/signup_link_presenter_spec.rb
+++ b/spec/presenters/signup_link_presenter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SignupLinksPresenter do
 
   let(:email_signup_hash) {
     {
-      web_url: "http://www.gov.uk/email_signup",
+      base_path: "/email_signup",
     }
   }
 
@@ -66,7 +66,7 @@ RSpec.describe SignupLinksPresenter do
         let(:facet_values) { [] }
 
         it "returns the finder URL appended with /email-signup" do
-          expect(subject.signup_links[:email_signup_link]).to eql("http://www.gov.uk/email_signup")
+          expect(subject.signup_links[:email_signup_link]).to eql("/email_signup")
         end
       end
 


### PR DESCRIPTION
This makes use of a new facet key: facet_connector. As added here: https://github.com/alphagov/govuk-content-schemas/pull/955.

This is intended to be used in cases where 'of' is not a useful joining word between a facet name and its values.

For example, "All documents of Statistics" reads better as "All documents filtered by Statistics"

This also permits not providing a prefix in a finder_email_signup content item.

https://trello.com/c/UX2Cd7vr/1211

---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu
- https://[HEROKU-APP-ID].herokuapp.com/prepare-business-uk-leaving-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
