### PR TITLE
Fix search filters' flash of height

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -183,6 +183,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (this.isClosed()) {
       this.$optionSelect.find('.js-container-button').attr('aria-expanded', true)
       this.$optionSelect.removeClass('js-closed')
+      this.$optionSelect.addClass('js-opened')
       if (!this.$optionsContainer.prop('style').height) {
         this.setupHeight()
       }
@@ -190,6 +191,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   OptionSelect.prototype.close = function close () {
+    this.$optionSelect.removeClass('js-opened')
     this.$optionSelect.addClass('js-closed')
     this.$optionSelect.find('.js-container-button').attr('aria-expanded', false)
   }

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -17,19 +17,7 @@
 
       // scss-lint:disable ColorVariable
       background-color: rgba(0, 0, 0, .5);
-      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
-    }
-  }
-
-  &.js-closed {
-    .app-c-option-select__filter,
-    .app-c-option-select__container,
-    .app-c-option-select__icon--up {
-      display: none;
-    }
-
-    .app-c-option-select__icon--down {
-      display: block;
+      -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.87);
     }
   }
 
@@ -131,12 +119,20 @@
     padding: 10px 8px 5px 43px;
   }
 
-  .app-c-option-select__icon--up {
+  [aria-expanded="true"] ~ .app-c-option-select__icon--up {
+    display: block;
+  }
+
+  [aria-expanded="false"] ~ .app-c-option-select__icon--down {
     display: block;
   }
 
   .app-c-option-select__container {
     height: 200px;
+  }
+
+  [data-closed-on-load="true"] .app-c-option-select__container {
+    display: none;
   }
 }
 
@@ -144,4 +140,18 @@
   @include govuk-font($size: 14);
   color: $govuk-text-colour;
   margin-top: 3px;
+}
+
+.app-c-option-select.js-closed {
+  .app-c-option-select__filter,
+  .app-c-option-select__container {
+    display: none;
+  }
+}
+
+.app-c-option-select.js-opened {
+  .app-c-option-select__filter,
+  .app-c-option-select__container {
+    display: block;
+  }
 }


### PR DESCRIPTION
## What
OptionSelect component loaded expanded and then collapsed using
Javascript, resulting in a flash of styles.

This PR minimises that by
- hiding filter content when JS is enabled and the filter is set to be
closed on load
- adding `js-opened` class styles to show content when expanded

## Why
Better user experience with fewer layout changes as the content is loading.

## Visual impact
Network setting: Online
Screen captures below, alternatively compare preview links here with live
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/3758555/73842786-2c1f8e00-4815-11ea-8c6e-92874c09fba4.gif" />

</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/3758555/73842986-9b957d80-4815-11ea-965b-41d393c19969.gif" />
</details>

## Search page examples to sanity check:

All facets collapsed
- https://finder-front-fix-filter-kjzfko.herokuapp.com/search/all

One facet expanded
- https://finder-front-fix-filter-kjzfko.herokuapp.com/search/cma-cases

Other
- https://finder-front-fix-filter-kjzfko.herokuapp.com/search/research-and-statistics
- https://finder-front-fix-filter-kjzfko.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0

[Trello ticket](https://trello.com/c/mVTU9FGo/1231-fix-flash-of-unstyled-content-on-facets)
