### PR TITLE
Refactor transition checker action tests to be less brittle

### DIFF
--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -41,15 +41,16 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_citizen_actions_are_grouped
     and_i_should_see_the_citizens_action_header
     and_i_should_see_the_business_action_header
-    and_i_should_see_a_mobile_roaming_action
-    and_i_should_see_an_air_freight_action
+    and_i_should_see_eu_settled_status_scheme
+    and_i_should_see_eu_settled_status_scheme
   end
 
   def then_i_see_business_results_only
     then_i_should_see_the_results_page
     and_i_should_see_the_business_action_header
     and_i_should_not_see_the_citizens_action_header
-    and_i_should_see_a_competition_markets_authority_action
+    and_i_should_see_customs_agent_action
+    and_i_should_not_see_eu_settled_status_scheme
   end
 
   def then_i_see_citizens_results_only
@@ -57,8 +58,8 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     and_i_should_see_the_citizens_action_header
     and_i_should_not_see_the_business_action_header
     and_i_should_see_citizen_actions_are_grouped
-    and_i_should_see_a_mobile_roaming_action
-    and_i_should_not_see_an_air_freight_action
+    and_i_should_see_eu_settled_status_scheme
+    and_i_should_not_see_customs_agent_action
   end
 
   def and_i_should_see_share_links
@@ -136,14 +137,14 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     answer_question("eu-uk-government-funding", "No")
     answer_question("public-sector-procurement", "No")
     answer_question("intellectual-property", "No")
-    answer_question("business-activity", "Provide services or do business in the EU")
-    answer_question("sector-business-area", "Air freight and air passenger services")
+    answer_question("business-activity", "Export to the EU")
+    answer_question("sector-business-area", "Fisheries (including wholesale)")
   end
 
   def and_i_answer_citizen_questions
-    answer_question("nationality", "British")
+    answer_question("nationality", "Another EU country, or Switzerland, Norway, Iceland or Liechtenstein")
     answer_question("living", "UK")
-    answer_question("employment")
+    answer_question("employment", "Work in the UK")
     answer_question("travelling-business", "Yes")
     answer_question("travelling", "To another EU country, or Switzerland, Norway, Iceland or Liechtenstein")
     answer_question("activities", "Take your pet")
@@ -157,29 +158,30 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     expect(page).to have_content I18n.t!("brexit_checker.results.title_no_actions")
   end
 
-  def and_i_should_see_a_mobile_roaming_action
-    action = BrexitChecker::Action.find_by_id("S010")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='You and your family - Visiting the EU - 1.3 - Guidance']")
+  def and_i_should_see_eu_settled_status_scheme
+    action = BrexitChecker::Action.find_by_id("S001")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
+    data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
+    expect(data_track_action).to eq("You and your family - Living in the UK - 4.1 - Guidance")
     action_is_shown(action)
     action_has_analytics(action)
   end
 
-  def and_i_should_not_see_an_air_freight_action
-    action_not_shown("T028")
+  def and_i_should_not_see_eu_settled_status_scheme
+    action_not_shown("S001")
   end
 
-  def and_i_should_see_an_air_freight_action
-    action = BrexitChecker::Action.find_by_id("T028")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.5 - Guidance']")
+  def and_i_should_see_customs_agent_action
+    action = BrexitChecker::Action.find_by_id("T099")
+    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
+    data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
+    expect(data_track_action).to eq("Your business or organisation - 1.15 - Guidance")
     action_is_shown(action)
     action_has_analytics(action)
   end
 
-  def and_i_should_see_a_competition_markets_authority_action
-    action = BrexitChecker::Action.find_by_id("T006")
-    expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action='Your business or organisation - 1.1 - Guidance']")
-    action_is_shown(action)
-    action_has_analytics(action)
+  def and_i_should_not_see_customs_agent_action
+    action_not_shown("T099")
   end
 
   def action_not_shown(key)


### PR DESCRIPTION
Trello: https://trello.com/c/XT3ekLSK/442-rewrite-checker-tests-to-make-them-less-brittle

## Why?

On the 30th and 31st we needed to bulk update a range of actions at once. After doing so we discovered some the actions that had been removed were required for tests. This made the process more intensive.

We can have higher degrees of confidence that some actions will remain for the duration of the transition period. The actions with the highest degree of confidence would make good candidates for tests, as they should weather any future changes to actions in the checker.

Those actions are suggested to be:
- Business: Getting a customs agent
- Individual: EU Settled status

Also, occasionally when we add new actions they will also match the criteria these tests select for. This will cause new additions to the test's result page, which can lead to changes in order the results are rendered. The data-track-action is a tracking attribute which explicitly records that, current tests with `has_css?` searching for the attribute key and value return only found/not found. 

A better strategy would be to return the string that is found and check that against our expectations, updating them if necessary.

## What's changed?

- Changes results page tests to use T099 (customs agent) as test candidate for business questions/results tests
- Changes results page tests to use S001 (EU settled status) as test candidate for business questions/results tests
- Changes integration test question selections to ensure that the above actions do / do not appear depending on the test
- Refactor the test for `data-track-action` into two tests, one for the existance of a govuk link with the correct href and _a_ `data-track-action`. Then a separate test that does a string match against the expected content of that string.