### PR TITLE
Add retirement question to brexit checker

### DIFF
--- a/lib/brexit_checker/criteria.yaml
+++ b/lib/brexit_checker/criteria.yaml
@@ -226,3 +226,5 @@ criteria:
   text: You travel to the EU for business
 - key: travel-eu-business-no
   text: You do not travel to the EU for business
+- key: retired
+  text: You are retired or semi-retired

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -47,6 +47,10 @@ questions:
             value: studying-ie
           - label: "Study in another EU country, or Switzerland, Norway, Iceland or Liechtenstein"
             value: studying-eu
+      - label: Retired
+        options:
+          - label: "I am retired or semi-retired"
+            value: retired
 
   - key: travelling-business
     type: single


### PR DESCRIPTION
Trello: https://trello.com/c/UUlLUAEj/461-add-option-for-retired-users-to-the-checker

Currently does not have any actions or grouping associated but serves a purpose by adding an option for users to create email subscriptions against or save their results URL