### PR TITLE
Add captions to questions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "google-api-client"
 gem "govuk_ab_testing", "~> 2.4.1"
 gem "govuk_app_config", "~> 2.0.3"
 gem "govuk_document_types", "~> 0.9.2"
-gem "govuk_publishing_components", "~> 21.22.1"
+gem "govuk_publishing_components", "~> 21.24.0"
 gem "rails", "~> 6.0.2"
 gem "slimmer", "~> 13.2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
     govuk_document_types (0.9.2)
-    govuk_publishing_components (21.22.1)
+    govuk_publishing_components (21.24.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -303,7 +303,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rouge (3.15.0)
+    rouge (3.16.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
@@ -442,7 +442,7 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 2.0.3)
   govuk_document_types (~> 0.9.2)
-  govuk_publishing_components (~> 21.22.1)
+  govuk_publishing_components (~> 21.24.0)
   govuk_schemas (~> 4.0)
   govuk_test
   jasmine-rails

--- a/app/views/brexit_checker/_question_multiple_choice.html.erb
+++ b/app/views/brexit_checker/_question_multiple_choice.html.erb
@@ -1,5 +1,6 @@
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "c[]",
+  heading_caption: current_question.caption,
   heading: current_question.text,
   description: formatted_description,
   hint_text: current_question.hint_text,

--- a/app/views/brexit_checker/_question_multiple_grouped_choice.html.erb
+++ b/app/views/brexit_checker/_question_multiple_grouped_choice.html.erb
@@ -1,5 +1,6 @@
 <%= render "govuk_publishing_components/components/title", {
   title: current_question.text,
+  context: current_question.caption,
   margin_bottom: 5
 } %>
 

--- a/app/views/brexit_checker/_question_single_choice.html.erb
+++ b/app/views/brexit_checker/_question_single_choice.html.erb
@@ -1,5 +1,6 @@
 <%= render "govuk_publishing_components/components/radio", {
   name: "c[]",
+  heading_caption: current_question.caption,
   heading: current_question.text,
   description: formatted_description,
   hint: current_question.hint_text,

--- a/app/views/brexit_checker/_question_single_wrapped.html.erb
+++ b/app/views/brexit_checker/_question_single_wrapped.html.erb
@@ -2,6 +2,7 @@
   <%= render "govuk_publishing_components/components/radio", {
     name: "c[]",
     heading: current_question.text,
+    heading_caption: current_question.caption,
     description: formatted_description,
     hint: current_question.hint_text,
     is_page_heading: true,

--- a/lib/brexit_checker/question.rb
+++ b/lib/brexit_checker/question.rb
@@ -8,7 +8,7 @@ class BrexitChecker::Question
   validate { errors.add("Options is not an array") unless options.is_a? Array }
 
   attr_reader :key, :text, :description, :hint_title, :hint_text, :type, :criteria,
-              :detail_text, :detail_title
+              :detail_text, :detail_title, :caption
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -2,6 +2,7 @@
 questions:
   - key: nationality
     type: single
+    caption: About you and your family
     text: 'What nationality are you?'
     options:
       - label: British
@@ -15,6 +16,7 @@ questions:
 
   - key: living
     type: single
+    caption: About you and your family
     text: 'Where do you live?'
     options:
       - label: UK
@@ -28,6 +30,7 @@ questions:
 
   - key: employment
     type: multiple_grouped
+    caption: About you and your family
     text: 'What do you do?'
     hint_text: 'Select all that apply. If you do something else, select continue.'
     options:
@@ -54,6 +57,7 @@ questions:
 
   - key: travelling-business
     type: single
+    caption: About you and your family
     text: 'Do you travel to the EU for business?'
     criteria:
       - living-uk
@@ -72,6 +76,7 @@ questions:
 
   - key: drive-in-eu
     type: single
+    caption: About you and your family
     text: "Do you drive in the EU using a UK licence?"
     criteria:
       - all_of:
@@ -85,6 +90,7 @@ questions:
 
   - key: travelling
     type: multiple
+    caption: About you and your family
     text: 'Where do you plan to travel for leisure and tourism?'
     hint_text: Select all that apply. If you do not plan to travel, select continue.
     detail_text: |
@@ -112,6 +118,7 @@ questions:
         - visiting-uk
         - travel-eu-business
     type: multiple
+    caption: About you and your family
     text: 'Do you plan to do either of the following when travelling?'
     hint_text: "Select all that apply. If neither apply, select continue."
     detail_text: |
@@ -124,6 +131,7 @@ questions:
         value: visiting-bring-pet
 
   - key: returning
+    caption: About you and your family
     criteria:
       - all_of:
         - nationality-uk
@@ -140,6 +148,7 @@ questions:
 
   - key: family-eu
     type: single
+    caption: About you and your family
     text: 'Are you a family member of an EU, EEA or Swiss citizen?'
     criteria:
       all_of:
@@ -153,6 +162,7 @@ questions:
 
   - key: join-family-uk
     type: single
+    caption: About you and your family
     text: "Do you plan to join a family member in the UK who's from the UK, EU, Switzerland, Norway, Iceland or Liechtenstein?"
     criteria:
       - all_of:
@@ -170,6 +180,7 @@ questions:
 
   - key: do-you-own-a-business
     type: "single"
+    caption: About your business
     text: "Do you own or help to run a UK business or organisation?"
     description: |
       <p>This includes sole traders (self-employed), limited companies, and small and medium enterprises.</p>
@@ -183,6 +194,7 @@ questions:
         value: does-not-own-operate-business-organisation
 
   - key: employ-eu-citizens
+    caption: About your business
     criteria:
       - owns-operates-business-organisation
     type: "single"
@@ -198,6 +210,7 @@ questions:
   - key: personal-data
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "single_wrapped"
     text: "Do you exchange personal data with another organisation in Europe?"
     description: |
@@ -219,6 +232,7 @@ questions:
   - key: eu-uk-government-funding
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "single"
     text: "Do you get EU or UK government funding?"
     description: |
@@ -232,6 +246,7 @@ questions:
   - key: public-sector-procurement
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "single_wrapped"
     text: "Do you sell your products or services to the UK public sector?"
     description: |
@@ -250,6 +265,7 @@ questions:
   - key: intellectual-property
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "single_wrapped"
     text: "Do you use or rely on intellectual property (IP) protection?"
     description: |
@@ -274,6 +290,7 @@ questions:
   - key: business-activity
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "multiple"
     text: "Does your business or organisation do any of the following?"
     description: |
@@ -291,6 +308,7 @@ questions:
   - key: sector-business-area
     criteria:
       - owns-operates-business-organisation
+    caption: About your business
     type: "multiple_grouped"
     text: "What does your business or organisation do?"
     hint_text: "Select all that apply."

--- a/spec/support/brexit_checker_helper.rb
+++ b/spec/support/brexit_checker_helper.rb
@@ -2,6 +2,7 @@ module BrexitCheckerHelper
   def answer_question(key, *options)
     question = BrexitChecker::Question.find_by_key(key)
     expect(page).to have_content(question.text)
+    expect(page).to have_content(question.caption)
     options.each { |o| find_field(o).click }
     click_on "Continue"
   end


### PR DESCRIPTION
Trello: https://trello.com/c/aMTEk0vX/263-add-govuk-caption-style-to-questions

- Adds a captions to individual and business sections to help users differentiate between citizen and business questions. 
