### PR TITLE
Don't show date metadata for recommended links

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -71,6 +71,8 @@ private
 
   def structure_metadata
     metadata.each_with_object({}) do |meta, component_metadata|
+      next if meta[:is_date] && format == "recommended-link"
+
       value = meta[:is_date] ? "<time datetime='#{meta[:machine_date]}'>#{meta[:human_date]}</time>" : meta[:value]
       component_metadata[meta[:label]] = sanitize("#{meta[:label]}: #{value}", tags: %w(time span))
     end


### PR DESCRIPTION
See https://finder-front-msw-recomm-o1qzps.herokuapp.com/search/all?keywords=%22nhs+111%22&order=relevance

These results don't have meaningful published/updated metadata, and we didn't show dates on the old search page.

---

## Search page examples to sanity check:

- https://finder-front-msw-recomm-o1qzps.herokuapp.com/search/all
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/search/research-and-statistics
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/drug-device-alerts
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-msw-recomm-o1qzps.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

---

[Trello card](https://trello.com/c/Q8cFZIuF/1379-dont-show-last-updated-date-for-external-links)
