### PR TITLE
Reduce compiled CSS file size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "govuk_publishing_components", "~> 21.25.0"
 gem "rails", "~> 6.0.2"
 gem "slimmer", "~> 13.2.0"
 
-gem "sass-rails", "~> 6.0.0"
+gem "sass-rails", "~> 5.1.0"
 gem "uglifier", "~> 4.2"
 gem "whenever", "~> 1.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,8 +345,12 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -453,7 +457,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails (~> 4.0.0.beta4)
   rubocop-govuk
-  sass-rails (~> 6.0.0)
+  sass-rails (~> 5.1.0)
   scss_lint-govuk
   sdoc
   simplecov (~> 0.18.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,8 +48,5 @@ module FinderFrontend
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
-    # https://github.com/alphagov/govuk-frontend/issues/1350
-    config.assets.css_compressor = nil
   end
 end


### PR DESCRIPTION
## What
Remove the disabled sass compression setting that was a workaround for failed sass-rails v6 compilation when we upgraded to rails 6.

As investigated in [this issue](https://github.com/alphagov/finder-frontend/issues/1124), sass will fail to compile with the error
```
SassC::SyntaxError: Error: "calc(0px)" is not a number for `max'
        on line 1181:20 of stdin, in function `max`
        from line 1181:20 of stdin
>> @supports (margin: max(calc(0px))) {
```
as sass-rails v6 moved the implementation to [sassc-rails](https://github.com/rails/sass-rails/releases/tag/v6.0.0)

We have now pinned sass-rails to version 5 which still uses Libsass

## Why
Reduce the weight of assets we ship to visitors, increase performance.

### Current production with GZIP
https://www.gov.uk/search/all
<img width="979" alt="Screenshot 2020-02-21 at 13 24 55" src="https://user-images.githubusercontent.com/3758555/75038107-94c16880-54ad-11ea-98d1-52d81e834cc7.png">

### Tests on integration (with GZIP)

**Before**
<img width="976" alt="before" src="https://user-images.githubusercontent.com/3758555/75033186-43f84280-54a2-11ea-85f0-73bccfed75c6.png">

**After**
<img width="948" alt="after" src="https://user-images.githubusercontent.com/3758555/75033192-49ee2380-54a2-11ea-9fff-f69d776084b9.png">


## Search page examples to sanity check:

- https://finder-front-pin-sass-r-b5hbtd.herokuapp.com/search/all
- https://finder-front-pin-sass-r-b5hbtd.herokuapp.com/search/research-and-statistics

[Trello ticket](https://trello.com/c/F872Wkxo/1407-reduce-the-size-of-css-bundle)