### PR TITLE
Don't require memcached in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # More details:
   # https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore
   config.cache_classes = true
-  config.cache_store = :dalli_store, nil, { namespace: :finder_frontend, compress: true }
+  config.cache_store = :memory_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
This uses memory_store rather than dalli when running tests, so we don't need to run memcached for the tests to pass.

Usin dalli rather memory_store in test doesn't seem to benefit us, since we talk to both caches through the Rails.cache methods.

We might also be able to remove the memcached docker container from the CI machines.