### PR TITLE
Add note regarding phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ To run the Jasmine tests separately: `bundle exec cucumber`
 
 To run the JavaScript Jasmine tests separately: `bundle exec rake spec:javascript`
 
+Note: Running the JS tests require you to also install phantomjs with `brew cask install phantomjs`.
+
 [govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
 [content_schema_examples]: https://github.com/alphagov/finder-frontend/blob/master/lib/govuk_content_schema_examples.rb
 


### PR DESCRIPTION
This is required for development otherwise one will see errors like 'sh: phantomjs: command not found'.

Phantomjs is no longer supported (since May 2018) so we may want to remove this dependency.