### PR TITLE
Add model ab tests

### DIFF
--- a/app/controllers/concerns/learning_to_rank_models_ab_testable.rb
+++ b/app/controllers/concerns/learning_to_rank_models_ab_testable.rb
@@ -1,0 +1,32 @@
+module LearningToRankModelsAbTestable
+  CUSTOM_DIMENSION = 42
+  ALLOWED_VARIANTS = %w(unchanged hippo elephant).freeze
+
+  def self.included(base)
+    base.helper_method(:model_variant)
+    base.after_action :set_model_response_header
+  end
+
+  def learning_to_rank_model_ab_test_params
+    return {} if model_variant.variant?("unchanged")
+
+    { mv: model_variant.variant_name }
+  end
+
+  def model_test
+    @model_test ||= GovukAbTesting::AbTest.new(
+      "LearningToRankModelABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "unchanged",
+    )
+  end
+
+  def model_variant
+    @model_variant ||= model_test.requested_variant(request.headers)
+  end
+
+  def set_model_response_header
+    model_variant.configure_response(response)
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
+  include LearningToRankModelsAbTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -110,7 +111,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: {},
+      ab_params: learning_to_rank_model_ab_test_params,
     )
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -15,6 +15,8 @@
   <% inverse = true %>
 <% end %>
 
+<%= model_variant.analytics_meta_tag.html_safe %>
+
 <form method="get" action="<%= content_item.base_path %>" class="js-live-search-form">
   <input type="hidden" name="parent" value="<%= @parent %>">
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -251,6 +251,28 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "Learning To Rank AB test" do
+    before do
+      stub_content_store_has_item("/search/all", all_content_finder)
+    end
+
+    it "requests the Hippo model" do
+      request = search_api_request(query: { ab_tests: "mv:hippo" })
+      with_variant LearningToRankModelABTest: "hippo" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+
+    it "requests the control variant by default" do
+      request = search_api_request
+      with_variant LearningToRankModelABTest: "unchanged" do
+        get :show, params: { slug: "search/all" }
+        expect(request).to have_been_made.once
+      end
+    end
+  end
+
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
       finder = govuk_content_schema_example("finder").to_hash.merge(


### PR DESCRIPTION
https://trello.com/c/1EjO05Dj/1333

This sets up finder-frontend to pass through the mv:<variant> ab test parameter to search-api when the AB test request header is set (https://github.com/alphagov/govuk_ab_testing/blob/master/README.md#govuk-ab-testing).