### PR TITLE
Import individual component styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,34 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
 @import 'reset';
-@import 'govuk_publishing_components/all_components';
+
+// see /component-guide for sass imports and
+// https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components
+// for guidance
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/_back-link';
+@import 'govuk_publishing_components/components/_breadcrumbs';
+@import 'govuk_publishing_components/components/_button';
+@import 'govuk_publishing_components/components/_checkboxes';
+@import 'govuk_publishing_components/components/_details';
+@import 'govuk_publishing_components/components/_document-list';
+@import 'govuk_publishing_components/components/_feedback';
+@import 'govuk_publishing_components/components/_govspeak';
+@import 'govuk_publishing_components/components/_hint';
+@import 'govuk_publishing_components/components/_input';
+@import 'govuk_publishing_components/components/_inverse-header';
+@import 'govuk_publishing_components/components/_metadata';
+@import 'govuk_publishing_components/components/_phase-banner';
+@import 'govuk_publishing_components/components/_previous-and-next-navigation';
+@import 'govuk_publishing_components/components/_radio';
+@import 'govuk_publishing_components/components/_search';
+@import 'govuk_publishing_components/components/_select';
+@import 'govuk_publishing_components/components/_share-links';
+@import 'govuk_publishing_components/components/_skip-link';
+@import 'govuk_publishing_components/components/_subscription-links';
+@import 'govuk_publishing_components/components/_title';
+
 @import 'components/*';
 @import 'finder_frontend';
 @import 'views/search';

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,14 @@
-@import "govuk_publishing_components/all_components_print";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/components/print/_back-link';
+@import 'govuk_publishing_components/components/print/_button';
+@import 'govuk_publishing_components/components/print/_feedback';
+@import 'govuk_publishing_components/components/print/_govspeak';
+@import 'govuk_publishing_components/components/print/_metadata';
+@import 'govuk_publishing_components/components/print/_search';
+@import 'govuk_publishing_components/components/print/_share-links';
+@import 'govuk_publishing_components/components/print/_skip-link';
+@import 'govuk_publishing_components/components/print/_subscription-links';
+@import 'govuk_publishing_components/components/print/_title';
 
 .filter-form,
 .feed {


### PR DESCRIPTION
## What

Replace import of all govuk_publishing_components' styles with imports of styles for the components actually in use.

## Why
Reduce the size of the compiled CSS, improve performance on slower connections (mobile)

## Filesize comparison

### GZIP, compressed

**Before**
<img width="464" alt="Screenshot 2020-02-25 at 10 54 04" src="https://user-images.githubusercontent.com/3758555/75241008-394cee80-57bd-11ea-8a3b-e69f26146388.png">


**After**
<img width="957" alt="Screenshot 2020-03-02 at 11 02 40" src="https://user-images.githubusercontent.com/3758555/75670833-66921480-5c75-11ea-9a6e-56155738133c.png">



## Search page examples to sanity check:

- https://finder-front-import-ind-zqvazi.herokuapp.com/search/all
- https://finder-front-import-ind-zqvazi.herokuapp.com/search/research-and-statistics
- https://finder-front-import-ind-zqvazi.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-import-ind-zqvazi.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-import-ind-zqvazi.herokuapp.com/drug-device-alerts
- https://finder-front-import-ind-zqvazi.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-import-ind-zqvazi.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-import-ind-zqvazi.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-import-ind-zqvazi.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

[Trello ticket](https://trello.com/c/FKfsEP3p/1418-further-reduce-css)
