### PR TITLE
Remove additional spacing below checker questions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,5 +6,4 @@ $govuk-use-legacy-palette: false;
 @import 'components/*';
 @import 'finder_frontend';
 @import 'views/search';
-@import 'views/brexit_checker_question_page';
 @import 'views/brexit_checker_results_page';

--- a/app/assets/stylesheets/views/_brexit_checker_question_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_question_page.scss
@@ -1,3 +1,0 @@
-.govuk-form-footer {
-  margin-bottom: govuk-spacing(9) * 2;
-}

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -71,11 +71,9 @@
             question_key: @current_question.key
           }
         %>
-        <div class="govuk-form-footer">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Continue"
-          } %>
-        </div>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Continue"
+        } %>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## What
Remove `govuk-form-footer` class.

## Why
It adds unnecessary spacing to the bottom of each question in the checker

## Before
<img width="675" alt="Screenshot 2020-02-28 at 11 32 03" src="https://user-images.githubusercontent.com/29889908/75545948-77e1e380-5a1f-11ea-8342-908ab4199643.png">

## After
<img width="590" alt="Screenshot 2020-02-28 at 11 35 03" src="https://user-images.githubusercontent.com/29889908/75545952-7b756a80-5a1f-11ea-8d0c-d09fd519e7f9.png">