### PR TITLE
Collapse breadcrumbs on mobile

### DIFF
--- a/app/presenters/finder_breadcrumbs_presenter.rb
+++ b/app/presenters/finder_breadcrumbs_presenter.rb
@@ -16,10 +16,6 @@ class FinderBreadcrumbsPresenter
       crumbs << { title: organisation["title"], url: "/government/organisations/#{organisation['slug']}" }
     end
 
-    if finder_name.present?
-      crumbs << { title: finder_name, is_current_page: true }
-    end
-
     crumbs
   end
 

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -6,24 +6,27 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [
-    {
-      title: t('brexit_checker.breadcrumbs.home'),
-      url: "/"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-home'),
-      url: "/transition"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-check'),
-      url: "/transition-check"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.results'),
-      url: transition_checker_results_path(c: criteria_keys)
-    }
-  ] %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-check'),
+        url: "/transition-check"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.results'),
+        url: transition_checker_results_path(c: criteria_keys)
+      }
+    ]
+  } %>
 
   <main class="govuk-main-wrapper" role="mail">
     <div class="govuk-grid-row">

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -19,20 +19,23 @@
 <% end %>
 
 <div class="govuk-width-container brexit-checker-results-page">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: [
-    {
-      title: t('brexit_checker.breadcrumbs.home'),
-      url: "/"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-home'),
-      url: "/transition"
-    },
-    {
-      title: t('brexit_checker.breadcrumbs.brexit-check'),
-      url: "/transition-check"
-    }
-  ] %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-check'),
+        url: "/transition-check"
+      }
+    ]
+  } %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", {

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -4,7 +4,11 @@
   <% end %>
 
   <% if @breadcrumbs.breadcrumbs %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs.breadcrumbs, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      breadcrumbs: @breadcrumbs.breadcrumbs,
+      inverse: inverse,
+      collapse_on_mobile: true
+    } %>
   <% else %>
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
@@ -26,18 +30,18 @@
             value: result_set_presenter.user_supplied_keywords,
           } %>
         </div>
-        <div id="js-spelling-suggestions" class="spelling-suggestions" 
+        <div id="js-spelling-suggestions" class="spelling-suggestions"
           data-analytics-ecommerce
           data-ecommerce-start-index="1"
           data-list-title="<%= content_item.title %> spelling suggestions"
           data-search-query="<%= result_set_presenter.user_supplied_keywords %>"
           data-track-click-label="Spelling suggestions"
-          > 
+          >
           <%= render 'spelling_suggestion' %>
         </div>
         <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
           data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-          data-module="track-click" data-track-category="filterClicked" 
+          data-module="track-click" data-track-category="filterClicked"
           data-track-action="mobile-filter-button" data-track-label="">
           Filter <span class="govuk-visually-hidden"> results</span>
           <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>

--- a/app/views/qa_to_content/show.html.erb
+++ b/app/views/qa_to_content/show.html.erb
@@ -4,7 +4,10 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    breadcrumbs: breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -93,7 +93,6 @@ Feature: Filtering documents
     Then I can see a breadcrumb for home
     And I can see a breadcrumb for all organisations
     And I can see a breadcrumb for the organisation
-    And I can see a breadcrumb that not a link for the finder
     And I sort by most viewed
     And I filter the results
     Then I can see a breadcrumb for the organisation

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -511,7 +511,7 @@ Then(/^I can see a breadcrumb for all organisations$/) do
   expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Organisations")
   expect(page).to have_css("a[data-track-action='2']", text: "Organisations")
   expect(page).to have_css("a[data-track-label='/government/organisations']", text: "Organisations")
-  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Organisations\"}']", text: "Organisations")
+  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"3\",\"dimension29\":\"Organisations\"}']", text: "Organisations")
 end
 
 And(/^no breadcrumb for all organisations$/) do
@@ -523,20 +523,18 @@ Then(/^I can see a breadcrumb for the organisation$/) do
   expect(page).to have_css("a[data-track-category='breadcrumbClicked']", text: "Ministry of Magic")
   expect(page).to have_css("a[data-track-action='3']", text: "Ministry of Magic")
   expect(page).to have_css("a[data-track-label='/government/organisations/ministry-of-magic']", text: "Ministry of Magic")
-  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"4\",\"dimension29\":\"Ministry of Magic\"}']", text: "Ministry of Magic")
-end
-
-Then(/^I can see a breadcrumb that not a link for the finder$/) do
-  expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Ministry of Silly Walks reports")
+  expect(page).to have_css("a[data-track-options='{\"dimension28\":\"3\",\"dimension29\":\"Ministry of Magic\"}']", text: "Ministry of Magic")
 end
 
 Then(/^I can see taxonomy breadcrumbs$/) do
   visit finder_path("cma-cases")
+  expect(page).to have_selector(".govuk-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile")
   expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Competition Act and cartels")
   expect(page.find_all(".govuk-breadcrumbs__list-item").count).to eql(2)
 end
 
 Then(/^I can see Brexit taxonomy breadcrumbs$/) do
+  expect(page).to have_selector(".govuk-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile")
   expect(page.find_all(".govuk-breadcrumbs__list-item").count).to eql(3)
   expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Home")
   expect(page).to have_selector(".govuk-breadcrumbs__list-item", text: "Government")

--- a/spec/presenters/finder_breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/finder_breadcrumbs_presenter_spec.rb
@@ -28,16 +28,5 @@ RSpec.describe FinderBreadcrumbsPresenter do
       urls = instance.breadcrumbs.map { |breadcrumb| breadcrumb[:url] }
       expect(urls).to_not include("/government/organisations/attorney-generals-office")
     end
-
-    it "displays finder title as text when the finder has a title" do
-      expect(instance.breadcrumbs.last).to eql(title: "Air Accidents Investigation Branch reports", is_current_page: true)
-    end
-
-    it "does not display a finder title when the finder has no title" do
-      finder_hash["title"] = ""
-      instance = described_class.new(org_breadcrumb_info, finder)
-      titles = instance.breadcrumbs.map { |breadcrumb| breadcrumb[:title] }
-      expect(titles).to_not include("Air Accidents Investigation Branch reports")
-    end
   end
 end


### PR DESCRIPTION
## What

- Stop showing the current page in the breadcrumbs
- Apply the collapse_on_mobile flag to all uses of the breadcrumb component.

## Why
We want breadcrumbs to display consistently across GOVUK. The latest version of the gem makes this opt-in rather than default behaviour.

## Example before
<img width="341" alt="Screenshot 2020-03-02 at 12 10 41" src="https://user-images.githubusercontent.com/29889908/75675337-e07acb80-5c7e-11ea-8be1-3014ccb6a16f.png">

## Example after
<img width="228" alt="Screenshot 2020-03-02 at 12 10 45" src="https://user-images.githubusercontent.com/29889908/75675346-e5d81600-5c7e-11ea-9252-07e93704a4ca.png">

## Search page examples to sanity check:

- https://finder-front-breadcrumb-epxqal.herokuapp.com/search/all
- https://finder-front-breadcrumb-epxqal.herokuapp.com/search/research-and-statistics
- https://finder-front-breadcrumb-epxqal.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-breadcrumb-epxqal.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-breadcrumb-epxqal.herokuapp.com/drug-device-alerts
- https://finder-front-breadcrumb-epxqal.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-breadcrumb-epxqal.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-breadcrumb-epxqal.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-breadcrumb-epxqal.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
