### PR TITLE
Update Transition checker alerts signup copy

### DIFF
--- a/config/locales/en/brexit_checker/email_signup.yml
+++ b/config/locales/en/brexit_checker/email_signup.yml
@@ -2,8 +2,9 @@ en:
   brexit_checker:
     email_signup:
       title: "How to get ready for new rules in 2021"
-      sign_up_heading: "Get email alerts"
+      sign_up_heading: "Get email alerts about your results"
       sign_up_message: |
-        <p class="govuk-body">You are signing up for email updates about how to prepare for new rules from 1 January 2021.</p>
-        <p class="govuk-body">This will include information about the transition period including what you, your family, or your business can do to prepare for new rules.</p>
+        <p class="govuk-body">You're signing up for email updates about changes to your results because of any additional arrangements between the UK and EU.</p>
+        <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
+        <p class="govuk-body">You will only get updates based on your results.</p>
       sign_up_button: Subscribe


### PR DESCRIPTION
What
------

Update the Get email alerts page to make it clear that the alerts as based on a users specific checker results and not just general transition updates


Why
------
Content recommendation from checker notification review. Users don't understand that they get email updates based on their checker results.  

https://trello.com/c/Fc1a2l3x/564-update-get-email-alerts-page

---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
