### PR TITLE
Fix topic link states on inverse header

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -290,8 +290,16 @@ mark {
 }
 // scss-lint:enable IdSelector
 
-.topic-finder__taxon-link {
+.topic-finder__taxon-link,
+.topic-finder__taxon-link:link,
+.topic-finder__taxon-link:visited {
   @include govuk-font(24, $weight: bold);
+  color: govuk-colour("white");
+
+  &:link:focus,
+  &:visited:focus {
+    color: $govuk-text-colour;
+  }
 }
 
 // NOTE: used to override govspeak component when it's used on an inverse header
@@ -354,7 +362,7 @@ mark {
 }
 
 // adjust spacing between items
-// not using govuk-spacing as they need to be consistent 
+// not using govuk-spacing as they need to be consistent
 // across breakpoints
 .finder-results .gem-c-document-list__item {
   margin-bottom: 20px;

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -47,7 +47,7 @@
           <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
         </button>
       <% elsif topic_finder?(filter_params) %>
-        <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'topic-finder__taxon-link' %>
+        <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'govuk-link topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: content_item.title,
           inverse: true,


### PR DESCRIPTION
## What
Apply the `govuk-link` class to the taxon link in topic page finders and add custom styles.

## Why
The original link was displaying as white on the old focus colour, which doesn't meet colour contrast guidelines.

## Before
<img width="330" alt="Screenshot 2020-03-03 at 11 55 20" src="https://user-images.githubusercontent.com/29889908/75773591-1cc52f00-5d46-11ea-9d39-cb676a8f4662.png">

## After
<img width="321" alt="Screenshot 2020-03-03 at 11 55 42" src="https://user-images.githubusercontent.com/29889908/75773600-1fc01f80-5d46-11ea-8844-61d0fedd562e.png">

Example: https://finder-front-fix-topic-ewc7sjd.herokuapp.com//search/services?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
