### PR TITLE
Show topical event title as extra header context

### DIFF
--- a/app/helpers/title_context_helper.rb
+++ b/app/helpers/title_context_helper.rb
@@ -1,0 +1,13 @@
+module TitleContextHelper
+  def title_context(filter_params = nil)
+    filter_params ||= params
+
+    topical_events = filter_params["topical_events"]
+    topical_events = [topical_events] if topical_events.is_a? String
+
+    if topical_events && topical_events.count == 1
+      registry = Services.registries.all["full_topical_events"]
+      (registry[topical_events.first] || {})["title"]
+    end
+  end
+end

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -55,6 +55,7 @@
       <% else %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: content_item.title,
+          context: title_context,
         } %>
       <% end %>
 

--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -12,6 +12,9 @@ module Registries
         "organisations" => organisations,
         "manual" => manuals,
         "full_topic_taxonomy" => full_topic_taxonomy,
+        # this isn't called "topical_events" because we don't want the
+        # facet tag to appear automatically
+        "full_topical_events" => full_topical_events,
       }
     end
 
@@ -59,6 +62,10 @@ module Registries
 
     def manuals
       @manuals ||= ManualsRegistry.new
+    end
+
+    def full_topical_events
+      @full_topical_events ||= TopicalEventsRegistry.new
     end
   end
 end

--- a/lib/registries/topical_events_registry.rb
+++ b/lib/registries/topical_events_registry.rb
@@ -1,0 +1,51 @@
+module Registries
+  class TopicalEventsRegistry < Registry
+    include CacheableRegistry
+
+    def [](slug)
+      topical_events[slug]
+    end
+
+    def values
+      topical_events
+    end
+
+    def cache_key
+      "registries/topical_events"
+    end
+
+  private
+
+    def cacheable_data
+      topical_events_as_hash
+    end
+
+    def topical_events
+      @topical_events ||= fetch_from_cache
+    end
+
+    def report_error
+      GovukStatsd.increment("registries.topical_events_api_errors")
+    end
+
+    def topical_events_as_hash
+      GovukStatsd.time("registries.topical_events.request_time") do
+        fetch_topical_events_from_rummager
+          .reject { |topical_event| topical_event["slug"].empty? || topical_event["title"].empty? }
+          .each_with_object({}) { |topical_event, topical_events|
+            topical_events[topical_event["slug"]] = { "title" => topical_event["title"], "slug" => topical_event["slug"] }
+          }
+      end
+    end
+
+    def fetch_topical_events_from_rummager
+      params = {
+        filter_format: "topical_event",
+        fields: %w(title slug),
+        count: 1500,
+        order: "title",
+      }
+      Services.rummager.search(params)["results"]
+    end
+  end
+end

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -39,7 +39,7 @@ describe "Healthcheck" do
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
-            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy.",
+            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, full_topical_events.",
             "status" => "warning",
           },
         },

--- a/spec/helpers/title_context_helper.rb
+++ b/spec/helpers/title_context_helper.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe TitleContextHelper, type: :helper do
+  include RegistrySpecHelper
+
+  let(:filter_params) { {} }
+
+  before :each do
+    stub_full_topical_events_registry_request
+  end
+
+  describe "#title_context" do
+    subject(:subject) { title_context(filter_params) }
+
+    context "there are no topical events" do
+      it "gives no context" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "there is one topical event (as a string)" do
+      let(:filter_params) { { "topical_events" => "2014-overseas-territories-joint-ministerial-council" } }
+
+      it "gives context" do
+        expect(subject).to eq("2014 Overseas Territories Joint Ministerial Council")
+      end
+    end
+
+    context "there is one topical event (as an array)" do
+      let(:filter_params) { { "topical_events" => %w(2014-overseas-territories-joint-ministerial-council) } }
+
+      it "gives context" do
+        expect(subject).to eq("2014 Overseas Territories Joint Ministerial Council")
+      end
+    end
+
+    context "there is more than one topical event" do
+      let(:filter_params) { { "topical_events" => %w(2014-overseas-territories-joint-ministerial-council anti-corruption-summit-london-2016) } }
+
+      it "gives no context" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Healthchecks::RegistriesCache do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
+      stub_full_topical_events_registry_request
 
       Registries::BaseRegistries.new.refresh_cache
     end
@@ -37,7 +38,7 @@ RSpec.describe Healthchecks::RegistriesCache do
   context "Registries caches are empty" do
     it "has an OK status" do
       expect(check.status).to eq :warning
-      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy."
+      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, full_topical_events."
     end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Registries::BaseRegistries do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
+      stub_full_topical_events_registry_request
     end
     after { clear_cache }
 
@@ -66,6 +67,7 @@ RSpec.describe Registries::BaseRegistries do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
+      stub_full_topical_events_registry_request
     end
     after { clear_cache }
 

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -144,4 +144,31 @@ module RegistrySpecHelper
         ],
       }.to_json)
   end
+
+  def stub_full_topical_events_registry_request
+    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    .with(query: {
+      count: 1500,
+      fields: %w(slug title),
+      filter_format: %(topical_event),
+      order: "title",
+    })
+    .to_return(body: { results: [
+      {
+        "title": "2014 Overseas Territories Joint Ministerial Council",
+        "slug": "2014-overseas-territories-joint-ministerial-council",
+        "_id": "/government/topical-events/2014-overseas-territories-joint-ministerial-council",
+      },
+      {
+        "title": "Anti-Corruption Summit: London 2016",
+        "slug": "anti-corruption-summit-london-2016",
+        "_id": "/government/topical-events/anti-corruption-summit-london-2016",
+      },
+      {
+        "title": "Autumn Budget 2017",
+        "slug": "autumn-budget-2017",
+        "_id": "/government/topical-events/autumn-budget-2017",
+      },
+    ] }.to_json)
+  end
 end


### PR DESCRIPTION
We've decided not to use the facet tag for this because there's no way
to get this filter back if you remove it (other than following
whatever link you found to the page again).

See https://finder-front-msw-topica-u27czb.herokuapp.com/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response

---

## Search page examples to sanity check:

- https://finder-front-msw-topica-u27czb.herokuapp.com/search/all
- https://finder-front-msw-topica-u27czb.herokuapp.com/search/research-and-statistics
- https://finder-front-msw-topica-u27czb.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-msw-topica-u27czb.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-msw-topica-u27czb.herokuapp.com/drug-device-alerts
- https://finder-front-msw-topica-u27czb.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-msw-topica-u27czb.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-msw-topica-u27czb.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-msw-topica-u27czb.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
