### PR TITLE
Reduce cache time of finder pages & feeds to 15m

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -5,10 +5,10 @@ class FindersController < ApplicationController
   before_action :remove_search_box
 
   before_action do
-    expires_in(30.minutes, public: true)
+    expires_in(15.minutes, public: true)
   end
 
-  ATOM_FEED_MAX_AGE = 30 * 60
+  ATOM_FEED_MAX_AGE = 15 * 60
   def show
     respond_to do |format|
       format.html do


### PR DESCRIPTION
Traffic is trending down now, and we don't have automated cache
clearing for finder pages (how would you efficiently work out all the
finder URLs which are affected by some publishing?), so we should
reduce this back to 5m ASAP.

I've gone for 15m for now because traffic is still pretty high, so it
would be good to monitor for a bit.

---

[Trello card](https://trello.com/c/zFh4dFhL/1462-reduce-cache-time-for-finder-frontend-again)