### PR TITLE
Add parts-in-results A/B test

### DIFF
--- a/app/controllers/concerns/parts_in_results_ab_testable.rb
+++ b/app/controllers/concerns/parts_in_results_ab_testable.rb
@@ -1,0 +1,30 @@
+module PartsInResultsAbTestable
+  CUSTOM_DIMENSION = 42
+  ALLOWED_VARIANTS = %w(unchanged showparts).freeze
+
+  def self.included(base)
+    base.helper_method(:parts_in_results_variant)
+    base.after_action :set_parts_in_results_response_header
+  end
+
+  def show_parts_in_results
+    parts_in_results_variant.variant?("showparts")
+  end
+
+  def parts_in_results_test
+    @parts_in_results_test ||= GovukAbTesting::AbTest.new(
+      "ShowPartsInResultsABTest",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "unchanged",
+    )
+  end
+
+  def parts_in_results_variant
+    @parts_in_results_variant ||= parts_in_results_test.requested_variant(request.headers)
+  end
+
+  def set_parts_in_results_response_header
+    parts_in_results_variant.configure_response(response)
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   include FinderTopResultAbTestable
+  include PartsInResultsAbTestable
 
   layout "finder_layout"
   before_action :remove_search_box
@@ -111,7 +112,7 @@ private
       filter_params,
       override_sort_for_feed: is_for_feed,
       ab_params: {},
-      show_parts: params["show_parts"] == "1",
+      show_parts: show_parts_in_results || params["show_parts"] == "1",
     )
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -15,6 +15,8 @@
   <% inverse = true %>
 <% end %>
 
+<%= parts_in_results_variant.analytics_meta_tag.html_safe %>
+
 <form method="get" action="<%= content_item.base_path %>" class="js-live-search-form">
   <input type="hidden" name="parent" value="<%= @parent %>">
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -127,7 +127,7 @@ describe FindersController, type: :controller do
       end
     end
 
-    describe "user requests parts" do
+    describe "parts in results A/B test" do
       before do
         stub_content_store_has_item(
           "/lunch-finder",
@@ -150,10 +150,12 @@ describe FindersController, type: :controller do
           .to_return(status: 200, body: rummager_response, headers: {})
       end
 
-      it "correctly renders a finder page" do
-        get :show, params: { slug: "lunch-finder", show_parts: "1" }
-        expect(response.status).to eq(200)
-        expect(response).to render_template("finders/show")
+      it "requests parts from search-api" do
+        with_variant ShowPartsInResultsABTest: "showparts" do
+          get :show, params: { slug: "lunch-finder" }
+          expect(response.status).to eq(200)
+          expect(response).to render_template("finders/show")
+        end
       end
     end
 


### PR DESCRIPTION
This removes the `show_parts=1` trick to get parts, as the GOV.UK browser extension lets you change what bucket you're in.

Based on https://github.com/alphagov/finder-frontend/commit/30388be1a08acbe8f78a0827bf117b9dd8c51eef

---

[Trello card](https://trello.com/c/sDDx1mn8/1463-display-parts-in-search-results-ab-test)