### PR TITLE
Drop cache time back down to 5 minutes

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -6,10 +6,10 @@ class FindersController < ApplicationController
   before_action :remove_search_box
 
   before_action do
-    expires_in(15.minutes, public: true)
+    expires_in(30.minutes, public: true)
   end
 
-  ATOM_FEED_MAX_AGE = 15 * 60
+  ATOM_FEED_MAX_AGE = 30 * 60
   def show
     respond_to do |format|
       format.html do

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -6,10 +6,10 @@ class FindersController < ApplicationController
   before_action :remove_search_box
 
   before_action do
-    expires_in(30.minutes, public: true)
+    expires_in(5.minutes, public: true)
   end
 
-  ATOM_FEED_MAX_AGE = 30 * 60
+  ATOM_FEED_MAX_AGE = 300
   def show
     respond_to do |format|
       format.html do

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -74,7 +74,7 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response.media_type).to eq("application/atom+xml")
         expect(response).to render_template("finders/show")
-        #expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
 
       it "can respond with JSON" do


### PR DESCRIPTION
We put this up to 30m in preparation of increased traffic, dropped it down to 15m yesterday, and now it's time to go back to 5m.