### PR TITLE
Update spelling suggestions Enhanced Ecommerce tracking to use page path

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -148,7 +148,7 @@ private
       suggested_queries,
       finder_url_builder.url(keywords: (suggested_queries.first || {}).dig("text")),
       # Search api is set to always return an array with one item
-      content_item.as_hash["content_id"],
+      content_item.as_hash["base_path"],
     )
   end
 

--- a/app/presenters/spelling_suggestion_presenter.rb
+++ b/app/presenters/spelling_suggestion_presenter.rb
@@ -1,8 +1,8 @@
 class SpellingSuggestionPresenter
-  def initialize(suggested_queries, url, content_item_id)
+  def initialize(suggested_queries, url, content_item_path)
     @suggested_queries = suggested_queries
     @url = url
-    @content_item_id = content_item_id
+    @content_item_path = content_item_path
   end
 
   def suggestions
@@ -12,7 +12,7 @@ class SpellingSuggestionPresenter
         highlighted: suggestion["highlighted"],
         link: @url,
         data_attributes: {
-          ecommerce_content_id: @content_item_id,
+          ecommerce_path: @content_item_path,
           ecommerce_row: 1,
           track_options: {
             dimension81: suggestion["text"],

--- a/spec/presenters/spelling_suggestion_presenter_spec.rb
+++ b/spec/presenters/spelling_suggestion_presenter_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe SpellingSuggestionPresenter do
     it "presents spelling suggestions" do
       suggested_queries = [{ "text" => "full english", "highlighted" => "<mark>full</mark> english" }]
       url = "/breakfast-finder?keywords=full+english"
-      content_item_id = "123AAA"
+      content_item_path = "fake/path"
 
       presenter = SpellingSuggestionPresenter.new(
         suggested_queries,
         url,
-        content_item_id,
+        content_item_path,
       )
       expected = [{ data_attributes: {
-          ecommerce_content_id: "123AAA",
+          ecommerce_path: "fake/path",
           ecommerce_row: 1,
           track_options: {
             dimension81: "full english",


### PR DESCRIPTION
At some point in the past we moved our tracking to the path of a page
rather than the ID. This wasn't updated for the search spelling
suggestions, which still used content ID.

This pull request fixes this issue. Unfortunately we do not have access
to anything more than the "base_path" from the content in this position,
though on testing the content in this path has an ID that matches the
content_ids that were being used before.


---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
