### PR TITLE
Add coronavirus business support checker

### DIFF
--- a/app/controllers/coronavirus_business_support_checker_controller.rb
+++ b/app/controllers/coronavirus_business_support_checker_controller.rb
@@ -1,0 +1,51 @@
+class CoronavirusBusinessSupportCheckerController < ApplicationController
+  include BrexitCheckerHelper
+
+  layout "finder_layout"
+
+  before_action do
+    expires_in(30.minutes, public: true) unless Rails.env.development?
+  end
+
+  def show
+    all_questions = BrexitChecker::Question.load_all
+    @question_index = next_question_index(
+      all_questions: all_questions,
+      criteria_keys: criteria_keys,
+      previous_question_index: page,
+    )
+
+    @current_question = all_questions[@question_index] if @question_index.present?
+
+    @previous_page = previous_question_index(
+      all_questions: all_questions,
+      criteria_keys: criteria_keys,
+      current_question_index: page,
+    )
+
+    redirect_to transition_checker_results_path(c: criteria_keys) if @current_question.nil?
+  end
+
+  def results
+    all_actions = BrexitChecker::Action.load_all
+    @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
+    @actions = filter_items(all_actions, criteria_keys)
+    audience_actions = @actions.group_by(&:audience)
+    @business_results = BrexitChecker::ResultsAudiences.populate_business_groups(audience_actions["business"], @criteria)
+    @citizen_results_groups = BrexitChecker::ResultsAudiences.populate_citizen_groups(audience_actions["citizen"], @criteria)
+  end
+
+private
+
+  def criteria_keys
+    @criteria_keys ||= begin
+                         keys = ParamsCleaner.new(params).fetch(:c, [])
+                         BrexitChecker::Criteria::Filter.new.call(keys)
+                       end
+  end
+  helper_method :criteria_keys
+
+  def page
+    @page ||= ParamsCleaner.new(params).fetch(:page, "0").to_i
+  end
+end

--- a/app/controllers/coronavirus_business_support_checker_controller.rb
+++ b/app/controllers/coronavirus_business_support_checker_controller.rb
@@ -1,5 +1,5 @@
 class CoronavirusBusinessSupportCheckerController < ApplicationController
-  include BrexitCheckerHelper
+  include CoronavirusBusinessSupportCheckerHelper
 
   layout "finder_layout"
 
@@ -8,7 +8,7 @@ class CoronavirusBusinessSupportCheckerController < ApplicationController
   end
 
   def show
-    all_questions = BrexitChecker::Question.load_all
+    all_questions = BusinessSupportChecker::Question.load_all
     @question_index = next_question_index(
       all_questions: all_questions,
       criteria_keys: criteria_keys,
@@ -23,16 +23,13 @@ class CoronavirusBusinessSupportCheckerController < ApplicationController
       current_question_index: page,
     )
 
-    redirect_to transition_checker_results_path(c: criteria_keys) if @current_question.nil?
+    redirect_to cbs_checker_results_path(c: criteria_keys) if @current_question.nil?
   end
 
   def results
-    all_actions = BrexitChecker::Action.load_all
-    @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
+    all_actions = BusinessSupportChecker::Action.load_all
+    @criteria = BusinessSupportChecker::Criterion.load_by(criteria_keys)
     @actions = filter_items(all_actions, criteria_keys)
-    audience_actions = @actions.group_by(&:audience)
-    @business_results = BrexitChecker::ResultsAudiences.populate_business_groups(audience_actions["business"], @criteria)
-    @citizen_results_groups = BrexitChecker::ResultsAudiences.populate_citizen_groups(audience_actions["citizen"], @criteria)
   end
 
 private
@@ -40,7 +37,7 @@ private
   def criteria_keys
     @criteria_keys ||= begin
                          keys = ParamsCleaner.new(params).fetch(:c, [])
-                         BrexitChecker::Criteria::Filter.new.call(keys)
+                         BusinessSupportChecker::Criteria::Filter.new.call(keys)
                        end
   end
   helper_method :criteria_keys

--- a/app/helpers/coronavirus_business_support_checker_helper.rb
+++ b/app/helpers/coronavirus_business_support_checker_helper.rb
@@ -58,31 +58,23 @@ module CoronavirusBusinessSupportCheckerHelper
     url.to_s
   end
 
-  def brexit_results_email_link_label(actions)
-    if actions.any?
-      t("brexit_checker.results.email_sign_up_link")
-    else
-      t("brexit_checker.results.email_sign_up_link_no_actions")
-    end
-  end
-
   def brexit_results_title(actions, criteria_keys)
     if actions.any?
-      t("brexit_checker.results.title")
+      t("business_support_checker.results.title")
     elsif criteria_keys.any?
-      t("brexit_checker.results.title_no_actions")
+      t("business_support_checker.results.title_no_actions")
     else
-      t("brexit_checker.results.title_no_answers")
+      t("business_support_checker.results.title_no_answers")
     end
   end
 
   def brexit_results_description(actions, criteria_keys)
     if actions.any?
-      t("brexit_checker.results.description")
+      t("business_support_checker.results.description")
     elsif criteria_keys.present?
-      t("brexit_checker.results.description_no_actions")
+      t("business_support_checker.results.description_no_actions")
     else
-      t("brexit_checker.results.description_no_answers").html_safe
+      t("business_support_checker.results.description_no_answers").html_safe
     end
   end
 end

--- a/app/helpers/coronavirus_business_support_checker_helper.rb
+++ b/app/helpers/coronavirus_business_support_checker_helper.rb
@@ -1,0 +1,88 @@
+require "addressable/uri"
+
+module CoronavirusBusinessSupportCheckerHelper
+  def encoded_results_url
+    CGI.escape(request.original_url)
+  end
+
+  def criteria_aside_label(heading = nil)
+    return "you-and-your-family-actions-group-#{heading.downcase.gsub(' ', '-')}-criteria" if !heading.nil?
+
+    "business-actions-criteria"
+  end
+
+  def filter_items(items, criteria_keys)
+    items.select { |i| i.show?(criteria_keys) }
+  end
+
+  def persistent_criteria_keys(question_criteria_keys)
+    criteria_keys - question_criteria_keys
+  end
+
+  def format_question_options(options, criteria_keys)
+    options.map { |o| format_question_option(o, criteria_keys) }
+  end
+
+  def format_question_option(option, criteria_keys)
+    checked = criteria_keys.include?(option.value)
+
+    { label: option.label,
+      text: option.label,
+      value: option.value,
+      checked: checked,
+      hint_text: option.hint_text }
+  end
+
+  def next_question_index(all_questions:, criteria_keys: [], previous_question_index: 0)
+    available_questions = all_questions[previous_question_index..] || []
+
+    relative_next_question_index = available_questions.find_index { |question| question.show?(criteria_keys) }
+    relative_next_question_index ? previous_question_index + relative_next_question_index : nil
+  end
+
+  def previous_question_index(all_questions:, criteria_keys: [], current_question_index: 0)
+    previous_questions = all_questions[0...current_question_index]
+    previous_questions.rindex { |question| question.show?(criteria_keys) }
+  end
+
+  def notification_email_link(non_tracked_url, notification)
+    url = Addressable::URI.parse(non_tracked_url)
+    return non_tracked_url unless url.host == "www.gov.uk"
+
+    url.query_values = (url.query_values || {}).merge(
+      utm_source: notification.id,
+      utm_medium: "email",
+      utm_campaign: "govuk-brexit-checker",
+    )
+
+    url.to_s
+  end
+
+  def brexit_results_email_link_label(actions)
+    if actions.any?
+      t("brexit_checker.results.email_sign_up_link")
+    else
+      t("brexit_checker.results.email_sign_up_link_no_actions")
+    end
+  end
+
+  def brexit_results_title(actions, criteria_keys)
+    if actions.any?
+      t("brexit_checker.results.title")
+    elsif criteria_keys.any?
+      t("brexit_checker.results.title_no_actions")
+    else
+      t("brexit_checker.results.title_no_answers")
+    end
+  end
+
+  def brexit_results_description(actions, criteria_keys)
+    if actions.any?
+      t("brexit_checker.results.description")
+    elsif criteria_keys.present?
+      t("brexit_checker.results.description_no_actions")
+    else
+      t("brexit_checker.results.description_no_answers").html_safe
+    end
+  end
+end

--- a/app/views/coronavirus_business_support_checker/_action_list.html.erb
+++ b/app/views/coronavirus_business_support_checker/_action_list.html.erb
@@ -1,0 +1,60 @@
+<% actions.each.with_index do | action, index | %>
+  <div class="govuk-grid-row brexit-checker__action">
+    <div class="brexit-checker__content-wrapper">
+      <p class="govuk-body brexit-checker__action_title">
+        <% if action.title_url.present? %>
+          <a
+            class="govuk-link"
+            href="<%= action.title_url %>"
+            data-module="track-click"
+            data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
+            data-track-category="brexit-checker-results"
+            data-track-label="<%= action.title_url %>"
+            data-ecommerce-row
+            data-ecommerce-path="<%= action.title_path %>"
+          ><%= action.title %></a>
+        <% else %>
+          <%= action.title %>
+        <% end %>
+      </p>
+      <% if action.lead_time.present? %>
+        <div class="govuk-body">
+          <div class="govuk-inset-text">
+            <%= action.lead_time %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if action.consequence.present? %>
+        <p class="govuk-body">
+          <%= action.consequence %>
+        </p>
+      <% end %>
+      <% if action.exception.present? %>
+        <p class="govuk-body">
+          <%= action.exception %>
+        </p>
+      <% end %>
+
+      <% if action.guidance_url.present? %>
+        <div class="govuk-body govuk-!-font-size-16">
+          <p>
+            <%= action.guidance_prompt || t("brexit_checker.action_list.guidance_prompt") %>:
+          </p>
+          <p>
+            <a
+              href="<%= action.guidance_url %>"
+              class="govuk-link"
+              data-module="track-click"
+              data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
+              data-track-category="brexit-checker-results"
+              data-track-label="<%= action.guidance_url %>"
+              data-ecommerce-row
+              data-ecommerce-path="<%= action.guidance_path %>"
+            ><%= action.guidance_link_text %></a>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/coronavirus_business_support_checker/_change_answers_link.html.erb
+++ b/app/views/coronavirus_business_support_checker/_change_answers_link.html.erb
@@ -1,0 +1,10 @@
+<a
+  class="govuk-link"
+  data-module="track-click"
+  data-track-action="ChangeAnswers"
+  data-track-category="ChangeAnswersClicked"
+  data-track-label="<%= transition_checker_questions_path %>"
+  href="<%= transition_checker_questions_path %>"
+>
+  <%= t("brexit_checker.change_answers_link.link_text") %>
+</a>

--- a/app/views/coronavirus_business_support_checker/_detail_text.html.erb
+++ b/app/views/coronavirus_business_support_checker/_detail_text.html.erb
@@ -1,0 +1,11 @@
+<% unless detail_text.nil? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: detail_title  || "Why am I being asked this question?",
+    data_attributes: {
+      track_category: "brexit-checker-qa",
+      track_action: question_key,
+    }
+  } do %>
+    <%= detail_text.html_safe %>
+  <% end %>
+<% end %>

--- a/app/views/coronavirus_business_support_checker/_form_data.html.erb
+++ b/app/views/coronavirus_business_support_checker/_form_data.html.erb
@@ -1,0 +1,4 @@
+<% criteria_keys.each do |key| %>
+  <input type="hidden" name="c[]" value="<%= key %>">
+<% end %>
+<input type="hidden" name="page" value="<%= next_page %>">

--- a/app/views/coronavirus_business_support_checker/_print_link.html.erb
+++ b/app/views/coronavirus_business_support_checker/_print_link.html.erb
@@ -1,0 +1,7 @@
+<button
+  class="brexit-checker__print-link govuk-link"
+  rel="alternate"
+  onclick="window.print();return false;"
+>
+   <%= t("brexit_checker.results.print_link") %>
+</button>

--- a/app/views/coronavirus_business_support_checker/_question_multiple_choice.html.erb
+++ b/app/views/coronavirus_business_support_checker/_question_multiple_choice.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "c[]",
+  heading_caption: current_question.caption,
+  heading: current_question.text,
+  description: formatted_description,
+  hint_text: current_question.hint_text,
+  is_page_heading: true,
+  items: format_question_options(current_question.options(criteria_keys), criteria_keys)
+} %>

--- a/app/views/coronavirus_business_support_checker/_question_multiple_grouped_choice.html.erb
+++ b/app/views/coronavirus_business_support_checker/_question_multiple_grouped_choice.html.erb
@@ -1,0 +1,22 @@
+<%= render "govuk_publishing_components/components/title", {
+  title: current_question.text,
+  context: current_question.caption,
+  margin_bottom: 5
+} %>
+
+<%= formatted_description %>
+
+<% if current_question.hint_text.present? %>
+  <%= render "govuk_publishing_components/components/hint", {
+    text: current_question.hint_text
+  } %>
+<% end %>
+
+<% current_question.options.each do | group | %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "c[]",
+    heading: group.label,
+    no_hint_text: true,
+    items: format_question_options(group.sub_options, criteria_keys)
+  } %>
+<% end %>

--- a/app/views/coronavirus_business_support_checker/_question_single_choice.html.erb
+++ b/app/views/coronavirus_business_support_checker/_question_single_choice.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/radio", {
+  name: "c[]",
+  heading_caption: current_question.caption,
+  heading: current_question.text,
+  description: formatted_description,
+  hint: current_question.hint_text,
+  is_page_heading: true,
+  items: format_question_options(current_question.options(criteria_keys), criteria_keys)
+} %>

--- a/app/views/coronavirus_business_support_checker/_question_single_wrapped.html.erb
+++ b/app/views/coronavirus_business_support_checker/_question_single_wrapped.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-!-margin-top-8">
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "c[]",
+    heading: current_question.text,
+    heading_caption: current_question.caption,
+    description: formatted_description,
+    hint: current_question.hint_text,
+    is_page_heading: true,
+    items: current_question.options.map do |option|
+      checkboxes = if option.sub_options.present?
+                     render "govuk_publishing_components/components/checkboxes", {
+                       name: "c[]",
+                       heading: option.label,
+                       visually_hide_heading: true,
+                       items: format_question_options(option.sub_options, criteria_keys)
+                     }
+                   end
+
+      format_question_option(option, criteria_keys).merge(conditional: checkboxes)
+    end
+  } %>
+</div>

--- a/app/views/coronavirus_business_support_checker/_results_business_actions.html.erb
+++ b/app/views/coronavirus_business_support_checker/_results_business_actions.html.erb
@@ -1,0 +1,26 @@
+<section
+  class="brexit-checker-actions"
+  data-analytics-ecommerce
+  data-ecommerce-start-index="1"
+  data-list-title="Brexit checker results: <%= t('brexit_checker.results.audiences.business.heading') %>"
+  data-search-query
+>
+  <section class="brexit-checker-audience">
+      <header>
+        <h2 class="govuk-heading-l action-audience__heading">
+          <%= t('brexit_checker.results.audiences.business.heading') %>
+        </h2>
+      </header>
+      <section class="brexit-checker-actions__group">
+        <div class="govuk-grid-row">
+          <%= render 'results_criteria', criteria: business_results[:criteria] %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "action_list", {
+              analytics_group: "#{t('brexit_checker.results.audiences.business.heading')} - 1.",
+              actions: business_results[:actions]
+            } %>
+          </div>
+        </div>
+      </section>
+  </section>
+</section>

--- a/app/views/coronavirus_business_support_checker/_results_citizen_actions.html.erb
+++ b/app/views/coronavirus_business_support_checker/_results_citizen_actions.html.erb
@@ -1,0 +1,28 @@
+<section class="brexit-checker-actions">
+  <header>
+    <h2 class="govuk-heading-l action-audience__heading">
+      <%= t('brexit_checker.results.audiences.citizen.heading') %>
+    </h2>
+  </header>
+  <section class="brexit-checker-audience">
+    <% citizen_results_groups.each.with_index do |grouping, group_index| %>
+      <section
+        class="brexit-checker-actions__group"
+        data-analytics-ecommerce
+        data-ecommerce-start-index=<%="#{group_index + 1}"%>
+        data-list-title="Brexit checker results: <%= "#{t('brexit_checker.results.audiences.citizen.heading')} - #{grouping[:group].heading}" %>"
+        data-search-query
+      >
+        <div class="govuk-grid-row">
+          <%= render 'results_criteria', criteria: grouping[:criteria], heading: grouping[:group].heading %>
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "action_list", {
+              analytics_group: "#{t('brexit_checker.results.audiences.citizen.heading')} - #{grouping[:group].heading} - #{group_index + 1}.",
+              actions: grouping[:actions]
+            } %>
+          </div>
+        </div>
+      </section>
+    <% end %>
+  </section>
+</section>

--- a/app/views/coronavirus_business_support_checker/_results_criteria.html.erb
+++ b/app/views/coronavirus_business_support_checker/_results_criteria.html.erb
@@ -1,0 +1,24 @@
+<% if criteria.present? %>
+  <aside
+    class="govuk-grid-column-one-third"
+    aria-label=<%="#{criteria_aside_label(local_assigns[:heading])}"%>
+  >
+    <% if local_assigns[:heading] %>
+      <h3 class="govuk-heading-m"><%= heading %></h3>
+    <% end %>
+    <p class="govuk-body brexit-checker__critera_explaination">
+      <%= t('brexit_checker.results.criteria.list_context') %>
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% criteria.each do |criterion| %>
+        <li class="brexit-checker__criterion">
+          <%= criterion.text %>
+        </li>
+      <% end %>
+    </ul>
+  </aside>
+<% else %>
+  <p class="govuk-body">
+    <%= t('brexit_checker.results.criteria.no_answers') %>
+  </p>
+<% end %>

--- a/app/views/coronavirus_business_support_checker/_results_with_no_actions.html.erb
+++ b/app/views/coronavirus_business_support_checker/_results_with_no_actions.html.erb
@@ -1,0 +1,10 @@
+<section class="brexit-checker__no-results">
+  <div class="govuk-grid-row">
+    <%= render 'results_criteria', criteria: @criteria %>
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body brexit-checker__no-results-warning">
+        <%= t("brexit_checker.action_audiences.no_results") %>
+      </p>
+    </div>
+  </div>
+</section>

--- a/app/views/coronavirus_business_support_checker/_share_links.html.erb
+++ b/app/views/coronavirus_business_support_checker/_share_links.html.erb
@@ -1,0 +1,38 @@
+<section class="brexit-checker__share">
+  <% hidden_text = capture do %>
+    <span class="govuk-visually-hidden">Share on</span>
+  <% end %>
+  <h2 class="govuk-heading-m">
+    <%= I18n.t("brexit_checker.results.share_link_title") %>
+  </h2>
+  <%= render "govuk_publishing_components/components/share_links", {
+    columns: true,
+    links: [
+      {
+        href: "https://www.facebook.com/sharer/sharer.php?u=#{encoded_results_url}",
+        text: hidden_text + "Facebook",
+        icon: "facebook"
+      },
+      {
+        href: "https://twitter.com/share?url=#{encoded_results_url}",
+        text: hidden_text + "Twitter",
+        icon: "twitter"
+      },
+      {
+        href: "https://api.whatsapp.com/send?text=#{encoded_results_url}",
+        text: hidden_text + "WhatsApp",
+        icon: "whatsapp"
+      },
+      {
+        href: "mailto:?body=#{encoded_results_url}&subject=#{I18n.t("brexit_checker.results.title")}",
+        text: hidden_text + "Email",
+        icon: "email"
+      },
+      {
+        href: "http://www.linkedin.com/shareArticle?url=#{encoded_results_url}",
+        text: hidden_text + "LinkedIn",
+        icon: "linkedin"
+      },
+    ]
+  } %>
+</section>

--- a/app/views/coronavirus_business_support_checker/_stay_updated.html.erb
+++ b/app/views/coronavirus_business_support_checker/_stay_updated.html.erb
@@ -1,0 +1,18 @@
+<h2 class="govuk-heading-m stay-updated__heading">
+  <%= t("brexit_checker.stay_updated.heading") %>
+</h2>
+
+<p class="stay-updated_description" >
+  <%= t("brexit_checker.stay_updated.description") %>
+</p>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: t("brexit_checker.stay_updated.sign_up"),
+  href: transition_checker_email_signup_path(c: criteria_keys),
+  data_attributes: {
+    "module": "track-click",
+    "track-action": t("brexit_checker.stay_updated.sign_up"),
+    "track-category": "StayUpdated",
+    "track-label": transition_checker_email_signup_path
+  }
+} %>

--- a/app/views/coronavirus_business_support_checker/email_signup.html.erb
+++ b/app/views/coronavirus_business_support_checker/email_signup.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, t('brexit_checker.email_signup.title') %>
+<% content_for :head do %>
+  <% unless params[:page] %>
+    <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-check'),
+        url: "/transition-check"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.results'),
+        url: transition_checker_results_path(c: criteria_keys)
+      }
+    ]
+  } %>
+
+  <main class="govuk-main-wrapper" role="mail">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l"><%= t('brexit_checker.email_signup.sign_up_heading') %></h1>
+        <%= t('brexit_checker.email_signup.sign_up_message').html_safe %>
+
+        <%= form_tag transition_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: t('brexit_checker.email_signup.sign_up_button'),
+            inline_layout: true
+          } %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/coronavirus_business_support_checker/results.html.erb
+++ b/app/views/coronavirus_business_support_checker/results.html.erb
@@ -63,6 +63,7 @@
         data-search-query
       >
         <div class="govuk-grid-row">
+          <%= render 'results_criteria', criteria: @criteria %>
           <div class="govuk-grid-column-two-thirds">
             <%= render "action_list", {
               analytics_group: "business-support",

--- a/app/views/coronavirus_business_support_checker/results.html.erb
+++ b/app/views/coronavirus_business_support_checker/results.html.erb
@@ -1,0 +1,78 @@
+<%
+  action_based_email_link_label = brexit_results_email_link_label(@actions)
+  action_based_title = brexit_results_title(@actions, criteria_keys)
+  action_based_description = brexit_results_description(@actions, criteria_keys)
+%>
+
+<% content_for :title, action_based_title %>
+<% content_for :head do %>
+  <% page_url = request.base_url + request.path %>
+  <meta name="govuk:search-result-count" content="<%= @actions.count %>">
+  <meta name="robots" content="noindex">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="GOV.UK">
+  <meta property="og:url" content="<%= page_url %>">
+  <meta property="og:title" content="<%= t('brexit_checker.results.social_media_meta.title') %>">
+  <meta property="og:description" content="<%= t('brexit_checker.results.social_media_meta.description') %>">
+  <meta name="twitter:card" content="summary">
+  <link rel="canonical" href="<%= page_url %>">
+<% end %>
+
+<div class="govuk-width-container brexit-checker-results-page">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-check'),
+        url: "/transition-check"
+      }
+    ]
+  } %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: action_based_title
+      } %>
+      <% unless @actions.any? %>
+        <p class="govuk-body-l">
+          <%= action_based_description %>
+        </p>
+      <% end %>
+      <% unless criteria_keys.present? %>
+        <p class="govuk-body-l">
+          <%= render "change_answers_link" %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <% if criteria_keys.present? %>
+    <%= render 'components/email_link', {
+      data_attributes: {
+        "module": "track-click",
+        "track-action": action_based_email_link_label,
+        "track-category": "StayUpdated",
+        "track-label": transition_checker_email_signup_path
+      },
+      link_text: action_based_email_link_label,
+      link_href: transition_checker_email_signup_path(c: criteria_keys),
+      link_title: t("brexit_checker.results.email_sign_up_title"),
+    } %>
+
+    <%= render 'results_business_actions', business_results: @business_results if @business_results.any? %>
+    <%= render 'results_citizen_actions', citizen_results_groups: @citizen_results_groups if @citizen_results_groups.any? %>
+    <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
+
+    <%= render 'stay_updated' %>
+    <%= render 'share_links' %>
+    <%= render 'print_link' if @business_results.any? || @citizen_results_groups.any? %>
+  <% end %>
+</div>

--- a/app/views/coronavirus_business_support_checker/results.html.erb
+++ b/app/views/coronavirus_business_support_checker/results.html.erb
@@ -12,8 +12,8 @@
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="GOV.UK">
   <meta property="og:url" content="<%= page_url %>">
-  <meta property="og:title" content="<%= t('brexit_checker.results.social_media_meta.title') %>">
-  <meta property="og:description" content="<%= t('brexit_checker.results.social_media_meta.description') %>">
+  <meta property="og:title" content="<%= t('business_support_checker.results.social_media_meta.title') %>">
+  <meta property="og:description" content="<%= t('business_support_checker.results.social_media_meta.description') %>">
   <meta name="twitter:card" content="summary">
   <link rel="canonical" href="<%= page_url %>">
 <% end %>
@@ -23,15 +23,15 @@
     collapse_on_mobile: true,
     breadcrumbs: [
       {
-        title: t('brexit_checker.breadcrumbs.home'),
+        title: t('business_support_checker.breadcrumbs.home'),
         url: "/"
       },
       {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        title: t('business_support_checker.breadcrumbs.coronavirus-home'),
         url: "/transition"
       },
       {
-        title: t('brexit_checker.breadcrumbs.brexit-check'),
+        title: t('business_support_checker.breadcrumbs.business-support-check'),
         url: "/transition-check"
       }
     ]

--- a/app/views/coronavirus_business_support_checker/results.html.erb
+++ b/app/views/coronavirus_business_support_checker/results.html.erb
@@ -55,24 +55,25 @@
   </div>
 
   <% if criteria_keys.present? %>
-    <%= render 'components/email_link', {
-      data_attributes: {
-        "module": "track-click",
-        "track-action": action_based_email_link_label,
-        "track-category": "StayUpdated",
-        "track-label": transition_checker_email_signup_path
-      },
-      link_text: action_based_email_link_label,
-      link_href: transition_checker_email_signup_path(c: criteria_keys),
-      link_title: t("brexit_checker.results.email_sign_up_title"),
-    } %>
+      <section
+        class="brexit-checker-actions__group"
+        data-analytics-ecommerce
+        data-ecommerce-start-index=1
+        data-list-title="Business support checker"
+        data-search-query
+      >
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "action_list", {
+              analytics_group: "business-support",
+              actions: @actions
+            } %>
+          </div>
+        </div>
+      </section>
+    <%= render 'results_with_no_actions', criteria: @criteria if @actions.empty? %>
 
-    <%= render 'results_business_actions', business_results: @business_results if @business_results.any? %>
-    <%= render 'results_citizen_actions', citizen_results_groups: @citizen_results_groups if @citizen_results_groups.any? %>
-    <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
-
-    <%= render 'stay_updated' %>
     <%= render 'share_links' %>
-    <%= render 'print_link' if @business_results.any? || @citizen_results_groups.any? %>
+    <%= render 'print_link' if @actions.any? %>
   <% end %>
 </div>

--- a/app/views/coronavirus_business_support_checker/show.html.erb
+++ b/app/views/coronavirus_business_support_checker/show.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-width-container">
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
-      href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
+      href: cbs_checker_questions_path(page: @previous_page, c: criteria_keys),
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/back_link", {
@@ -26,7 +26,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form
-        action="<%= transition_checker_questions_path %>"
+        action="<%= cbs_checker_questions_path %>"
         method="get"
         id="finder-qa-facet-filter-selection"
         data-module="track-brexit-qa-choices"

--- a/app/views/coronavirus_business_support_checker/show.html.erb
+++ b/app/views/coronavirus_business_support_checker/show.html.erb
@@ -1,0 +1,80 @@
+<% content_for :title, "#{@current_question.text} - #{t('brexit_checker.show.title')}" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex">
+<% end %>
+
+<%
+  formatted_description = nil
+  if @current_question.description
+    formatted_description = render("govuk_publishing_components/components/govspeak", {
+      content: @current_question.description.html_safe
+    })
+  end
+%>
+
+<div class="govuk-width-container">
+  <% if @previous_page %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: "/get-ready-brexit-check",
+    } %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form
+        action="<%= transition_checker_questions_path %>"
+        method="get"
+        id="finder-qa-facet-filter-selection"
+        data-module="track-brexit-qa-choices"
+        data-question-key="<%= @current_question.key %>"
+      >
+        <% if @current_question.multiple? %>
+          <div class="govuk-!-margin-top-8">
+            <%= render 'question_multiple_choice', {
+              current_question: @current_question,
+              formatted_description: formatted_description
+            } %>
+          </div>
+        <% elsif @current_question.multiple_grouped? %>
+          <div class="govuk-!-margin-top-8">
+            <%= render 'question_multiple_grouped_choice', {
+              current_question: @current_question,
+              formatted_description: formatted_description
+            } %>
+          </div>
+        <% elsif @current_question.single_wrapped? %>
+          <div class="govuk-!-margin-top-8">
+            <%= render 'question_single_wrapped', {
+              current_question: @current_question,
+              formatted_description: formatted_description
+            } %>
+          </div>
+        <% else %>
+          <div class="govuk-!-margin-top-8">
+            <%= render 'question_single_choice', {
+              current_question: @current_question,
+              formatted_description: formatted_description
+            } %>
+          </div>
+        <% end %>
+        <%= render 'form_data',
+          criteria_keys: persistent_criteria_keys(@current_question.all_values),
+          next_page: (@question_index + 1)
+        %>
+        <%= render 'detail_text', {
+            detail_text: @current_question.detail_text,
+            detail_title: @current_question.detail_title,
+            question_key: @current_question.key
+          }
+        %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Continue"
+        } %>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,6 +8,7 @@
   <p>The following pages are rendered by this application:</p>
 
   <ul>
+    <li><%= link_to "Coronavirus business support checker", cbs_checker_questions_path %></li>
     <li><%= link_to "How to prepare for a no deal Brexit questions", transition_checker_questions_path %></li>
   <% @rendered_pages.each do |page| %>
     <li><%= link_to page.fetch("title"), page.fetch("link") %></li>

--- a/config/locales/en/business_support_checker/action_list.yml
+++ b/config/locales/en/business_support_checker/action_list.yml
@@ -1,0 +1,4 @@
+en:
+  brexit_checker:
+    action_list:
+      guidance_prompt: Read the guidance

--- a/config/locales/en/business_support_checker/breadcrumbs.yml
+++ b/config/locales/en/business_support_checker/breadcrumbs.yml
@@ -1,0 +1,8 @@
+en:
+  business_support_checker:
+    breadcrumbs:
+      home: Home
+      coronavirus-home: Coronavirus
+      business-support-check: "Check what business support your eligble for"
+      questions: Questions
+      results: Your results

--- a/config/locales/en/business_support_checker/change_answers_link.yml
+++ b/config/locales/en/business_support_checker/change_answers_link.yml
@@ -1,0 +1,4 @@
+en:
+  brexit_checker:
+    change_answers_link:
+      link_text: Start again

--- a/config/locales/en/business_support_checker/results.yml
+++ b/config/locales/en/business_support_checker/results.yml
@@ -1,0 +1,35 @@
+en:
+  business_support_checker:
+    results:
+      title: "Coronavirus business support:"
+      title_no_actions: You do not need to take action now
+      title_no_answers: You did not answer any of the questions
+      description: |
+        You may not need to take all these actions now. Actions you need to take will depend on your own circumstances.
+      description_no_actions: |
+        Based on your responses, you do not need to take any action to prepare for new rules from 1 January 2021.
+      description_no_answers: |
+        <p class="govuk-body-l">To change your answers, follow the link below.</p>
+        <p class="govuk-body-l">This is a safe and secure service. We do not store any of your personal information.</p>
+      email_sign_up_title: What you need to do may change
+      email_sign_up_link: |
+        Subscribe to email updates about changes that may affect you and get a link to your results
+      email_sign_up_link_no_actions: |
+        Subscribe to email updates about changes that may affect you and get a link to your results
+      share_link_title: Share your results
+      social_media_meta:
+        title: "How to get ready for new rules in 2021: Your results"
+        description: |
+          What you, your family, or your business can do now to prepare for new rules from 1 January 2021.
+      criteria:
+        list_context: "Because you said:"
+        no_answers: |
+          You did not answer any of the questions.
+          This is a safe and secure service. We don't store any of your personal information.
+          To change your answers, follow the link below.
+      audiences:
+        citizen:
+          heading: You and your family
+        business:
+          heading: Your business or organisation
+      print_link: Print your results

--- a/config/locales/en/business_support_checker/show.yml
+++ b/config/locales/en/business_support_checker/show.yml
@@ -1,0 +1,4 @@
+en:
+  brexit_checker:
+    show:
+      title: "How to get ready for new rules in 2021"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ FinderFrontend::Application.routes.draw do
     get "/test-search/search/opensearch" => "search#opensearch"
   end
 
+  # Routes for the for Coronavirus Business Support Checker
+  get "/coronavirus-business-support/results" => "coronavirus_business_support_checker#results"
+  get "/coronavirus-business-support/questions" => "coronavirus_business_support_checker#show"
+
   # Routes for the for Brexit Checker
   get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
   get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,8 @@ FinderFrontend::Application.routes.draw do
   end
 
   # Routes for the for Coronavirus Business Support Checker
-  get "/coronavirus-business-support/results" => "coronavirus_business_support_checker#results"
-  get "/coronavirus-business-support/questions" => "coronavirus_business_support_checker#show"
+  get "/business-support/results" => "coronavirus_business_support_checker#results", as: :cbs_checker_results
+  get "/business-support/questions" => "coronavirus_business_support_checker#show", as: :cbs_checker_questions
 
   # Routes for the for Brexit Checker
   get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results

--- a/lib/business_support_checker/action.rb
+++ b/lib/business_support_checker/action.rb
@@ -1,0 +1,69 @@
+require "addressable/uri"
+
+class BusinessSupportChecker::Action
+  include ActiveModel::Validations
+
+  CONFIG_PATH = Rails.root.join("lib/business_support_checker/actions.yaml")
+
+  validates_presence_of :id, :title, :criteria
+  validates_numericality_of :priority, only_integer: true
+  validate :has_criteria
+
+  attr_reader :id, :title, :consequence, :exception, :title_url, :title_path,
+              :lead_time, :criteria, :audience, :guidance_link_text,
+              :guidance_url, :guidance_path, :guidance_prompt, :priority,
+              :grouping_criteria
+
+  def initialize(attrs)
+    attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    @title_path = path_from_url(title_url) if title_url
+    @guidance_path = path_from_url(guidance_url) if guidance_url
+    validate!
+  end
+
+  def show?(selected_criteria)
+    BusinessSupportChecker::Criteria::Evaluator.evaluate(criteria, selected_criteria)
+  end
+
+  def self.find_by_id(id)
+    load_all.find { |a| a.id == id }
+  end
+
+  def self.load_all
+    @load_all = nil if Rails.env.development?
+    @load_all ||= YAML.load_file(CONFIG_PATH)["actions"].map { |a| new(a) }
+  end
+
+  def all_criteria
+    BusinessSupportChecker::Criterion.load_by(all_criteria_keys)
+  end
+
+  def all_criteria_keys
+    BusinessSupportChecker::Criteria::Extractor.extract(criteria)
+  end
+
+  def hash
+    id.hash
+  end
+
+  def eql?(other)
+    id == other.id
+  end
+
+private
+
+  def has_criteria
+    return unless all_criteria_keys.none?
+
+    errors.add "Action must have at least one criterion"
+  end
+
+  def path_from_url(full_url)
+    url = Addressable::URI.parse(full_url)
+    if url.host == "www.gov.uk"
+      url.path
+    else
+      full_url
+    end
+  end
+end

--- a/lib/business_support_checker/actions.yaml
+++ b/lib/business_support_checker/actions.yaml
@@ -4,6 +4,10 @@ actions:
   priority: 5
   title: Coronavirus Job retention Scheme 
   title_url: https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status
+  consequence: "Under the coronavirus Job Retention Scheme, all UK employers with a PAYE scheme will be able to access support to continue paying part of their employees’ salary for those that would otherwise have been laid off during this crisis."
+  guidance_prompt: Read the guidance
+  guidance_link_text: Claim for your employees' wages 
+  guidance_url: https://www.gov.uk/settled-status-eu-citizens-families
   criteria:
   - all_of:
     - not-self-employed
@@ -11,6 +15,7 @@ actions:
   priority: 5
   title: Deferring VAT
   title_url: https://www.gov.uk/family-permit
+  consequence: "We will support businesses by deferring Valued Added Tax (VAT) payments for 3 months." 
   criteria:
   - any_of:
     - 45m-plus-turnover 
@@ -19,13 +24,17 @@ actions:
   priority: 5
   title: Deferring Self-Assessment payments on account
   title_url: https://www.gov.uk/family-permit
+  consequence: "The Self- Assessment payment on account, that is ordinarily due to be paid to HMRC by 31 July 2020 may now be deferred until January 2021." 
   criteria:
   - all_of:
     - self-assessment-due-31-06-20
 - id: F004
   priority: 5
   title: Statutory Sick Pay Rebate
-  title_url: https://www.gov.uk/family-permit
+  consequence: "The Government will bring forward legislation to allow small and medium-sized businesses to reclaim Statutory Sick Pay (SSP) paid for staff sickness absence due to coronavirus."
+  guidance_prompt: Read the guidance
+  guidance_link_text: Claim for your employees' wages 
+  guidance_url: https://www.gov.uk/settled-status-eu-citizens-families
   criteria:
   - all_of:
     - 0-249-employees
@@ -35,6 +44,7 @@ actions:
   priority: 5
   title: Support for self-employed through the Self-employment Income Support Scheme
   title_url: https://www.gov.uk/family-permit
+  consequence: "The Self-employment Income Support Scheme (SEISS) will support self-employed individuals (including members of partnerships) whose income has been negatively impacted by COVID-19."
   criteria:
   - all_of:
     - 0-249-employees
@@ -43,6 +53,7 @@ actions:
   priority: 5
   title: Business Rates holiday for retail, hospitality and leisure
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - registered-england
@@ -55,6 +66,7 @@ actions:
   priority: 5
   title: Retail, Hospitality and Leisure Grant Funding
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - registered-england
@@ -70,6 +82,7 @@ actions:
   priority: 5
   title: Support for nursery businesses that pay business rates 
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - registered-england
@@ -79,6 +92,7 @@ actions:
   priority: 5
   title: Small Business Grant Funding
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - registered-england
@@ -88,6 +102,7 @@ actions:
   priority: 5
   title: Coronavirus Business Interruption Loan Scheme
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - not-self-employed
@@ -98,6 +113,7 @@ actions:
   priority: 5
   title: Covid-19 Corporate Financing Facility
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - not-self-employed
@@ -105,6 +121,7 @@ actions:
   priority: 5
   title: "Support for businesses paying tax: Time To Pay Service" 
   title_url: https://www.gov.uk/family-permit
+  consequence: "Some description."
   criteria:
   - all_of:
     - not-self-employed

--- a/lib/business_support_checker/actions.yaml
+++ b/lib/business_support_checker/actions.yaml
@@ -1,0 +1,113 @@
+---
+actions:
+- id: F001
+  priority: 5
+  title: Coronavirus Job retention Scheme 
+  title_url: https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status
+  criteria:
+  - all_of:
+    - not-self-employed
+- id: F002
+  priority: 5
+  title: Deferring VAT
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - any_of:
+    - 45m-plus-turnover 
+    - 85k-45m-turnover
+- id: F003
+  priority: 5
+  title: Deferring Self-Assessment payments on account
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - self-assessment-due-31-06-20
+- id: F004
+  priority: 5
+  title: Statutory Sick Pay Rebate
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - 0-249-employees
+    - not-self-employed
+    - self-assessment-due-31-06-20
+- id: F005
+  priority: 5
+  title: Support for self-employed through the Self-employment Income Support Scheme
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - 0-249-employees
+    - self-employed
+- id: F006
+  priority: 5
+  title: Business Rates holiday for retail, hospitality and leisure
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - registered-england
+    - pay-business-rates
+    - any_of:
+      - sector_retail
+      - sector_hospitality
+      - sector_leisure
+- id: F007
+  priority: 5
+  title: Retail, Hospitality and Leisure Grant Funding
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - registered-england
+    - pay-business-rates
+    - any_of:
+      - 15k-51k-property-rateable-value
+      - 0-15k-property-rateable-value
+    - any_of:
+      - sector_retail
+      - sector_hospitality
+      - sector_leisure
+- id: F008
+  priority: 5
+  title: Support for nursery businesses that pay business rates 
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - registered-england
+    - pay-business-rates
+    - sector_nurseries
+- id: F009
+  priority: 5
+  title: Small Business Grant Funding
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - registered-england
+    - 0-249-employees
+    - 0-15k-property-rateable-value
+- id: F010
+  priority: 5
+  title: Coronavirus Business Interruption Loan Scheme
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - not-self-employed
+    - any_of:
+      - 85k-45m-turnover
+      - 0-85k-turnover
+- id: F011
+  priority: 5
+  title: Covid-19 Corporate Financing Facility
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - not-self-employed
+- id: F012
+  priority: 5
+  title: "Support for businesses paying tax: Time To Pay Service" 
+  title_url: https://www.gov.uk/family-permit
+  criteria:
+  - all_of:
+    - not-self-employed
+    - any_of:
+      - 85k-45m-turnover
+      - 0-85k-turnover

--- a/lib/business_support_checker/criteria.yaml
+++ b/lib/business_support_checker/criteria.yaml
@@ -1,0 +1,48 @@
+---
+criteria:
+- text: Your business is registered in England
+  key: registered-england
+- text: Your business is registered in Scotland
+  key: registered-scotland
+- text: Your business is registered in Wales
+  key: registered-wales
+- text: Your business is registered in Northern Ireland
+  key: registered-northern-ireland
+- text: 'Your business has between 0 to 249 employees'
+  key: 0-249-employees
+- text: 'Your business has 250 or more employees'
+  key: 250-plus-employees
+- text: "You are self employed"
+  key: self-employeed
+- text: "You are not self employed"
+  key: not-self-employeed
+- text: "Your business has a turnover over £45 million"
+  key: 45m-plus-turnover
+- text: "Your business has a turnover between £85,000 and £45 million"
+  key: 85k-45m-turnover
+- text: "Your business has a turnover under £85,000"
+  key: 0-85k-turnover
+- text: "You pay business rates"
+  key: pay-business-rates
+- text: "You do not pay business rates"
+  key: no-pay-business-rates
+- text: "Your non-domestic business property has a rateable value over £51,000"
+  key: 51k-plus-property-rateable-value
+- text: "Your non-domestic business property has a rateable value over £15,000 and under £51,000"
+  key: 15k-51k-property-rateable-value
+- text: "Your non-domestic business property has a rateable value under £15,000"
+  key: 0-15k-property-rateable-value
+- text: "Your self assessment is due on the 31 of August 2020"
+  key: self-assessment-due-31-06-20
+- text: "Your self assessment is not due on the 31 of August 2020"
+  key: no-self-assessment-due-31-06-20
+- text: "Your business is in the retail sector"
+  key: sector-retail
+- text: "Your business is in the hospitality sector"
+  key: sector-hospitality
+- text: "Your business is in the leisure sector"
+  key: sector-leisure
+- text: "Your business is in the nurserises sector"
+  key: sector-nurseries
+- text: "None of the above"
+  key: sector-none

--- a/lib/business_support_checker/criteria/evaluator.rb
+++ b/lib/business_support_checker/criteria/evaluator.rb
@@ -1,0 +1,51 @@
+class BusinessSupportChecker::Criteria::Evaluator
+  def initialize(expression, selected_criteria)
+    @expression = expression
+    @selected_criteria = selected_criteria
+  end
+
+  def evaluate
+    return true if expression.blank?
+
+    evaluate_node(expression)
+  end
+
+  def self.evaluate(*args)
+    new(*args).evaluate
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :expression, :selected_criteria
+
+  def evaluate_node(node)
+    case node
+    when Array
+      evaluate_all_of(node)
+    when Hash
+      evaluate_hash(node)
+    when String
+      selected_criteria.include?(node)
+    end
+  end
+
+  def evaluate_hash(node)
+    if node["any_of"]
+      evaluate_any_of(node["any_of"])
+    elsif node["all_of"]
+      evaluate_all_of(node["all_of"])
+    else
+      raise "Unknown node: #{node}"
+    end
+  end
+
+  def evaluate_all_of(nodes)
+    nodes.all? { |node| evaluate_node(node) }
+  end
+
+  def evaluate_any_of(nodes)
+    nodes.any? { |node| evaluate_node(node) }
+  end
+end

--- a/lib/business_support_checker/criteria/extractor.rb
+++ b/lib/business_support_checker/criteria/extractor.rb
@@ -1,0 +1,15 @@
+class BusinessSupportChecker::Criteria::Extractor
+  class << self
+    def extract(expression)
+      case expression
+      when Array
+        expression.flat_map { |element| extract(element) }
+      when Hash
+        extract(expression.symbolize_keys.fetch(:any_of, [])) +
+          extract(expression.symbolize_keys.fetch(:all_of, []))
+      when String
+        [expression]
+      end
+    end
+  end
+end

--- a/lib/business_support_checker/criteria/filter.rb
+++ b/lib/business_support_checker/criteria/filter.rb
@@ -1,0 +1,39 @@
+class BusinessSupportChecker::Criteria::Filter
+  def call(selected_criteria)
+    loop do
+      old_size = selected_criteria.size
+      selected_criteria &= possible_criteria(selected_criteria)
+      assert_loop_terminates(selected_criteria, old_size)
+      break if selected_criteria.size == old_size
+    end
+
+    selected_criteria
+  end
+
+private
+
+  def assert_loop_terminates(selected_criteria, old_size)
+    return if selected_criteria.size <= old_size
+
+    raise "Number of filtered criteria is larger than number of original criteria"
+  end
+
+  def possible_criteria(selected_criteria)
+    relevant_questions = BusinessSupportChecker::Question.load_all
+      .select { |question| question.show?(selected_criteria) }
+
+    relevant_questions
+      .flat_map(&:options)
+      .flat_map { |o| filter_option_tree(o, selected_criteria) }
+      .map(&:value).compact
+  end
+
+  def filter_option_tree(option, selected_criteria)
+    return [] unless option.value.blank? ||
+      selected_criteria.include?(option.value)
+
+    [option] + option.sub_options.flat_map do |sub_option|
+      filter_option_tree(sub_option, selected_criteria)
+    end
+  end
+end

--- a/lib/business_support_checker/criteria/parser.rb
+++ b/lib/business_support_checker/criteria/parser.rb
@@ -1,0 +1,160 @@
+class BusinessSupportChecker::Criteria::Parser
+  def self.parse(string)
+    tokens = Lexer.tokenise(string)
+    ast = AST.parse(tokens)
+    Generator.generate(ast)
+  end
+
+  class Lexer
+    def self.tokenise(string)
+      scanner = StringScanner.new(string)
+      tokens = []
+
+      until scanner.eos?
+        if scanner.scan(/\s+/)
+          # ignore whitespace
+        elsif scanner.scan(/\(/)
+          tokens << { type: :open_parens }
+        elsif scanner.scan(/\)/)
+          tokens << { type: :close_parens }
+        elsif scanner.scan(/AND|OR/)
+          tokens << { type: :operator, value: scanner.matched }
+        elsif scanner.scan(/[\w-]+/)
+          tokens << { type: :identifier, value: scanner.matched }
+        else
+          raise "Unknown token."
+        end
+      end
+
+      tokens
+    end
+  end
+
+  class AST
+    def initialize(tokens)
+      @tokens = tokens
+    end
+
+    def parse
+      read_expression
+    end
+
+    def self.parse(*args)
+      new(*args).parse
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :tokens
+
+    def ensure_token
+      raise "Unexpected end" if tokens.empty?
+    end
+
+    def read_token(type)
+      ensure_token
+
+      token = tokens.shift
+      raise "Unknown token: #{token}" unless token[:type] == type
+
+      token
+    end
+
+    def is_token(type)
+      tokens.first && tokens.first[:type] == type
+    end
+
+    def is_operator(value)
+      is_token(:operator) && tokens.first[:value] == value
+    end
+
+    def read_expression
+      lhs = read_operand_expression
+      return lhs unless is_token(:operator)
+
+      read_binary_expression(lhs)
+    end
+
+    def read_operand_expression
+      ensure_token
+
+      case tokens.first[:type]
+      when :identifier
+        read_token(:identifier)
+      when :open_parens
+        read_token(:open_parens)
+        expr = read_expression
+        read_token(:close_parens)
+        expr
+      else
+        raise "Unknown operand: #{tokens.first}"
+      end
+    end
+
+    def read_binary_expression(lhs)
+      while is_token(:operator)
+        op_token = read_token(:operator)
+        operator = op_token[:value]
+        operands = [lhs, read_operand_expression]
+
+        while is_operator(operator)
+          read_token(:operator)
+          operands << read_operand_expression
+        end
+
+        lhs = { type: :operator, operator: operator, operands: operands }
+      end
+
+      lhs
+    end
+  end
+
+  class Generator
+    def initialize(ast)
+      @ast = ast
+    end
+
+    def generate
+      [generate_node(ast)]
+    end
+
+    def self.generate(*args)
+      new(*args).generate
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :ast
+
+    def generate_node(node)
+      case node[:type]
+      when :identifier
+        generate_identifer(node)
+      when :operator
+        generate_operator(node)
+      else
+        raise "Unknown node: #{node}"
+      end
+    end
+
+    def generate_identifer(node)
+      node[:value]
+    end
+
+    OPERATOR_KEYS = {
+      "AND" => "all_of",
+      "OR" => "any_of",
+    }.freeze
+
+    def generate_operator(node)
+      operands = node[:operands].map { |n| generate_node(n) }
+      key = OPERATOR_KEYS.fetch(node[:operator])
+
+      { key => operands }
+    end
+  end
+end

--- a/lib/business_support_checker/criterion.rb
+++ b/lib/business_support_checker/criterion.rb
@@ -1,0 +1,32 @@
+class BusinessSupportChecker::Criterion
+  include ActiveModel::Validations
+
+  CONFIG_PATH = Rails.root.join("lib/business_support_checker/criteria.yaml")
+
+  validates_presence_of :key, :text
+
+  attr_reader :key, :text
+
+  def initialize(attrs)
+    attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    validate!
+  end
+
+  def hash
+    key.hash
+  end
+
+  # Overwriting functionality of eql? so we can call uniq on an criteria array
+  def eql?(other)
+    key == other.key
+  end
+
+  def self.load_all
+    @load_all = nil if Rails.env.development?
+    @load_all ||= YAML.load_file(CONFIG_PATH)["criteria"].map { |c| new(c) }
+  end
+
+  def self.load_by(criteria_keys)
+    load_all.select { |c| criteria_keys.include?(c.key) }
+  end
+end

--- a/lib/business_support_checker/question.rb
+++ b/lib/business_support_checker/question.rb
@@ -1,0 +1,53 @@
+class BusinessSupportChecker::Question
+  include ActiveModel::Validations
+
+  CONFIG_PATH = Rails.root.join("lib/business_support_checker/questions.yaml")
+
+  validates_presence_of :key, :text
+  validates_inclusion_of :type, in: %w(single single_wrapped multiple multiple_grouped)
+  validate { errors.add("Options is not an array") unless options.is_a? Array }
+
+  attr_reader :key, :text, :description, :hint_title, :hint_text, :type, :criteria,
+              :detail_text, :detail_title, :caption
+
+  def initialize(attrs)
+    attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    validate!
+  end
+
+  def options(criteria_keys = nil)
+    return @options if criteria_keys.nil?
+
+    @options.reject { |option| criteria_keys.include?(option.exclude_if) }
+  end
+
+  def multiple?; type == "multiple" end
+
+  def multiple_grouped?; type == "multiple_grouped" end
+
+  def single_wrapped?; type == "single_wrapped" end
+
+  def self.find_by_key(key)
+    load_all.find { |q| q.key == key }
+  end
+
+  def show?(selected_criteria)
+    BrexitChecker::Criteria::Evaluator.evaluate(criteria, selected_criteria)
+  end
+
+  def all_values
+    sub_options = options.flat_map(&:sub_options)
+    (options + sub_options).map(&:value).compact
+  end
+
+  def self.load(params)
+    parsed_params = params.dup
+    parsed_params["options"] = Option.load_all(params["options"])
+    new(parsed_params)
+  end
+
+  def self.load_all
+    @load_all = nil if Rails.env.development?
+    @load_all ||= YAML.load_file(CONFIG_PATH)["questions"].map { |q| load(q) }
+  end
+end

--- a/lib/business_support_checker/question/option.rb
+++ b/lib/business_support_checker/question/option.rb
@@ -1,0 +1,22 @@
+class BusinessSupportChecker::Question::Option
+  include ActiveModel::Validations
+
+  validates_presence_of :label
+
+  attr_reader :label, :value, :sub_options, :hint_text, :exclude_if
+
+  def initialize(attrs)
+    attrs.each { |key, value| instance_variable_set("@#{key}", value) }
+    validate!
+  end
+
+  def self.load(params)
+    parsed_params = params.dup
+    parsed_params["sub_options"] = load_all(params["options"].to_a)
+    new(parsed_params)
+  end
+
+  def self.load_all(options)
+    options.map { |o| load(o) }
+  end
+end

--- a/lib/business_support_checker/questions.yaml
+++ b/lib/business_support_checker/questions.yaml
@@ -1,0 +1,96 @@
+---
+questions:
+  - key: registered-location
+    type: single
+    caption: About you and your family
+    text: 'Where is you business registered?'
+    options:
+      - label: England
+        value: registered-england
+      - label: Scotland
+        value: registered-scotland
+      - label: Wales
+        value: registered-wales
+      - label: Northern Ireland
+        value: registered-northern-ireland
+
+  - key: employee-number
+    type: single
+    caption: About you and your family
+    text: 'How many people do you employ?'
+    options:
+      - label: '0 to 249 employees'
+        value: 0-249-employees
+      - label: '250 or more employees'
+        value: 250-plus-employees
+
+  - key: self-employed
+    type: single
+    caption: About you and your family
+    text: 'Are you self-employed?'
+    options:
+      - label: "Yes"
+        value: self-employed
+      - label: "No"
+        value: not-self-employed
+
+  - key: turnover
+    type: single
+    caption: About you and your family
+    text: 'What is your turnover per year?'
+    options:
+      - label: "Over £45 million"
+        value: 45m-plus-turnover
+      - label: "Over £85,000 and under £45 million"
+        value: 85k-45m-turnover
+      - label: "Under £85,000 (i.e. you are not VAT registered)"
+        value: 0-85k-turnover
+
+  - key: business-rates
+    type: single
+    caption: About you and your family
+    text: 'Do you pay business rates?'
+    options:
+      - label: "Yes"
+        value: pay-business-rates
+      - label: "No"
+        value: no-pay-business-rates
+
+  - key: property-rateable-value
+    type: single
+    caption: About you and your family
+    text: 'What is the rateable value of non-domestic property?'
+    options:
+      - label: "Over £51,000"
+        value: 51k-plus-property-rateable-value
+      - label: "Over £15,000 and under £51,000"
+        value: 15k-51k-property-rateable-value
+      - label: "Under £15,000"
+        value: 0-15k-property-rateable-value
+
+  - key: self-assessment-due-31-06-20
+    type: single
+    caption: About you and your family
+    text: 'Are you due to pay a self-assessment payment on account by 31 July 2020?'
+    options:
+      - label: "Yes"
+        value: self-assessment-due-31-06-20
+      - label: "No"
+        value: no-self-assessment-due-31-06-20
+
+  - key: business-sector
+    caption: About your business
+    type: multiple
+    text: "What does your business or organisation do?"
+    hint_text: "Select all that apply."
+    options:
+      - label: "Retail"
+        value: sector-retail
+      - label: "Hospitality"
+        value: sector-hospitality
+      - label: "Leisure"
+        value: sector-leisure
+      - label: "Nurserises"
+        value: sector-nurseries
+      - label: "None of the above"
+        value: sector-none


### PR DESCRIPTION
Investigate adding a coronavirus business support checker by copying the transition checker pattern.

---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
