### PR TITLE
Don't render non-finder content items as search pages

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -12,6 +12,8 @@ class FindersController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        raise UnsupportedContentItem unless content_item.is_finder?
+
         show_page_variables
       end
       format.json do
@@ -35,6 +37,8 @@ class FindersController < ApplicationController
     end
   rescue ActionController::UnknownFormat
     render plain: "Not acceptable", status: :not_acceptable
+  rescue UnsupportedContentItem
+    render plain: "Not found", status: :not_found
   end
 
   def show_page_variables
@@ -47,6 +51,8 @@ class FindersController < ApplicationController
   end
 
 private
+
+  class UnsupportedContentItem < StandardError; end
 
   attr_reader :search_query
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -135,6 +135,7 @@ describe FindersController, type: :controller do
       it "returns a 404, rather than 5xx" do
         get :show, params: { slug: "does-not-exist" }
         expect(response.status).to eq(404)
+        expect(response.body).to include("404 error not found")
       end
 
       it "returns a 404, rather than 5xx for the atom feed" do
@@ -172,6 +173,13 @@ describe FindersController, type: :controller do
           }.to_json,
           headers: {},
         )
+      end
+
+      it "returns a 404 for HTML requests" do
+        get :show, params: { slug: "unpublished-finder" }
+
+        expect(response.status).to eq(404)
+        expect(response.body).to include("Not found")
       end
 
       it "returns a message indicating the atom feed has ended" do


### PR DESCRIPTION
This will help if we forget to unpublish a finder.

We have some quite interesting behaviour at the moment. Finder frontend will try to render any content item as a search page, which leads to interesting search results.

This will make things less interesting unfortunately.

Links to check:

_There's no link for an unpublished finder unfortunately, but the tests should cover it_

404: http://finder-front-bilbof-404-ianvvm.herokuapp.com/blah
200: https://finder-front-bilbof-404-ianvvm.herokuapp.com/search/all
200: http://finder-front-bilbof-404-ianvvm.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
