### PR TITLE
Reject alpha taxons from the topic selector

### DIFF
--- a/lib/registries/topic_taxonomy_registry.rb
+++ b/lib/registries/topic_taxonomy_registry.rb
@@ -45,17 +45,19 @@ module Registries
 
     def format_child_taxons(taxon)
       children = taxon.dig("links", "child_taxons") || []
-      formatted_children = children.map { |child_taxon|
-        format_taxon(child_taxon, taxon["content_id"])
-      }
+      formatted_children = children
+        .reject { |child_taxon| child_taxon["phase"] == "alpha" }
+        .map { |child_taxon| format_taxon(child_taxon, taxon["content_id"]) }
 
       formatted_children.sort_by { |child_taxon| child_taxon["title"] }
     end
 
     def fetch_level_one_taxons_from_api
       taxons = fetch_taxon.dig("links", "level_one_taxons") || []
-      sorted = taxons.sort_by { |taxon| taxon["title"] }
-      sorted.map { |taxon| fetch_taxon(taxon["base_path"]) }
+      taxons
+        .reject { |taxon| taxon["phase"] == "alpha" }
+        .sort_by { |taxon| taxon["title"] }
+        .map { |taxon| fetch_taxon(taxon["base_path"]) }
     end
 
     def fetch_taxon(base_path = "/")

--- a/spec/lib/registries/topic_taxonomy_registry_spec.rb
+++ b/spec/lib/registries/topic_taxonomy_registry_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
   let(:content_id_two) { SecureRandom.uuid }
   let(:top_level_taxon_one) { FactoryBot.build(:level_one_taxon_hash, content_id: content_id_one, title: content_id_one) }
   let(:top_level_taxon_two) { FactoryBot.build(:level_one_taxon_hash, content_id: content_id_two, title: content_id_two) }
+  let(:top_level_taxon_three) { FactoryBot.build(:level_one_taxon_hash, content_id: SecureRandom.uuid, title: "Alpha topic", phase: "alpha") }
 
   before :each do
     Rails.cache.clear
@@ -24,12 +25,12 @@ RSpec.describe Registries::TopicTaxonomyRegistry do
 
   describe "when topic taxonomy api is available" do
     before :each do
-      topic_taxonomy_has_taxons([top_level_taxon_one, top_level_taxon_two])
+      topic_taxonomy_has_taxons([top_level_taxon_one, top_level_taxon_two, top_level_taxon_three])
     end
 
     subject(:registry) { described_class.new }
 
-    it "will provide the taxonomy tree" do
+    it "will provide the taxonomy tree not including those in the alpha phase" do
       expect(registry.taxonomy_tree.keys).to match_array([content_id_one, content_id_two])
     end
 


### PR DESCRIPTION
In order to open the coronavirus taxon to publishers in Whitehall, we need to publish it.

The taxon will remain hidden from most things on the public facing site if it is in the `alpha` phase.  Unfortunately, the topic facet is not one of those things.

We're OK with it being ingested into the full taxonomy registry because this is just used to populate titles and other context on faceted search from topics and not the facets themselves.

The coronavirus taxon will be moved into the live or beta phase when we're happy that it is up to date with the tagged content.

## Search page examples to sanity check:

- https://finder-front-no-alpha-t-blobtp.herokuapp.com/search/all
- https://finder-front-no-alpha-t-blobtp.herokuapp.com/search/research-and-statistics
- https://finder-front-no-alpha-t-blobtp.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0

[Other finders](https://live-stuff.herokuapp.com/finders)
