### PR TITLE
Expand taxon registry in finder-frontend to render email signup choices

### DIFF
--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -30,11 +30,7 @@ private
   end
 
   def signup_presenter
-    @signup_presenter ||= SignupPresenter.new(content_item, taxon_facet, params)
-  end
-
-  def taxon_facet
-    TaxonFacet.new({}, filter_params.slice("level_one_taxon", "level_two_taxon", "topic"))
+    @signup_presenter ||= SignupPresenter.new(content_item, params)
   end
 
   def subscriber_list_params

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -34,7 +34,7 @@ private
   end
 
   def taxon_facet
-    TaxonFacet.new({}, filter_params.slice("level_one_taxon", "level_two_taxon"))
+    TaxonFacet.new({}, filter_params.slice("level_one_taxon", "level_two_taxon", "topic"))
   end
 
   def subscriber_list_params

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,7 +1,7 @@
 class EmailAlertSubscriptionsController < ApplicationController
   layout "finder_layout"
   protect_from_forgery except: :create
-  before_action :signup_presenter
+  before_action :signup_presenter, :selected_taxon
   helper_method :subscriber_list_params
 
   def create
@@ -31,6 +31,10 @@ private
 
   def signup_presenter
     @signup_presenter ||= SignupPresenter.new(content_item, params)
+  end
+
+  def selected_taxon
+    @selected_taxon ||= TaxonFacet.new({}, params.slice("level_one_taxon", "level_two_taxon", "topic")).selected_taxon_value
   end
 
   def subscriber_list_params

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,7 +1,7 @@
 class EmailAlertSubscriptionsController < ApplicationController
   layout "finder_layout"
   protect_from_forgery except: :create
-  before_action :signup_presenter, :set_taxon
+  before_action :signup_presenter, :set_taxons
   helper_method :subscriber_list_params
 
   def create
@@ -33,10 +33,10 @@ private
     @signup_presenter ||= SignupPresenter.new(content_item, params)
   end
 
-  def set_taxon
-    content_id = filter_params[:level_one_taxon]
-    @registry ||= Registries::BaseRegistries.new
-    @taxon ||= @registry.topic_taxon_with_content_id(content_id)
+  def set_taxons
+    @taxon_facet = TaxonFacet.new({}, { "level_one_taxon" => filter_params[:level_one_taxon], "level_two_taxon" => filter_params[:level_two_taxon] })
+    @level_one_taxon = @taxon_facet.selected_level_one_value
+    @sub_taxons = @level_one_taxon[:sub_topics] if @level_one_taxon
   end
 
   def subscriber_list_params

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,7 +1,7 @@
 class EmailAlertSubscriptionsController < ApplicationController
   layout "finder_layout"
   protect_from_forgery except: :create
-  before_action :signup_presenter, :set_taxons
+  before_action :signup_presenter
   helper_method :subscriber_list_params
 
   def create
@@ -30,13 +30,11 @@ private
   end
 
   def signup_presenter
-    @signup_presenter ||= SignupPresenter.new(content_item, params)
+    @signup_presenter ||= SignupPresenter.new(content_item, taxon_facet, params)
   end
 
-  def set_taxons
-    @taxon_facet = TaxonFacet.new({}, { "level_one_taxon" => filter_params[:level_one_taxon], "level_two_taxon" => filter_params[:level_two_taxon] })
-    @level_one_taxon = @taxon_facet.selected_level_one_value
-    @sub_taxons = @level_one_taxon[:sub_topics] if @level_one_taxon
+  def taxon_facet
+    TaxonFacet.new({}, filter_params.slice("level_one_taxon", "level_two_taxon"))
   end
 
   def subscriber_list_params

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -26,6 +26,10 @@ class ContentItem
     document_type == "redirect"
   end
 
+  def content_id
+    content_item_hash["content_id"]
+  end
+
   def description
     content_item_hash["description"]
   end

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -44,7 +44,16 @@ class TaxonFacet < FilterableFacet
   end
 
   def selected_taxon_value
-    selected_level_one_value || selected_level_two_value
+    selected_level_one_value || selected_level_two_value || selected_topic_value
+  end
+
+  def selected_topic_value
+    topic = flat_taxons.dig(@value_hash["topic"])
+    {
+      value: topic["content_id"],
+      text: topic["title"],
+      sub_topics: topic["children"],
+    }
   end
 
 private
@@ -64,6 +73,10 @@ private
       "parameter_key" => key,
       "value" => value[:value],
     }
+  end
+
+  def flat_taxons
+    registry.flat_taxonomy_tree
   end
 
   def level_one_taxons

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -47,20 +47,20 @@ class TaxonFacet < FilterableFacet
     selected_level_one_value || selected_level_two_value || selected_topic_value
   end
 
+private
+
   def selected_topic_value
     return unless @value_hash["topic"]
 
-    ContentItem.from_content_store(@value_hash["topic"]).content_id
-
+    content_id = ContentItem.from_content_store(@value_hash["topic"]).content_id
     topic = full_topic_taxonomy.taxonomy.dig(content_id)
+
     {
       value: topic["content_id"],
       text: topic["title"],
       sub_topics: topic["children"],
     }
   end
-
-private
 
   def value_fragments
     [

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -43,6 +43,12 @@ class TaxonFacet < FilterableFacet
     }
   end
 
+  def selected_level_one_value
+    @selected_level_one_value ||= level_one_taxons.find do |v|
+      v[:value] == @value_hash[LEVEL_ONE_TAXON_KEY]
+    end
+  end
+
 private
 
   def value_fragments
@@ -101,12 +107,6 @@ private
   def selected_level_two_value
     @selected_level_two_value ||= level_two_taxons.find do |v|
       v[:value] == @value_hash[LEVEL_TWO_TAXON_KEY]
-    end
-  end
-
-  def selected_level_one_value
-    @selected_level_one_value ||= level_one_taxons.find do |v|
-      v[:value] == @value_hash[LEVEL_ONE_TAXON_KEY]
     end
   end
 

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -43,10 +43,8 @@ class TaxonFacet < FilterableFacet
     }
   end
 
-  def selected_level_one_value
-    @selected_level_one_value ||= level_one_taxons.find do |v|
-      v[:value] == @value_hash[LEVEL_ONE_TAXON_KEY]
-    end
+  def selected_taxon_value
+    selected_level_one_value || selected_level_two_value
   end
 
 private
@@ -93,6 +91,7 @@ private
         {
           text: v["title"],
           value: v["content_id"],
+          sub_topics: v["children"],
           data_attributes: {
             track_category: "filterClicked",
             track_action: "level_two_taxon",
@@ -107,6 +106,12 @@ private
   def selected_level_two_value
     @selected_level_two_value ||= level_two_taxons.find do |v|
       v[:value] == @value_hash[LEVEL_TWO_TAXON_KEY]
+    end
+  end
+
+  def selected_level_one_value
+    @selected_level_one_value ||= level_one_taxons.find do |v|
+      v[:value] == @value_hash[LEVEL_ONE_TAXON_KEY]
     end
   end
 

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -48,7 +48,11 @@ class TaxonFacet < FilterableFacet
   end
 
   def selected_topic_value
-    topic = flat_taxons.dig(@value_hash["topic"])
+    return unless @value_hash["topic"]
+
+    ContentItem.from_content_store(@value_hash["topic"]).content_id
+
+    topic = full_topic_taxonomy.taxonomy.dig(content_id)
     {
       value: topic["content_id"],
       text: topic["title"],
@@ -75,12 +79,8 @@ private
     }
   end
 
-  def flat_taxons
-    registry.flat_taxonomy_tree
-  end
-
   def level_one_taxons
-    @level_one_taxons ||= registry.taxonomy_tree.values.map do |v|
+    @level_one_taxons ||= partial_topic_taxonomy.taxonomy_tree.values.map do |v|
       {
         value: v["content_id"],
         text: v["title"],
@@ -136,7 +136,11 @@ private
     { text: "All topics", value: "" }
   end
 
-  def registry
-    @registry ||= Registries::BaseRegistries.new.all["part_of_taxonomy_tree"]
+  def full_topic_taxonomy
+    @full_topic_taxonomy ||= Registries::BaseRegistries.new.all["full_topic_taxonomy"]
+  end
+
+  def partial_topic_taxonomy
+    @partial_topic_taxonomy ||= Registries::BaseRegistries.new.all["part_of_taxonomy_tree"]
   end
 end

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -10,16 +10,12 @@ class SignupPresenter
     @params = params
   end
 
-  def show_taxon_choices?
-    taxon_facet.query_params.compact.present?
-  end
-
-  def level_one_taxon
-    taxon_facet.selected_level_one_value
+  def selected_taxon
+    taxon_facet.selected_taxon_value
   end
 
   def sub_taxons
-    level_one_taxon[:sub_topics]
+    selected_taxon[:sub_topics]
   end
 
   def page_title

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -2,16 +2,19 @@ class SignupPresenter
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::CaptureHelper
 
-  attr_reader :content_item, :taxon_facet, :params
+  attr_reader :content_item, :params
 
-  def initialize(content_item, taxon_facet, params)
+  def initialize(content_item, params)
     @content_item = content_item
-    @taxon_facet = taxon_facet
     @params = params
   end
 
   def selected_taxon
     taxon_facet.selected_taxon_value
+  end
+
+  def taxon_facet
+    TaxonFacet.new({}, params.slice("level_one_taxon", "level_two_taxon", "topic"))
   end
 
   def sub_taxons

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,11 +1,25 @@
 class SignupPresenter
   include ActionView::Helpers::UrlHelper
   include ActionView::Helpers::CaptureHelper
-  attr_reader :content_item, :params
 
-  def initialize(content_item, params)
+  attr_reader :content_item, :taxon_facet, :params
+
+  def initialize(content_item, taxon_facet, params)
     @content_item = content_item
+    @taxon_facet = taxon_facet
     @params = params
+  end
+
+  def show_taxon_choices?
+    taxon_facet.query_params.compact.present?
+  end
+
+  def level_one_taxon
+    taxon_facet.selected_level_one_value
+  end
+
+  def sub_taxons
+    level_one_taxon[:sub_topics]
   end
 
   def page_title

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -9,18 +9,6 @@ class SignupPresenter
     @params = params
   end
 
-  def selected_taxon
-    taxon_facet.selected_taxon_value
-  end
-
-  def taxon_facet
-    TaxonFacet.new({}, params.slice("level_one_taxon", "level_two_taxon", "topic"))
-  end
-
-  def sub_taxons
-    selected_taxon[:sub_topics]
-  end
-
   def page_title
     "#{name} emails"
   end

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -26,20 +26,22 @@
           value: @signup_presenter.selected_taxon[:value],
           text: @signup_presenter.selected_taxon[:text],
           checked: true,
-          conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe,
+          conditional: @signup_presenter.sub_taxons.any? ? '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe : nil,
         }]
       } %>
 
-      <p>or only one of the following <%= @signup_presenter.sub_taxons.count %> topics</p>
+      <% if @signup_presenter.sub_taxons.any? %>
+        <p>or only one of the following <%= @signup_presenter.sub_taxons.count %> topics</p>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "subscriber_list_params[all_part_of_taxonomy_tree]",
-        items: @signup_presenter.sub_taxons.map { |sub_taxon| {
-          value: sub_taxon["content_id"],
-          text: sub_taxon["title"],
-          conditional: sub_taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{sub_taxon["description"]}</p>").html_safe : nil
-        } }
-      } %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "subscriber_list_params[all_part_of_taxonomy_tree]",
+          items: @signup_presenter.sub_taxons.map { |sub_taxon| {
+            value: sub_taxon["content_id"],
+            text: sub_taxon["title"],
+            conditional: sub_taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{sub_taxon["description"]}</p>").html_safe : nil
+          } }
+        } %>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Create subscription",

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -8,38 +8,86 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+
+  <% if @taxon %>
+    <%= render partial: 'govuk_publishing_components/components/title', locals: {
+      title: @taxon["title"],
+      context: "Email alert subscription"
+    } %>
+
+    <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
+
+    <%= form_tag email_alert_subscriptions_path, class: 'signup-choices' do %>
+      <p>Everything published to GOV.UK about</p>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "level_one_taxon",
+        id_prefix: "all",
+        items: [{
+          value: @taxon["content_id"],
+          text: @taxon["title"],
+          checked: true,
+          conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe
+        }]
+      } %>
+
+      <p>or only one of the following <%= @taxon["children"].count %> topics</p>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "level_two_taxon",
+        id_prefix: "topics",
+        items: @taxon["children"].each.map { |taxon| {
+          value: taxon["content_id"],
+          text: taxon["title"],
+          checked: taxon["content_id"] == @filter_params[:level_two_taxon],
+          conditional: taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{taxon['description']}</p>").html_safe : nil
+        } }
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create subscription",
+        margin_bottom: true
+      } %>
+    <% end %>
+
+  <% else %>
+
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
       title: @signup_presenter.name,
       context: "Email alert subscription"
     } %>
 
-    <% if @signup_presenter.can_modify_choices? %>
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: nil,
-        heading: @signup_presenter.name,
-        hint_text: "Choose the email alerts you need.",
-        items: @signup_presenter.choices_formatted,
-        visually_hide_heading: true
+    <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+      <% if @signup_presenter.can_modify_choices? %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: nil,
+          heading: @signup_presenter.name,
+          hint_text: "Choose the email alerts you need.",
+          items: @signup_presenter.choices_formatted,
+          visually_hide_heading: true
+        } %>
+      <% end %>
+
+      <% if @error_message.present? %>
+        <p class="signup-choices__message"><%= @error_message %></p>
+      <% end %>
+
+      <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
+        <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
+      <% end %>
+
+      <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
+        <div class="govspeak-wrapper">
+          <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+        </div>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create subscription",
+        margin_bottom: true
       } %>
-    <% end %>
-    <% if @error_message.present? %>
-      <p class="signup-choices__message"><%= @error_message %></p>
-    <% end %>
 
-    <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
-      <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
     <% end %>
-
-    <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
-      <div class="govspeak-wrapper">
-        <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
-      </div>
-    <% end %>
-
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Create subscription",
-      margin_bottom: true
-    } %>
   <% end %>
+
 </div>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,38 +9,36 @@
 
 <div class="govuk-width-container">
 
-  <% if @taxon %>
+  <% if @level_one_taxon %>
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @taxon["title"],
+      title: @level_one_taxon[:title],
       context: "Email alert subscription"
     } %>
 
     <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
 
-    <%= form_tag email_alert_subscriptions_path, class: 'signup-choices' do %>
+    <%= form_tag email_alert_subscriptions_path(@taxon_facet.query_params), class: 'signup-choices' do %>
       <p>Everything published to GOV.UK about</p>
 
       <%= render "govuk_publishing_components/components/radio", {
-        name: "level_one_taxon",
-        id_prefix: "all",
+        name: "subscriber_list_params[all_part_of_taxonomy_tree]",
         items: [{
-          value: @taxon["content_id"],
-          text: @taxon["title"],
-          checked: true,
-          conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe
+          value: @level_one_taxon[:value],
+          text: @level_one_taxon[:text],
+          checked: @filter_params[:level_two_taxon].blank?,
+          conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe,
         }]
       } %>
 
-      <p>or only one of the following <%= @taxon["children"].count %> topics</p>
+      <p>or only one of the following <%= @sub_taxons.count %> topics</p>
 
       <%= render "govuk_publishing_components/components/radio", {
-        name: "level_two_taxon",
-        id_prefix: "topics",
-        items: @taxon["children"].each.map { |taxon| {
-          value: taxon["content_id"],
-          text: taxon["title"],
-          checked: taxon["content_id"] == @filter_params[:level_two_taxon],
-          conditional: taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{taxon['description']}</p>").html_safe : nil
+        name: "subscriber_list_params[all_part_of_taxonomy_tree]",
+        items: @sub_taxons.map { |sub_taxon| {
+          value: sub_taxon["content_id"],
+          text: sub_taxon["title"],
+          checked: sub_taxon["content_id"] == @filter_params[:level_two_taxon],
+          conditional: sub_taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{sub_taxon["description"]}</p>").html_safe : nil
         } }
       } %>
 

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,32 +9,32 @@
 
 <div class="govuk-width-container">
 
-  <% if @level_one_taxon %>
+  <% if @signup_presenter.show_taxon_choices? %>
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @level_one_taxon[:title],
+      title: @signup_presenter.level_one_taxon[:title],
       context: "Email alert subscription"
     } %>
 
     <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
 
-    <%= form_tag email_alert_subscriptions_path(@taxon_facet.query_params), class: 'signup-choices' do %>
+    <%= form_tag email_alert_subscriptions_path(@signup_presenter.taxon_facet.query_params), class: 'signup-choices' do %>
       <p>Everything published to GOV.UK about</p>
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "subscriber_list_params[all_part_of_taxonomy_tree]",
         items: [{
-          value: @level_one_taxon[:value],
-          text: @level_one_taxon[:text],
-          checked: @filter_params[:level_two_taxon].blank?,
+          value: @signup_presenter.level_one_taxon[:value],
+          text: @signup_presenter.level_one_taxon[:text],
+          checked: @signup_presenter.level_one_taxon[:value] == @filter_params[:level_one_taxon],
           conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe,
         }]
       } %>
 
-      <p>or only one of the following <%= @sub_taxons.count %> topics</p>
+      <p>or only one of the following <%= @signup_presenter.sub_taxons.count %> topics</p>
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "subscriber_list_params[all_part_of_taxonomy_tree]",
-        items: @sub_taxons.map { |sub_taxon| {
+        items: @signup_presenter.sub_taxons.map { |sub_taxon| {
           value: sub_taxon["content_id"],
           text: sub_taxon["title"],
           checked: sub_taxon["content_id"] == @filter_params[:level_two_taxon],

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,9 +9,9 @@
 
 <div class="govuk-width-container">
 
-  <% if @signup_presenter.show_taxon_choices? %>
+  <% if @signup_presenter.selected_taxon %>
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup_presenter.level_one_taxon[:title],
+      title: @signup_presenter.selected_taxon[:title],
       context: "Email alert subscription"
     } %>
 
@@ -23,9 +23,9 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "subscriber_list_params[all_part_of_taxonomy_tree]",
         items: [{
-          value: @signup_presenter.level_one_taxon[:value],
-          text: @signup_presenter.level_one_taxon[:text],
-          checked: @signup_presenter.level_one_taxon[:value] == @filter_params[:level_one_taxon],
+          value: @signup_presenter.selected_taxon[:value],
+          text: @signup_presenter.selected_taxon[:text],
+          checked: true,
           conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe,
         }]
       } %>
@@ -37,7 +37,6 @@
         items: @signup_presenter.sub_taxons.map { |sub_taxon| {
           value: sub_taxon["content_id"],
           text: sub_taxon["title"],
-          checked: sub_taxon["content_id"] == @filter_params[:level_two_taxon],
           conditional: sub_taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{sub_taxon["description"]}</p>").html_safe : nil
         } }
       } %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,33 +9,33 @@
 
 <div class="govuk-width-container">
 
-  <% if @signup_presenter.selected_taxon %>
+  <% if @selected_taxon.present? %>
     <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup_presenter.selected_taxon[:title],
+      title: @selected_taxon[:title],
       context: "Email alert subscription"
     } %>
 
     <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
 
-    <%= form_tag email_alert_subscriptions_path(@signup_presenter.taxon_facet.query_params), class: 'signup-choices' do %>
+    <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
       <p>Everything published to GOV.UK about</p>
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "subscriber_list_params[all_part_of_taxonomy_tree]",
         items: [{
-          value: @signup_presenter.selected_taxon[:value],
-          text: @signup_presenter.selected_taxon[:text],
+          value: @selected_taxon[:value],
+          text: @selected_taxon[:text],
           checked: true,
-          conditional: @signup_presenter.sub_taxons.any? ? '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe : nil,
+          conditional: @selected_taxon[:sub_topics].any? ? '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe : nil,
         }]
       } %>
 
-      <% if @signup_presenter.sub_taxons.any? %>
-        <p>or only one of the following <%= @signup_presenter.sub_taxons.count %> topics</p>
+      <% if @selected_taxon[:sub_topics].any? %>
+        <p>or only one of the following <%= @selected_taxon[:sub_topics].count %> topics</p>
 
         <%= render "govuk_publishing_components/components/radio", {
           name: "subscriber_list_params[all_part_of_taxonomy_tree]",
-          items: @signup_presenter.sub_taxons.map { |sub_taxon| {
+          items: @selected_taxon[:sub_topics].map { |sub_taxon| {
             value: sub_taxon["content_id"],
             text: sub_taxon["title"],
             conditional: sub_taxon["description"].present? ? ("<p class=\"govuk-body\">This will include: #{sub_taxon["description"]}</p>").html_safe : nil

--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -37,7 +37,7 @@ module Registries
     def topic_taxon_with_content_id(content_id)
       topic_taxonomy
         .taxonomy_tree
-        .select { |key, value| key == content_id }
+        .select { |key, _value| key == content_id }
         .dig(content_id)
     end
 

--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -34,6 +34,13 @@ module Registries
       end
     end
 
+    def topic_taxon_with_content_id(content_id)
+      topic_taxonomy
+        .taxonomy_tree
+        .select { |key, value| key == content_id }
+        .dig(content_id)
+    end
+
   private
 
     def full_topic_taxonomy

--- a/lib/registries/base_registries.rb
+++ b/lib/registries/base_registries.rb
@@ -34,13 +34,6 @@ module Registries
       end
     end
 
-    def topic_taxon_with_content_id(content_id)
-      topic_taxonomy
-        .taxonomy_tree
-        .select { |key, _value| key == content_id }
-        .dig(content_id)
-    end
-
   private
 
     def full_topic_taxonomy

--- a/lib/registries/full_topic_taxonomy_registry.rb
+++ b/lib/registries/full_topic_taxonomy_registry.rb
@@ -39,6 +39,7 @@ module Registries
         taxon["content_id"] =>
         {
           "title" => taxon["title"],
+          "content_id" => taxon["content_id"],
           "base_path" => taxon["base_path"],
           "children" => formatted_children,
         },

--- a/lib/registries/full_topic_taxonomy_registry.rb
+++ b/lib/registries/full_topic_taxonomy_registry.rb
@@ -27,11 +27,20 @@ module Registries
     end
 
     def format_taxon(taxon)
+      formatted_children = Array(taxon.dig("links", "child_taxons")).map do |child|
+        {
+          "title" => child["title"],
+          "content_id" => child["content_id"],
+          "base_path" => child["base_path"],
+        }
+      end
+
       {
         taxon["content_id"] =>
         {
           "title" => taxon["title"],
           "base_path" => taxon["base_path"],
+          "children" => formatted_children,
         },
       }
     end

--- a/lib/registries/topic_taxonomy_registry.rb
+++ b/lib/registries/topic_taxonomy_registry.rb
@@ -8,42 +8,6 @@ module Registries
       @taxonomy_tree ||= fetch_from_cache
     end
 
-    def flat_taxonomy_tree
-      flatten_taxonomy(fetch_level_one_taxons_from_api)
-    end
-
-    def flatten_taxonomy(taxons)
-      return {} if taxons.empty?
-
-      taxons.inject({}) do |result, taxon|
-        child_taxons = taxon.dig("links", "child_taxons") || []
-
-        taxon_hash = format_taxon_flat(taxon)
-        child_taxon_hashes = flatten_taxonomy(child_taxons)
-
-        result.merge(taxon_hash).merge(child_taxon_hashes)
-      end
-    end
-
-    def format_taxon_flat(taxon)
-      formatted_children = Array(taxon.dig("links", "child_taxons")).map do |child|
-        {
-          "title" => child["title"],
-          "content_id" => child["content_id"],
-          "base_path" => child["base_path"],
-        }
-      end
-
-      {
-        taxon["base_path"] =>
-        {
-          "title" => taxon["title"],
-          "content_id" => taxon["content_id"],
-          "children" => formatted_children
-        }
-      }
-    end
-
     def values
       taxonomy_tree
     end

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -70,6 +70,7 @@ describe TaxonFacet do
         :text,
         :data_attributes,
         :selected,
+        :sub_topics,
       )
     end
 

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -101,4 +101,44 @@ describe TaxonFacet do
       specify { expect(subject.sentence_fragment).to be_nil }
     end
   end
+
+  describe "#selected_taxon_value" do
+    let(:level_one_taxons) do
+      JSON.parse(File.read(Rails.root.join("features/fixtures/level_one_taxon.json")))
+    end
+
+    before :each do
+      topic_taxonomy_has_taxons(level_one_taxons)
+    end
+
+    context "when a level one taxon is selected" do
+      subject { TaxonFacet.new({}, { "level_one_taxon" => "3cf97f69-84de-41ae-bc7b-7e2cc238fa58" }) } # /environment level one taxon
+
+      it "returns selected level one taxon value" do
+        expect(subject.selected_taxon_value[:text]).to eql "Environment"
+        expect(subject.selected_taxon_value[:value]).to eql "3cf97f69-84de-41ae-bc7b-7e2cc238fa58"
+        expect(subject.selected_taxon_value[:sub_topics].count).to eql 2
+      end
+    end
+
+    context "when a level two taxon is selected" do
+      subject { TaxonFacet.new({}, { "level_two_taxon" => "52ff5c99-a17b-42c4-a9d7-2cc92cccca39" }) } # /environment/food-and-faming level two taxon
+
+      it "returns selected level two taxon value" do
+        expect(subject.selected_taxon_value[:text]).to eql "Food and farming"
+        expect(subject.selected_taxon_value[:value]).to eql "52ff5c99-a17b-42c4-a9d7-2cc92cccca39"
+        expect(subject.selected_taxon_value[:sub_topics].count).to eql 1
+      end
+    end
+
+    context "when a topic is selected" do
+      subject { TaxonFacet.new({}, { "topic" => "/environment/farming-food-grants-payments" }) }
+
+      it "returns selected topic value" do
+        expect(subject.selected_taxon_value[:text]).to eql "Farming and food grants and payments"
+        expect(subject.selected_taxon_value[:value]).to eql "2368b8b1-9405-4e66-b396-a5d54b777a0a"
+        expect(subject.selected_taxon_value[:sub_topics].count).to eql 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Changes the email signup link on [topic pages](https://www.gov.uk/money) to go to [/search/all/email-signup](https://www.gov.uk/search/all/email-signup) with the appropriate taxon pre-selected.

This works for any taxon, at any level in the taxon tree.

https://trello.com/c/r7XXLulF/303-expand-taxon-registry-in-finder-frontend-to-render-email-signup-choices

---

## Search page examples to sanity check:

- https://finder-front-taxon-sign-7gfoam.herokuapp.com/search/all
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/search/research-and-statistics
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/get-ready-brexit-check/questions
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/drug-device-alerts
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/find-eu-exit-guidance-business
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-front-taxon-sign-7gfoam.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.