### PR TITLE
Reduce content item cache

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -8,7 +8,7 @@ module Services
   end
 
   def self.cached_content_item(base_path)
-    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 6.hours) do
+    Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 5.minutes) do
       GovukStatsd.time("content_store.fetch_request_time") do
         content_store.content_item(base_path).to_h
       end


### PR DESCRIPTION
We did this in expectation of a high load at the time of ["The Text Message"](https://github.com/alphagov/finder-frontend/commit/fa61402e1a4265e660101b5d30d4c82ce6b2c469).

5 minutes is plenty, because content store requests are pretty quick, and we do generally need to be responsive to changes in finder definitions. 

We cache these because it's not really necessary for these to be requested by every search as they don't change _that_ often. Search pages are some of the heavier weight pages on GOV.UK, and it's good to keep them snappy if possible. 
