### PR TITLE
Switch asset path and host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,11 @@ module FinderFrontend
     }
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = "/finder-frontend"
+    config.assets.prefix = "/assets/finder-frontend"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,10 +41,6 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  if ENV["GOVUK_ASSET_ROOT"].present?
-    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
-  end
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,10 +1,4 @@
 Rails.application.configure do
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -39,12 +33,7 @@ Rails.application.configure do
   config.assets.compile = false
   config.assets.digest = true
   config.assets.version = "1.0"
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
-  config.slimmer.asset_host = Plek.current.find("static")
   config.log_level = :info
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This configures this app to serve assets from the current host by
default rather than the GOVUK_ASSET_ROOT environment variable. This is
to support the switch of assets from assets.publishing.service.gov.uk to
www.gov.uk.

The host for assets can be specified with an ASSET_HOST env var which is
intended to be used in development environments where router isn't set
up for proxying. Unlike GOVUK_ASSET_ROOT this is expected to be app
specific hence why it doesn't have a GOVUK prefix.

This also removes some redundant config and comments.