### PR TITLE
Fix feedback component layout

### DIFF
--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -21,7 +21,9 @@
           <%= yield %>
         </div>
       </main>
-      <%= render 'govuk_publishing_components/components/feedback' %>
+      <div class="govuk-width-container">
+        <%= render 'govuk_publishing_components/components/feedback' %>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
- feedback component collides with the edges of the screen on mobile because it sits outside of any kind of page container styles
- fix is to wrap it in a govuk-width-container

This PR relates to this forthcoming change: https://github.com/alphagov/govuk_publishing_components/pull/1547, which removes the internal spacing on the feedback component. During testing for that PR, this problem was noticed. This PR should be moved and deployed before that PR.

Before:

<img width="414" alt="Screenshot 2020-06-10 at 13 51 13" src="https://user-images.githubusercontent.com/861310/84269757-8f9e2d00-ab21-11ea-95a4-bb5ed911e4bf.png">

After:

<img width="413" alt="Screenshot 2020-06-10 at 13 51 01" src="https://user-images.githubusercontent.com/861310/84269767-9462e100-ab21-11ea-82c8-0adea6cda4e2.png">



---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
