### PR TITLE
Retire feeds for the coronavirus topical event

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -26,10 +26,12 @@ class FindersController < ApplicationController
         end
       end
       format.atom do
-        @search_query = initialize_search_query(is_for_feed: true)
         if content_item.is_redirect?
           redirect_to_destination
+        elsif covid_topical_event_feed? # delete me after July 2020
+          show_retired_covid_feed
         else
+          @search_query = initialize_search_query(is_for_feed: true)
           expires_in(ATOM_FEED_MAX_AGE, public: true)
           @feed = AtomPresenter.new(content_item, results, facet_tags)
         end
@@ -196,5 +198,13 @@ private
 
   def debug_score?
     params[:debug_score]
+  end
+
+  def covid_topical_event_feed?
+    filter_params["topical_events"] && filter_params["topical_events"].include?("coronavirus-covid-19-uk-government-response")
+  end
+
+  def show_retired_covid_feed
+    render "finders/retired_covid_feed"
   end
 end

--- a/app/views/finders/retired_covid_feed.atom.builder
+++ b/app/views/finders/retired_covid_feed.atom.builder
@@ -1,0 +1,33 @@
+summary = <<~SUMMARY
+  <p>
+    We've changed the way coronavirus content is organised on GOV.​UK to help you find information more easily.
+  </p>
+
+  <p>
+    You might want to subscribe to any of the following feeds:
+    <ul>
+      <li><a href="#{absolute_url_for('/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c')}">All coronavirus content</a></li>
+      <li><a href="#{absolute_url_for('/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest')}">News and communications</a></li>
+      <li><a href="#{absolute_url_for('/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=policy_and_engagement&order=updated-newest')}">Policy papers and consultations</a></li>
+      <li><a href="#{absolute_url_for('/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=research_and_statistics&order=updated-newest')}">Research and statistics</a></li>
+    </ul>
+  </p>
+SUMMARY
+
+atom_feed do |feed|
+  feed.title("/#{@finder_slug}")
+  feed.updated(Time.zone.iso8601("2020-06-24T00:00:00"))
+
+  feed.entry(
+    nil,
+    id: EntryPresenter.feed_ended_id(feed, @finder_slug),
+    url: absolute_url_for("/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c"),
+  ) do |entry|
+    entry.title("This feed has ended")
+    entry.summary(summary, type: "html")
+    entry.updated(Time.zone.iso8601("2020-06-24T00:00:00").rfc3339)
+    entry.author do |author|
+      author.name("HM Government")
+    end
+  end
+end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -220,6 +220,19 @@ describe FindersController, type: :controller do
       end
     end
 
+    describe "Feeds for the retired coronavirus topical event" do
+      before do
+        stub_content_store_has_item("/search/all", all_content_finder)
+      end
+
+      it "returns a message indicating the atom feed has ended" do
+        get :show, params: { slug: "search/all", format: "atom", topical_events: %w[coronavirus-covid-19-uk-government-response] }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("We've changed the way coronavirus content is organised on GOV.​UK")
+      end
+    end
+
     describe "Show/Hiding site search form" do
       before do
         stub_content_store_has_item("/search/all", all_content_finder)


### PR DESCRIPTION
The topical event has been removed, as content is now tagged to the coronavirus taxonomy topic (and sub-topics) instead. This allows for greater granularity of notifications, whether that's email or RSS feed.

We've moved email subscriptions over, but we don't want to do that with feeds because:

 - the feeds are probably different because publishers' tagging is imperfect (potentially confusing RSS readers)
 - we want people to sign up for the feed _they_ want, not the feed we give them
 - we also don't want to build up reams of redirect logic.  I intend to delete this _soon_

We should be able to delete the redirect logic for this feed soon, once all RSS readers have had a chance to collect it.

It validates: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Ffinder-front-redirect-a-5m5fgb.herokuapp.com%2Fsearch%2Fall.atom%3Ftopical_events%255B%255D%3Dcoronavirus-covid-19-uk-government-response

https://trello.com/c/ssPOXxya/347-retire-topical-event-rss-feeds-in-finder-frontend


