### PR TITLE
Add tracking on Subscribe button for Transition alerts

### DIFF
--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -37,7 +37,12 @@
         <%= form_tag transition_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.email_signup.sign_up_button'),
-            inline_layout: true
+            inline_layout: true,
+            data_attributes: {
+              module: "track-click",
+              "track-category": "transition-email-alert",
+              "track-action": "subscribe",
+            }
           } %>
         <% end %>
       </div>


### PR DESCRIPTION
We want to be able to track user journeys on email signups.

https://trello.com/c/mTcA2hFA

<img width="1440" alt="Screenshot 2020-06-25 at 3 09 25 pm" src="https://user-images.githubusercontent.com/424772/85736108-1c3a1500-b6f6-11ea-9560-ebf3bb06c56c.png">

<img width="527" alt="Screenshot at Jun 25 3-09-53 pm" src="https://user-images.githubusercontent.com/424772/85736074-13494380-b6f6-11ea-9d90-0099dd253685.png">
