### PR TITLE
Add new grouping for Common Travel Area

### DIFF
--- a/lib/brexit_checker/group.rb
+++ b/lib/brexit_checker/group.rb
@@ -12,7 +12,8 @@ class BrexitChecker::Group
                                 living-uk
                                 working-uk
                                 studying-eu
-                                studying-uk]
+                                studying-uk
+                                common-travel-area]
 
   attr_reader :key, :heading
 

--- a/lib/brexit_checker/groups.yaml
+++ b/lib/brexit_checker/groups.yaml
@@ -18,3 +18,5 @@ groups:
   heading: Studying in the EU
 - key: studying-uk
   heading: Studying in the UK
+- key: common-travel-area
+  heading: Common Travel Area


### PR DESCRIPTION
This is added in advance of content that applies to this category. This won't be visible until there are actions/criteria that map to this.

https://trello.com/c/mtqrgCou/301-create-results-page-grouping-for-common-travel-area
