### PR TITLE
Remove custom "content_ids" for signup choices

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -64,7 +64,7 @@ class SignupPresenter
           {
             name: "filter[#{choice['facet_id']}][]",
             label: facet_choice["radio_button_name"],
-            value: facet_choice.fetch("content_id", nil) || facet_choice["key"],
+            value: facet_choice["key"],
             checked: facet_choice["prechecked"] || selected_choices.fetch(choice["facet_id"], []).include?(facet_choice["key"]),
           }
         end,


### PR DESCRIPTION
Related to: https://github.com/alphagov/govuk-content-schemas/pull/996

Previously we added this to support custom facet groups [1] [2]
with the Brexit Business finder, which was subsequently removed [3].

[1]: https://github.com/alphagov/finder-frontend/commit/86fb95a302c0681e7ecb19a15ce4a846502173ee
[2]: https://github.com/alphagov/search-api/pull/1558/commits/3bdde9b68d66ac78308b72d2f4da4fd28deb108f#diff-3eee213b7c8f76b443b911304c24c32eR19
[3]: https://github.com/alphagov/search-api/pull/1967/commits/7789a8ffb27fc012a2840c710bd406dde28f44a5



---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)