### PR TITLE
Order actions on the brexit checker results page by priority

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -12,7 +12,13 @@ module BrexitCheckerHelper
   end
 
   def filter_items(items, criteria_keys)
-    items.select { |i| i.show?(criteria_keys) }
+    filtered = items.select { |i| i.show?(criteria_keys) }
+    sorted_items(filtered)
+  end
+
+  def sorted_items(items)
+    descending = -1
+    items.sort_by { |action| [(action.priority * descending), action.title] }
   end
 
   def persistent_criteria_keys(question_criteria_keys)

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -177,7 +177,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     action = BrexitChecker::Action.find_by_id("T099")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
     data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
-    expect(data_track_action).to eq("Your business or organisation - 1.10 - Guidance")
+    expect(data_track_action).to eq("Your business or organisation - 1.3 - Guidance")
     action_is_shown(action)
     action_has_analytics(action)
   end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -3,12 +3,31 @@ require "spec_helper"
 describe BrexitCheckerHelper, type: :helper do
   describe "#filter_items" do
     it "filters actions that should be shown" do
-      action1 = instance_double BrexitChecker::Action, show?: true
-      action2 = instance_double BrexitChecker::Action, show?: false
+      action1 = instance_double BrexitChecker::Action, show?: true, priority: 1, title: "title"
+      action2 = instance_double BrexitChecker::Action, show?: false, priority: 1, title: "title"
       expect(action1).to receive(:show?).with([])
       expect(action2).to receive(:show?).with([])
       results = filter_items([action1, action2], [])
       expect(results).to eq([action1])
+    end
+
+    context "multiple actions with different priorities" do
+      let(:action1) { FactoryBot.build(:brexit_checker_action, priority: 1, title: "a title") }
+      let(:action2) { FactoryBot.build(:brexit_checker_action, priority: 2, title: "a title") }
+      let(:action3) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "a title") }
+      let(:action4) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "b title") }
+      let(:action5) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "c title") }
+      let(:criteria) { action1.criteria }
+
+      it "returns the filtered actions sorted by order of priority" do
+        results = filter_items([action1, action2, action3], criteria)
+        expect(results).to eq([action3, action2, action1])
+      end
+
+      it "returns the filtered actions sorted by order of priority and then title" do
+        results = filter_items([action1, action2, action3, action4, action5], criteria)
+        expect(results).to eq([action3, action4, action5, action2, action1])
+      end
     end
   end
 


### PR DESCRIPTION
## What

Order actions by priority on the brexit checker results page. If multiple actions have the same priority score, order them by priority then by title.

[trello](https://trello.com/c/MoAlk4BK/317-bug-checker-action-priority-score-not-working)

## Bug on live
[Link](https://www.gov.uk/transition-check/results?c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=provide-services-do-business-in-eu&c%5B%5D=haulage-goods-across-eu-borders&c%5B%5D=trade-developing&c%5B%5D=eu-domain&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

## Fixed version on review app
[Link](https://finder-front-priority-b-rde7xl.herokuapp.com/transition-check/results?c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=provide-services-do-business-in-eu&c%5B%5D=haulage-goods-across-eu-borders&c%5B%5D=trade-developing&c%5B%5D=eu-domain&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)