### PR TITLE
Add slimmer to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         dependency-type: direct
       - dependency-name: rubocop-govuk
         dependency-type: direct
+      - dependency-name: slimmer
+        dependency-type: direct
       # Framework gems
       - dependency-name: factory_bot
         dependency-type: direct


### PR DESCRIPTION
This got missed in the initial config creation.
As Slimmer is an internal gem, it should be added
to the config.

https://trello.com/c/uPoriyfJ/2049-add-dependabot-configuration-to-each-repo-blitz-pair


---

## Search page examples to sanity check:

- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/research-and-statistics
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/get-ready-brexit-check/questions
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://[HEROKU-APP-ID].herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://[HEROKU-APP-ID].herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
