### PR TITLE
Remove transition-check breadcrumb references

### DIFF
--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -18,10 +18,6 @@
         url: "/transition"
       },
       {
-        title: t('brexit_checker.breadcrumbs.brexit-check'),
-        url: "/transition-check"
-      },
-      {
         title: t('brexit_checker.breadcrumbs.results'),
         url: transition_checker_results_path(c: criteria_keys)
       }

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -29,10 +29,6 @@
       {
         title: t('brexit_checker.breadcrumbs.brexit-home'),
         url: "/transition"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-check'),
-        url: "/transition-check"
       }
     ]
   } %>

--- a/config/locales/en/brexit_checker/breadcrumbs.yml
+++ b/config/locales/en/brexit_checker/breadcrumbs.yml
@@ -3,6 +3,5 @@ en:
     breadcrumbs:
       home: Home
       brexit-home: Transition period
-      brexit-check: "Check how to get ready for new rules in 2021"
       questions: Questions
       results: Your results


### PR DESCRIPTION
This page is now only a redirect, so including it in navigation is not useful.

https://trello.com/c/vui7aBCS/327-review-checker-breadcrumb

Affected pages:

- https://finder-front-breadcrumb-eome0t.herokuapp.com//transition-check/results?c%5B%5D=import-from-eu&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation
- https://finder-front-breadcrumb-eome0t.herokuapp.com/transition-check/email-signup?c%5B%5D=import-from-eu&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation

