### PR TITLE
Fix yaml indentation

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -224,7 +224,7 @@ questions:
       - label: "EU"
         value: owns-operates-business-organisation-eu
       - label: "Somewhere else"
-    value: owns-operates-business-organisation-row
+        value: owns-operates-business-organisation-row
 
   - key: employ-eu-citizens
     caption: About your business


### PR DESCRIPTION
This value should be indented to the same level as the label above it.

Results in the "Somewhere else" option having no value on https://www.gov.uk/transition-check/questions?c%5B%5D=owns-operates-business-organisation&page=12 

Fixed version: https://finder-front-fix-missin-mzbzyw.herokuapp.com/transition-check/questions?c%5B%5D=owns-operates-business-organisation&page=12
