### PR TITLE
Remove question

### DIFF
--- a/lib/brexit_checker/questions.yaml
+++ b/lib/brexit_checker/questions.yaml
@@ -130,24 +130,6 @@ questions:
       - label: Take your pet or an assistance dog
         value: visiting-bring-pet
 
-  - key: move-eu
-    caption: About you and your family
-    criteria:
-      - all_of:
-        - nationality-uk
-        - any_of:
-          - living-uk
-          - living-ie
-          - living-row
-    type: single
-    text: Do you plan to move to the EU or visit for more than 90 days?
-    hint_text: This includes Switzerland, Norway, Iceland or Liechtenstein but does not include Ireland.
-    options:
-      - label: "Yes"
-        value: move-to-eu
-      - label: "No"
-        value: move-to-eu-no
-
   - key: returning
     caption: About you and your family
     criteria:


### PR DESCRIPTION
https://trello.com/c/VgbEYlwv/339-remove-checker-question-do-you-plan-to-move-to-the-eu-or-visit-for-more-than-90-days

There is no action for the "Do you plan to visit the EU for more than 90 days"
question yet, so we should remove it.

Any existing subscriptions will be persisted, so as long as we reinstate the
question with the same keys, it should just work.

