### PR TITLE
Update brexit checker email subscription content

### DIFF
--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -29,7 +29,9 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l"><%= t('brexit_checker.email_signup.sign_up_heading') %></h1>
         <%= t('brexit_checker.email_signup.sign_up_message').html_safe %>
-
+        <ul class="govuk-list govuk-list--bullet">
+          <%= t('brexit_checker.email_signup.sign_up_message_criteria').html_safe %>
+        </ul>
         <%= form_tag transition_checker_confirm_email_signup_path(c: criteria_keys), id: "checklist-email-signup" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.email_signup.sign_up_button'),

--- a/config/locales/en/brexit_checker/email_signup.yml
+++ b/config/locales/en/brexit_checker/email_signup.yml
@@ -6,5 +6,8 @@ en:
       sign_up_message: |
         <p class="govuk-body">You're signing up for email updates about changes to your results because of any additional arrangements between the UK and EU.</p>
         <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
-        <p class="govuk-body">You will only get updates based on your results.</p>
+        <p class="govuk-body">You will only get updates if:</p>
+      sign_up_message_criteria:
+        <li>there are changes to your results</li>
+        <li>questions or results are added which may affect you</li>
       sign_up_button: Subscribe


### PR DESCRIPTION
## Before
<img width="685" alt="Screenshot 2020-07-28 at 14 45 31" src="https://user-images.githubusercontent.com/17908089/88673878-06e34c80-d0e1-11ea-8c82-3d5e931a34f4.png">

## After
<img width="570" alt="Screenshot 2020-07-28 at 14 46 10" src="https://user-images.githubusercontent.com/17908089/88673943-182c5900-d0e1-11ea-8013-60f53374d800.png">

Release app: https://finder-front-email-subs-am7ebb.herokuapp.com/transition-check/email-signup

Trello: https://trello.com/c/5p5dshqe/337-update-email-subscription-page