### PR TITLE
Bug fix for Brexit checker action groupings

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -35,8 +35,8 @@ class BrexitCheckerController < ApplicationController
     @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
     @actions = filter_actions(all_actions, criteria_keys)
     @audience_actions = @actions.group_by(&:audience)
-    @business_results = audience_results.populate_business_groups
-    @citizen_results_groups = audience_results.populate_citizen_groups
+    @business_results = grouped_results.populate_business_groups
+    @citizen_results_groups = grouped_results.populate_citizen_groups
   end
 
   def email_signup; end
@@ -50,8 +50,8 @@ class BrexitCheckerController < ApplicationController
 
 private
 
-  def audience_results
-    @audience_results ||= BrexitChecker::ResultsAudiences.new(@audience_actions, @criteria)
+  def grouped_results
+    @grouped_results ||= BrexitChecker::Results::GroupByAudience.new(@audience_actions, @criteria)
   end
 
   def subscriber_list_options

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -34,9 +34,9 @@ class BrexitCheckerController < ApplicationController
     all_actions = BrexitChecker::Action.load_all
     @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
     @actions = filter_actions(all_actions, criteria_keys)
-    audience_actions = @actions.group_by(&:audience)
-    @business_results = BrexitChecker::ResultsAudiences.populate_business_groups(audience_actions["business"], @criteria)
-    @citizen_results_groups = BrexitChecker::ResultsAudiences.populate_citizen_groups(audience_actions["citizen"], @criteria)
+    @audience_actions = @actions.group_by(&:audience)
+    @business_results = audience_results.populate_business_groups
+    @citizen_results_groups = audience_results.populate_citizen_groups
   end
 
   def email_signup; end
@@ -49,6 +49,10 @@ class BrexitCheckerController < ApplicationController
   end
 
 private
+
+  def audience_results
+    @audience_results ||= BrexitChecker::ResultsAudiences.new(@audience_actions, @criteria)
+  end
 
   def subscriber_list_options
     path = transition_checker_results_path(c: criteria_keys)

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -33,7 +33,7 @@ class BrexitCheckerController < ApplicationController
   def results
     all_actions = BrexitChecker::Action.load_all
     @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
-    @actions = filter_items(all_actions, criteria_keys)
+    @actions = filter_actions(all_actions, criteria_keys)
     audience_actions = @actions.group_by(&:audience)
     @business_results = BrexitChecker::ResultsAudiences.populate_business_groups(audience_actions["business"], @criteria)
     @citizen_results_groups = BrexitChecker::ResultsAudiences.populate_citizen_groups(audience_actions["citizen"], @criteria)

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -11,14 +11,14 @@ module BrexitCheckerHelper
     "business-actions-criteria"
   end
 
-  def filter_items(items, criteria_keys)
-    filtered = items.select { |i| i.show?(criteria_keys) }
-    sorted_items(filtered)
+  def filter_actions(actions, criteria_keys)
+    filtered = actions.select { |a| a.show?(criteria_keys) }
+    sorted_actions(filtered)
   end
 
-  def sorted_items(items)
+  def sorted_actions(actions)
     descending = -1
-    items.sort_by { |action| [(action.priority * descending), action.title] }
+    actions.sort_by { |action| [(action.priority * descending), action.title] }
   end
 
   def persistent_criteria_keys(question_criteria_keys)

--- a/app/lib/brexit_checker/action.rb
+++ b/app/lib/brexit_checker/action.rb
@@ -62,6 +62,10 @@ class BrexitChecker::Action
     id == other.id
   end
 
+  def multiple_grouping_criteria?
+    grouping_criteria.count > 1
+  end
+
 private
 
   def has_criteria

--- a/app/lib/brexit_checker/group.rb
+++ b/app/lib/brexit_checker/group.rb
@@ -27,6 +27,10 @@ class BrexitChecker::Group
     @load_all ||= YAML.load_file(GROUPS_PATH)["groups"].map { |a| new(a) }
   end
 
+  def self.find_by(key)
+    load_all.detect { |group| group.key == key }
+  end
+
   delegate :hash, to: :key
 
   def eql?(other)

--- a/app/lib/brexit_checker/group.rb
+++ b/app/lib/brexit_checker/group.rb
@@ -15,7 +15,7 @@ class BrexitChecker::Group
                                 studying-uk
                                 common-travel-area]
 
-  attr_reader :key, :heading
+  attr_reader :key, :heading, :priority
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/app/lib/brexit_checker/groups.yaml
+++ b/app/lib/brexit_checker/groups.yaml
@@ -2,21 +2,31 @@
 groups:
 - key: visiting-eu
   heading: Visiting the EU
+  priority: 9
 - key: visiting-uk
   heading: Visiting the UK
+  priority: 8
 - key: visiting-ie
   heading: Visiting Ireland
+  priority: 7
 - key: living-eu
   heading: Living in the EU
+  priority: 6
 - key: living-ie
   heading: Living in Ireland
+  priority: 6
 - key: living-uk
   heading: Living in the UK
+  priority: 6
 - key: working-uk
   heading: Working in the UK
+  priority: 5
 - key: studying-eu
   heading: Studying in the EU
+  priority: 4
 - key: studying-uk
   heading: Studying in the UK
+  priority: 3
 - key: common-travel-area
   heading: Common Travel Area
+  priority: 1

--- a/app/lib/brexit_checker/results/criteria_filter.rb
+++ b/app/lib/brexit_checker/results/criteria_filter.rb
@@ -1,0 +1,33 @@
+class BrexitChecker::Results::CriteriaFilter
+  attr_reader :action, :group_key, :selected_criteria
+
+  def initialize(action, group_key, selected_criteria)
+    @action = action
+    @group_key = group_key
+    @selected_criteria = selected_criteria
+  end
+
+  def self.call(*args)
+    new(*args).filter
+  end
+
+  def filter
+    action.multiple_grouping_criteria? ? filtered_criteria : criteria
+  end
+
+private
+
+  def filtered_criteria
+    criteria.reject do |criterion|
+      irrelevant_criteria_keys.include? criterion.key
+    end
+  end
+
+  def irrelevant_criteria_keys
+    action.grouping_criteria - [group_key]
+  end
+
+  def criteria
+    action.all_criteria & selected_criteria
+  end
+end

--- a/app/lib/brexit_checker/results/group_by_audience.rb
+++ b/app/lib/brexit_checker/results/group_by_audience.rb
@@ -1,4 +1,4 @@
-class BrexitChecker::ResultsAudiences
+class BrexitChecker::Results::GroupByAudience
   attr_reader :citizen_actions, :business_actions, :criteria
 
   def initialize(actions, criteria)
@@ -21,21 +21,22 @@ class BrexitChecker::ResultsAudiences
 
     citizen_actions.each_with_object([]) do |action, grouped_actions|
       next if action.grouping_criteria.empty?
-        group_key_array(action).each do |key|
-          group = BrexitChecker::Group.find_by(key)
-          next if grouped_actions.any? { |actions| actions[:group] == group }
 
-          grouped_actions << {
-            group: group,
-            actions: actions_for_group(group, citizen_actions),
-            criteria: criteria_for_group(group, citizen_actions),
-          }
-        end
+      group_key_array(action).each do |key|
+        group = BrexitChecker::Group.find_by(key)
+        next if grouped_actions.any? { |actions| actions[:group] == group }
+
+        grouped_actions << {
+          group: group,
+          actions: actions_for_group(group, citizen_actions),
+          criteria: criteria_for_group(group, citizen_actions),
+        }
+      end
       sort_by_priority(grouped_actions)
     end
   end
 
-  private
+private
 
   def group_key_array(action)
     action.multiple_grouping_criteria? ? selected_grouping_criteria(action) : action.grouping_criteria
@@ -43,7 +44,7 @@ class BrexitChecker::ResultsAudiences
 
   def sort_by_priority(grouped)
     descending = -1
-    grouped.sort_by! { |actions| [(actions[:group].priority * descending ), actions[:group].key] }
+    grouped.sort_by! { |actions| [(actions[:group].priority * descending), actions[:group].key] }
   end
 
   def selected_grouping_criteria(action)
@@ -63,13 +64,13 @@ class BrexitChecker::ResultsAudiences
   end
 
   def criteria_for_group(group, actions)
-    actions_for_group(group, actions).map do |action|
+    actions_for_group(group, actions).map { |action|
       if action.multiple_grouping_criteria?
         filtered_criteria(action, group.key)
       else
         criteria_for_action(action)
       end
-    end.flatten.uniq
+    }.flatten.uniq
   end
 
   def filtered_criteria(action, group_key)

--- a/app/lib/brexit_checker/results/group_by_audience.rb
+++ b/app/lib/brexit_checker/results/group_by_audience.rb
@@ -65,21 +65,7 @@ private
 
   def criteria_for_group(group, actions)
     actions_for_group(group, actions).map { |action|
-      if action.multiple_grouping_criteria?
-        filtered_criteria(action, group.key)
-      else
-        criteria_for_action(action)
-      end
+      BrexitChecker::Results::CriteriaFilter.call(action, group.key, criteria)
     }.flatten.uniq
-  end
-
-  def filtered_criteria(action, group_key)
-    unfiltered = criteria_for_action(action)
-    rogue_criteria_keys = (action.grouping_criteria - [group_key])
-    unfiltered.reject { |criterion| rogue_criteria_keys.include? criterion.key }
-  end
-
-  def criteria_for_action(action)
-    (action.all_criteria & criteria).flatten.uniq
   end
 end

--- a/app/lib/brexit_checker/results_audiences.rb
+++ b/app/lib/brexit_checker/results_audiences.rb
@@ -12,17 +12,36 @@ class BrexitChecker::ResultsAudiences
     def populate_citizen_groups(audience_actions, selected_criteria)
       return [] if audience_actions.blank? || selected_criteria.blank?
 
-      BrexitChecker::Group.load_all.each_with_object([]) do |group, result|
-        selected_actions = group.actions & audience_actions
-        unless selected_actions.empty?
-          result << {
+      audience_actions.each_with_object([]) do |action, grouped_actions|
+        next if action.grouping_criteria.empty?
+
+        group_keys =
+          multiple_grouping_criteria?(action) ? selected_group(action, selected_criteria) : action.grouping_criteria
+        group_keys.each do |key|
+          group = BrexitChecker::Group.find_by(key)
+          next if grouped_actions.any? { |actions| actions[:group] == group }
+          selected_actions = group.actions & audience_actions
+          grouped_actions << {
             group: group,
             actions: selected_actions,
             criteria: selected_actions.flat_map(&:all_criteria).uniq & selected_criteria,
           }
         end
-        result
+        grouped_actions
       end
+    end
+
+    def selected_group(action, selected_criteria)
+      criteria_keys = selected_criteria.map(&:key)
+      action.grouping_criteria.select { |group_key| criteria_keys.include? group_key }
+    end
+
+    def all_groups
+      @all_groups ||= BrexitChecker::Group.load_all
+    end
+
+    def multiple_grouping_criteria?(action)
+      action.grouping_criteria.count > 1
     end
   end
 end

--- a/app/lib/brexit_checker/results_audiences.rb
+++ b/app/lib/brexit_checker/results_audiences.rb
@@ -1,79 +1,84 @@
 class BrexitChecker::ResultsAudiences
-  class << self
-    def populate_business_groups(audience_actions, selected_criteria)
-      return {} if audience_actions.blank? || selected_criteria.blank?
+  attr_reader :citizen_actions, :business_actions, :criteria
 
-      {
-        actions: audience_actions,
-        criteria: audience_actions.flat_map(&:all_criteria).uniq & selected_criteria,
-      }
-    end
+  def initialize(actions, criteria)
+    @citizen_actions = actions["citizen"]
+    @business_actions = actions["business"]
+    @criteria = criteria
+  end
 
-    def populate_citizen_groups(audience_actions, selected_criteria)
-      return [] if audience_actions.blank? || selected_criteria.blank?
+  def populate_business_groups
+    return {} if business_actions.blank? || criteria.blank?
 
-      audience_actions.each_with_object([]) do |action, grouped_actions|
-        next if action.grouping_criteria.empty?
+    {
+      actions: business_actions,
+      criteria: business_actions.flat_map(&:all_criteria).uniq & criteria,
+    }
+  end
 
-        group_key_array(action, selected_criteria).each do |key|
+  def populate_citizen_groups
+    return [] if citizen_actions.blank? || criteria.blank?
+
+    citizen_actions.each_with_object([]) do |action, grouped_actions|
+      next if action.grouping_criteria.empty?
+        group_key_array(action).each do |key|
           group = BrexitChecker::Group.find_by(key)
           next if grouped_actions.any? { |actions| actions[:group] == group }
 
           grouped_actions << {
             group: group,
-            actions: actions_for_group(audience_actions, group),
-            criteria: criteria_for_group(audience_actions, group, selected_criteria),
+            actions: actions_for_group(group, citizen_actions),
+            criteria: criteria_for_group(group, citizen_actions),
           }
         end
-        sort_by_priority(grouped_actions)
+      sort_by_priority(grouped_actions)
+    end
+  end
+
+  private
+
+  def group_key_array(action)
+    action.multiple_grouping_criteria? ? selected_grouping_criteria(action) : action.grouping_criteria
+  end
+
+  def sort_by_priority(grouped)
+    descending = -1
+    grouped.sort_by! { |actions| [(actions[:group].priority * descending ), actions[:group].key] }
+  end
+
+  def selected_grouping_criteria(action)
+    action.grouping_criteria.select { |group_key| criteria_keys.include? group_key }
+  end
+
+  def all_groups
+    @all_groups ||= BrexitChecker::Group.load_all
+  end
+
+  def actions_for_group(group, actions)
+    actions & group.actions
+  end
+
+  def criteria_keys
+    criteria.map(&:key)
+  end
+
+  def criteria_for_group(group, actions)
+    actions_for_group(group, actions).map do |action|
+      if action.multiple_grouping_criteria?
+        filtered_criteria(action, group.key)
+      else
+        criteria_for_action(action)
       end
-    end
+    end.flatten.uniq
+  end
 
-    def group_key_array(action, selected_criteria)
-      multiple_grouping_criteria?(action) ? selected_group(action, selected_criteria) : action.grouping_criteria
-    end
+  def filtered_criteria(action, group_key)
+    unfiltered = criteria_for_action(action)
+    rogue_criteria_keys = (action.grouping_criteria - [group_key])
+    unfiltered.reject { |criterion| rogue_criteria_keys.include? criterion.key }
+  end
 
-    def sort_by_priority(grouped)
-      descending = -1
-      grouped.sort_by! { |actions| [(actions[:group].priority * descending ), actions[:group].key] }
-    end
-
-    def selected_group(action, selected_criteria)
-      criteria_keys = selected_criteria.map(&:key)
-      action.grouping_criteria.select { |group_key| criteria_keys.include? group_key }
-    end
-
-    def all_groups
-      @all_groups ||= BrexitChecker::Group.load_all
-    end
-
-    def actions_for_group(audience_actions, group)
-      audience_actions & group.actions
-    end
-
-    def criteria_for_group(audience_actions, group, selected_criteria)
-      actions_for_group(audience_actions, group).map do |action|
-        if multiple_grouping_criteria?(action)
-          filtered_criteria(selected_criteria, action, group.key)
-        else
-          criteria_for_action(action, selected_criteria)
-        end
-      end.flatten.uniq
-    end
-
-    def filtered_criteria(selected_criteria, action, group_key)
-      criteria = criteria_for_action(action, selected_criteria )
-      rogue_criteria_keys = (action.grouping_criteria - [group_key])
-      criteria.reject { |criterion| rogue_criteria_keys.include? criterion.key }
-    end
-
-    def criteria_for_action(action, selected_criteria)
-      c = (action.all_criteria & selected_criteria)
-      c.flatten.uniq
-    end
-
-    def multiple_grouping_criteria?(action)
-      action.grouping_criteria.count > 1
-    end
+  def criteria_for_action(action)
+    (action.all_criteria & criteria).flatten.uniq
   end
 end

--- a/app/lib/brexit_checker/results_audiences.rb
+++ b/app/lib/brexit_checker/results_audiences.rb
@@ -27,8 +27,13 @@ class BrexitChecker::ResultsAudiences
             criteria: selected_actions.flat_map(&:all_criteria).uniq & selected_criteria,
           }
         end
-        grouped_actions
+        sort_by_priority(grouped_actions)
       end
+    end
+
+    def sort_by_priority(grouped)
+      descending = -1
+      grouped.sort_by! { |actions| [(actions[:group].priority * descending ), actions[:group].key] }
     end
 
     def selected_group(action, selected_criteria)

--- a/spec/factories/brexit_checker/group.rb
+++ b/spec/factories/brexit_checker/group.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :brexit_checker_group, class: BrexitChecker::Group do
     key { "living-uk" }
     heading { "You live in the UK" }
-
+    priority { 6 }
     initialize_with { BrexitChecker::Group.new(attributes) }
   end
 end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -164,7 +164,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     action = BrexitChecker::Action.find_by_id("S001")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
     data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
-    expect(data_track_action).to eq("You and your family - Living in the UK - 4.1 - Guidance")
+    expect(data_track_action).to eq("You and your family - Living in the UK - 2.1 - Guidance")
     action_is_shown(action)
     action_has_analytics(action)
   end

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
 describe BrexitCheckerHelper, type: :helper do
-  describe "#filter_items" do
+  describe "#filter_actions" do
     it "filters actions that should be shown" do
       action1 = instance_double BrexitChecker::Action, show?: true, priority: 1, title: "title"
       action2 = instance_double BrexitChecker::Action, show?: false, priority: 1, title: "title"
       expect(action1).to receive(:show?).with([])
       expect(action2).to receive(:show?).with([])
-      results = filter_items([action1, action2], [])
+      results = filter_actions([action1, action2], [])
       expect(results).to eq([action1])
     end
 
@@ -20,12 +20,12 @@ describe BrexitCheckerHelper, type: :helper do
       let(:criteria) { action1.criteria }
 
       it "returns the filtered actions sorted by order of priority" do
-        results = filter_items([action1, action2, action3], criteria)
+        results = filter_actions([action1, action2, action3], criteria)
         expect(results).to eq([action3, action2, action1])
       end
 
       it "returns the filtered actions sorted by order of priority and then title" do
-        results = filter_items([action1, action2, action3, action4, action5], criteria)
+        results = filter_actions([action1, action2, action3, action4, action5], criteria)
         expect(results).to eq([action3, action4, action5, action2, action1])
       end
     end

--- a/spec/lib/brexit_checker/action_spec.rb
+++ b/spec/lib/brexit_checker/action_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe BrexitChecker::Action do
       allow(BrexitChecker::Criterion).to receive(:load_all).and_return([criteria1, criteria2])
     end
 
-    it "returns a single criteira key from the action" do
+    it "returns a single criteria key from the action" do
       expect(action1.all_criteria_keys).to eq(%w[living-uk])
     end
 
@@ -116,6 +116,16 @@ RSpec.describe BrexitChecker::Action do
 
     it "correctly removes duplicates from an array by id" do
       expect([action1, action2, action3].uniq.map(&:id)).to eq(%w[S01 S02])
+    end
+  end
+
+  describe "#multiple_grouping_criteria?" do
+    let(:action1) { FactoryBot.build(:brexit_checker_action, :citizen, grouping_criteria: %w[living-uk]) }
+    let(:action2) { FactoryBot.build(:brexit_checker_action, :citizen, grouping_criteria: %w[living-uk visiting-eu]) }
+
+    it "returns true if action has more than one grouping criteria" do
+      expect(action1.multiple_grouping_criteria?).to be false
+      expect(action2.multiple_grouping_criteria?).to be true
     end
   end
 end

--- a/spec/lib/brexit_checker/group_spec.rb
+++ b/spec/lib/brexit_checker/group_spec.rb
@@ -1,10 +1,27 @@
 require "spec_helper"
 
 RSpec.describe BrexitChecker::Group do
+  let(:action1) { FactoryBot.build(:brexit_checker_action, id: "S01", grouping_criteria: %w[visiting-eu]) }
+  let(:action2) { FactoryBot.build(:brexit_checker_action, id: "S02", grouping_criteria: %w[living-ie]) }
+  let(:action3) { FactoryBot.build(:brexit_checker_action, id: "S03", grouping_criteria: %w[living-ie]) }
+  let(:group1) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu") }
+  let(:group2) { FactoryBot.build(:brexit_checker_group, key: "living-ie") }
+  let(:group3) { FactoryBot.build(:brexit_checker_group, key: "studying-uk") }
+
   describe "factories" do
     it "has a valid default factory" do
       group = FactoryBot.build(:brexit_checker_group)
       expect(group.valid?).to be(true)
+    end
+  end
+
+  describe ".find_all" do
+    before :each do
+      allow(described_class).to receive(:load_all).and_return([group1, group2, group3])
+    end
+
+    it "returns a group by key" do
+      expect(described_class.find_by("living-ie")).to eq group2
     end
   end
 
@@ -19,13 +36,6 @@ RSpec.describe BrexitChecker::Group do
   end
 
   describe "#actions" do
-    let(:action1) { FactoryBot.build(:brexit_checker_action, id: "S01", grouping_criteria: %w[visiting-eu]) }
-    let(:action2) { FactoryBot.build(:brexit_checker_action, id: "S02", grouping_criteria: %w[living-ie]) }
-    let(:action3) { FactoryBot.build(:brexit_checker_action, id: "S03", grouping_criteria: %w[living-ie]) }
-    let(:group1) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu") }
-    let(:group2) { FactoryBot.build(:brexit_checker_group, key: "living-ie") }
-    let(:group3) { FactoryBot.build(:brexit_checker_group, key: "studying-uk") }
-
     before :each do
       allow(BrexitChecker::Action).to receive(:load_all).and_return([action1, action2, action3])
     end

--- a/spec/lib/brexit_checker/results/criteria_filter_spec.rb
+++ b/spec/lib/brexit_checker/results/criteria_filter_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe BrexitChecker::Results::CriteriaFilter do
+  let(:criteria_1) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu") }
+  let(:criteria_2) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-uk") }
+  let(:criteria_3) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie") }
+  let(:criteria) { [{ "all_of" => [criteria_1.key, criteria_2.key] }] }
+  let(:group_1) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu") }
+  let(:group_2) { FactoryBot.build(:brexit_checker_group, key: "visiting-uk") }
+  let(:action_1) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: criteria, grouping_criteria: [group_1.key]) }
+  let(:action_2) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: criteria, grouping_criteria: [group_1.key, group_2.key]) }
+  let(:selected_criteria) { [criteria_1, criteria_2, criteria_3] }
+
+  before :each do
+    allow(BrexitChecker::Criterion).to receive(:load_all).and_return([criteria_1, criteria_2, criteria_3])
+  end
+
+  describe "#call" do
+    context "when the action has a single grouping criteria" do
+      subject { described_class.call(action_1, group_1.key, selected_criteria) }
+      it "returns all of the action's criteria" do
+        expect(subject).to eq([criteria_1, criteria_2])
+      end
+    end
+
+    context "when the action has multiple grouping criteria" do
+      subject { described_class.call(action_2, group_1.key, selected_criteria) }
+      it "returns only criteria that relate to group" do
+        expect(subject).to eq([criteria_1])
+      end
+    end
+  end
+end

--- a/spec/lib/brexit_checker/results/group_by_audience_spec.rb
+++ b/spec/lib/brexit_checker/results/group_by_audience_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe BrexitChecker::ResultsAudiences do
+describe BrexitChecker::Results::GroupByAudience do
   describe "#populate_citizen_groups" do
     let(:living_uk) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk") }
     let(:visiting_driving) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving") }

--- a/spec/lib/brexit_checker/results_audiences_spec.rb
+++ b/spec/lib/brexit_checker/results_audiences_spec.rb
@@ -2,28 +2,28 @@ require "spec_helper"
 
 describe BrexitChecker::ResultsAudiences do
   describe "#populate_citizen_groups" do
-    living_uk = FactoryBot.build(:brexit_checker_criterion, key: "living-uk")
-    visiting_driving = FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving")
-    visiting_bring_pet = FactoryBot.build(:brexit_checker_criterion, key: "visiting-bring-pet")
-    visiting_eu = FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu")
-    visiting_ie = FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie")
+    let(:living_uk) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk") }
+    let(:visiting_driving) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving") }
+    let(:visiting_bring_pet) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-bring-pet") }
+    let(:visiting_eu) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu") }
+    let(:visiting_ie) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie") }
 
-    action1_criteria = [{ "all_of" => [living_uk.key] }]
-    action1 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 1", criteria: action1_criteria, grouping_criteria: %w[living-uk])
+    let(:action1_criteria) { [{ "all_of" => [living_uk.key] }] }
+    let(:action1) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 1", criteria: action1_criteria, grouping_criteria: %w[living-uk]) }
 
-    action2_criteria = [{ "all_of" => [visiting_driving.key] }]
-    action2 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 2", criteria: action2_criteria, grouping_criteria: %w[visiting-eu])
+    let(:action2_criteria) { [{ "all_of" => [visiting_driving.key] }] }
+    let(:action2) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 2", criteria: action2_criteria, grouping_criteria: %w[visiting-eu]) }
 
-    action3_criteria = [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }]
-    action3 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie])
+    let(:action3_criteria) { [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }] }
+    let(:action3) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie]) }
 
-    group_visiting_eu = FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU", priority: 9)
-    group_visiting_ie = FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland", priority: 7)
-    group_living_uk = FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK", priority: 6)
+    let(:group_visiting_eu) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU", priority: 9) }
+    let(:group_visiting_ie) { FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland", priority: 7) }
+    let(:group_living_uk) { FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK", priority: 6) }
 
-    all_actions = [action1, action2, action3]
-    all_criteria = [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie]
-    all_groups = [group_visiting_eu, group_visiting_ie, group_living_uk]
+    let(:all_actions) { [action1, action2, action3] }
+    let(:all_criteria) { [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie] }
+    let(:all_groups) { [group_visiting_eu, group_visiting_ie, group_living_uk] }
 
     before :each do
       allow(BrexitChecker::Action).to receive(:load_all).and_return(all_actions)
@@ -31,24 +31,26 @@ describe BrexitChecker::ResultsAudiences do
       allow(BrexitChecker::Group).to receive(:load_all).and_return(all_groups)
     end
 
-    context "when actions are provided but there are no criteria" do
-      let(:grouped_citizen_actions) { described_class.populate_citizen_groups(all_actions, []) }
+    context "when citizen actions are provided but there are no criteria" do
+      let(:actions) { { "citizen" => all_actions } }
+      subject { described_class.new(actions, []) }
       it "returns an empty array" do
-        expect(grouped_citizen_actions).to be_empty
+        expect(subject.populate_citizen_groups).to be_empty
       end
     end
 
-    context "when criteria are provided but there are no actions" do
-      let(:grouped_citizen_actions) { described_class.populate_citizen_groups([], all_criteria) }
+    context "when criteria are provided but there are no citizen actions" do
+      let(:actions) { { "citizen" => [] } }
+      subject { described_class.new(actions, all_criteria) }
       it "returns an empty array" do
-        expect(grouped_citizen_actions).to be_empty
+        expect(subject.populate_citizen_groups).to be_empty
       end
     end
 
     context "when actions are provided that only have a single grouping criterion" do
       let(:selected_criteria) { [living_uk, visiting_driving] }
-      let(:filtered_actions) { [action1, action2] }
-      let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
+      let(:filtered_actions) { { "citizen" => [action1, action2] } }
+      subject { described_class.new(filtered_actions, selected_criteria) }
       it "produces an array of group hashes, ordered by priority" do
         grouped_actions_fixture = [
           {
@@ -62,15 +64,15 @@ describe BrexitChecker::ResultsAudiences do
             criteria: [living_uk],
           },
         ]
-        expect(grouped_citizen_actions).to eq grouped_actions_fixture
+        expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
       end
     end
 
     context "when actions have multiple grouping criteria" do
       context "when the user selects ONE of the action's ANY OF criteria" do
         let(:selected_criteria) { [living_uk, visiting_eu, visiting_bring_pet] }
-        let(:filtered_actions) { [action1, action3] }
-        let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
+        let(:filtered_actions) { { "citizen" => [action1, action3] } }
+        subject { described_class.new(filtered_actions, selected_criteria) }
 
         it "only shows the groups matching the selected criteria, ordered by priority" do
           grouped_actions_fixture = [
@@ -85,14 +87,14 @@ describe BrexitChecker::ResultsAudiences do
               criteria: [living_uk],
             },
           ]
-          expect(grouped_citizen_actions).to eq grouped_actions_fixture
+          expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
         end
       end
 
       context "when the user selects ALL of the action's ANY OF criteria" do
         let(:selected_criteria) { [living_uk, visiting_eu, visiting_ie, visiting_bring_pet] }
-        let(:filtered_actions) { [action1, action3] }
-        let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
+        let(:filtered_actions) { { "citizen" => [action1, action3] } }
+        subject { described_class.new(filtered_actions, selected_criteria) }
 
         it "shows all of the groups that have matching criteria, ordered by priority, and duplicates actions " do
           grouped_actions_fixture = [
@@ -112,7 +114,7 @@ describe BrexitChecker::ResultsAudiences do
               criteria: [living_uk],
             },
           ]
-          expect(grouped_citizen_actions).to eq grouped_actions_fixture
+          expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
         end
       end
     end
@@ -136,21 +138,21 @@ describe BrexitChecker::ResultsAudiences do
     end
 
     context "actions are provided but there are no criteria" do
-      let(:result) { described_class.populate_business_groups(actions, []) }
+      let(:result) { described_class.new({ "business" => actions }, []).populate_business_groups }
       it "returns an empty array" do
         expect(result).to be_empty
       end
     end
 
     context "criteria are provided but there are no actions" do
-      let(:result) { described_class.populate_business_groups([], selected_criteria) }
+      let(:result) { described_class.new({}, selected_criteria).populate_business_groups }
       it "returns an empty array" do
         expect(result).to be_empty
       end
     end
 
     context "actions and criteria are provided" do
-      let(:result) { described_class.populate_business_groups(actions, selected_criteria) }
+      let(:result) { described_class.new({ "business" => actions }, selected_criteria).populate_business_groups }
 
       it "produces an hash of actions and criteria" do
         expect(result[:actions]).to eq(actions)

--- a/spec/lib/brexit_checker/results_audiences_spec.rb
+++ b/spec/lib/brexit_checker/results_audiences_spec.rb
@@ -17,9 +17,9 @@ describe BrexitChecker::ResultsAudiences do
     action3_criteria = [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }]
     action3 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie])
 
-    group_visiting_eu = FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU")
-    group_visiting_ie = FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland")
-    group_living_uk = FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK")
+    group_visiting_eu = FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU", priority: 9)
+    group_visiting_ie = FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland", priority: 7)
+    group_living_uk = FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK", priority: 6)
 
     all_actions = [action1, action2, action3]
     all_criteria = [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie]
@@ -49,17 +49,17 @@ describe BrexitChecker::ResultsAudiences do
       let(:selected_criteria) { [living_uk, visiting_driving] }
       let(:filtered_actions) { [action1, action2] }
       let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
-      it "produces an array of group hashes" do
+      it "produces an array of group hashes, ordered by priority" do
         grouped_actions_fixture = [
-          {
-            group: group_living_uk,
-            actions: [action1],
-            criteria: [living_uk],
-          },
           {
             group: group_visiting_eu,
             actions: [action2],
             criteria: [visiting_driving],
+          },
+          {
+            group: group_living_uk,
+            actions: [action1],
+            criteria: [living_uk],
           },
         ]
         expect(grouped_citizen_actions).to eq grouped_actions_fixture
@@ -72,18 +72,18 @@ describe BrexitChecker::ResultsAudiences do
         let(:filtered_actions) { [action1, action3] }
         let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
 
-        it "only shows the group matching the selected criteria" do
+        it "only shows the groups matching the selected criteria, ordered by priority" do
           grouped_actions_fixture = [
+            {
+              group: group_visiting_eu,
+              actions: [action3],
+              criteria: [living_uk, visiting_bring_pet, visiting_eu],
+            },
             {
               group: group_living_uk,
               actions: [action1],
               criteria: [living_uk],
             },
-            {
-              group: group_visiting_eu,
-              actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_eu],
-            }
           ]
           expect(grouped_citizen_actions).to eq grouped_actions_fixture
         end
@@ -94,13 +94,8 @@ describe BrexitChecker::ResultsAudiences do
         let(:filtered_actions) { [action1, action3] }
         let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
 
-        it "shows all of the groups that have matching criteria, and duplicates actions" do
+        it "shows all of the groups that have matching criteria, ordered by priority, and duplicates actions " do
           grouped_actions_fixture = [
-            {
-              group: group_living_uk,
-              actions: [action1],
-              criteria: [living_uk],
-            },
             {
               group: group_visiting_eu,
               actions: [action3],
@@ -111,7 +106,11 @@ describe BrexitChecker::ResultsAudiences do
               actions: [action3],
               criteria: [living_uk, visiting_bring_pet, visiting_eu, visiting_ie],
             },
-
+            {
+              group: group_living_uk,
+              actions: [action1],
+              criteria: [living_uk],
+            },
           ]
           expect(grouped_citizen_actions).to eq grouped_actions_fixture
         end

--- a/spec/lib/brexit_checker/results_audiences_spec.rb
+++ b/spec/lib/brexit_checker/results_audiences_spec.rb
@@ -2,81 +2,122 @@ require "spec_helper"
 
 describe BrexitChecker::ResultsAudiences do
   describe "#populate_citizen_groups" do
-    let(:action1) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[living-uk living-row], grouping_criteria: %w[living-uk]) }
-    let(:action2) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[join-family-uk-yes], grouping_criteria: %w[living-uk]) }
-    let(:action3) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[nationality-uk], grouping_criteria: %w[living-uk]) }
-    let(:action4) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[visiting-driving], grouping_criteria: %w[visiting-eu]) }
-    let(:action5) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[studying-eu], grouping_criteria: %w[studying-eu]) }
-    let(:action6) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[living-uk visiting-ie], grouping_criteria: %w[living-uk visiting-ie]) }
+    living_uk = FactoryBot.build(:brexit_checker_criterion, key: "living-uk")
+    visiting_driving = FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving")
+    visiting_bring_pet = FactoryBot.build(:brexit_checker_criterion, key: "visiting-bring-pet")
+    visiting_eu = FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu")
+    visiting_ie = FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie")
 
-    let(:criteria1) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk", text: "Living in the UK") }
-    let(:criteria2) { FactoryBot.build(:brexit_checker_criterion, key: "join-family-uk-yes", text: "You plan to join an EU or EEA family member in the UK") }
-    let(:criteria3) { FactoryBot.build(:brexit_checker_criterion, key: "nationality-uk", text: "You are a British national") }
-    let(:criteria4) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving", text: "You need to drive abroad") }
-    let(:criteria5) { FactoryBot.build(:brexit_checker_criterion, key: "studying-eu", text: "You are studying in the EU") }
-    let(:criteria6) { FactoryBot.build(:brexit_checker_criterion, key: "living-row", text: "You do not live in the UK or the EU") }
-    let(:criteria7) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie", text: "Visiting Ireland") }
+    action1_criteria = [{ "all_of" => [living_uk.key] }]
+    action1 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 1", criteria: action1_criteria, grouping_criteria: %w[living-uk])
 
-    let(:group_living_uk) { FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK") }
-    let(:group_visiting_eu) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU") }
-    let(:group_studying_eu) { FactoryBot.build(:brexit_checker_group, key: "studying-eu", heading: "Studying in the EU") }
-    let(:group_visiting_ie) { FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland") }
+    action2_criteria = [{ "all_of" => [visiting_driving.key] }]
+    action2 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 2", criteria: action2_criteria, grouping_criteria: %w[visiting-eu])
 
-    let(:selected_criteria) { [criteria1, criteria2, criteria3, criteria4, criteria5] }
-    let(:actions) { [action1, action2, action3, action4, action5, action6] }
+    action3_criteria = [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }]
+    action3 = FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie])
+
+    group_visiting_eu = FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU")
+    group_visiting_ie = FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland")
+    group_living_uk = FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK")
+
+    all_actions = [action1, action2, action3]
+    all_criteria = [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie]
+    all_groups = [group_visiting_eu, group_visiting_ie, group_living_uk]
 
     before :each do
-      allow(BrexitChecker::Action).to receive(:load_all).and_return([action1, action2, action3, action4, action5, action6])
-      allow(BrexitChecker::Criterion).to receive(:load_all).and_return([criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7])
-      allow(BrexitChecker::Group).to receive(:load_all).and_return([group_living_uk, group_visiting_eu, group_studying_eu, group_visiting_ie])
+      allow(BrexitChecker::Action).to receive(:load_all).and_return(all_actions)
+      allow(BrexitChecker::Criterion).to receive(:load_all).and_return(all_criteria)
+      allow(BrexitChecker::Group).to receive(:load_all).and_return(all_groups)
     end
 
-    context "actions are provided but there are no criteria" do
-      let(:result) { described_class.populate_citizen_groups(actions, []) }
+    context "when actions are provided but there are no criteria" do
+      let(:grouped_citizen_actions) { described_class.populate_citizen_groups(all_actions, []) }
       it "returns an empty array" do
-        expect(result).to be_empty
+        expect(grouped_citizen_actions).to be_empty
       end
     end
 
-    context "criteria are provided but there are no actions" do
-      let(:result) { described_class.populate_citizen_groups([], selected_criteria) }
+    context "when criteria are provided but there are no actions" do
+      let(:grouped_citizen_actions) { described_class.populate_citizen_groups([], all_criteria) }
       it "returns an empty array" do
-        expect(result).to be_empty
+        expect(grouped_citizen_actions).to be_empty
       end
     end
 
-    context "actions and criteria are provided" do
-      let(:result) { described_class.populate_citizen_groups(actions, selected_criteria) }
-
+    context "when actions are provided that only have a single grouping criterion" do
+      let(:selected_criteria) { [living_uk, visiting_driving] }
+      let(:filtered_actions) { [action1, action2] }
+      let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
       it "produces an array of group hashes" do
         grouped_actions_fixture = [
           {
             group: group_living_uk,
-            actions: [action1, action2, action3, action6],
-            criteria: [criteria1, criteria2, criteria3],
+            actions: [action1],
+            criteria: [living_uk],
           },
           {
             group: group_visiting_eu,
-            actions: [action4],
-            criteria: [criteria4],
-          },
-          {
-            group: group_studying_eu,
-            actions: [action5],
-            criteria: [criteria5],
-          },
-          {
-            group: group_visiting_ie,
-            actions: [action6],
-            criteria: [criteria1],
+            actions: [action2],
+            criteria: [visiting_driving],
           },
         ]
+        expect(grouped_citizen_actions).to eq grouped_actions_fixture
+      end
+    end
 
-        expect(result).to eql(grouped_actions_fixture)
+    context "when actions have multiple grouping criteria" do
+      context "when the user selects ONE of the action's ANY OF criteria" do
+        let(:selected_criteria) { [living_uk, visiting_eu, visiting_bring_pet] }
+        let(:filtered_actions) { [action1, action3] }
+        let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
+
+        it "only shows the group matching the selected criteria" do
+          grouped_actions_fixture = [
+            {
+              group: group_living_uk,
+              actions: [action1],
+              criteria: [living_uk],
+            },
+            {
+              group: group_visiting_eu,
+              actions: [action3],
+              criteria: [living_uk, visiting_bring_pet, visiting_eu],
+            }
+          ]
+          expect(grouped_citizen_actions).to eq grouped_actions_fixture
+        end
+      end
+
+      context "when the user selects ALL of the action's ANY OF criteria" do
+        let(:selected_criteria) { [living_uk, visiting_eu, visiting_ie, visiting_bring_pet] }
+        let(:filtered_actions) { [action1, action3] }
+        let(:grouped_citizen_actions) { described_class.populate_citizen_groups(filtered_actions, selected_criteria) }
+
+        it "shows all of the groups that have matching criteria, and duplicates actions" do
+          grouped_actions_fixture = [
+            {
+              group: group_living_uk,
+              actions: [action1],
+              criteria: [living_uk],
+            },
+            {
+              group: group_visiting_eu,
+              actions: [action3],
+              criteria: [living_uk, visiting_bring_pet, visiting_eu, visiting_ie],
+            },
+            {
+              group: group_visiting_ie,
+              actions: [action3],
+              criteria: [living_uk, visiting_bring_pet, visiting_eu, visiting_ie],
+            },
+
+          ]
+          expect(grouped_citizen_actions).to eq grouped_actions_fixture
+        end
       end
     end
   end
-
   describe "#populate_business_groups" do
     let(:action1) { FactoryBot.build(:brexit_checker_action, criteria: %w[owns-operates-business-organisation automotive]) }
     let(:action2) { FactoryBot.build(:brexit_checker_action, criteria: %w[aero-space]) }

--- a/spec/lib/brexit_checker/results_audiences_spec.rb
+++ b/spec/lib/brexit_checker/results_audiences_spec.rb
@@ -7,6 +7,7 @@ describe BrexitChecker::ResultsAudiences do
     let(:action3) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[nationality-uk], grouping_criteria: %w[living-uk]) }
     let(:action4) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[visiting-driving], grouping_criteria: %w[visiting-eu]) }
     let(:action5) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[studying-eu], grouping_criteria: %w[studying-eu]) }
+    let(:action6) { FactoryBot.build(:brexit_checker_action, :citizen, criteria: %w[living-uk visiting-ie], grouping_criteria: %w[living-uk visiting-ie]) }
 
     let(:criteria1) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk", text: "Living in the UK") }
     let(:criteria2) { FactoryBot.build(:brexit_checker_criterion, key: "join-family-uk-yes", text: "You plan to join an EU or EEA family member in the UK") }
@@ -14,18 +15,20 @@ describe BrexitChecker::ResultsAudiences do
     let(:criteria4) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving", text: "You need to drive abroad") }
     let(:criteria5) { FactoryBot.build(:brexit_checker_criterion, key: "studying-eu", text: "You are studying in the EU") }
     let(:criteria6) { FactoryBot.build(:brexit_checker_criterion, key: "living-row", text: "You do not live in the UK or the EU") }
+    let(:criteria7) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie", text: "Visiting Ireland") }
 
     let(:group_living_uk) { FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK") }
     let(:group_visiting_eu) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU") }
     let(:group_studying_eu) { FactoryBot.build(:brexit_checker_group, key: "studying-eu", heading: "Studying in the EU") }
+    let(:group_visiting_ie) { FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland") }
 
     let(:selected_criteria) { [criteria1, criteria2, criteria3, criteria4, criteria5] }
-    let(:actions) { [action1, action2, action3, action4, action5] }
+    let(:actions) { [action1, action2, action3, action4, action5, action6] }
 
     before :each do
-      allow(BrexitChecker::Action).to receive(:load_all).and_return([action1, action2, action3, action4, action5])
-      allow(BrexitChecker::Criterion).to receive(:load_all).and_return([criteria1, criteria2, criteria3, criteria4, criteria5, criteria6])
-      allow(BrexitChecker::Group).to receive(:load_all).and_return([group_living_uk, group_visiting_eu, group_studying_eu])
+      allow(BrexitChecker::Action).to receive(:load_all).and_return([action1, action2, action3, action4, action5, action6])
+      allow(BrexitChecker::Criterion).to receive(:load_all).and_return([criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7])
+      allow(BrexitChecker::Group).to receive(:load_all).and_return([group_living_uk, group_visiting_eu, group_studying_eu, group_visiting_ie])
     end
 
     context "actions are provided but there are no criteria" do
@@ -49,7 +52,7 @@ describe BrexitChecker::ResultsAudiences do
         grouped_actions_fixture = [
           {
             group: group_living_uk,
-            actions: [action1, action2, action3],
+            actions: [action1, action2, action3, action6],
             criteria: [criteria1, criteria2, criteria3],
           },
           {
@@ -62,7 +65,13 @@ describe BrexitChecker::ResultsAudiences do
             actions: [action5],
             criteria: [criteria5],
           },
+          {
+            group: group_visiting_ie,
+            actions: [action6],
+            criteria: [criteria1],
+          },
         ]
+
         expect(result).to eql(grouped_actions_fixture)
       end
     end

--- a/spec/lib/brexit_checker/results_audiences_spec.rb
+++ b/spec/lib/brexit_checker/results_audiences_spec.rb
@@ -99,12 +99,12 @@ describe BrexitChecker::ResultsAudiences do
             {
               group: group_visiting_eu,
               actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_eu, visiting_ie],
+              criteria: [living_uk, visiting_bring_pet, visiting_eu],
             },
             {
               group: group_visiting_ie,
               actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_eu, visiting_ie],
+              criteria: [living_uk, visiting_bring_pet, visiting_ie],
             },
             {
               group: group_living_uk,


### PR DESCRIPTION
## What
Fix two bugs on the Brexit checker results page.

### Bug one
A user's selected criteria results in an action that has two grouping criteria. We always show both groups, regardless of the selected criteria. eg A user selects `living-uk`, `visiting-ie` and `visiting-bring-pet`.  Because the action for taking a pet abroad has both `visiting-eu` and `visiting-ie` as grouping criteria, the user is shown the `visiting-ie` group (makes sense) and also the `visiting-eu` group (whoops!). 

- [bug on production](https://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=living-uk)

#### New logic:
- If an action has more than one grouping criteria, and a user selects
all of the ANY_OF criteria, we should show duplicate actions under both groups.
- If an action has more than one grouping criteria, and a user selects
some of the ANY_OF criteria, we should only show the action under the grouping that
has a key in common with the user's selected criteria.

- [fixed on review app](https://finder-front-remove-dup-ynsole.herokuapp.com/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=living-uk)

### Bug two
When an action has two grouping criteria, and both criteria have been selected by the user, we display both criteria under each group. Eg a user selects `visiting-bring-pet` `visiting-ie` `visiting-eu` `living-uk`. This gives them the following grouped actions:

**Visiting the EU**
Because you said:

You live in the UK
You plan to travel to Ireland
You plan to travel to the EU
You are travelling with a pet

**Visiting Ireland**
Because you said:

You live in the UK
You plan to travel to Ireland
You plan to travel to the EU
You are travelling with a pet

-[bug on production](https://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=living-uk)

#### New logic:
Previously we were creating the list of criteria by combining all of the criteria for all of the actions displayed in a group. Now if an action has multiple grouping criteria, we check if the action's criteria shares a key with the current group. If it does we display the criteria, if it does not we don't.

-[fixed on review app](https://finder-front-remove-dup-ynsole.herokuapp.com/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=living-uk)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.

https://trello.com/c/MufPWtKB/376-investigate-how-we-can-remove-duplicate-actions-from-the-results-page
