### PR TITLE
Prioritise open organisations for metadata labels

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -111,9 +111,17 @@ private
   end
 
   def text_labels_for(key)
-    Array(document_hash.fetch(key, []))
-      .map { |label| get_metadata_label(key, label) }
-      .select(&:present?)
+    labels = Array(document_hash.fetch(key, []))
+               .map { |label| get_metadata_label(key, label) }
+               .select(&:present?)
+
+    if key == "organisations"
+      labels = labels.sort_by do |label|
+        label.sub("Closed organisation: ", "ZZ").upcase
+      end
+    end
+
+    labels
   end
 
   def build_text_metadata(key)


### PR DESCRIPTION
So that rather than saying "From: Closed organisation: Foreign &
Commonwealth Office and 1 others", a finder will say "From: Foreign,
Commonwealth & Development Office and 1 others".

## Before

![image](https://user-images.githubusercontent.com/1130010/91463629-86507100-e883-11ea-92a2-4d99f9f81060.png)

## After

![image](https://user-images.githubusercontent.com/1130010/91463565-759ffb00-e883-11ea-82c2-148d741c47eb.png)


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
