### PR TITLE
Replace DFID Research Output with Research For Development Output

### DIFF
--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -29,7 +29,7 @@ module Filters
           "value" => "research",
           "label" => "Research",
           "filter" => {
-            "content_store_document_type" => %w[dfid_research_output independent_report research],
+            "content_store_document_type" => %w[research_for_development_output independent_report research],
           },
         },
       ]

--- a/features/fixtures/research_and_statistics_email_signup.json
+++ b/features/fixtures/research_and_statistics_email_signup.json
@@ -62,7 +62,7 @@
           {
             "key": "research",
             "filter_values": [
-              "dfid_research_output",
+              "research_for_development_output",
               "independent_report",
               "research"
             ],

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -220,7 +220,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
                 national_statistics
                 statistical_data_set
                 official_statistics
-                dfid_research_output
+                research_for_development_output
                 independent_report
                 research
               ],
@@ -269,7 +269,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
                   national_statistics
                   statistical_data_set
                   official_statistics
-                  dfid_research_output
+                  research_for_development_output
                   independent_report
                   research
                 ],
@@ -302,7 +302,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
                   national_statistics
                   statistical_data_set
                   official_statistics
-                  dfid_research_output
+                  research_for_development_output
                   independent_report
                   research
                 ],


### PR DESCRIPTION
The DFID Research Output has been superceded by the [Research for Development Output](https://github.com/alphagov/specialist-publisher/pull/1692) document type, and so this code can be removed.

[trello](https://trello.com/c/wXE33m26/2117-remove-dfidresearchoutputs-finder)
