### PR TITLE
Fix expander markup

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -84,7 +84,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
   }
 
   Expander.prototype.attachSelectedCounter = function attachSelectedCounter (selectedString) {
-    var $selectedCounter = document.createElement('div')
+    var $selectedCounter = document.createElement('span')
     $selectedCounter.classList.add('app-c-expander__selected-counter')
     $selectedCounter.classList.add('js-selected-counter')
     $selectedCounter.innerHTML = selectedString

--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -75,6 +75,7 @@
 
 .app-c-expander__selected-counter {
   @include govuk-font($size: 14);
+  display: block;
   color: $govuk-text-colour;
   margin-top: 3px;
 }


### PR DESCRIPTION
- when options in the expander are chosen the number chosen is appended to the top of the component using JS
- this is done by inserting a div into a h2, which is invalid markup
- replacing the div with a span and setting the span to display block fixes this

Trello card: https://trello.com/c/8IWsfvOs/359-search-results-invalid-html

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
