### PR TITLE
Fix facet tag layout when styles disabled

### DIFF
--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -11,9 +11,9 @@
       <div class="facet-tags__group">
         <% applied_filter.each do |filter| %>
           <div class="facet-tags__wrapper">
-            <p class="facet-tags__preposition"><%= filter[:preposition] %></p>
-            <div class="facet-tag">
-              <p class="facet-tag__text"><%= filter[:text] %></p>
+            <span class="facet-tags__preposition"><%= filter[:preposition] %></span>
+            <span class="facet-tag">
+              <span class="facet-tag__text"><%= filter[:text] %></span>
               <button type="button"
                 class="facet-tag__remove"
                 aria-label="Remove filter <%= filter[:text] %>"
@@ -22,7 +22,7 @@
                 data-facet="<%= filter[:data_facet] %>"
                 data-value="<%= filter[:data_value] %>"
                 data-name="<%= filter[:data_name] %>">&#x2715;</button>
-            </div>
+            </span>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
- changing the p and div elements to spans makes the button to remove the facet tag line up better with the text of the facet tag if styles are disabled
- this makes the layout much clearer

Trello card: https://trello.com/c/sMBiJpNG/360-search-results-facet-tags-disjointed

## Visual changes

No changes other than when styles are disabled.

Before | After
------ | ------
<img width="412" alt="Screenshot 2020-09-03 at 12 32 33" src="https://user-images.githubusercontent.com/861310/92109819-9adfbc80-ede1-11ea-8b0d-dd34d2334371.png"> | <img width="359" alt="Screenshot 2020-09-03 at 12 30 50" src="https://user-images.githubusercontent.com/861310/92109833-a03d0700-ede1-11ea-8914-6d8277876b74.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
