### PR TITLE
Use inset-text component for lead times

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/inverse-header';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/metadata';

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -19,9 +19,7 @@
       </p>
       <% if action.lead_time.present? %>
         <div class="govuk-body">
-          <div class="govuk-inset-text">
-            <%= action.lead_time %>
-          </div>
+          <%= render "govuk_publishing_components/components/inset_text", text: action.lead_time %>
         </div>
       <% end %>
 


### PR DESCRIPTION

The styling broke because we were using the direct class from the design system,
which we shouldn't do. Because of this, it was not spotted when we switched to
directly requiring the CSS/JS for each component to improve performance.

Using the component from the Gem fixes all.

## Before 

![Screenshot 2020-09-03 at 14 23 47](https://user-images.githubusercontent.com/773037/92120594-2ca2f600-edf1-11ea-8c5c-727c775343fe.png)

## After 

![Screenshot 2020-09-03 at 14 21 09](https://user-images.githubusercontent.com/773037/92120598-2e6cb980-edf1-11ea-9387-054cb98ddb8b.png)


https://trello.com/c/mMGs7zZa/425-bug-inset-component-not-displaying-next-to-lead-time-in-checker-actions

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
