### PR TITLE
Upgrade to 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "chronic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,8 +492,5 @@ DEPENDENCIES
   webmock
   whenever
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3

--- a/app/lib/email_alert_title_builder.rb
+++ b/app/lib/email_alert_title_builder.rb
@@ -1,6 +1,6 @@
 class EmailAlertTitleBuilder
-  def self.call(*args)
-    new(*args).call
+  def self.call(**args)
+    new(**args).call
   end
 
   def initialize(filter:, subscription_list_title_prefix:, facets:)


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7

Since there is an automated process for updating Ruby versions in govuk apps, I changed the version locally and have made the necessary updates. The tests should pass for both old and new Ruby versions.

There are some deprecation warnings that relate to Ruby 2.7 coming from FactoryBot and ActiveSupport.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
