### PR TITLE
Change search region roles

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,6 +1,6 @@
 <div class="filter-form">
   <% if !content_item.all_content_finder? %>
-    <div id="keywords">
+    <div id="keywords" role="search" aria-label="<%= content_item.title %>">
       <% label_text = capture do %>
         Search <span class="govuk-visually-hidden"><%= content_item.title %></span>
       <% end %>
@@ -17,7 +17,7 @@
     <% if facets.select(&:filterable?).any? %>
       <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
         data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-        data-module="track-click" data-track-category="filterClicked" 
+        data-module="track-click" data-track-category="filterClicked"
         data-track-action="mobile-filter-button" data-track-label="">
         Filter <span class="govuk-visually-hidden"> results</span>
         <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
@@ -34,7 +34,7 @@
   </div>
 
   <% if facets.select(&:filterable?).any? %>
-    <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets">
+    <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets" role="search" aria-label="Search filters">
       <div class="facets__box">
         <div class="facets__header">
           <h1 class="gem-c-title__text">Filter</h1>
@@ -49,7 +49,7 @@
           </div>
           <button class="app-c-button-as-link facets__clear-link js-clear-selected-filters" type="button">
             Clear all filters
-          </button> 
+          </button>
         </div>
         <div class="facets__footer">
           <button class="gem-c-button govuk-button js-close-filters js-show-results" type="button">

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -21,7 +21,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>
         <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
-        <div id="keywords" class="app-patch--search-input-override">
+        <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide">
           <%= render "govuk_publishing_components/components/search", {
             aria_controls: "js-search-results-info",
             id: "finder-keyword-search",

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -32,7 +32,7 @@
 
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third" role="search" aria-label="<%= content_item.title %>">
+      <div class="govuk-grid-column-one-third">
         <%= render partial: 'facet_collection'%>
       </div>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -22,12 +22,16 @@
     <%= render "govuk_publishing_components/components/inverse_header", {
       full_width: true
     } do %>
-      <%= render partial: 'show_header', locals: { inverse: inverse,
-                                                   page_metadata: page_metadata(content_item, filter_params) } %>
+      <%= render partial: 'show_header', locals: {
+        inverse: inverse,
+        page_metadata: page_metadata(content_item, filter_params)
+      } %>
     <% end %>
   <% else %>
-    <%= render partial: 'show_header', locals: { inverse: inverse,
-                                                 page_metadata: page_metadata(content_item, filter_params) } %>
+    <%= render partial: 'show_header', locals: {
+      inverse: inverse,
+      page_metadata: page_metadata(content_item, filter_params)
+    } %>
   <% end %>
 
   <div class="govuk-width-container">


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.

---

## What

Make changes to the `role` attributes on the main search page and other finders to correct an accessibility issue.

Previously, on `/search/all`, the search filters (topic, content type, date etc.) had a role of `search`, which was correct but did not include the search box itself. The page was structured as follows:

- filters had `role="search" aria-label="Search"`
- search results had `role="region" aria-label="Search search results"`

(the repetition in that aria-label is because on other finders the first 'Search' is replaced with the name of the finder, e.g. `News and communications search results`).

The structure of the markup means that it's not possible to wrap all of the search controls in the `role="search"` without also wrapping the results. 

According to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role you can have multiple search roles on a page but they need an aria-label to distinguish them. I've therefore changed the roles and labels to be as follows.

### `/search/all`

<img width="985" alt="Screenshot 2020-09-09 at 10 39 41" src="https://user-images.githubusercontent.com/861310/92584860-13d08f80-f28c-11ea-9062-32564d665a9c.png">

### Other finders e.g. `/search/news-and-communications`

<img width="990" alt="Screenshot 2020-09-09 at 10 48 57" src="https://user-images.githubusercontent.com/861310/92584894-21861500-f28c-11ea-887b-784f6f1760d8.png">

Note that I've marked the site search in the header as having an updated `aria-label`. This isn't part of this PR but from reading the guidance I believe this is necessary so will do in a [separate PR](https://github.com/alphagov/static/pull/2265).

## Why

`role` attribute was set only around the search filters on the main search and did not include the search box.

Trello card: https://trello.com/c/pv1P0xgu/362-search-results-wrong-use-of-search-aria-role
