### PR TITLE
Do not redirect atom feeds

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,10 @@ FinderFrontend::Application.routes.draw do
 
   get "/*slug" => "redirection#redirect_covid", constraints: lambda { |request|
     topical_events = request.params["topical_events"]
-    topical_events && topical_events.include?("coronavirus-covid-19-uk-government-response")
+
+    request.format == :html &&
+      topical_events &&
+      topical_events.include?("coronavirus-covid-19-uk-government-response")
   }
 
   get "/*slug" => "finders#show", as: :finder

--- a/spec/routing/redirection_spec.rb
+++ b/spec/routing/redirection_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe "Redirecting coronavirus topical event searches", type: :routing 
       topical_events: %w[coronavirus-covid-19-uk-government-response],
     )
   end
+
+  it "ignores atom feeds" do
+    expect(
+      get: "/any-old-finder.atom?keywords=bernard&topical_events[]=coronavirus-covid-19-uk-government-response&organisations[]=ministry-of-pirates",
+    ).to route_to(
+      format: "atom",
+      controller: "finders",
+      action: "show",
+      slug: "any-old-finder",
+      keywords: "bernard",
+      organisations: %w[ministry-of-pirates],
+      topical_events: %w[coronavirus-covid-19-uk-government-response],
+    )
+  end
 end


### PR DESCRIPTION
This was not supposed to capture atom feeds, as we had a separate handler for [retiring the covid topical event feed](https://github.com/alphagov/finder-frontend/pull/2127). We did this so that people could make an informed choice about which new feed to choose, rather than just getting the firehose of everything again.

This redirect also had the unfortunate side-effect of pinning the request to the html format, so atom feed requests got an html response. RSS readers would have silently ignored this though, so I don't think this is too bad.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
