### PR TITLE
Use an h2 for the email subscription header

### DIFF
--- a/app/views/components/_email_link.html.erb
+++ b/app/views/components/_email_link.html.erb
@@ -4,7 +4,7 @@
 %>
 <div class="app-c-email-link">
   <% if link_title %>
-    <p class="govuk-heading-m"><%= link_title %></p>
+    <h2 class="govuk-heading-m"><%= link_title %></h2>
   <% end %>
   <svg class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="21" width="18" viewBox="0 0 18 21">
     <path d="M7.05,19.01C7.05,20.11,7.92,21,9,21c1.08,0,1.95-0.89,1.95-1.99H7.05z M15.73,14.82V9c0-3.25-2.2-5.97-5.18-6.69V1.59C10.56,0.71,9.86,0,9,0C8.14,0,7.44,0.71,7.44,1.59v0.72C4.47,3.03,2.27,5.75,2.27,9v5.82l-2.08,2.12V18h17.62v-1.06L15.73,14.82z"></path>


### PR DESCRIPTION
This is presented as a header (bold, uses the govuk-heading-m class), but uses a p tag. It seems semantically better to use an h2. It appears below the page h1, so h3 would be inappropriate. 

This also matches the h2 used on the email callout at the bottom of the page.

An alternative would be to not present this as a heading, but this may require a change to the design, which we don't have time for right now.

There is no visible change.

<img width="708" alt="Screenshot 2020-09-10 at 16 18 18" src="https://user-images.githubusercontent.com/773037/92752903-427c6200-f381-11ea-9ad5-9b0006254b59.png">

[Example URL on GOV.UK](https://www.gov.uk/transition-check/results?c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

https://trello.com/c/EE5x4wxA/444-transition-check-results-heading-looks-like-heading-but-isnt-one

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
