### PR TITLE
GOV.UK Accounts discovery | Save your results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_document_types"
 gem "govuk_publishing_components"
+gem "jwt"
 gem "slimmer"
 
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -474,6 +474,7 @@ DEPENDENCIES
   govuk_test
   jasmine
   jasmine_selenium_runner
+  jwt
   launchy
   listen
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,3 +38,4 @@ $govuk-use-legacy-palette: false;
 @import 'finder_frontend';
 @import 'views/search';
 @import 'views/brexit_checker_results_page';
+@import 'views/brexit_checker_account_signup';

--- a/app/assets/stylesheets/views/_brexit_checker_account_signup.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_account_signup.scss
@@ -1,0 +1,7 @@
+.govuk-experiment .govuk-inset-text {
+  border-color: #1d70b8;
+}
+
+.account-signup {
+  margin-bottom: 2rem;
+}

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -11,6 +11,8 @@ class BrexitCheckerController < ApplicationController
     expires_in(30.minutes, public: true) unless Rails.env.development?
   end
 
+  before_action :check_accounts_enabled, only: [:save_results]
+
   def show
     all_questions = BrexitChecker::Question.load_all
     @question_index = next_question_index(
@@ -47,6 +49,8 @@ class BrexitCheckerController < ApplicationController
 
     redirect_to email_alert_frontend_signup_path(topic_id: subscriber_list_slug)
   end
+
+  def save_results; end
 
 private
 

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -85,4 +85,23 @@ module BrexitCheckerHelper
       t("brexit_checker.results.description_no_answers").html_safe
     end
   end
+
+  def account_signup_jwt(criteria_keys)
+    account_jwt = BrexitChecker::AccountJwt.new(criteria_keys)
+    account_jwt.encode
+  end
+
+  def path_based_on_account_feature_flag
+    if Rails.configuration.feature_flag_govuk_accounts
+      transition_checker_save_results_path(c: criteria_keys)
+    else
+      transition_checker_email_signup_path(c: criteria_keys)
+    end
+  end
+
+  def check_accounts_enabled
+    unless Rails.configuration.feature_flag_govuk_accounts
+      render file: Rails.root.join(Rails.root, "public/404.html"), status: :not_found
+    end
+  end
 end

--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -1,0 +1,42 @@
+class BrexitChecker::AccountJwt
+  def initialize(criteria_keys)
+    @criteria_keys = criteria_keys
+  end
+
+  def encode(key = ecdsa_key, algorithmn = "ES256")
+    JWT.encode payload, key, algorithmn
+  end
+
+private
+
+  attr_reader :criteria_keys
+
+  def payload
+    {
+      uid: client_oauth_id,
+      key: client_oauth_key_uuid,
+      scopes: scopes,
+      attributes: attributes,
+    }
+  end
+
+  def scopes
+    %w[transition_checker]
+  end
+
+  def attributes
+    { transition_checker_state: criteria_keys }
+  end
+
+  def client_oauth_id
+    ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID")
+  end
+
+  def client_oauth_key_uuid
+    ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID")
+  end
+
+  def ecdsa_key
+    OpenSSL::PKey::EC.new(ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"))
+  end
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -30,4 +30,10 @@ module Services
   def self.registries
     Registries::BaseRegistries.new
   end
+
+  if Rails.configuration.feature_flag_govuk_accounts
+    def self.accounts_api
+      Plek.find("account-manager")
+    end
+  end
 end

--- a/app/views/brexit_checker/_experiment_banner.html.erb
+++ b/app/views/brexit_checker/_experiment_banner.html.erb
@@ -1,0 +1,15 @@
+<div class = "govuk-experiment">
+  <%= render "govuk_publishing_components/components/inset_text", {} do %>
+    <%= render "govuk_publishing_components/components/heading", {
+        text: t('brexit_checker.experiment_banner.heading'),
+        font_size: "m",
+        heading_level: 2,
+      } %>
+
+    <% t('brexit_checker.experiment_banner.proposition').each do |prop| %>
+      <p class="govuk-body">
+        <%= prop %>
+      </p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -8,7 +8,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("brexit_checker.stay_updated.sign_up"),
-  href: transition_checker_email_signup_path(c: criteria_keys),
+  href: path_based_on_account_feature_flag,
   data_attributes: {
     "module": "track-click",
     "track-action": t("brexit_checker.stay_updated.sign_up"),

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -64,7 +64,7 @@
         "track-label": transition_checker_email_signup_path
       },
       link_text: action_based_email_link_label,
-      link_href: transition_checker_email_signup_path(c: criteria_keys),
+      link_href: path_based_on_account_feature_flag,
       link_title: t("brexit_checker.results.email_sign_up_title"),
     } %>
 

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -1,0 +1,55 @@
+<% content_for :title, t('brexit_checker.account_signup.title') %>
+<% content_for :head do %>
+  <% unless params[:page] %>
+    <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.results'),
+        url: transition_checker_results_path(c: criteria_keys)
+      }
+    ]
+  } %>
+
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('brexit_checker.account_signup.heading'),
+            font_size: "xl",
+            heading_level: 1,
+          } %>
+
+        <%= t('brexit_checker.account_signup.proposition').html_safe %>
+
+        <%= render "experiment_banner" %>
+
+        <%= render "govuk_publishing_components/components/button", {
+            text: t('brexit_checker.account_signup.cta_button'),
+            href: sign_up_url,
+            margin_bottom: true
+          } %>
+
+        <p class="govuk-body">
+          <%= t('brexit_checker.account_signup.or') %>
+          <a class="govuk-link" href="<%= transition_checker_email_signup_path(c: criteria_keys) %>">
+            <%= t('brexit_checker.account_signup.alternative_path_link_text') %>
+          </a>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -37,11 +37,13 @@
 
         <%= render "experiment_banner" %>
 
-        <%= render "govuk_publishing_components/components/button", {
+        <%= form_tag Services.accounts_api, id: "account-signup", class: "account-signup" do %>
+          <input type="hidden" name="jwt" value="<%= account_signup_jwt(criteria_keys) %>">
+          <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),
-            href: sign_up_url,
-            margin_bottom: true
+            inline_layout: true,
           } %>
+        <% end %>
 
         <p class="govuk-body">
           <%= t('brexit_checker.account_signup.or') %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,5 +56,12 @@ module FinderFrontend
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # As part of the 2020 user discovery into GOV.UK accounts we want to deploy
+    # a live prototype allowing Brexit/Transition checker users to persisit their
+    # results page. We want to be able to toggle this feature on/off in the environment
+    # so we can launch this seemlessly with finder-frontend's continuious deployment
+    # and roll back if required.
+    config.feature_flag_govuk_accounts = ENV["FEATURE_FLAG_ACCOUNTS"] == "enabled"
   end
 end

--- a/config/locales/en/brexit_checker/account_signup.yml
+++ b/config/locales/en/brexit_checker/account_signup.yml
@@ -1,0 +1,17 @@
+en:
+  brexit_checker:
+    account_signup:
+      title: Stay up to date with a new GOV.UK account
+      heading: Stay up to date with a new GOV.UK account
+      proposition: |
+        <p class="govuk-body">
+          Create a GOV.UK account to hep you get ready for new rules in 2021. You'll be able to:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>get email updates about changes that may affect you</li>
+          <li>get a link to your UK transition results</li>
+        </ul>
+      cta_button: Create a GOV.UK account
+      or: or
+      alternative_path_link_text: stay up to date with email alerts only

--- a/config/locales/en/brexit_checker/experiment_banner.yml
+++ b/config/locales/en/brexit_checker/experiment_banner.yml
@@ -1,0 +1,7 @@
+en:
+  brexit_checker:
+    experiment_banner:
+      heading: GOV.UK accounts are an experimental new feature
+      proposition:
+        - They're a first step towards making GOV.UK more tailored to you and your circumstances.
+        - You'll be able to give feedback and suggest how to make the account better. You can also decide to delete your account at any time.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,16 +18,20 @@ FinderFrontend::Application.routes.draw do
     get "/test-search/search/opensearch" => "search#opensearch"
   end
 
-  # Routes for the for Brexit Checker
+  # Routes for the for Transition/Brexit Checker
   get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
   get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions
   get "/transition-check/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup
   post "/transition-check/email-signup" => "brexit_checker#confirm_email_signup", as: :transition_checker_confirm_email_signup
 
+  # Transition/Brexit checker email signup routes
   get "/email/subscriptions/new", to: proc { [200, {}, [""]] }, as: :email_alert_frontend_signup
 
   get "/*slug/email-signup" => "email_alert_subscriptions#new", as: :new_email_alert_subscriptions
   post "/*slug/email-signup" => "email_alert_subscriptions#create", as: :email_alert_subscriptions
+
+  # GOV.UK Accounts discovery routes
+  get "/transition-check/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
 
   # Q&A frontend for "UK Nationals in the EU" (www.gov.uk/uk-nationals-in-the-eu)
   get "/uk-nationals-living-eu" => "qa_to_content#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,5 +46,6 @@ FinderFrontend::Application.routes.draw do
       topical_events.include?("coronavirus-covid-19-uk-government-response")
   }
 
+  # Whatever else you do here... keep this at the bottom of the file
   get "/*slug" => "finders#show", as: :finder
 end

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -37,6 +37,14 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   context "with the GOV.UK Account feature flag" do
+    before do
+      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
+      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
+      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
+      allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
+      allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
+    end
+
     scenario "user clicks to signup to email alerts with existing subscriber list" do
       given_im_on_the_results_page
       and_email_alert_api_has_subscriber_list

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -16,20 +16,50 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     }
   end
 
-  scenario "user clicks to signup to email alerts with existing subscriber list" do
-    given_im_on_the_results_page
-    and_email_alert_api_has_subscriber_list
-    then_i_click_to_signup_to_emails
-    and_i_am_taken_to_email_alert_frontend
+  context "without the GOV.UK Account feature flag" do
+    scenario "user clicks to signup to email alerts with existing subscriber list" do
+      given_im_on_the_results_page
+      and_email_alert_api_has_subscriber_list
+      then_i_click_to_subscribe # on main results page
+      then_i_click_to_subscribe # on overview of subscription page
+      and_i_am_taken_to_email_alert_frontend
+    end
+
+    scenario "user clicks to signup to email alerts without existing subscriber list" do
+      given_im_on_the_results_page
+      and_email_alert_api_does_not_have_subscriber_list
+      and_email_alert_api_creates_subscriber_list
+      then_i_click_to_subscribe # on main results page
+      then_i_click_to_subscribe # on overview of subscription page
+      and_the_subscriber_list_was_created
+      and_i_am_taken_to_email_alert_frontend
+    end
   end
 
-  scenario "user clicks to signup to email alerts without existing subscriber list" do
-    given_im_on_the_results_page
-    and_email_alert_api_does_not_have_subscriber_list
-    and_email_alert_api_creates_subscriber_list
-    then_i_click_to_signup_to_emails
-    and_the_subscriber_list_was_created
-    and_i_am_taken_to_email_alert_frontend
+  context "with the GOV.UK Account feature flag" do
+    scenario "user clicks to signup to email alerts with existing subscriber list" do
+      given_im_on_the_results_page
+      and_email_alert_api_has_subscriber_list
+      then_i_click_to_subscribe
+      and_i_am_taken_to_choose_how_to_subscribe_page
+      then_i_click_email_alerts_only
+      and_i_am_taken_to_email_alert_signup_page
+      then_i_click_to_subscribe
+      and_i_am_taken_to_email_alert_frontend
+    end
+
+    scenario "user clicks to signup to email alerts without existing subscriber list" do
+      given_im_on_the_results_page
+      and_email_alert_api_does_not_have_subscriber_list
+      and_email_alert_api_creates_subscriber_list
+      then_i_click_to_subscribe
+      and_i_am_taken_to_choose_how_to_subscribe_page
+      then_i_click_email_alerts_only
+      and_i_am_taken_to_email_alert_signup_page
+      then_i_click_to_subscribe
+      and_the_subscriber_list_was_created
+      and_i_am_taken_to_email_alert_frontend
+    end
   end
 
   def given_im_on_the_results_page
@@ -49,9 +79,12 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
                         .with(body: subscriber_list.except("slug").as_json)
   end
 
-  def then_i_click_to_signup_to_emails
-    click_on "Subscribe" # on main results page
-    click_on "Subscribe" # on overview of subscription page
+  def then_i_click_email_alerts_only
+    click_on "stay up to date with email alerts only"
+  end
+
+  def then_i_click_to_subscribe
+    click_on "Subscribe"
   end
 
   def and_the_subscriber_list_was_created
@@ -60,5 +93,13 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
 
   def and_i_am_taken_to_email_alert_frontend
     expect(page).to have_current_path(email_alert_frontend_signup_path(topic_id: "your-get-ready-for-brexit-results-a1a2a3a4a5"))
+  end
+
+  def and_i_am_taken_to_email_alert_signup_page
+    expect(page).to have_current_path(transition_checker_email_signup_url(c: %w[nationality-eu]))
+  end
+
+  def and_i_am_taken_to_choose_how_to_subscribe_page
+    expect(page).to have_current_path(transition_checker_save_results_url(c: %w[nationality-eu]))
   end
 end

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -16,7 +16,13 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     }
   end
 
-  let(:jwt) { "i_am_a_string_pretending_to_be_a_jwt" }
+  before do
+    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
+    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
+    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
+    allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
+    allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
+  end
 
   scenario "user clicks Create a GOV.UK account" do
     given_im_on_the_results_page
@@ -41,6 +47,6 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     form = page.find("form#account-signup")
     expect(form.text).to eql("Create a GOV.UK account")
     expect(form["method"]).to eql("post")
-    expect(form["action"]).to eql("http://account.service.dev.test.gov.uk/")
+    expect(form["action"]).to eql(Plek.find("account-manager"))
   end
 end

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  let(:subscriber_list) do
+    {
+      "title" => "Get ready for 2021",
+      "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
+      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
+      "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
+      "url" => "/transition-check/results?c%5B%5D=nationality-eu",
+      "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
+    }
+  end
+
+  let(:jwt) { "i_am_a_string_pretending_to_be_a_jwt" }
+
+  scenario "user clicks Create a GOV.UK account" do
+    given_im_on_the_results_page
+    then_i_click_to_subscribe
+    and_i_am_taken_to_choose_how_to_subscribe_page
+    i_see_a_create_account_button
+  end
+
+  def given_im_on_the_results_page
+    visit transition_checker_results_url(c: %w[nationality-eu])
+  end
+
+  def then_i_click_to_subscribe
+    click_on "Subscribe"
+  end
+
+  def and_i_am_taken_to_choose_how_to_subscribe_page
+    expect(page).to have_current_path(transition_checker_save_results_url(c: %w[nationality-eu]))
+  end
+
+  def i_see_a_create_account_button
+    form = page.find("form#account-signup")
+    expect(form.text).to eql("Create a GOV.UK account")
+    expect(form["method"]).to eql("post")
+    expect(form["action"]).to eql("http://account.service.dev.test.gov.uk/")
+  end
+end

--- a/spec/support/account_signup_helper_spec.rb
+++ b/spec/support/account_signup_helper_spec.rb
@@ -1,0 +1,5 @@
+module AccountSignupHelper
+  def self.test_ec_key_fixture
+    OpenSSL::PKey::EC.new("prime256v1").generate_key.export
+  end
+end


### PR DESCRIPTION
## What is this?

Adds a feature flag change to the results page signup.

Clicks to signup will now go to a new screen where the user can choose a route to be kept up to date. Current designs look like this:

![image](https://user-images.githubusercontent.com/3694062/94144778-7cf9fa80-fe69-11ea-8e46-c0dc0db63fe9.png)

The feature flag will be off after this is deployed and merged, so unless there are changes to the Environment we shouldn't see any changes to production from this PR.

## Why?

TLDR; It's a part of the GOV.UK Accounts 2020 discovery work.

Previously the ability for a user to keep up to date was entirely dependent on email signups. In Autumn 2020 we are hoping to conduct a live prototype test of GOV.UK accounts as an additional route to retrieve results.

As GOV.UK accounts are optional and on a consent basis, we preserve the old email signup route and add this alongside.

## How should I set up to test it?

If you would like to test this with a running version of email-alert-frontend and api you should use govuk-docker.
If you would like to add accounts into the mix, speak to the GOV.UK accounts team about how you can spin that up in govuk-docker too.

In any case, you will need some additional environemnt variables for this to work:

- `FEATURE_FLAG_ACCOUNTS`: set to `"enabled"` will turn the feature on, if it is set to anything else or absent all tests and features will revert to existing production code.
- `GOVUK_ACCOUNT_OAUTH_CLIENT_ID`: This can be anything unless you're testing end to end with accounts I've used `"fake_credentials_for_development"`
- `GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID`: Can also be anything, will uniquely identify the key used to sign the JWT
- `GOVUK_ACCOUNT_OAUTH_CLIENT_KEY`: Same for the key, if you're testing end to end, use the same credentials as are in the account app ENV, otherwise just generate a new EC key
- `PLEK_SERVICE_ACCOUNT_MANAGER_URI`: Might want `"www.login.service.dev.gov.uk"` if you're testing with GOV.UK docker

Here's something you can copy paste if you're using a `docker-compose.yml`
```
      FEATURE_FLAG_ACCOUNTS: "enabled"
      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: "fake_client_key_for_development"
      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIBjlMYhN/1FiZX7RRUyKpqDM2bPIHQswhjm+ZPaOXlgQoAoGCCqGSM49\nAwEHoUQDQgAE2pGXU3YkENblp+SMC8CWpkwPDdWXJdEsXoSQ8dWNYxFFbnXKN4Vv\nRGeLYoNKjuK/2t9rlEEumIzm5EtMxts7Jg==\n-----END EC PRIVATE KEY-----\n"
      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID: "fake_uuid_for_development"
      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "www.login.service.dev.gov.uk"
```

## How should I set up to test it?

- Ensure the feature flag is turned on
- Visit `transition-check/questions`
- Step through until your results page
- hit subscribe at the top or bottom
- Test out accounts subscription
- Test our email subscription

Then... you could also toggle the flag off and poke around and compare what's there to production.