### PR TITLE
Transition accessibility fixes

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -5,12 +5,6 @@ module BrexitCheckerHelper
     CGI.escape(request.original_url)
   end
 
-  def criteria_aside_label(heading = nil)
-    return "you-and-your-family-actions-group-#{heading.downcase.gsub(' ', '-')}-criteria" unless heading.nil?
-
-    "business-actions-criteria"
-  end
-
   def filter_actions(actions, criteria_keys)
     filtered = actions.select { |a| a.show?(criteria_keys) }
     sorted_actions(filtered)

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -1,7 +1,7 @@
 <% actions.each.with_index do | action, index | %>
   <div class="govuk-grid-row brexit-checker__action">
     <div class="brexit-checker__content-wrapper">
-      <p class="govuk-body brexit-checker__action_title">
+      <h4 class="govuk-body brexit-checker__action_title">
         <% if action.title_url.present? %>
           <a
             class="govuk-link"
@@ -16,7 +16,7 @@
         <% else %>
           <%= action.title %>
         <% end %>
-      </p>
+      </h4>
       <% if action.lead_time.present? %>
         <div class="govuk-body">
           <%= render "govuk_publishing_components/components/inset_text", text: action.lead_time %>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -1,7 +1,10 @@
+<% heading_level ||= 4 %>
+<% heading_tag = "h#{heading_level}"%>
+
 <% actions.each.with_index do | action, index | %>
   <div class="govuk-grid-row brexit-checker__action">
     <div class="brexit-checker__content-wrapper">
-      <h4 class="govuk-body brexit-checker__action_title">
+      <%= content_tag(heading_tag, class: "govuk-body brexit-checker__action_title") do %>
         <% if action.title_url.present? %>
           <a
             class="govuk-link"
@@ -16,7 +19,7 @@
         <% else %>
           <%= action.title %>
         <% end %>
-      </h4>
+      <% end %>
       <% if action.lead_time.present? %>
         <div class="govuk-body">
           <%= render "govuk_publishing_components/components/inset_text", text: action.lead_time %>

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -17,7 +17,8 @@
           <div class="govuk-grid-column-two-thirds">
             <%= render "action_list", {
               analytics_group: "#{t('brexit_checker.results.audiences.business.heading')} - 1.",
-              actions: business_results[:actions]
+              actions: business_results[:actions],
+              heading_level: 3
             } %>
           </div>
         </div>

--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -1,22 +1,21 @@
 <% if criteria.present? %>
-  <aside
-    class="govuk-grid-column-one-third"
-    aria-label=<%="#{criteria_aside_label(local_assigns[:heading])}"%>
-  >
-    <% if local_assigns[:heading] %>
-      <h3 class="govuk-heading-m"><%= heading %></h3>
-    <% end %>
-    <p class="govuk-body brexit-checker__critera_explaination">
-      <%= t('brexit_checker.results.criteria.list_context') %>
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <% criteria.each do |criterion| %>
-        <li class="brexit-checker__criterion">
-          <%= criterion.text %>
-        </li>
-      <% end %>
-    </ul>
-  </aside>
+  <div class="govuk-grid-column-one-third">
+  <% if local_assigns[:heading] %>
+    <h3 class="govuk-heading-m"><%= heading %></h3>
+  <% end %>
+    <aside>
+      <p class="govuk-body brexit-checker__critera_explaination">
+        <%= t('brexit_checker.results.criteria.list_context') %>
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <% criteria.each do |criterion| %>
+          <li class="brexit-checker__criterion">
+            <%= criterion.text %>
+          </li>
+        <% end %>
+      </ul>
+    </aside>
+  </div>
 <% else %>
   <p class="govuk-body">
     <%= t('brexit_checker.results.criteria.no_answers') %>

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -162,6 +162,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def and_i_should_see_eu_settled_status_scheme
     action = BrexitChecker::Action.find_by_id("S001")
+    expect(page).to have_css("h4", text: "Apply to the EU Settlement Scheme by 30 June 2021 to continue living in the UK - you must have arrived in the UK before January 2021")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
     data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
     expect(data_track_action).to eq("You and your family - Living in the UK - 2.1 - Guidance")
@@ -175,6 +176,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def and_i_should_see_customs_agent_action
     action = BrexitChecker::Action.find_by_id("T099")
+    expect(page).to have_css("h3", text: "Decide how you want to make customs declarations and whether you need to get someone to deal with customs for you" )
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
     data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
     expect(data_track_action).to eq("Your business or organisation - 1.4 - Guidance")

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -246,14 +246,4 @@ describe BrexitCheckerHelper, type: :helper do
       expect(brexit_results_description([], [])).to eq(t("brexit_checker.results.description_no_answers").html_safe)
     end
   end
-
-  describe "#criteria_aside_label" do
-    it "returns string 'buisness-criteira' if not provided with a group heading" do
-      expect(criteria_aside_label).to eql("business-actions-criteria")
-    end
-
-    it "returns an identifying string for citizen group criteria if provided with a group heading" do
-      expect(criteria_aside_label("I am an Official Group heading")).to eq("you-and-your-family-actions-group-i-am-an-official-group-heading-criteria")
-    end
-  end
 end


### PR DESCRIPTION
## Make heading-like things actual headings

Each action in the results page starts with a line of text / link that is styled like a heading, but is a `p` tag. The content is designed in a heading style, and it would be useful for them to be listed as headings so that they can be recounted by a voice assistant etc, so let's make them so.

I've used h3s for actions appearing in the business section and h4s for citizen results. It's suboptimal to have a mixture, but pending a redesign (which is actually happening next week), I'm not sure what the alternative is, while honouring the page structure.

## Remove aria-label from Brexit results asides

The labels are not sensible at the moment - they are supposed to be readable language, not kebab-case slugs.

This also rejigs the markup a little to extract the section heading from the aside. The heading refers to both the aside, and any actions that are presented for this group. It makes sense if it is not encapsulated within the aside.

[Example results page](https://finder-front-a11y-label-mjeoku.herokuapp.com/transition-check/results?c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=working-ie&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

https://trello.com/c/DtragFBC/473-transition-check-results-unintelligible-labels

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
