### PR TITLE
Move Brexit breadcrumbs so skiplinks skip them

### DIFF
--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -19,21 +19,21 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-<div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: t('brexit_checker.breadcrumbs.home'),
-        url: "/"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
-        url: "/transition"
-      }
-    ]
-  } %>
-</div>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t('brexit_checker.breadcrumbs.home'),
+          url: "/"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.brexit-home'),
+          url: "/transition"
+        }
+      ]
+    } %>
+  </div>
 <% end %>
 
 <div class="govuk-width-container brexit-checker-results-page">

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -18,7 +18,8 @@
   <link rel="canonical" href="<%= page_url %>">
 <% end %>
 
-<div class="govuk-width-container brexit-checker-results-page">
+<% content_for :breadcrumbs do %>
+<div class="govuk-width-container">
   <%= render 'govuk_publishing_components/components/breadcrumbs', {
     collapse_on_mobile: true,
     breadcrumbs: [
@@ -32,6 +33,10 @@
       }
     ]
   } %>
+</div>
+<% end %>
+
+<div class="govuk-width-container brexit-checker-results-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", {

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -13,17 +13,17 @@
 %>
 
 <% content_for :breadcrumbs do %>
-<div class="govuk-width-container">
-  <% if @previous_page %>
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
-    } %>
-  <% else %>
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: "/transition",
-    } %>
-  <% end %>
-</div>
+  <div class="govuk-width-container">
+    <% if @previous_page %>
+      <%= render "govuk_publishing_components/components/back_link", {
+        href: transition_checker_questions_path(page: @previous_page, c: criteria_keys),
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/back_link", {
+        href: "/transition",
+      } %>
+    <% end %>
+  </div>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -12,6 +12,7 @@
   end
 %>
 
+<% content_for :breadcrumbs do %>
 <div class="govuk-width-container">
   <% if @previous_page %>
     <%= render "govuk_publishing_components/components/back_link", {
@@ -19,10 +20,13 @@
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/back_link", {
-      href: "/get-ready-brexit-check",
+      href: "/transition",
     } %>
   <% end %>
+</div>
+<% end %>
 
+<div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -16,6 +16,7 @@
 
   <body class="<%= yield :body_classes %>">
     <div id="wrapper">
+      <%= yield :breadcrumbs %>
       <main id="content" class="finder-frontend-content">
         <div class="finder-frontend">
           <%= yield %>

--- a/spec/features/brexit_checker/question_navigation_spec.rb
+++ b/spec/features/brexit_checker/question_navigation_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Navigating Brexit Checker questions", type: :feature do
 
   def when_i_visit_the_brexit_checker_flow
     visit transition_checker_questions_path
-    expect(page).to have_link("Back", href: "/get-ready-brexit-check")
+    expect(page).to have_link("Back", href: "/transition")
   end
 
   def and_i_answer_travel_questions


### PR DESCRIPTION
I've moved the breadcrumbs/back links on the Brexit checker so that they live outside the main content section. This means that using skiplinks navigates you to the start of the content, and not just to a confusing breadcrumb link.

Check the skip links on:
- [a question page](https://finder-front-a11y-fix-f-d1ljfw.herokuapp.com/transition-check/questions)
- [a results page](https://finder-front-a11y-fix-f-d1ljfw.herokuapp.com/transition-check/results?c%5B%5D=nationality-uk&page=1)

They should now link to the main content section, and skip over the breadcrumbs.

I've also updated a link to /get-ready-brexit-check so that it points to /transition. The old page has been retired, redirecting to the transition landing page, so this change eliminates that redirected request, while not changing the outcome.

Describe the problem
--------------------
The main element of the transition check flow includes the back link and the skip link leads to the back link.
The same is happening on the transition check results page but with the breadcrumbs.

Problem category
----------------
Fail of WCAG SC 2.4.1

Impact of the problem
---------------------
Skip link: Keyboard only users cannot skip directly to the main content.
Main element: Screen reader users cannot skip directly to the main content.

https://trello.com/c/meGNv7bk/474-search-results-main-element-and-skip-link-before-main-content
https://trello.com/c/MR7bfTid/475-transition-check-main-element-and-skip-link-before-main-content

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
