### PR TITLE
Speed up tests by enabling cache_classes

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   #
   # More details:
   # https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-memcachestore
-  config.cache_classes = false
+  config.cache_classes = true
   config.action_view.cache_template_loading = true
   config.cache_store = :memory_store
 


### PR DESCRIPTION
From the [Configuring Rails Apps guide](https://guides.rubyonrails.org/configuring.html):

> config.cache_classes controls whether or not application classes and modules should be reloaded if they change. Defaults to false in development mode, and true in production mode. In test mode, the default is false if Spring is installed, true otherwise.

We don't have Spring installed here, so setting the value to true is effectively reverting to the default setting.

I performed some basic speed tests by running `bundle exec rspec -p` with the results below. The TLDR is that the current settings mean that currently RSpec tests take around 200 seconds to run. Enabling class caching cuts this to ~18s.

Enabling controller caching seems to make a slight difference, but not enough to risk changing for.

## Results

### No caching (current config)

Finished in 3 minutes 34.6 seconds (files took 7.97 seconds to load)
941 examples, 0 failures

### Cache classes enabled (the chosen option)

Finished in 17.96 seconds (files took 7.08 seconds to load)
941 examples, 0 failures

### Controller caching enabled

Finished in 3 minutes 24.5 seconds (files took 8.05 seconds to load)
941 examples, 0 failures

### Both caching options enabled

Finished in 17.17 seconds (files took 7.18 seconds to load)
941 examples, 0 failures

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
