### PR TITLE
Allow logging into the Transition Checker using a GOV.UK Account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "govuk_app_config"
 gem "govuk_document_types"
 gem "govuk_publishing_components"
 gem "jwt"
+gem "openid_connect", "~> 1.2.0"
 gem "slimmer"
 
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,12 +58,15 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.1)
+    attr_required (1.0.1)
     awesome_print (1.8.0)
     better_errors (2.7.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bindata (2.4.8)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     brakeman (4.9.1)
@@ -204,6 +207,10 @@ GEM
       jasmine (~> 3.0)
       selenium-webdriver (~> 3.8)
     json (2.3.1)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
@@ -246,6 +253,16 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
+    openid_connect (1.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     os (1.1.1)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -267,6 +284,12 @@ GEM
     puma (5.0.2)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-oauth2 (1.16.0)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.3)
@@ -416,6 +439,10 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    swd (1.2.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     sys-uname (1.2.1)
       ffi (>= 1.0.0)
     thor (1.0.1)
@@ -434,10 +461,19 @@ GEM
     unicorn (5.6.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.11)
+      activemodel (>= 3.0.0)
+      public_suffix
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -477,6 +513,7 @@ DEPENDENCIES
   jwt
   launchy
   listen
+  openid_connect (~> 1.2.0)
   pry-byebug
   rails (= 6.0.3.3)
   rails-controller-testing

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,12 @@ private
     end
   end
 
+  def logout!
+    session.delete(:sub)
+    session.delete(:access_token)
+    session.delete(:refresh_token)
+  end
+
   def error_503(exception)
     error(503, exception)
   end
@@ -84,5 +90,13 @@ private
 
       ParamsCleaner.new(permitted_params).cleaned
     end
+  end
+
+  def logged_in?
+    current_user.present?
+  end
+
+  def current_user
+    session[:sub]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper :application
 
+  after_action :skip_session_cookie
+
   # rescue_from precedence is bottom up - https://stackoverflow.com/a/9121054/170864
   unless Rails.env.development?
     rescue_from GdsApi::BaseError, with: :error_503
@@ -25,6 +27,12 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def skip_session_cookie
+    unless current_user
+      request.session_options[:drop] = true
+    end
+  end
 
   def error_503(exception)
     error(503, exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,6 +92,14 @@ private
     end
   end
 
+  def oidc
+    @oidc ||= OidcClient.new(
+      Services.accounts_api,
+      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID"),
+      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"),
+    )
+  end
+
   def logged_in?
     current_user.present?
   end

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -13,7 +13,7 @@ class BrexitCheckerController < ApplicationController
     expires_in(30.minutes, public: true) unless Rails.env.development?
   end
 
-  before_action :check_accounts_enabled, only: %i[save_results saved_results]
+  before_action :check_accounts_enabled, only: %i[save_results saved_results edit_saved_results]
 
   def show
     all_questions = BrexitChecker::Question.load_all
@@ -69,6 +69,16 @@ class BrexitCheckerController < ApplicationController
       redirect_to transition_checker_questions_path
     else
       redirect_to transition_checker_results_path(c: results_from_account)
+    end
+  end
+
+  def edit_saved_results
+    redirect_to transition_checker_new_session_path(redirect_path: transition_checker_edit_saved_results_path) and return unless logged_in?
+
+    if results_from_account.empty?
+      redirect_to transition_checker_questions_path
+    else
+      redirect_to transition_checker_questions_path(c: results_from_account, page: 0)
     end
   end
 

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -13,13 +13,15 @@ class BrexitCheckerController < ApplicationController
     expires_in(30.minutes, public: true) unless Rails.env.development?
   end
 
-  before_action :check_accounts_enabled, only: [:save_results]
+  before_action :check_accounts_enabled, only: %i[save_results saved_results]
 
   def show
-    @account_information = if logged_in?
+    @account_information = if logged_in? && accounts_enabled?
                              "Logged in. <a class=\"govuk-link\" href=\"#{transition_checker_end_session_path}\">Log out.</a>"
-                           else
+                           elsif accounts_enabled?
                              "Not logged in. <a class=\"govuk-link\" href=\"#{transition_checker_new_session_path}\">Login.</a>"
+                           else
+                             ""
                            end
 
     all_questions = BrexitChecker::Question.load_all

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -1,3 +1,5 @@
+require_relative "../lib/oidc_client.rb"
+
 class BrexitCheckerController < ApplicationController
   include BrexitCheckerHelper
 
@@ -14,6 +16,12 @@ class BrexitCheckerController < ApplicationController
   before_action :check_accounts_enabled, only: [:save_results]
 
   def show
+    @account_information = if logged_in?
+                             "Logged in. <a class=\"govuk-link\" href=\"#{transition_checker_end_session_path}\">Log out.</a>"
+                           else
+                             "Not logged in. <a class=\"govuk-link\" href=\"#{transition_checker_new_session_path}\">Login.</a>"
+                           end
+
     all_questions = BrexitChecker::Question.load_all
     @question_index = next_question_index(
       all_questions: all_questions,

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -65,31 +65,32 @@ class BrexitCheckerController < ApplicationController
   def saved_results
     redirect_to transition_checker_new_session_path(redirect_path: transition_checker_saved_results_path) and return unless logged_in?
 
-    @saved_results =
-      begin
-        Array(
-          update_session_tokens(
-            oidc.get_checker_attribute(
-              access_token: session[:access_token],
-              refresh_token: session[:refresh_token],
-            ),
-          ),
-        )
-      rescue OidcClient::OAuthFailure
-        # this means the refresh token has been revoked or the
-        # accounts services are down
-        logout!
-        []
-      end
-
-    if @saved_results.empty?
+    if results_from_account.empty?
       redirect_to transition_checker_questions_path
     else
-      redirect_to transition_checker_results_path(c: @saved_results)
+      redirect_to transition_checker_results_path(c: results_from_account)
     end
   end
 
 private
+
+  def results_from_account
+    @results_from_account ||= begin
+      Array(
+        update_session_tokens(
+          oidc.get_checker_attribute(
+            access_token: session[:access_token],
+            refresh_token: session[:refresh_token],
+          ),
+        ),
+      )
+                              rescue OidcClient::OAuthFailure
+                                # this means the refresh token has been revoked or the
+                                # accounts services are down
+                                logout!
+                                []
+    end
+  end
 
   def grouped_results
     @grouped_results ||= BrexitChecker::Results::GroupByAudience.new(@audience_actions, @criteria)

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -61,31 +61,29 @@ class BrexitCheckerController < ApplicationController
   def save_results; end
 
   def saved_results
-    redirect_to transition_checker_new_session_path and return unless logged_in?
+    redirect_to transition_checker_new_session_path(redirect_path: transition_checker_saved_results_path) and return unless logged_in?
 
     @saved_results =
-      if logged_in?
-        begin
-          Array(
-            update_session_tokens(
-              oidc.get_checker_attribute(
-                access_token: session[:access_token],
-                refresh_token: session[:refresh_token],
-              ),
+      begin
+        Array(
+          update_session_tokens(
+            oidc.get_checker_attribute(
+              access_token: session[:access_token],
+              refresh_token: session[:refresh_token],
             ),
-          )
-        rescue OidcClient::OAuthFailure
-          # this means the refresh token has been revoked or the
-          # accounts services are down
-          logout!
-          []
-        end
+          ),
+        )
+      rescue OidcClient::OAuthFailure
+        # this means the refresh token has been revoked or the
+        # accounts services are down
+        logout!
+        []
       end
 
     if @saved_results.empty?
       redirect_to transition_checker_questions_path
     else
-      redirect_to transition_checker_results_path(c: @saved_results["criteria_keys"])
+      redirect_to transition_checker_results_path(c: @saved_results)
     end
   end
 

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -16,14 +16,6 @@ class BrexitCheckerController < ApplicationController
   before_action :check_accounts_enabled, only: %i[save_results saved_results]
 
   def show
-    @account_information = if logged_in? && accounts_enabled?
-                             "Logged in. <a class=\"govuk-link\" href=\"#{transition_checker_end_session_path}\">Log out.</a>"
-                           elsif accounts_enabled?
-                             "Not logged in. <a class=\"govuk-link\" href=\"#{transition_checker_new_session_path}\">Login.</a>"
-                           else
-                             ""
-                           end
-
     all_questions = BrexitChecker::Question.load_all
     @question_index = next_question_index(
       all_questions: all_questions,
@@ -43,6 +35,14 @@ class BrexitCheckerController < ApplicationController
   end
 
   def results
+    @account_information = if logged_in? && accounts_enabled?
+                             "Logged in. <a class=\"govuk-link\" href=\"#{transition_checker_end_session_path}\">Log out.</a>"
+                           elsif accounts_enabled?
+                             "Not logged in. <a class=\"govuk-link\" href=\"#{transition_checker_new_session_path}\">Login.</a>"
+                           else
+                             ""
+                           end
+
     all_actions = BrexitChecker::Action.load_all
     @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
     @actions = filter_actions(all_actions, criteria_keys)

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -95,6 +95,12 @@ private
     @grouped_results ||= BrexitChecker::Results::GroupByAudience.new(@audience_actions, @criteria)
   end
 
+  def update_session_tokens(result)
+    session[:access_token] = result[:access_token]
+    session[:refresh_token] = result[:refresh_token]
+    result[:result]
+  end
+
   def subscriber_list_options
     path = transition_checker_results_path(c: criteria_keys)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,51 @@
+require_relative "../lib/oidc_client.rb"
+
+class SessionsController < ApplicationController
+  def create
+    if logged_in?
+      redirect_to redirect_path
+      return
+    end
+
+    redirect_to oidc.auth_uri[:uri]
+  end
+
+  def callback
+    unless params[:code]
+      redirect_to redirect_path
+      return
+    end
+
+    state = params.require(:state)
+
+    user_info = oidc.callback(
+      params.require(:code),
+      state,
+    )
+
+    session[:sub] = user_info.sub
+    session[:email] = user_info.email
+
+    redirect_to redirect_path
+  end
+
+  def delete
+    session.delete(:sub)
+    session.delete(:email)
+    redirect_to redirect_path
+  end
+
+private
+
+  def redirect_path
+    transition_checker_questions_path
+  end
+
+  def oidc
+    @oidc ||= OidcClient.new(
+      Services.accounts_api,
+      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID"),
+      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"),
+    )
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,13 +18,16 @@ class SessionsController < ApplicationController
 
     state = params.require(:state)
 
-    user_info = oidc.callback(
+    callback = oidc.callback(
       params.require(:code),
       state,
     )
 
-    session[:sub] = user_info.sub
-    session[:email] = user_info.email
+    access_token = callback[:access_token]
+    sub = callback[:sub]
+
+    session[:sub] = sub
+    session[:access_token] = access_token.token_response[:access_token]
 
     redirect_to redirect_path
   end
@@ -32,6 +35,7 @@ class SessionsController < ApplicationController
   def delete
     session.delete(:sub)
     session.delete(:email)
+    session.delete(:access_token)
     redirect_to redirect_path
   end
 
@@ -39,13 +43,5 @@ private
 
   def redirect_path
     transition_checker_questions_path
-  end
-
-  def oidc
-    @oidc ||= OidcClient.new(
-      Services.accounts_api,
-      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID"),
-      ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"),
-    )
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,14 +28,13 @@ class SessionsController < ApplicationController
 
     session[:sub] = sub
     session[:access_token] = access_token.token_response[:access_token]
+    session[:refresh_token] = access_token.token_response[:refresh_token]
 
     redirect_to redirect_path
   end
 
   def delete
-    session.delete(:sub)
-    session.delete(:email)
-    session.delete(:access_token)
+    logout!
     redirect_to redirect_path
   end
 

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -99,8 +99,12 @@ module BrexitCheckerHelper
     end
   end
 
+  def accounts_enabled?
+    Rails.configuration.feature_flag_govuk_accounts
+  end
+
   def check_accounts_enabled
-    unless Rails.configuration.feature_flag_govuk_accounts
+    unless accounts_enabled?
       render file: Rails.root.join(Rails.root, "public/404.html"), status: :not_found
     end
   end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -1,0 +1,64 @@
+require "openid_connect"
+
+class OidcClient
+  attr_reader :client_id,
+              :provider_uri
+
+  delegate :authorization_endpoint,
+           :token_endpoint,
+           :userinfo_endpoint,
+           :end_session_endpoint,
+           to: :discover
+
+  def initialize(provider_uri, client_id, secret)
+    @provider_uri = provider_uri
+    @client_id = client_id
+    @secret = secret
+  end
+
+  def auth_uri
+    nonce = SecureRandom.hex(16)
+    {
+      uri: client.authorization_uri(
+        scope: scopes,
+        state: nonce,
+        nonce: nonce,
+      ),
+      state: nonce,
+    }
+  end
+
+  def redirect_uri
+    host = "http://#{ENV['VIRTUAL_HOST']}" || ENV["GOVUK_WEBSITE_ROOT"]
+    host + Rails.application.routes.url_helpers.transition_checker_new_session_callback_path
+  end
+
+  def scopes
+    %i[email transition_checker]
+  end
+
+  def callback(code, state)
+    client.authorization_code = code
+    access_token = client.access_token!
+    id_token = OpenIDConnect::ResponseObject::IdToken.decode access_token.id_token, discover.jwks
+    id_token.verify! client_id: client_id, issuer: discover.issuer, nonce: state
+    access_token.userinfo!
+  end
+
+private
+
+  def client
+    @client ||= OpenIDConnect::Client.new(
+      identifier: client_id,
+      secret: @secret,
+      redirect_uri: redirect_uri,
+      authorization_endpoint: authorization_endpoint,
+      token_endpoint: token_endpoint,
+      userinfo_endpoint: userinfo_endpoint,
+    )
+  end
+
+  def discover
+    @discover ||= OpenIDConnect::Discovery::Provider::Config.discover! provider_uri
+  end
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -31,9 +31,7 @@ module Services
     Registries::BaseRegistries.new
   end
 
-  if Rails.configuration.feature_flag_govuk_accounts
-    def self.accounts_api
-      Plek.find("account-manager")
-    end
+  def self.accounts_api
+    Plek.find("account-manager")
   end
 end

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -39,6 +39,9 @@
 <div class="govuk-width-container brexit-checker-results-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= sanitize(@account_information) %>
+
+
       <%= render "govuk_publishing_components/components/title", {
         title: action_based_title
       } %>

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -29,8 +29,6 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= sanitize(@account_information) %>
-
       <form
         action="<%= transition_checker_questions_path %>"
         method="get"

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -29,6 +29,8 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= sanitize(@account_information) %>
+
       <form
         action="<%= transition_checker_questions_path %>"
         method="get"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,3 +54,34 @@ Rails.application.configure do
   # Allow requests for all domains e.g. <app>.dev.gov.uk
   config.hosts.clear
 end
+
+# make discovery work over HTTP
+module OpenIDConnect
+  module Discovery
+    module Provider
+      class Config
+        class Resource
+          def initialize(uri)
+            @host = uri.host
+            @port = uri.port unless [80, 443].include?(uri.port)
+            @path = File.join uri.path, ".well-known/openid-configuration"
+            @scheme = uri.scheme
+            attr_missing!
+          end
+
+          def endpoint
+            SWD.url_builder = case @scheme
+                              when "http"
+                                URI::HTTP
+                              else
+                                URI::HTTPS
+                              end
+            SWD.url_builder.build [nil, host, port, path, nil, nil]
+          rescue URI::Error => e
+            raise SWD::Exception, e.message
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-FinderFrontend::Application.config.session_store :disabled
+FinderFrontend::Application.config.session_store :cookie_store

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,20 +18,19 @@ FinderFrontend::Application.routes.draw do
     get "/test-search/search/opensearch" => "search#opensearch"
   end
 
-  # Routes for the for Transition/Brexit Checker
-  get "/transition-check/results" => "brexit_checker#results", as: :transition_checker_results
-  get "/transition-check/questions" => "brexit_checker#show", as: :transition_checker_questions
-  get "/transition-check/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup
-  post "/transition-check/email-signup" => "brexit_checker#confirm_email_signup", as: :transition_checker_confirm_email_signup
+  scope "/transition-check" do
+    get "/results" => "brexit_checker#results", as: :transition_checker_results
+    get "/questions" => "brexit_checker#show", as: :transition_checker_questions
+    get "/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup
+    post "/email-signup" => "brexit_checker#confirm_email_signup", as: :transition_checker_confirm_email_signup
+    get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
+  end
 
   # Transition/Brexit checker email signup routes
   get "/email/subscriptions/new", to: proc { [200, {}, [""]] }, as: :email_alert_frontend_signup
 
   get "/*slug/email-signup" => "email_alert_subscriptions#new", as: :new_email_alert_subscriptions
   post "/*slug/email-signup" => "email_alert_subscriptions#create", as: :email_alert_subscriptions
-
-  # GOV.UK Accounts discovery routes
-  get "/transition-check/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
 
   # Q&A frontend for "UK Nationals in the EU" (www.gov.uk/uk-nationals-in-the-eu)
   get "/uk-nationals-living-eu" => "qa_to_content#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ FinderFrontend::Application.routes.draw do
     get "/questions" => "brexit_checker#show", as: :transition_checker_questions
     get "/email-signup" => "brexit_checker#email_signup", as: :transition_checker_email_signup
     post "/email-signup" => "brexit_checker#confirm_email_signup", as: :transition_checker_confirm_email_signup
+    get "/login", to: "sessions#create", as: :transition_checker_new_session
+    get "/login/callback", to: "sessions#callback", as: :transition_checker_new_session_callback
+    get "/logout", to: "sessions#delete", as: :transition_checker_end_session
     get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ FinderFrontend::Application.routes.draw do
     get "/logout", to: "sessions#delete", as: :transition_checker_end_session
     get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
     get "/saved-results", to: "brexit_checker#saved_results", as: :transition_checker_saved_results
+    get "/edit-saved-results", to: "brexit_checker#edit_saved_results", as: :transition_checker_edit_saved_results
   end
 
   # Transition/Brexit checker email signup routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ FinderFrontend::Application.routes.draw do
     get "/login/callback", to: "sessions#callback", as: :transition_checker_new_session_callback
     get "/logout", to: "sessions#delete", as: :transition_checker_end_session
     get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
+    get "/saved-results", to: "brexit_checker#saved_results", as: :transition_checker_saved_results
   end
 
   # Transition/Brexit checker email signup routes

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -40,7 +40,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret"
 
       allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
-      allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
 
       allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint)
         .and_return("#{attribute_service_url}/oidc/user_info")

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -1,0 +1,243 @@
+require "spec_helper"
+
+RSpec.feature "Brexit Checker accounts", type: :feature do
+  context "without accounts enabled" do
+    let(:mock_results) { %w[nationality-eu] }
+
+    context "/transition-check/results" do
+      it "does not show the login state" do
+        given_i_am_on_a_question_page
+        expect(page).to_not have_content("Logged in.")
+        expect(page).to_not have_content("Not logged in.")
+      end
+    end
+
+    context "/transition-check/saved-results" do
+      it "returns a 404" do
+        given_i_am_on_the_saved_results_page
+        expect(page.status_code).to eq(404)
+      end
+    end
+
+    def given_i_am_on_a_question_page
+      visit transition_checker_questions_path
+    end
+
+    def given_i_am_on_the_results_page
+      visit transition_checker_results_path(c: mock_results)
+    end
+
+    def given_i_am_on_the_saved_results_page
+      visit transition_checker_saved_results_path
+    end
+  end
+
+  context "with accounts enabled" do
+    let(:attribute_service_url) { "http://attribute-service" }
+
+    before do
+      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "id"
+      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret"
+
+      allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
+      allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
+
+      allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint)
+        .and_return("#{attribute_service_url}/oidc/user_info")
+    end
+
+    let(:mock_results) { %w[nationality-eu] }
+
+    context "the user is not logged in" do
+      context "/transition-check/results" do
+        it "shows the login state" do
+          given_i_am_on_the_results_page
+          expect(page).to_not have_content("Logged in.")
+          expect(page).to have_content("Not logged in.")
+        end
+      end
+
+      context "/transition-check/saved-results" do
+        before do
+          discovery_response = double(authorization_endpoint: "foo", token_endpoint: "foo", userinfo_endpoint: "foo", end_session_endpoint: "foo")
+
+          allow_any_instance_of(OidcClient).to receive(:discover)
+            .and_return(discovery_response)
+
+          allow_any_instance_of(OidcClient).to receive(:auth_uri)
+            .and_return({ uri: "http://account-mamager/login", state: SecureRandom.hex(16) })
+        end
+
+        it "redirects to login page" do
+          given_i_am_on_the_saved_results_page
+          expect(current_path).to eq(transition_checker_new_session_path)
+        end
+      end
+    end
+
+    context "the user is logged in" do
+      before { log_in }
+      after { log_out }
+
+      let(:transition_checker_state) { %w[nationality-uk] }
+
+      context "/transition-check/questions" do
+        it "does not show the login state" do
+          given_i_am_on_a_question_page
+          expect(page).to_not have_content("Logged in.")
+          expect(page).to_not have_content("Not logged in.")
+        end
+      end
+
+      context "/transition-check/results" do
+        it "shows the login state" do
+          given_i_am_on_the_results_page
+          expect(page).to have_content("Logged in.")
+          expect(page).to_not have_content("Not logged in.")
+        end
+      end
+
+      context "/transition-check/saved-results" do
+        it "redirects to first question if no previous results present" do
+          stub = stub_attribute_service_request(:get, body: { claim_value: [] })
+
+          given_i_am_on_the_saved_results_page
+
+          expect(stub).to have_been_made
+
+          expect(page).to have_current_path(transition_checker_questions_path)
+          expect(page).to_not have_content("Not logged in.")
+        end
+
+        it "redirects to previous results if present" do
+          stub = stub_attribute_service_request(:get, body: { claim_value: transition_checker_state })
+
+          given_i_am_on_the_saved_results_page
+
+          expect(stub).to have_been_made
+
+          expect(page).to have_current_path(transition_checker_results_path(c: %w[nationality-uk]))
+          expect(page).to_not have_content("Not logged in.")
+        end
+      end
+
+      context "the access token has expired" do
+        context "the refresh token is valid" do
+          before { allow_token_refresh }
+
+          context "/transition-check/results" do
+            context "token expires before the GET" do
+              it "refreshes the access token and retries" do
+                stub_get_fail = stub_attribute_service_request(:get, status: 401)
+                stub_get_success = stub_attribute_service_request(
+                  :get,
+                  access_token: "new-access-token",
+                  body: { claim_value: transition_checker_state },
+                )
+
+                given_i_am_on_the_saved_results_page
+
+                expect(stub_get_fail).to have_been_made
+                expect(stub_get_success).to have_been_made
+
+                expect(page).to have_content("Logged in")
+                expect(page).to have_content("Your results")
+              end
+            end
+          end
+
+          context "/transition-check/saved-results" do
+            it "refreshes the access token and retries" do
+              stub_fail = stub_attribute_service_request(:get, status: 401)
+              stub_success = stub_attribute_service_request(
+                :get,
+                access_token: "new-access-token",
+                body: { claim_value: transition_checker_state },
+              )
+
+              given_i_am_on_the_saved_results_page
+
+              expect(stub_fail).to have_been_made
+              expect(stub_success).to have_been_made
+
+              expect(page).to have_current_path(transition_checker_results_path(c: %w[nationality-uk]))
+              expect(page).to_not have_content("Not logged in.")
+            end
+          end
+
+          def allow_token_refresh
+            new_access_token = Rack::OAuth2::AccessToken::Bearer.new(
+              access_token: "new-access-token",
+              refresh_token: "new-refresh-token",
+            )
+
+            client_dub = double("Client")
+            allow(client_dub).to receive(:"refresh_token=").with("refresh-token")
+            allow(client_dub).to receive(:access_token!).and_return(new_access_token)
+
+            allow_any_instance_of(OidcClient).to receive(:client).and_return(client_dub)
+          end
+        end
+
+        context "the refresh token is invalid" do
+          before { forbid_token_refresh }
+
+          it "logs the user out" do
+            stub_fail = stub_attribute_service_request(:get, status: 401)
+
+            given_i_am_on_the_saved_results_page
+
+            expect(stub_fail).to have_been_made
+
+            expect(current_path).to eq(transition_checker_questions_path)
+          end
+
+          def forbid_token_refresh
+            client_dub = double("Client")
+            allow(client_dub).to receive(:"refresh_token=").with("refresh-token")
+            allow(client_dub).to receive(:access_token!)
+              .and_raise(Rack::OAuth2::Client::Error.new(401, { error: "bad", error_description: "bad" }))
+
+            allow_any_instance_of(OidcClient).to receive(:client).and_return(client_dub)
+          end
+        end
+      end
+
+      def log_in
+        access_token = Rack::OAuth2::AccessToken::Bearer.new(
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+        )
+
+        sub = "subject-identifier"
+
+        allow_any_instance_of(OidcClient).to receive(:callback)
+          .and_return({ access_token: access_token, sub: sub })
+
+        visit transition_checker_new_session_callback_path(state: "state", code: "code")
+      end
+
+      def log_out
+        visit transition_checker_end_session_path
+      end
+    end
+
+    def given_i_am_on_a_question_page
+      visit transition_checker_questions_path
+    end
+
+    def given_i_am_on_the_results_page
+      visit transition_checker_results_path(c: mock_results)
+    end
+
+    def given_i_am_on_the_saved_results_page
+      visit transition_checker_saved_results_path
+    end
+
+    def stub_attribute_service_request(method, access_token: "access-token", status: 200, body: "")
+      stub_request(method, "#{attribute_service_url}/v1/attributes/transition_checker_state")
+        .with(headers: { "Authorization" => "Bearer #{access_token}" })
+        .to_return(status: status, body: body.to_json)
+    end
+  end
+end

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -42,7 +42,6 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
       allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
-      allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
     end
 
     scenario "user clicks to signup to email alerts with existing subscriber list" do

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
     allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
-    allow(Services).to receive(:accounts_api).and_return(Plek.find("account-manager"))
   end
 
   scenario "user clicks Create a GOV.UK account" do


### PR DESCRIPTION
Allows logging into the Transition Checker using a GOV.UK Account and retrieval of previous results.

All the functionality here is currently hidden from users behind a feature flag, therefore there will be no public changes until we enable this flag.

This adds a number of routes:
- `/transition-check/login`
- `/transition-check/login/callback`
- `/transition-check/logout`
- `/transition-check/saved-results`
- `/transition-check/edit-saved-results`

All the routes should be self explanatory, apart from the final two.

The `saved-results` route conducts some logic:
- User logged in and has checker results: redirects to the results page with their responses pre-populated as part of the query string
- User logged in and has no checker results: redirects to first question in checker
- User logged out: redirects to login route, then one of the above two scenarios after login

The `edit-saved-results` route is similar:
- User logged in and has checker results: redirects to the first question with their responses pre-populated as part of the query string
- User logged in and has no checker results: redirects to first question in checker
- User logged out: redirects to login route, then one of the above two scenarios after login

Trello card: https://trello.com/c/F2pCU73B