### PR TITLE
Add Ruby linter to Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,5 +16,5 @@ end
 FinderFrontend::Application.load_tasks
 
 unless Rails.env.production?
-  task default: %w[jasmine:ci]
+  task default: %w[jasmine:ci lint]
 end

--- a/app/lib/brexit_checker/convert_csv_to_yaml/converter.rb
+++ b/app/lib/brexit_checker/convert_csv_to_yaml/converter.rb
@@ -34,11 +34,11 @@ module BrexitChecker
     private
 
       FIELD_NAME_OVERRIDES = {
-        "Priority (1 is low, 10 is high)" => "priority"
+        "Priority (1 is low, 10 is high)" => "priority",
       }.freeze
 
       def convert_headers
-        ->(field, _) {
+        lambda { |field, _|
           field = FIELD_NAME_OVERRIDES[field] || field
           field.downcase.gsub(" ", "_")
         }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def and_i_should_see_customs_agent_action
     action = BrexitChecker::Action.find_by_id("T099")
-    expect(page).to have_css("h3", text: "Decide how you want to make customs declarations and whether you need to get someone to deal with customs for you" )
+    expect(page).to have_css("h3", text: "Decide how you want to make customs declarations and whether you need to get someone to deal with customs for you")
     expect(page).to have_css(".govuk-link[href='#{action.guidance_url}'][data-track-action]")
     data_track_action = page.find(".govuk-link[href='#{action.guidance_url}']")["data-track-action"]
     expect(data_track_action).to eq("Your business or organisation - 1.4 - Guidance")


### PR DESCRIPTION
- Add Rubocop Ruby linting to Rake.
- Fix existing lint errors.

Rubocop will now run as part of `bundle exec rake`.


