### PR TITLE
Add service to get Mapit data for postcode

### DIFF
--- a/app/models/mapit_postcode_response.rb
+++ b/app/models/mapit_postcode_response.rb
@@ -1,0 +1,35 @@
+class MapitPostcodeResponse
+  attr_reader :location
+
+  def initialize(location)
+    @location = location
+  end
+
+  def gss
+    location["codes"]["gss"]
+  end
+
+  def area_name
+    location["name"]
+  end
+
+  def country
+    location["country_name"]
+  end
+
+  def england?
+    country == "England"
+  end
+
+  def scotland?
+    country == "Scotland"
+  end
+
+  def wales?
+    country == "Wales"
+  end
+
+  def northern_ireland?
+    country == "Northern Ireland"
+  end
+end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -22,10 +22,14 @@ class LocationLookupService
 private
 
   def areas
+    return [] if response.blank?
+
     response["response"].select { |data| data.first == "areas" }.first.last
   end
 
   def response
     JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+  rescue GdsApi::HTTPNotFound
+    []
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -28,8 +28,10 @@ private
   end
 
   def response
-    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
-  rescue GdsApi::HTTPNotFound
-    []
+    @response ||= begin
+                    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+                  rescue GdsApi::HTTPNotFound
+                    []
+                  end
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -7,13 +7,8 @@ class LocationLookupService
 
   def data
     location_data = areas.map do |_, area|
-      next if area["codes"]["gss"].blank?
-
-      {
-        gss: area["codes"]["gss"],
-        area_name: area["name"],
-        country: area["country_name"],
-      }
+      location = MapitPostcodeResponse.new(area)
+      location if location.gss
     end
 
     location_data.compact

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -1,0 +1,31 @@
+class LocationLookupService
+  attr_reader :postcode
+
+  def initialize(postcode)
+    @postcode = postcode
+  end
+
+  def data
+    location_data = areas.map do |_, area|
+      next if area["codes"]["gss"].blank?
+
+      {
+        gss: area["codes"]["gss"],
+        area_name: area["name"],
+        country: area["country_name"],
+      }
+    end
+
+    location_data.compact
+  end
+
+private
+
+  def areas
+    response["response"].select { |data| data.first == "areas" }.first.last
+  end
+
+  def response
+    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+  end
+end

--- a/spec/models/mapit_postcode_response_spec.rb
+++ b/spec/models/mapit_postcode_response_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.describe MapitPostcodeResponse do
+  let(:location) do
+    {
+      "codes" => {
+        "ons" => "01",
+        "gss" => "E01000123",
+        "govuk_slug" => "test-one",
+      },
+      "name" => "Coruscant Planetary Council",
+      "type" => "LBO",
+      "country_name" => "England",
+    }
+  end
+
+  it "returns the gss code" do
+    expect(described_class.new(location).gss).to eq("E01000123")
+  end
+
+  it "returns the area name" do
+    expect(described_class.new(location).area_name).to eq("Coruscant Planetary Council")
+  end
+
+  it "returns the country" do
+    expect(described_class.new(location).country).to eq("England")
+  end
+
+  describe "#england?" do
+    it "returns true if the country is England" do
+      expect(described_class.new(location).england?).to be true
+    end
+  end
+
+  describe "#scotland?" do
+    it "returns true if the country is Scotland" do
+      location["country_name"] = "Scotland"
+
+      expect(described_class.new(location).scotland?).to be true
+    end
+  end
+
+  describe "#wales?" do
+    it "returns true if the country is Wales" do
+      location["country_name"] = "Wales"
+
+      expect(described_class.new(location).wales?).to be true
+    end
+  end
+
+  describe "#northern_ireland?" do
+    it "returns true if the country is Northern Ireland" do
+      location["country_name"] = "Northern Ireland"
+
+      expect(described_class.new(location).northern_ireland?).to be true
+    end
+  end
+end

--- a/spec/services/location_lookup_service_spec.rb
+++ b/spec/services/location_lookup_service_spec.rb
@@ -73,5 +73,12 @@ RSpec.describe LocationLookupService do
 
       expect(described_class.new(postcode).data).to eq(expected_data)
     end
+
+    it "returns nothing if the postcode isn't found" do
+      postcode = "E18QS"
+      stub_mapit_does_not_have_a_postcode(postcode)
+
+      expect(described_class.new(postcode).data).to eq([])
+    end
   end
 end

--- a/spec/services/location_lookup_service_spec.rb
+++ b/spec/services/location_lookup_service_spec.rb
@@ -27,20 +27,14 @@ RSpec.describe LocationLookupService do
       ]
       stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-      expected_data = [
-        {
-          gss: "E01000123",
-          area_name: "Coruscant Planetary Council",
-          country: "England",
-        },
-        {
-          gss: "E02000456",
-          area_name: "Galactic Empire",
-          country: "England",
-        },
-      ]
+      data = described_class.new(postcode).data
 
-      expect(described_class.new(postcode).data).to eq(expected_data)
+      expect(data.size).to eq(2)
+      expect(data.first).to be_a(MapitPostcodeResponse)
+      expect(data.first.gss).to eq("E01000123")
+
+      expect(data.second).to be_a(MapitPostcodeResponse)
+      expect(data.second.gss).to eq("E02000456")
     end
 
     it "only returns locations with a gss code" do
@@ -63,15 +57,11 @@ RSpec.describe LocationLookupService do
       ]
       stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-      expected_data = [
-        {
-          gss: "E01000123",
-          area_name: "Coruscant Planetary Council",
-          country: "England",
-        },
-      ]
+      data = described_class.new(postcode).data
 
-      expect(described_class.new(postcode).data).to eq(expected_data)
+      expect(data.size).to eq(1)
+      expect(data.first).to be_a(MapitPostcodeResponse)
+      expect(data.first.gss).to eq("E01000123")
     end
 
     it "returns nothing if the postcode isn't found" do

--- a/spec/services/location_lookup_service_spec.rb
+++ b/spec/services/location_lookup_service_spec.rb
@@ -1,0 +1,77 @@
+require "spec_helper"
+require "gds_api/test_helpers/mapit"
+
+RSpec.describe LocationLookupService do
+  include GdsApi::TestHelpers::Mapit
+
+  describe "#data" do
+    it "returns location data" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "ons" => "01",
+          "gss" => "E01000123",
+          "govuk_slug" => "test-one",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+          "country_name" => "England",
+        },
+        {
+          "ons" => "02",
+          "gss" => "E02000456",
+          "govuk_slug" => "test-two",
+          "name" => "Galactic Empire",
+          "type" => "GLA",
+          "country_name" => "England",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      expected_data = [
+        {
+          gss: "E01000123",
+          area_name: "Coruscant Planetary Council",
+          country: "England",
+        },
+        {
+          gss: "E02000456",
+          area_name: "Galactic Empire",
+          country: "England",
+        },
+      ]
+
+      expect(described_class.new(postcode).data).to eq(expected_data)
+    end
+
+    it "only returns locations with a gss code" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "ons" => "01",
+          "gss" => "E01000123",
+          "govuk_slug" => "test-one",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+          "country_name" => "England",
+        },
+        {
+          "govuk_slug" => "test-two",
+          "name" => "Galactic Empire",
+          "type" => "GLA",
+          "country_name" => "England",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      expected_data = [
+        {
+          gss: "E01000123",
+          area_name: "Coruscant Planetary Council",
+          country: "England",
+        },
+      ]
+
+      expect(described_class.new(postcode).data).to eq(expected_data)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/k6gph1nJ

# What?
Adds a service that takes a postcode as an input and gets location data from Mapit.

The service return the following for each "area" (local authority, ward etc) that the postcode is in:
- The "gss" code
- The area name, E.g "Maldon District Council"
- The country the postcode is in.

# Why?
A local restrictions postcode lookup is being built to help users find local restrictions in their area. The local restrictions will be LTLA (Lower Tier Local Authority) and will use GSS codes to match users to their area. People don't know which GSS codes they are in, so we need be able to find it for them from their postcode.

# How to test the changes

Mapit data isn't available locally unless you download all of the data (not recommended) so the best way to test this is to deploy a branch to integration and run the following in a console:

```
LocationLookupService.new("E1 8QS").data
```

## Results from testing

```
irb(main):001:0> data = LocationLookupService.new("E1 8QS").data
=> [#<MapitPostcodeResponse:0x00007f08c1e9e438 @location={"all_names"=>{}, "parent_area"=>nil, "type_name"=>"UK Parliament constituency", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"WMC", "name"=>"Bethnal Green and Bow", "country_name"=>"England", "codes"=>{"ons"=>"A26", "gss"=>"E14000555", "unit_id"=>"25070"}, "id"=>10675}>, #<MapitPostcodeResponse:0x00007f08c1e9e410 @location={"all_names"=>{}, "parent_area"=>1684, "type_name"=>"London Assembly constituency", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"LAC", "name"=>"City and East", "country_name"=>"England", "codes"=>{"ons"=>"", "gss"=>"E32000004", "unit_id"=>"41444"}, "id"=>9221}>, #<MapitPostcodeResponse:0x00007f08c1e9e3e8 @location={"all_names"=>{}, "parent_area"=>nil, "type_name"=>"European region", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"EUR", "name"=>"London", "country_name"=>"England", "codes"=>{"ons"=>"07", "gss"=>"E15000007", "unit_id"=>"41428"}, "id"=>9209}>, #<MapitPostcodeResponse:0x00007f08c1e9e3c0 @location={"all_names"=>{}, "parent_area"=>2004, "type_name"=>"London borough ward", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"LBW", "name"=>"Whitechapel", "country_name"=>"England", "codes"=>{"gss"=>"E05009336", "unit_id"=>"11192"}, "id"=>5082}>, #<MapitPostcodeResponse:0x00007f08c1e9e398 @location={"all_names"=>{}, "parent_area"=>nil, "type_name"=>"London borough", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"LBO", "name"=>"London Borough of Tower Hamlets", "country_name"=>"England", "codes"=>{"ons"=>"00BG", "gss"=>"E09000030", "govuk_slug"=>"tower-hamlets", "unit_id"=>"11185"}, "id"=>2004}>]
irb(main):002:0> data.first
=> #<MapitPostcodeResponse:0x00007f08c1e9e438 @location={"all_names"=>{}, "parent_area"=>nil, "type_name"=>"UK Parliament constituency", "generation_low"=>1, "country"=>"E", "generation_high"=>1, "type"=>"WMC", "name"=>"Bethnal Green and Bow", "country_name"=>"England", "codes"=>{"ons"=>"A26", "gss"=>"E14000555", "unit_id"=>"25070"}, "id"=>10675}>
irb(main):003:0> data.first.gss
=> "E14000555"
irb(main):004:0> data.first.england?
=> true
irb(main):005:0> data.first.country
=> "England"
irb(main):006:0> data.last.country
=> "England"
irb(main):008:0> data.last.area_name
=> "London Borough of Tower Hamlets"
irb(main):009:0> data.last.gss
=> "E09000030"
```

Paired with: @Rosa-Fox 


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
