### PR TITLE
Model local restriction data

### DIFF
--- a/app/models/local_restriction.rb
+++ b/app/models/local_restriction.rb
@@ -1,0 +1,43 @@
+class LocalRestriction
+  FILE_PATH = "app/lib/local_restrictions/local-restrictions.yaml".freeze
+
+  attr_reader :gss_code
+
+  def initialize(gss_code)
+    @gss_code = gss_code
+  end
+
+  def area_name
+    restriction["name"]
+  end
+
+  def alert_level
+    restriction["alert_level"]
+  end
+
+  def guidance
+    restriction["guidance"]
+  end
+
+  def extra_restrictions
+    restriction["extra_restrictions"]
+  end
+
+  def start_date
+    restriction["start_date"]&.to_date
+  end
+
+  def end_date
+    restriction["end_date"]&.to_date
+  end
+
+private
+
+  def all_restrictions
+    @all_restrictions ||= YAML.load_file(FILE_PATH)
+  end
+
+  def restriction
+    all_restrictions[gss_code] || {}
+  end
+end

--- a/spec/fixtures/local-restrictions.yaml
+++ b/spec/fixtures/local-restrictions.yaml
@@ -1,0 +1,10 @@
+---
+E08000001:
+  alert_level: 4
+  name: Tatooine
+  start_date: "01 October 2020"
+  end_date: "02 October 2020"
+  guidance:
+    label: These are not the restrictions you are looking for
+    link: "guidance/tatooine-local-restrictions"
+  extra_restrictions:

--- a/spec/models/local_restriction_spec.rb
+++ b/spec/models/local_restriction_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe LocalRestriction do
+  before do
+    stub_const("LocalRestriction::FILE_PATH", "spec/fixtures/local-restrictions.yaml")
+  end
+
+  let(:restriction) { described_class.new("E08000001") }
+
+  it "returns the area name" do
+    expect(restriction.area_name).to eq("Tatooine")
+  end
+
+  it "returns the alert level" do
+    expect(restriction.alert_level).to eq(4)
+  end
+
+  it "returns the guidance" do
+    guidance = restriction.guidance
+    expect(guidance["label"]).to eq("These are not the restrictions you are looking for")
+    expect(guidance["link"]).to eq("guidance/tatooine-local-restrictions")
+  end
+
+  it "returns the extra restrictions" do
+    expect(restriction.extra_restrictions).to be nil
+  end
+
+  it "returns nil values if the gss code doesn't exist" do
+    restriction = described_class.new("fake code")
+    name = restriction.area_name
+    guidance = restriction.guidance
+    expect(name).to be nil
+    expect(guidance).to be nil
+  end
+
+  describe "#start_date" do
+    it "returns the start date" do
+      expect(restriction.start_date).to eq("01 October 2020".to_date)
+    end
+
+    it "allows the start date to be nil" do
+      restriction = described_class.new("E08000002")
+      expect(restriction.start_date).to be nil
+    end
+  end
+
+  describe "#end_date" do
+    it "returns the end date" do
+      expect(restriction.end_date).to eq("02 October 2020".to_date)
+    end
+
+    it "allows the end date to be nil" do
+      restriction = described_class.new("E08000002")
+      expect(restriction.end_date).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Adds a service that takes a GSS code (from Mapit), and matches against the local lockdown data held in finder-frontend, and returns data for that area.

We have chosen to stub out the fixture path in order to separate test data from that which is live.

## Testing locally

The test suite can be run with `bundle exec rake`. You can also open a rails console and check that the LocalRestriction class is responding to the expected methods. 

```
irb(main):004:0> restriction = LocalRestriction.new("E08000001")
=> #<LocalRestriction:0x00007fc98d9b7c20 @gss_code="E08000001">
irb(main):005:0> restriction.area_name
=> "Bolton"
```

## Trello 
https://trello.com/c/40EHq00z/829-add-mapping-service-to-get-lockdown-data-from-gss-code

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
