### PR TITLE
Adding lookup partial

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/subscription-links';
 @import 'govuk_publishing_components/components/title';
+@import "govuk_publishing_components/components/error-alert";
 
 @import 'components/*';
 @import 'finder_frontend';

--- a/app/assets/stylesheets/components/_lookup.scss
+++ b/app/assets/stylesheets/components/_lookup.scss
@@ -1,0 +1,5 @@
+.app-c-lookup {
+  padding: govuk-spacing(3);
+  margin: govuk-spacing(6) 0;
+  background: govuk-colour("light-grey");
+}

--- a/app/views/components/_lookup.html.erb
+++ b/app/views/components/_lookup.html.erb
@@ -1,0 +1,44 @@
+<%
+  input_label ||= "Enter your postcode"
+  input_value ||= ""
+  input_error ||= ""
+  hint_text ||= ""
+  button_text ||= ""
+  error_message ||= nil
+  error_description ||= nil
+  autocomplete ||= nil
+  link ||= nil
+%>
+<% if error_message %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+      message: error_message,
+      description: error_description,
+    } %>
+<% end %>
+<div class="app-c-lookup">
+  <form method="post">
+    <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: input_label
+          },
+          heading_size: "s",
+          error_message: input_error,
+          value: input_value,
+          name: "app-c-lookup",
+          hint: hint_text,
+          invalid: error_message ? 'true' : 'false',
+          autocomplete: autocomplete,
+        } %>
+    <%= render "govuk_publishing_components/components/button", text: button_text, margin_bottom: true %>
+  </form>
+
+  <% if link %>
+    <%= tag.p link_to(
+      link[:text],
+      link[:href],
+      target: "_blank",
+      class: "govuk-link govuk-link--external",
+      rel: "external"),
+      class: "govuk-body" %>
+  <% end %>
+</div>

--- a/spec/components/lookup_spec.rb
+++ b/spec/components/lookup_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe "lookup", type: :view do
+  def component_name
+    "lookup"
+  end
+
+  def render_component(locals)
+    if block_given?
+      render("components/#{component_name}", locals) { yield }
+    else
+      render "components/#{component_name}", locals
+    end
+  end
+
+  it "displays external link" do
+    render_component(link: { text: "Find a postcode on Royal Mail", href: "royalmail.com/share" })
+    assert_select ".govuk-link--external"
+    assert_select ".govuk-link.govuk-link--external", text: "Find a postcode on Royal Mail"
+    assert_select ".govuk-link.govuk-link--external", href: /royalmail\.com\/share/
+  end
+
+  it "displays inline input error alert" do
+    render_component(error_message: "error message", input_error: "input error")
+    assert_select ".gem-c-error-message", text: "Error: input error"
+    assert_select ".gem-c-error-alert"
+  end
+
+  it "displays error alert box" do
+    render_component(error_message: "This isn't a valid postcode.", error_description: "Check it and enter it again.")
+    assert_select ".gem-c-error-alert"
+    assert_select ".gem-c-error-summary__title", text: "This isn't a valid postcode."
+    assert_select ".gem-c-error-summary__body", text: "Check it and enter it again."
+  end
+
+  it "has lookup question" do
+    render_component(input_label: "Enter a postcode")
+    assert_select "label.gem-c-label.govuk-label.govuk-label--s", text: "Enter a postcode"
+  end
+
+  it "missing lookup question" do
+    render_component(input_label: "Enter a postcode")
+    assert_select "label.gem-c-label.govuk-label.govuk-label--s", text: "Enter a postcode"
+  end
+
+  it "contains lookup hint text" do
+    render_component(hint_text: "For example SW1A 2AA")
+    assert_select ".govuk-hint", text: "For example SW1A 2AA"
+  end
+
+  it "contains lookup button and text" do
+    render_component(button_text: "Find")
+    assert_select ".gem-c-button", text: "Find"
+  end
+
+  it "contains autocomplete" do
+    render_component(autocomplete: "postcode")
+    assert_select ".gem-c-input.govuk-input"
+    assert_select ".gem-c-input.govuk-input", autocomplete: "postcode"
+  end
+end


### PR DESCRIPTION
Postcode lookup partial & styling for MVP (based on postcode lookup partial for `[find-my-council](https://github.com/alphagov/frontend/tree/master/app/views/find_local_council)`), adjusted to be more generic and partially portable, adding tests focusing on error copy, updating after feedback.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
