### PR TITLE
Add a :has_session key to the session for tracking login state

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
 private
 
   def skip_session_cookie
-    unless current_user
+    unless session[:has_session]
       request.session_options[:drop] = true
     end
   end
@@ -111,7 +111,7 @@ private
   end
 
   def logged_in?
-    current_user.present?
+    current_user.present? && session[:has_session]
   end
 
   def current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,6 +33,7 @@ class SessionsController < ApplicationController
     sub = callback[:sub]
     redirect_path = callback[:redirect_path] || default_redirect_path
 
+    session[:has_session] = true
     session[:sub] = sub
     session[:access_token] = access_token.token_response[:access_token]
     session[:refresh_token] = access_token.token_response[:refresh_token]


### PR DESCRIPTION
We can't drop the session if :sub isn't set, because :sub gets unset
when a user is logged out, which means the updated session never gets
committed and the user is still logged in!

This isn't ideal, but by setting a key when the user logs in (and
never unsetting it), we can ensure that the session gets dropped for
non-accounts users.

---

[Trello card](https://trello.com/c/F2pCU73B/298-implement-signing-in-to-the-checker)
