### PR TITLE
Fix typos in CSS class name

### DIFF
--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -1,5 +1,5 @@
 .brexit-checker-results-page {
-  .brexit-checker__critera_explaination,
+  .brexit-checker__criteria_explanation,
   .brexit-checker__criterion {
     @include govuk-font(16);
   }

--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -4,7 +4,7 @@
     <h3 class="govuk-heading-m"><%= heading %></h3>
   <% end %>
     <aside>
-      <p class="govuk-body brexit-checker__critera_explaination">
+      <p class="govuk-body brexit-checker__criteria_explanation">
         <%= t('brexit_checker.results.criteria.list_context') %>
       </p>
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
There are two typos in the CSS class name, so fixing those here.