### PR TITLE
Don't always assume VIRTUAL_HOST requires http

### DIFF
--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -33,7 +33,7 @@ class OidcClient
   end
 
   def redirect_uri
-    host = "http://#{ENV['VIRTUAL_HOST']}" || ENV["GOVUK_WEBSITE_ROOT"]
+    host = ENV["VIRTUAL_HOST"] || ENV["GOVUK_WEBSITE_ROOT"]
     host + Rails.application.routes.url_helpers.transition_checker_new_session_callback_path
   end
 


### PR DESCRIPTION
We may wish to deploy versions of the checker that don't exist in the main GOV.UK infrastructure but are using https.  Therefore we shouldn't assume http will always be the protocol.