### PR TITLE
Email topic slug

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -11,6 +11,8 @@ class BrexitCheckerController < ApplicationController
   before_action :enable_caching, only: %i[show]
   before_action :enable_caching_unless_accounts, only: %i[results email_signup confirm_email_signup save_results saved_results edit_saved_results]
 
+  helper_method :subscriber_list_slug
+
   def show
     all_questions = BrexitChecker::Question.load_all
     @question_index = next_question_index(
@@ -51,9 +53,6 @@ class BrexitCheckerController < ApplicationController
   def email_signup; end
 
   def confirm_email_signup
-    request = Services.email_alert_api.find_or_create_subscriber_list_cached(subscriber_list_options)
-    subscriber_list_slug = request.dig("subscriber_list", "slug")
-
     redirect_to email_alert_frontend_signup_path(topic_id: subscriber_list_slug)
   end
 
@@ -106,6 +105,12 @@ class BrexitCheckerController < ApplicationController
   end
 
 private
+
+  def subscriber_list_slug
+    @subscriber_list_slug ||= Services.email_alert_api
+      .find_or_create_subscriber_list_cached(subscriber_list_options)
+      .dig("subscriber_list", "slug")
+  end
 
   def enable_caching
     expires_in(30.minutes, public: true) unless Rails.env.development?

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -86,10 +86,11 @@ module BrexitCheckerHelper
     end
   end
 
-  def account_signup_jwt(criteria_keys)
+  def account_signup_jwt(criteria_keys, subscriber_list_slug)
     account_jwt = BrexitChecker::AccountJwt.new(
       criteria_keys,
       Services.oidc.auth_uri(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys))[:uri],
+      subscriber_list_slug,
     )
     account_jwt.encode
   end

--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -1,7 +1,8 @@
 class BrexitChecker::AccountJwt
-  def initialize(criteria_keys, oauth_uri)
+  def initialize(criteria_keys, oauth_uri, subscriber_list_slug)
     @criteria_keys = criteria_keys
     @oauth_uri = oauth_uri
+    @subscriber_list_slug = subscriber_list_slug
   end
 
   def encode(key = ecdsa_key, algorithmn = "ES256")
@@ -10,7 +11,7 @@ class BrexitChecker::AccountJwt
 
 private
 
-  attr_reader :criteria_keys, :oauth_uri
+  attr_reader :criteria_keys, :oauth_uri, :subscriber_list_slug
 
   def payload
     {
@@ -31,6 +32,7 @@ private
       transition_checker_state: {
         criteria_keys: criteria_keys,
         timestamp: Time.zone.now.to_i,
+        email_topic_slug: subscriber_list_slug,
       },
     }
   end

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -58,7 +58,7 @@
         </ul>
 
         <%= form_tag Services.accounts_api, id: "account-signup", class: "account-signup" do %>
-          <input type="hidden" name="jwt" value="<%= account_signup_jwt(criteria_keys) %>">
+          <input type="hidden" name="jwt" value="<%= account_signup_jwt(criteria_keys, subscriber_list_slug) %>">
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),
             margin_bottom: true,

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")
     allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
     allow_any_instance_of(OidcClient).to receive(:auth_uri).and_return({ uri: "http://account-mamager/login", state: SecureRandom.hex(16) })
+    stub_email_subscription_confirmation
   end
 
   scenario "user clicks Create a GOV.UK account" do
@@ -52,5 +53,12 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     expect(form.text).to eql("Create a GOV.UK account")
     expect(form["method"]).to eql("post")
     expect(form["action"]).to eql(Plek.find("account-manager"))
+  end
+
+  def stub_email_subscription_confirmation
+    fixture = { "subscriber_list": { "slug": "test-slug" } }.to_json
+    expected_url = "http://email-alert-api.dev.gov.uk/subscriber-lists?tags%5Bbrexit_checklist_criteria%5D%5Bany%5D%5B0%5D=nationality-eu"
+
+    stub_request(:get, expected_url).to_return(status: 200, body: fixture)
   end
 end

--- a/spec/lib/brexit_checker/account_jwt_spec.rb
+++ b/spec/lib/brexit_checker/account_jwt_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BrexitChecker::AccountJwt do
   let(:key_uuid) { "38d7dd82-8436-43b5-ae97-e160101cec50" }
   let(:criteria_keys) { %w[hello world] }
   let(:oauth_uri) { "http://www.example.com" }
+  let(:subscriber_list_slug) { "test-slug" }
 
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = oauth_client_id
@@ -21,7 +22,7 @@ RSpec.describe BrexitChecker::AccountJwt do
   end
 
   it "generates a valid JWT" do
-    jwt = described_class.new(criteria_keys, oauth_uri).encode
+    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload).to_not be_nil
     expect(payload["uid"]).to eq(oauth_client_id)
@@ -31,14 +32,20 @@ RSpec.describe BrexitChecker::AccountJwt do
   end
 
   it "includes the criteria keys" do
-    jwt = described_class.new(criteria_keys, oauth_uri).encode
+    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload.dig("attributes", "transition_checker_state", "criteria_keys")).to eq(criteria_keys)
   end
 
   it "includes the timestamp" do
-    jwt = described_class.new(criteria_keys, oauth_uri).encode
+    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload.dig("attributes", "transition_checker_state", "timestamp")).to_not be_nil
+  end
+
+  it "includes the email topic slug" do
+    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
+    payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
+    expect(payload.dig("attributes", "transition_checker_state", "email_topic_slug")).to_not be_nil
   end
 end


### PR DESCRIPTION
Relates to: [GOV.UK accounts | Send email topic slug in the JWT](https://trello.com/c/zZ7uOGy4/326-send-email-topic-slug-in-the-jwt)

## What
- Make the query to email-alert-api for checker results subscription slugs reusable
- Query it (or get it as a memoised value) when we're building a JWT to send over to accounts
- Put it in the payload to be encoded into the Account JWT.

## Why

On account creation we want to offer users the chance to be notified of changes to their checker results. So we'll send this slug across to the account manager so we can set up a subscription if the user chooses to.