### PR TITLE
Update email alerts when updating answers

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -64,9 +64,27 @@ class BrexitCheckerController < ApplicationController
 
     @old_criteria_keys = saved_results
     redirect_to transition_checker_results_path(c: criteria_keys) and return if criteria_keys == @old_criteria_keys
+
+    @has_email_subscription = update_session_tokens(
+      Services.oidc.has_email_subscription(
+        access_token: session[:access_token],
+        refresh_token: session[:refresh_token],
+      ),
+    )
   end
 
+  def save_results_email_signup; end
+
   def save_results_apply
+    if params[:email_decision] == "yes"
+      update_session_tokens(
+        Services.oidc.update_email_subscription(
+          slug: subscriber_list_slug,
+          access_token: session[:access_token],
+          refresh_token: session[:refresh_token],
+        ),
+      )
+    end
     update_session_tokens(
       Services.oidc.set_checker_attribute(
         value: { criteria_keys: criteria_keys, timestamp: Time.zone.now.to_i },

--- a/app/views/brexit_checker/save_results_confirm.html.erb
+++ b/app/views/brexit_checker/save_results_confirm.html.erb
@@ -52,11 +52,22 @@
 
         <p class="govuk-body"><%= t("brexit_checker.confirm_changes.message") %></p>
 
-        <%= form_tag transition_checker_save_results_confirm_path(c: criteria_keys), method: :post do %>
-          <%= render "govuk_publishing_components/components/button", {
-            text: t('brexit_checker.confirm_changes.save_button'),
-            inline_layout: true,
-          } %>
+        <% if @has_email_subscription %>
+          <%= form_tag transition_checker_save_results_confirm_path(c: criteria_keys), method: :post do %>
+            <%= hidden_field_tag :email_decision, "yes" %>
+            <%= render "govuk_publishing_components/components/button", {
+              text: t('brexit_checker.confirm_changes.save_button'),
+              inline_layout: true,
+            } %>
+          <% end %>
+        <% else %>
+          <%= form_tag transition_checker_save_results_email_signup_path, method: :get do %>
+            <% criteria_keys.each do |key| %><%= hidden_field_tag :"c[]", key %><% end %>
+            <%= render "govuk_publishing_components/components/button", {
+              text: t('brexit_checker.confirm_changes.save_button'),
+              inline_layout: true,
+            } %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/brexit_checker/save_results_email_signup.html.erb
+++ b/app/views/brexit_checker/save_results_email_signup.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, t('brexit_checker.confirm_changes.title') %>
+<% content_for :head do %>
+  <% unless params[:page] %>
+    <meta name="robots" content="noindex">
+  <% end %>
+<% end %>
+
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    collapse_on_mobile: true,
+    breadcrumbs: [
+      {
+        title: t('brexit_checker.breadcrumbs.home'),
+        url: "/"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.brexit-home'),
+        url: "/transition"
+      },
+      {
+        title: t('brexit_checker.breadcrumbs.results'),
+        url: transition_checker_results_path(c: criteria_keys)
+      }
+    ]
+  } %>
+
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('brexit_checker.confirm_changes_email_signup.heading'),
+            font_size: "xl",
+            heading_level: 1,
+          } %>
+
+        <%= form_tag transition_checker_save_results_confirm_path, method: :post do %>
+          <% criteria_keys.each do |key| %><%= hidden_field_tag :"c[]", key %><% end %>
+          <%= sanitize(t("brexit_checker.confirm_changes_email_signup.description")) %>
+
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "email_decision",
+            heading: t("brexit_checker.confirm_changes_email_signup.radio.prompt"),
+            heading_size: "s",
+            items: [
+              {
+                value: "yes",
+                text: t("brexit_checker.confirm_changes_email_signup.radio.yes")
+              },
+              {
+                value: "no",
+                text: t("brexit_checker.confirm_changes_email_signup.radio.no")
+              }
+            ]
+          } %>
+
+         <%= render "govuk_publishing_components/components/inset_text", {
+           text: t("brexit_checker.confirm_changes_email_signup.unsubscribe")
+         } %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: t('brexit_checker.confirm_changes_email_signup.save_button'),
+            inline_layout: true,
+          } %>
+        <% end %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/config/locales/en/brexit_checker/confirm_changes_email_signup.yml
+++ b/config/locales/en/brexit_checker/confirm_changes_email_signup.yml
@@ -1,0 +1,18 @@
+en:
+  brexit_checker:
+    confirm_changes_email_signup:
+      heading: Do you want to receive emails about the UK transition?
+      description: |
+        <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
+        <p class="govuk-body">You will only get updates if:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>there are changes to your results</li>
+          <li>questions or results are added which may affect you</li>
+        </ul>
+        <p class="govuk-body">You’ll never get more than one email a day. The email will include all the updates made that day.</p>
+      unsubscribe: You can unsubscribe from emails or change your subscription at any time.
+      radio:
+        prompt: Do you want to receive emails about the UK transition?
+        "yes": "Yes"
+        "no": No, I just want to save my results
+      save_button: Continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ FinderFrontend::Application.routes.draw do
     get "/logout", to: "sessions#delete", as: :transition_checker_end_session
     get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
     get "/save-your-results/confirm", to: "brexit_checker#save_results_confirm", as: :transition_checker_save_results_confirm
+    get "/save-your-results/email-signup", to: "brexit_checker#save_results_email_signup", as: :transition_checker_save_results_email_signup
     post "/save-your-results/confirm", to: "brexit_checker#save_results_apply"
     get "/saved-results", to: "brexit_checker#saved_results", as: :transition_checker_saved_results
     get "/edit-saved-results", to: "brexit_checker#edit_saved_results", as: :transition_checker_edit_saved_results


### PR DESCRIPTION
If the user doesn't already have an active subscription, prompt them
to create one.  This isn't quite ideal, as we now have the email
signup frontend and content in both the account manager (for the
registration journey) and here, but we want to rethink this whole
email integration later anyway.

If the user already has an active subscription just update it without
explicitly asking, as we tell them on the confirmation page that this
will happen.

---

[Trello card](https://trello.com/c/9UxDwIhI/340-in-the-update-flow-create-or-update-email-subscriptions)
