### PR TITLE
Rename JWT environment variables

### DIFF
--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -42,10 +42,10 @@ private
   end
 
   def client_oauth_key_uuid
-    ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID")
+    ENV.fetch("GOVUK_ACCOUNT_JWT_KEY_UUID")
   end
 
   def ecdsa_key
-    OpenSSL::PKey::EC.new(ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"))
+    OpenSSL::PKey::EC.new(ENV.fetch("GOVUK_ACCOUNT_JWT_KEY_PEM"))
   end
 end

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -40,8 +40,8 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     before do
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret"
-      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
-      ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
+      ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = "fake_key_uuid"
+      ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = AccountSignupHelper.test_ec_key_fixture
       allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
       discovery_response = double(authorization_endpoint: "foo", token_endpoint: "foo", userinfo_endpoint: "foo", end_session_endpoint: "foo")
       allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret!"
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = "fake_key_uuid"
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = AccountSignupHelper.test_ec_key_fixture
+    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = "fake_key_uuid"
+    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = AccountSignupHelper.test_ec_key_fixture
     allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
     discovery_response = double(authorization_endpoint: "foo", token_endpoint: "foo", userinfo_endpoint: "foo", end_session_endpoint: "foo")
     allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")

--- a/spec/lib/brexit_checker/account_jwt_spec.rb
+++ b/spec/lib/brexit_checker/account_jwt_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe BrexitChecker::AccountJwt do
 
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = oauth_client_id
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = key_uuid
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = private_key.to_pem
+    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = key_uuid
+    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = private_key.to_pem
   end
 
   after do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = nil
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID"] = nil
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_KEY"] = nil
+    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = nil
+    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = nil
   end
 
   it "generates a valid JWT" do


### PR DESCRIPTION
This makes it clear the environment variables are related to JWT, rather than the OAuth flow.

This corresponds with the environment variables set in https://github.com/alphagov/govuk-puppet/pull/10777.

Trello card: https://trello.com/c/CyOeHwIY