### PR TITLE
Update Govspeak component usage

### DIFF
--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -6,9 +6,9 @@
 <%
   formatted_description = nil
   if @current_question.description
-    formatted_description = render("govuk_publishing_components/components/govspeak", {
-      content: @current_question.description.html_safe
-    })
+    formatted_description = render "govuk_publishing_components/components/govspeak", {} do
+      sanitize(@current_question.description)
+    end
   end
 %>
 

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -33,7 +33,9 @@
 
     <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
       <div class="govspeak-wrapper">
-        <%= render 'govuk_publishing_components/components/govspeak', content: @signup_presenter.body.html_safe %>
+        <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+          <%= sanitize(@signup_presenter.body) %>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -67,7 +67,9 @@
     <% if content_item.summary %>
       <div class="govuk-grid-column-two-thirds">
         <div class="metadata-summary ">
-          <%= render 'govuk_publishing_components/components/govspeak', content: content_item.summary.html_safe %>
+          <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+            <%= sanitize(content_item.summary) %>
+          <% end %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## What

Updates the way the Govspeak component to not use the `content` parameter.

## Why

The Govspeak component should not be used with the `content` parameter as that will be deprecated; it should use a `do` block wrapped around sanitized markup instead.

See https://github.com/alphagov/govuk_publishing_components/pull/1632 for more info.

## Visual differences

None.

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
