### PR TITLE
Add post_register_uri to accounts JWT

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -88,9 +88,10 @@ module BrexitCheckerHelper
 
   def account_signup_jwt(criteria_keys, subscriber_list_slug)
     account_jwt = BrexitChecker::AccountJwt.new(
-      criteria_keys,
-      Services.oidc.auth_uri(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys))[:uri],
-      subscriber_list_slug,
+      criteria_keys: criteria_keys,
+      subscriber_list_slug: subscriber_list_slug,
+      post_register_uri: Services.oidc.auth_uri(redirect_path: transition_checker_saved_results_path)[:uri],
+      post_login_uri: Services.oidc.auth_uri(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys))[:uri],
     )
     account_jwt.encode
   end

--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -1,8 +1,9 @@
 class BrexitChecker::AccountJwt
-  def initialize(criteria_keys, oauth_uri, subscriber_list_slug)
+  def initialize(criteria_keys:, subscriber_list_slug:, post_register_uri:, post_login_uri:)
     @criteria_keys = criteria_keys
-    @oauth_uri = oauth_uri
     @subscriber_list_slug = subscriber_list_slug
+    @post_register_uri = post_register_uri
+    @post_login_uri = post_login_uri
   end
 
   def encode(key = ecdsa_key, algorithmn = "ES256")
@@ -11,7 +12,7 @@ class BrexitChecker::AccountJwt
 
 private
 
-  attr_reader :criteria_keys, :oauth_uri, :subscriber_list_slug
+  attr_reader :criteria_keys, :subscriber_list_slug, :post_register_uri, :post_login_uri
 
   def payload
     {
@@ -19,7 +20,8 @@ private
       key: client_oauth_key_uuid,
       scopes: scopes,
       attributes: attributes,
-      post_login_oauth: oauth_uri,
+      post_register_oauth: post_register_uri,
+      post_login_oauth: post_login_uri,
     }
   end
 

--- a/spec/lib/brexit_checker/account_jwt_spec.rb
+++ b/spec/lib/brexit_checker/account_jwt_spec.rb
@@ -6,8 +6,18 @@ RSpec.describe BrexitChecker::AccountJwt do
   let(:oauth_client_id) { "transition-checker-id" }
   let(:key_uuid) { "38d7dd82-8436-43b5-ae97-e160101cec50" }
   let(:criteria_keys) { %w[hello world] }
-  let(:oauth_uri) { "http://www.example.com" }
+  let(:post_register_uri) { "http://www.example.com/register" }
+  let(:post_login_uri) { "http://www.example.com/login" }
   let(:subscriber_list_slug) { "test-slug" }
+
+  let(:jwt) do
+    described_class.new(
+      criteria_keys: criteria_keys,
+      subscriber_list_slug: subscriber_list_slug,
+      post_register_uri: post_register_uri,
+      post_login_uri: post_login_uri,
+    ).encode
+  end
 
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = oauth_client_id
@@ -22,29 +32,26 @@ RSpec.describe BrexitChecker::AccountJwt do
   end
 
   it "generates a valid JWT" do
-    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload).to_not be_nil
     expect(payload["uid"]).to eq(oauth_client_id)
     expect(payload["key"]).to eq(key_uuid)
     expect(payload["scopes"]).to eq(%w[transition_checker])
-    expect(payload["post_login_oauth"]).to eq(oauth_uri)
+    expect(payload["post_register_oauth"]).to eq(post_register_uri)
+    expect(payload["post_login_oauth"]).to eq(post_login_uri)
   end
 
   it "includes the criteria keys" do
-    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload.dig("attributes", "transition_checker_state", "criteria_keys")).to eq(criteria_keys)
   end
 
   it "includes the timestamp" do
-    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload.dig("attributes", "transition_checker_state", "timestamp")).to_not be_nil
   end
 
   it "includes the email topic slug" do
-    jwt = described_class.new(criteria_keys, oauth_uri, subscriber_list_slug).encode
     payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
     expect(payload.dig("attributes", "transition_checker_state", "email_topic_slug")).to_not be_nil
   end


### PR DESCRIPTION
With this parameter we can get a link back from the post-registration
screen to the transition checker's saved-results page.  This will log
the user into the checker (previously they would only have been logged
into the account manager) and lets us send back additional data in the
query string (though we have to be careful with that because not
everyone will click it).

---

Related to https://github.com/alphagov/govuk-account-manager-prototype/pull/245

Part of [trello card](https://trello.com/c/YB2MRHmh/362-change-link-in-the-confirmation-page-to-update-user-cookie-preference)
