### PR TITLE
New transition urgency AB test

### DIFF
--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -27,6 +27,16 @@
     }
   }
 
+  .brexit-checker__action-urgent-tag {
+    margin-bottom: govuk-spacing(2);
+  }
+
+  .brexit-checker__action-urgent {
+    background-color: govuk-colour('light-grey');
+    padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(3) govuk-spacing(5);
+    border-left: 5px solid $govuk-brand-colour;
+  }
+
   .brexit-checker__content-wrapper {
     padding: 0 0 15px 0;
     border-bottom: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -1,3 +1,5 @@
+$urgency-blue: #0055D2;
+
 .brexit-checker-results-page {
   .brexit-checker__criteria_explanation,
   .brexit-checker__criterion {
@@ -28,13 +30,19 @@
   }
 
   .brexit-checker__action-urgent-tag {
-    margin-bottom: govuk-spacing(2);
+    margin-bottom: govuk-spacing(4);
+    background-color: $urgency-blue;
   }
 
   .brexit-checker__action-urgent {
     background-color: govuk-colour('light-grey');
     padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(3) govuk-spacing(5);
-    border-left: 5px solid $govuk-brand-colour;
+    border-left: 5px solid $urgency-blue;
+  }
+
+  .brexit-checker__content-wrapper-urgent {
+    padding: 0 0 30px 0;
+    border-bottom: 1px solid $govuk-border-colour;
   }
 
   .brexit-checker__content-wrapper {

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -1,5 +1,6 @@
 class BrexitCheckerController < ApplicationController
   include BrexitCheckerHelper
+  include BrexitResultsAbTestable
 
   SUBSCRIBER_LIST_GROUP_ID = "5a7c11f2-e737-4531-a0bc-b5f707046607".freeze
 
@@ -11,7 +12,7 @@ class BrexitCheckerController < ApplicationController
   before_action :enable_caching, only: %i[show email_signup confirm_email_signup]
   before_action :enable_caching_unless_accounts, only: %i[results]
 
-  helper_method :subscriber_list_slug
+  helper_method :subscriber_list_slug, :ab_test_variant, :show_variant?
 
   def show
     all_questions = BrexitChecker::Question.load_all
@@ -33,6 +34,8 @@ class BrexitCheckerController < ApplicationController
   end
 
   def results
+    ab_test_variant.configure_response(response)
+
     if accounts_enabled?
       results_in_account = results_from_account
       if logged_in?

--- a/app/controllers/concerns/brexit_results_ab_testable.rb
+++ b/app/controllers/concerns/brexit_results_ab_testable.rb
@@ -1,0 +1,20 @@
+module BrexitResultsAbTestable
+  CUSTOM_DIMENSION = 44
+  TEST_NAME = "TransitionUrgency5".freeze
+
+  def ab_test_variant
+    @ab_test_variant ||= begin
+      ab_test = GovukAbTesting::AbTest.new(
+        TEST_NAME,
+        dimension: CUSTOM_DIMENSION,
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      ab_test.requested_variant(request.headers)
+    end
+  end
+
+  def show_variant?
+    ab_test_variant.variant?("B")
+  end
+end

--- a/app/lib/brexit_checker/action.rb
+++ b/app/lib/brexit_checker/action.rb
@@ -67,7 +67,7 @@ class BrexitChecker::Action
   end
 
   def urgent?
-    priority >= 8
+    priority >= 9
   end
 
 private

--- a/app/lib/brexit_checker/action.rb
+++ b/app/lib/brexit_checker/action.rb
@@ -66,6 +66,10 @@ class BrexitChecker::Action
     grouping_criteria.count > 1
   end
 
+  def urgent?
+    priority >= 8
+  end
+
 private
 
   def has_criteria

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -47,14 +47,14 @@
       <% end %>
 
       <% if action.guidance_url.present? %>
-        <div class="govuk-body govuk-!-font-size-16">
+        <div class="govuk-body-m">
           <p>
             <%= action.guidance_prompt || t("brexit_checker.action_list.guidance_prompt") %>:
           </p>
           <p>
             <a
               href="<%= action.guidance_url %>"
-              class="govuk-link"
+              class="govuk-link govuk-body"
               data-module="track-click"
               data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -1,9 +1,14 @@
 <% heading_level ||= 4 %>
 <% heading_tag = "h#{heading_level}"%>
 
+
 <% actions.each.with_index do | action, index | %>
   <div class="govuk-grid-row brexit-checker__action">
+  <% if action.urgent? && show_variant? %>
+    <div class="brexit-checker__content-wrapper-urgent">
+  <% else %>
     <div class="brexit-checker__content-wrapper">
+  <% end %>
       <% if action.urgent? && show_variant? %>
         <div class="brexit-checker__action-urgent">
         <strong class="govuk-tag brexit-checker__action-urgent-tag"><%= t("brexit_checker.results.urgent") %></strong>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -6,7 +6,7 @@
     <div class="brexit-checker__content-wrapper">
       <% if action.urgent? && show_variant? %>
         <div class="brexit-checker__action-urgent">
-        <strong class="govuk-tag brexit-checker__action-urgent-tag">Urgent</strong>
+        <strong class="govuk-tag brexit-checker__action-urgent-tag"><%= t("brexit_checker.results.urgent") %></strong>
       <% end %>
       <%= content_tag(heading_tag, class: "govuk-body brexit-checker__action_title") do %>
         <% if action.title_url.present? %>

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -4,6 +4,10 @@
 <% actions.each.with_index do | action, index | %>
   <div class="govuk-grid-row brexit-checker__action">
     <div class="brexit-checker__content-wrapper">
+      <% if action.urgent? && show_variant? %>
+        <div class="brexit-checker__action-urgent">
+        <strong class="govuk-tag brexit-checker__action-urgent-tag">Urgent</strong>
+      <% end %>
       <%= content_tag(heading_tag, class: "govuk-body brexit-checker__action_title") do %>
         <% if action.title_url.present? %>
           <a
@@ -54,6 +58,10 @@
               data-ecommerce-path="<%= action.guidance_path %>"
             ><%= action.guidance_link_text %></a>
           </p>
+        </div>
+      <% end %>
+      <% if action.urgent? && show_variant? %>
+        <%# closing div from .brexit-checker__action-urgent %>
         </div>
       <% end %>
     </div>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -16,6 +16,7 @@
   <meta property="og:description" content="<%= t('brexit_checker.results.social_media_meta.description') %>">
   <meta name="twitter:card" content="summary">
   <link rel="canonical" href="<%= page_url %>">
+  <%= ab_test_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -4,6 +4,7 @@ en:
       title: "How to get ready for new rules in 2021: Your results"
       title_no_actions: You do not need to take action now
       title_no_answers: You did not answer any of the questions
+      urgent: Urgent
       description: |
         You may not need to take all these actions now. Actions you need to take will depend on your own circumstances.
       description_no_actions: |

--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 describe BrexitCheckerController, type: :controller do
   include GovukAbTesting::RspecHelpers
+  render_views
 
-  context "results page AB test" do
-    render_views
+  context "results page AB test setup" do
     subject { get :results }
 
     %w[A B Z].each do |variant|
@@ -12,6 +12,42 @@ describe BrexitCheckerController, type: :controller do
         with_variant TransitionUrgency5: variant do
           expect(subject).to render_template(:results)
         end
+      end
+    end
+  end
+
+  context "results page AB test urgency styling" do
+    let(:params_to_get_some_urgent_results) do
+      {
+        c: %w[
+          owns-operates-business-organisation
+          visiting-driving
+          visiting-ie
+          visiting-eu
+          visiting-row
+          travel-eu-business-no
+          working-uk
+          living-uk
+          nationality-uk
+        ],
+      }
+    end
+
+    %w[A Z].each do |variant|
+      it "Variant #{variant} does not show the alternate urgency styling" do
+        with_variant TransitionUrgency5: variant do
+          get :results, params: params_to_get_some_urgent_results
+          expect(response.body).to_not have_css(".brexit-checker__action-urgent")
+          expect(response.body).to_not have_text("Urgent")
+        end
+      end
+    end
+
+    it "Variant B shows the alternate urgency styling" do
+      with_variant TransitionUrgency5: "B" do
+        get :results, params: params_to_get_some_urgent_results
+        expect(response.body).to have_css(".brexit-checker__action-urgent")
+        expect(response.body).to have_css(".brexit-checker__action-urgent-tag", text: "Urgent")
       end
     end
   end

--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe BrexitCheckerController, type: :controller do
+  include GovukAbTesting::RspecHelpers
+
+  context "results page AB test" do
+    render_views
+    subject { get :results }
+
+    %w[A B Z].each do |variant|
+      it "Variant #{variant} includes the AB testing headers and metatags" do
+        with_variant TransitionUrgency5: variant do
+          expect(subject).to render_template(:results)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This shows some new urgency styling on result actions that have a priority of 8 or over. You'll need to configure ModHeader (or similar) to provide a header of `GOVUK-ABTEST-TRANSITIONURGENCY5: B` in the review app to be able to see the good stuff. 

A url similar to [this live checker results page](https://www.gov.uk/transition-check/results?c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=visiting-row&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk) should be sufficient to get you some urgent results.

It should be similar to the prototype at https://govuk-transition-test.herokuapp.com/results

https://trello.com/c/ThOTJ50f/528-ab-test-checker-results-page-implement-urgency-messaging-design-feature-to-priority-actions-in-the-checker

## [Variant B](https://finder-front-urgency5-za4pttmn.herokuapp.com/transition-check/results?c%5B%5D=creative&c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=eu-domain-no&c%5B%5D=ip&c%5B%5D=ip-copyright&c%5B%5D=ip-trade-marks&c%5B%5D=ip-designs&c%5B%5D=ip-patents&c%5B%5D=ip-exhaustion-rights&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=do-not-eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-use&c%5B%5D=personal-eu-org-provide&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=return-to-uk-no&c%5B%5D=visiting-driving&c%5B%5D=visiting-uk&c%5B%5D=visiting-row&c%5B%5D=living-driving-eu&c%5B%5D=working-uk&c%5B%5D=studying-uk&c%5B%5D=living-eu&c%5B%5D=nationality-uk)

<img width="616" alt="Screenshot 2020-10-26 at 16 11 57" src="https://user-images.githubusercontent.com/17908089/97197886-10468880-17a6-11eb-91d8-cf36414c543b.png">



:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
