### PR TITLE
Manage our own session cookie for accounts

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,16 +27,14 @@ class SessionsController < ApplicationController
       state,
     )
 
-    access_token = callback[:access_token]
-    sub = callback[:sub]
-    redirect_path = callback[:redirect_path] || default_redirect_path
+    tokens = callback[:access_token].token_response
+    set_account_session_cookie(
+      sub: callback[:sub],
+      access_token: tokens[:access_token],
+      refresh_token: tokens[:refresh_token],
+    )
 
-    session[:has_session] = true
-    session[:sub] = sub
-    session[:access_token] = access_token.token_response[:access_token]
-    session[:refresh_token] = access_token.token_response[:refresh_token]
-
-    redirect_to redirect_path
+    redirect_to callback[:redirect_path] || default_redirect_path
   end
 
   def delete

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-FinderFrontend::Application.config.session_store :cookie_store, expire_after: 15.minutes
+FinderFrontend::Application.config.session_store :disabled


### PR DESCRIPTION
Using the rails session management has a couple of problems: we had to
implement the "has_session" hack to avoid setting the cookie on people
who haven't opted in to accounts; and we can't delete the cookie, only
reset it to a blank session.  It would be nice if the cookie only
existed while a user was logged in, because then we could use "does
the cookie exist?" in the collections app to determine whether to
render the accounts header on /transition.

By managing our own cookies we solve both of those problems: we can
set the cookie on log in and delete it on log out.  We do need to bump
the expiration time ourselves, which is a bit of extra work, but I
think the benefits outweigh that.

---

[Trello card](https://trello.com/c/vdZrgBRy/363-make-changes-to-transition-for-trial-launch)