### PR TITLE
Update cookie consent based on accounts response

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,6 +34,11 @@ class SessionsController < ApplicationController
       refresh_token: tokens[:refresh_token],
     )
 
+    if callback[:cookie_consent] && cookies[:cookies_policy]
+      cookies_policy = JSON.decode(cookies[:cookies_policy]).symbolize_keys
+      cookies[:cookies_policy] = cookies_policy.merge(usage: true).to_json
+    end
+
     redirect_to callback[:redirect_path] || default_redirect_path
   end
 

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -44,13 +44,14 @@ class OidcClient
   def callback(code, state)
     client.authorization_code = code
     access_token = client.access_token!
-    (nonce, redirect_path) = state.split(":")
+    (nonce, redirect_path, cookie_consent) = state.split(":")
     id_token = OpenIDConnect::ResponseObject::IdToken.decode access_token.id_token, discover.jwks
     id_token.verify! client_id: client_id, issuer: discover.issuer, nonce: nonce
     {
       access_token: access_token,
       sub: id_token.sub,
       redirect_path: redirect_path,
+      cookie_consent: cookie_consent == "cookies-yes",
     }
   end
 


### PR DESCRIPTION
We're asking if the user consents to analytics cookies during account
registration, and passing this information back if they do.  So we
need to update the GOV.UK policy cookie with that information.

---

[Trello card](https://trello.com/c/YB2MRHmh/362-change-link-in-the-confirmation-page-to-update-user-cookie-preference)