### PR TITLE
Redirect from accounts signup to email signup if accounts is down

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -60,7 +60,11 @@ class BrexitCheckerController < ApplicationController
     redirect_to email_alert_frontend_signup_path(topic_id: subscriber_list_slug)
   end
 
-  def save_results; end
+  def save_results
+    @account_jwt = account_signup_jwt(criteria_keys, subscriber_list_slug)
+  rescue StandardError
+    redirect_to transition_checker_email_signup_path(c: criteria_keys)
+  end
 
   def save_results_confirm
     saved_results = results_from_account.fetch("criteria_keys", [])

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -58,7 +58,7 @@
         </ul>
 
         <%= form_tag Services.accounts_api, id: "account-signup", class: "account-signup" do %>
-          <input type="hidden" name="jwt" value="<%= account_signup_jwt(criteria_keys, subscriber_list_slug) %>">
+          <input type="hidden" name="jwt" value="<%= @account_jwt %>">
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),
             margin_bottom: true,


### PR DESCRIPTION
If the accounts system is down we don't want to prevent users from
signing up to email alerts.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD)
