### PR TITLE
Implement rough frontend for the "save changes" screens

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,6 +34,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/subscription-links';
 @import 'govuk_publishing_components/components/success-alert';
+@import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/title';
 
 @import 'components/*';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/inverse-header';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/metadata';
+@import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
 @import 'govuk_publishing_components/components/radio';
@@ -32,6 +33,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/subscription-links';
+@import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/title';
 
 @import 'components/*';

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -103,4 +103,15 @@ module BrexitCheckerHelper
       transition_checker_email_signup_path(c: criteria_keys)
     end
   end
+
+  def results_comparison(old_criteria_keys, new_criteria_keys)
+    answers_diff = BrexitChecker::Question.load_all.map do |question|
+      old_values = question.options.select { |o| old_criteria_keys.include? o.value }
+      new_values = question.options.select { |o| new_criteria_keys.include? o.value }
+      unless old_values == new_values
+        [{ text: question.text }, { text: old_values.map(&:label).join(", ") }, { text: new_values.map(&:label).join(", ") }]
+      end
+    end
+    answers_diff.compact
+  end
 end

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -40,17 +40,6 @@
 <div class="govuk-width-container brexit-checker-results-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if accounts_enabled? %>
-        <% if logged_in? %>
-          <% if @results_differ %>
-            <p class="govuk-body">You've changed your answers. <a class="govuk-link" href="<%= transition_checker_save_results_confirm_path(c: criteria_keys) %>">Save this page instead?</a></p>
-          <% end %>
-          <% if @results_saved %>
-            <p class="govuk-body">Saved!</p>
-          <% end %>
-        <% end %>
-      <% end %>
-
       <%= render "govuk_publishing_components/components/title", {
         title: action_based_title
       } %>
@@ -68,7 +57,19 @@
   </div>
 
   <% if criteria_keys.present? %>
-    <% unless accounts_enabled? && logged_in? %>
+    <% if accounts_enabled? && logged_in? %>
+      <% if @results_differ %>
+        <%= render 'govuk_publishing_components/components/notice', {
+          title: t('brexit_checker.results.accounts.results_differ.message'),
+          description: sanitize(t('brexit_checker.results.accounts.results_differ.description', link: transition_checker_save_results_confirm_path(c: criteria_keys)))
+        } %>
+      <% elsif @results_saved %>
+        <%= render 'govuk_publishing_components/components/success_alert', {
+          message: t('brexit_checker.results.accounts.results_saved.message'),
+          description: t('brexit_checker.results.accounts.results_saved.description')
+        } %>
+      <% end %>
+    <% else %>
       <%= render 'components/email_link', {
         data_attributes: {
           "module": "track-click",
@@ -86,7 +87,14 @@
     <%= render 'results_citizen_actions', citizen_results_groups: @citizen_results_groups if @citizen_results_groups.any? %>
     <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
 
-    <% unless accounts_enabled? && logged_in? %>
+    <% if accounts_enabled? && logged_in? %>
+      <% if @results_differ %>
+        <%= render 'govuk_publishing_components/components/notice', {
+          title: t('brexit_checker.results.accounts.results_differ.message'),
+          description: sanitize(t('brexit_checker.results.accounts.results_differ.description', link: transition_checker_save_results_confirm_path(c: criteria_keys)))
+        } %>
+      <% end %>
+    <% else %>
       <%= render 'stay_updated' %>
     <% end %>
 

--- a/app/views/brexit_checker/save_results_confirm.html.erb
+++ b/app/views/brexit_checker/save_results_confirm.html.erb
@@ -49,14 +49,16 @@
           rows: results_comparison(@old_criteria_keys, criteria_keys)
         } %>
 
-        <p class="govuk-body"><%= t("brexit_checker.confirm_changes.message") %></p>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          text: t("brexit_checker.confirm_changes.message")
+        } %>
 
         <% if @has_email_subscription %>
           <%= form_tag transition_checker_save_results_confirm_path(c: criteria_keys), method: :post do %>
             <%= hidden_field_tag :email_decision, "yes" %>
             <%= render "govuk_publishing_components/components/button", {
               text: t('brexit_checker.confirm_changes.save_button'),
-              inline_layout: true,
+              margin_bottom: 1
             } %>
           <% end %>
         <% else %>
@@ -64,10 +66,12 @@
             <% criteria_keys.each do |key| %><%= hidden_field_tag :"c[]", key %><% end %>
             <%= render "govuk_publishing_components/components/button", {
               text: t('brexit_checker.confirm_changes.save_button'),
-              inline_layout: true,
+              margin_bottom: 1
             } %>
           <% end %>
         <% end %>
+
+        <p class="govuk-body"><%= sanitize(t("brexit_checker.confirm_changes.cancel", link: transition_checker_results_path(c: criteria_keys))) %></p>
       </div>
     </div>
   </main>

--- a/app/views/brexit_checker/save_results_confirm.html.erb
+++ b/app/views/brexit_checker/save_results_confirm.html.erb
@@ -34,6 +34,7 @@
           } %>
 
         <%= render "govuk_publishing_components/components/table", {
+          first_cell_is_header: true,
           head: [
             {
               text: t("brexit_checker.confirm_changes.table.question")
@@ -45,9 +46,7 @@
               text: t("brexit_checker.confirm_changes.table.new_answer")
             }
           ],
-          rows: [
-            [ { text: "all of them" }, { text: @old_criteria_keys }, { text: criteria_keys } ]
-          ]
+          rows: results_comparison(@old_criteria_keys, criteria_keys)
         } %>
 
         <p class="govuk-body"><%= t("brexit_checker.confirm_changes.message") %></p>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-FinderFrontend::Application.config.session_store :disabled
+FinderFrontend::Application.config.session_store :cookie_store, key: "_finder-frontend_session", expire_after: 15.minutes

--- a/config/locales/en/brexit_checker/confirm_changes.yml
+++ b/config/locales/en/brexit_checker/confirm_changes.yml
@@ -9,4 +9,5 @@ en:
         new_answer: New answer
       message: Saving your new answers will automatically update your email notifications at the same time.
       save_button: Save new answers
+      cancel: or <a class="govuk-link" href="%{link}">cancel</a> if you want to keep your previous results
 

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -34,3 +34,10 @@ en:
         business:
           heading: Your business or organisation
       print_link: Print your results
+      accounts:
+        results_differ:
+          message: These results are different to the ones saved in your account.
+          description: You can <a class="govuk-link" href="%{link}">see what answers you’ve changed and save these results to your account instead.</a>
+        results_saved:
+          message: Success
+          description: Your results have been saved.

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -136,21 +136,21 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         context "the querystring differs to the value in the account" do
           it "shows a link to save the new results" do
             given_i_am_on_the_results_page_with(%w[bring-pet-abroad nationality-eu])
-            expect(page).to have_content("You've changed your answers.")
+            expect(page).to have_content(I18n.t("brexit_checker.results.accounts.results_differ.message"))
           end
         end
 
         context "the querystring matches what's stored in the account" do
           it "doesn't show a link to save the new results" do
             given_i_am_on_the_results_page_with(criteria_keys)
-            expect(page).to_not have_content("You've changed your answers.")
+            expect(page).to_not have_content(I18n.t("brexit_checker.results.accounts.results_differ.message"))
           end
 
           context "the account has been updated in the last 10 seconds" do
             it "shows a 'saved' notification" do
               Timecop.freeze(Time.zone.at(transition_checker_state[:timestamp] - 9)) do
                 given_i_am_on_the_results_page_with(criteria_keys)
-                expect(page).to have_content("Saved!")
+                expect(page).to have_content(I18n.t("brexit_checker.results.accounts.results_saved.message"))
               end
             end
           end
@@ -216,8 +216,8 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
           it "shows a comparison of the result sets" do
             given_i_am_on_the_save_results_confirm_page_with(new_criteria_keys)
-            expect(page).to have_content(new_criteria_keys.first)
-            expect(page).to have_content(criteria_keys.first)
+            expect(page).to have_content("British")
+            expect(page).to have_content("Another EU country, or Switzerland, Norway, Iceland or Liechtenstein")
           end
 
           context "the user does not have an email subscription" do


### PR DESCRIPTION
This isn't quite right, but it's much closer than it was, and now has the right content.

## Results are different

I've gone for a ~~success alert~~ notice here because it's the closest component to what we want, but we actually want something more bespoke:

<img width="1111" alt="Screenshot 2020-10-28 at 09 05 28" src="https://user-images.githubusercontent.com/75235/97415146-c4f2be00-18fc-11eb-954b-58f4bf60a314.png">

## Results comparison

I think we want some highlighting or shading on the two answer columns:

<img width="777" alt="Screenshot 2020-10-27 at 18 11 07" src="https://user-images.githubusercontent.com/75235/97343963-0a24da80-1880-11eb-95e5-45f8aa3a7340.png">

## Saved

Again, we want something a bit different to the success alert:

<img width="1140" alt="Screenshot 2020-10-27 at 18 11 40" src="https://user-images.githubusercontent.com/75235/97343967-0abd7100-1880-11eb-99fe-bb26b1c59dfb.png">

---

[Trello card](https://trello.com/c/uTPaVhv1/344-implement-frontend-for-change-your-answers-journey)