### PR TITLE
Redirect to account manager on sign in if no redirect_path

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
       cookies[:cookies_policy] = cookies_policy.merge(usage: true).to_json
     end
 
-    redirect_to callback[:redirect_path] || transition_checker_questions_path
+    redirect_if_not_test(callback[:redirect_path] || Plek.find("account-manager"))
   end
 
   def delete


### PR DESCRIPTION
We have separate session cookies for www.gov.uk and the accounts
domain itself, this is an unfortunate necessity of not being able to
share a single cookie across domains.

By changing the fallback redirect path to the account manager itself,
we can send a user to /transition-check/login to make them log into
both apps:

1. /transition-check/login sends them to the account manager
2. They log in, creating an accounts session cookie
3. Accounts redirects them to /transition-check/callback
4. finder-frontend creates a gov.uk session cookie
5. finder-frontend redirects them back to the account manager

So the user ends up logged into both, and seeing the account manager.
This is what we want the "sign in" link in the GOV.UK header to do, as
only signing into one app would be confusing.

---

[Trello card](https://trello.com/c/vdZrgBRy/363-make-changes-to-transition-for-trial-launch)