### PR TITLE
Remove broken ecommerce tracking

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -26,7 +26,6 @@ class SearchResultPresenter
         text: title,
         path: link,
         description: sanitize(summary_text),
-        data_attributes: ecommerce_data(link, title),
       },
       metadata: structure_metadata,
       metadata_raw: metadata,
@@ -73,7 +72,7 @@ private
   end
 
   def structure_parts
-    structured_parts = parts.map.with_index(1) do |part, index|
+    structured_parts = parts.map.with_index(1) do |part, _index|
       has_required_data = %i[title slug body].all? { |key| part.key? key }
       unless has_required_data
         GovukError.notify(MalformedPartError.new, extra: { part: part, link: link })
@@ -84,27 +83,10 @@ private
           text: part[:title],
           path: "#{link}/#{part[:slug]}",
           description: part[:body],
-          data_attributes: ecommerce_data("#{link}/#{part[:slug]}", part[:title], part_index: index),
         },
       }
     end
     structured_parts.compact
-  end
-
-  def ecommerce_data(link, title, part_index: nil)
-    {
-      ecommerce_path: link,
-      ecommerce_row: 1,
-      ecommerce_index: document.index,
-      track_category: "navFinderLinkClicked",
-      track_action: [content_item.title, document.index, part_index].compact.join("."),
-      track_label: link,
-      track_options: {
-        dimension22: part_index,
-        dimension28: @count,
-        dimension29: title,
-      }.compact,
-    }
   end
 
   attr_reader :document, :metadata, :content_item

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -133,18 +133,6 @@ RSpec.describe ResultSetPresenter do
             text: "document_title",
             path: "/path/to/doc",
             description: "document_description",
-            data_attributes: {
-              ecommerce_path: "/path/to/doc",
-              ecommerce_row: 1,
-              ecommerce_index: 1,
-              track_category: "navFinderLinkClicked",
-              track_action: "A finder.1",
-              track_label: "/path/to/doc",
-              track_options: {
-                dimension28: 1,
-                dimension29: "document_title",
-              },
-            },
           },
           metadata: {
             "Organisations" => "Organisations: Department for Work and Pensions",

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -64,18 +64,6 @@ RSpec.describe SearchResultPresenter do
           text: title,
           path: link,
           description: "I am a document.",
-          data_attributes: {
-            ecommerce_path: link,
-            ecommerce_row: 1,
-            ecommerce_index: 1,
-            track_category: "navFinderLinkClicked",
-            track_action: "finder-title.1",
-            track_label: link,
-            track_options: {
-              dimension28: 10,
-              dimension29: title,
-            },
-          },
         },
         metadata: {},
         metadata_raw: [],
@@ -105,19 +93,6 @@ RSpec.describe SearchResultPresenter do
               text: "I am a part title",
               path: "#{link}/part-path",
               description: "Part description",
-              data_attributes: {
-                ecommerce_path: "#{link}/part-path",
-                ecommerce_row: 1,
-                ecommerce_index: 1,
-                track_category: "navFinderLinkClicked",
-                track_action: "finder-title.1.1",
-                track_label: "#{link}/part-path",
-                track_options: {
-                  dimension22: 1,
-                  dimension28: 10,
-                  dimension29: "I am a part title",
-                },
-              },
             },
           },
         ]


### PR DESCRIPTION
This is currently causing JS errors when visiting pages like:

- /government/organisations
- /government/groups

and is leading to Smokey test failures, which is masking our
visibility of real issues. Investigation shows this is related
to the size of the request, and removing some parts of the data
appears to fix the issue. Since the data is non-critical, and a
permanent fix is elusive, this removes the tracking attributes
for affected pages to avoid unnecessary errors.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.