### PR TITLE
Disable ecommerce tracking on /government/groups

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -96,6 +96,7 @@ private
       content_item.metadata_class,
       show_top_result?,
       debug_score?,
+      include_ecommerce?,
     )
   end
 
@@ -196,5 +197,12 @@ private
 
   def debug_score?
     params[:debug_score]
+  end
+
+  def include_ecommerce?
+    # this page causes a javascript error because of the number of
+    # results, so disable ecommerce until we have a proper solution to
+    # splitting big GA requests.
+    content_item.base_path != "/government/groups"
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -2,11 +2,11 @@ class ResultSetPresenter
   include ERB::Util
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :pluralised_document_noun, :debug_score, :start_offset
+  attr_reader :pluralised_document_noun, :debug_score, :start_offset, :include_ecommerce
 
   delegate :atom_url, to: :content_item
 
-  def initialize(content_item, facets, results, filter_params, sort_presenter, metadata_presenter_class, show_top_result = false, debug_score = false)
+  def initialize(content_item, facets, results, filter_params, sort_presenter, metadata_presenter_class, show_top_result = false, debug_score = false, include_ecommerce = true)
     @content_item = content_item
     @facets = facets
     @documents = results.documents
@@ -18,6 +18,7 @@ class ResultSetPresenter
     @show_top_result = show_top_result
     @metadata_presenter_class = metadata_presenter_class
     @debug_score = debug_score
+    @include_ecommerce = include_ecommerce
   end
 
   def displayed_total
@@ -64,6 +65,7 @@ private
         facets: facets,
         content_item: content_item,
         debug_score: debug_score,
+        include_ecommerce: include_ecommerce,
       ).document_list_component_data
     end
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -11,13 +11,14 @@ class SearchResultPresenter
            :original_rank,
            to: :document
 
-  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:)
+  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, include_ecommerce: true)
     @document = document
     @rank = rank
     @metadata = metadata_presenter_class.new(document.metadata(facets)).present
     @count = doc_count
     @debug_score = debug_score
     @content_item = content_item
+    @include_ecommerce = include_ecommerce
   end
 
   def document_list_component_data
@@ -92,6 +93,8 @@ private
   end
 
   def ecommerce_data(link, title, part_index: nil)
+    return {} unless @include_ecommerce
+
     {
       ecommerce_path: link,
       ecommerce_row: 1,

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -14,11 +14,13 @@ RSpec.describe ResultSetPresenter do
       metadata_presenter_class,
       show_top_result,
       debug_score,
+      enable_ecommerce,
     )
   end
 
   let(:show_top_result) { false }
   let(:debug_score) { false }
+  let(:enable_ecommerce) { true }
 
   let(:finder_content_id) { "content_id" }
 
@@ -179,6 +181,47 @@ RSpec.describe ResultSetPresenter do
       it "shows debug metadata" do
         search_result_objects = subject.search_results_content[:document_list_component_data]
         expect(search_result_objects.first[:subtext]).to eql(expected_document_content_with_debug)
+      end
+    end
+
+    context "with ecommerce disabled" do
+      let(:enable_ecommerce) { false }
+      let(:results) do
+        [FactoryBot.build(
+          :document_hash,
+          content_id: "content_id",
+          link: "/path/to/doc",
+          title: "document_title",
+          description_with_highlighting: "document_description",
+        )]
+      end
+
+      it "doesn't include ecommerce attributes" do
+        expected_hash = {
+          link: {
+            text: "document_title",
+            path: "/path/to/doc",
+            description: "document_description",
+            data_attributes: {},
+          },
+          metadata: {
+            "Organisations" => "Organisations: Department for Work and Pensions",
+          },
+          metadata_raw: [
+            {
+              id: "organisations",
+              label: "Organisations",
+              value: "Department for Work and Pensions",
+              labels: ["Department for Work and Pensions"],
+              is_text: true,
+            },
+          ],
+          subtext: nil,
+          parts: [],
+        }
+
+        search_result_objects = subject.search_results_content[:document_list_component_data]
+        expect(search_result_objects.first).to eql(expected_hash)
       end
     end
   end


### PR DESCRIPTION
This page has a huge number of unpaginated results, and is generating
too large a GA request, which throws a javascript error, and causes a
Smokey failure.  We don't really need ecommerce tracking for this
page, so for now just disable it.

---

Replacement for #2282 
