### PR TITLE
Say "previous answer" instead of "old answer"

### DIFF
--- a/config/locales/en/brexit_checker/confirm_changes.yml
+++ b/config/locales/en/brexit_checker/confirm_changes.yml
@@ -5,7 +5,7 @@ en:
       heading: You’ve changed your answer to some questions
       table:
         question: Question
-        old_answer: Old answer
+        old_answer: Previous answer
         new_answer: New answer
       message: Saving your new answers will automatically update your email notifications at the same time.
       save_button: Save new answers


### PR DESCRIPTION
[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD)