### PR TITLE
Handle nested options in results comparison

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -106,12 +106,22 @@ module BrexitCheckerHelper
 
   def results_comparison(old_criteria_keys, new_criteria_keys)
     answers_diff = BrexitChecker::Question.load_all.map do |question|
-      old_values = question.options.select { |o| old_criteria_keys.include? o.value }
-      new_values = question.options.select { |o| new_criteria_keys.include? o.value }
-      unless old_values == new_values
-        [{ text: question.text }, { text: old_values.map(&:label).join(", ") }, { text: new_values.map(&:label).join(", ") }]
+      flattened_options = flatten_options(question.options)
+      old_values = flattened_options.select { |k, _v| old_criteria_keys.include? k }
+      new_values = flattened_options.select { |k, _v| new_criteria_keys.include? k }
+      unless old_values.keys == new_values.keys
+        [{ text: question.text }, { text: old_values.values.join(", ") }, { text: new_values.values.join(", ") }]
       end
     end
     answers_diff.compact
+  end
+
+  def flatten_options(options, hash = nil)
+    hash ||= {}
+    options.each do |option|
+      hash[option.value] = option.label if option.value
+      flatten_options(option.sub_options, hash)
+    end
+    hash
   end
 end


### PR DESCRIPTION
An option can have sub_options.  Currently this only goes one level
deep, but I thought the code would be clearer by solving the general
case of arbitrarily nested options.

This change means that if multiple options are selected, they'll be
sorted by key.  But the key names are similar to the value names, so
that should be ok.

---

[Trello card](https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD)
