### PR TITLE
Persist cross domain tracking through form leading to accounts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require live_search
 //= require search-analytics
 //= require taxonomy-select
+//= require ga_cross_domain_form_tracking
 //= require_tree ./modules
 //= require_tree ./components
 

--- a/app/assets/javascripts/ga_cross_domain_form_tracking.js
+++ b/app/assets/javascripts/ga_cross_domain_form_tracking.js
@@ -1,0 +1,25 @@
+/* eslint-env jquery */
+/* global ga */
+
+function attachCrossDomainTrackerToInput (form, trackers) {
+  if (trackers.length) {
+    var existingAction = form.attr('action')
+    var linker = new window.gaplugins.Linker(trackers[0])
+    var trackedAction = linker.decorate(existingAction)
+    form.attr('action', trackedAction)
+  }
+}
+
+window.GOVUK = window.GOVUK || {}
+var GOVUK = window.GOVUK
+GOVUK.attachCrossDomainTrackerToInput = attachCrossDomainTrackerToInput
+
+$(window).on('load', function () {
+  if (window.ga !== undefined && typeof window.ga.getAll === 'function') {
+    var trackers = ga.getAll()
+    var form = $('form#account-signup')
+    if (form.length) {
+      window.GOVUK.attachCrossDomainTrackerToInput(form, trackers)
+    }
+  }
+})

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -66,7 +66,7 @@
           <% end %>
         </ul>
 
-        <%= form_tag Services.accounts_api, id: "account-signup", class: "account-signup" do %>
+        <%= form_tag Services.accounts_api, id: "account-signup" do %>
           <input type="hidden" name="jwt" value="<%= @account_jwt %>">
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),

--- a/spec/javascripts/ga_cross_domain_form_tracking_spec.js
+++ b/spec/javascripts/ga_cross_domain_form_tracking_spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jasmine, jquery */
+
+describe('attachCrossDomainTrackerToInput', function () {
+  var form
+  var tracker
+  var linker
+  var GOVUK = window.GOVUK || {}
+
+  beforeEach(function () {
+    form = $('<form method="POST" action="/somewhere" class="account-signup">' +
+               '<input type="hidden" name="key" value="value" />' +
+               '<button type="submit">Create a GOV.UK account</button>' +
+             '</form>')
+
+    window.ga = {
+      getAll: function () {}
+    }
+
+    window.gaplugins = {
+      Linker: function () {}
+    }
+
+    linker = {
+      decorate: function () {}
+    }
+
+    spyOn(window.ga, 'getAll').and.returnValue([])
+    spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
+    spyOn(linker, 'decorate').and.returnValue('/somewhere?_ga=abc123')
+  })
+
+  afterEach(function () {
+    form.remove()
+  })
+
+  it('leaves the form action unchanged if ga is not present', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere')
+  })
+
+  it('leaves the form action if unchanged there are no trackers in ga', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere')
+  })
+
+  it('modifies the form action to append ids from ga to the destination url', function () {
+    tracker = [{ ga_mock: 'foobar' }]
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere?_ga=abc123')
+  })
+})


### PR DESCRIPTION
[Trello](https://trello.com/c/4kIhJHvE/390-analytics-snags)

## What

The button leading to the accounts system is inside a form, so cross domain tracking doesn't work through it (unlike links, which are automatically decorated). So we're going to need to manually decorate the target of the form with the ga parameter.

This is a proof of concept using an approach of clicking on the button, but I think it'll be easier if we have the decoration happening on page load, so we don't have to intercept the button click.

References:

- https://www.knewledge.com/en/blog/2013/11/cross-domain-tracking-for-links-with-gtm/#manual-tagging
