### PR TITLE
Brexit checker: Test model validations

### DIFF
--- a/app/lib/brexit_checker/action.rb
+++ b/app/lib/brexit_checker/action.rb
@@ -5,7 +5,7 @@ class BrexitChecker::Action
 
   CONFIG_PATH = Rails.root.join("app/lib/brexit_checker/actions.yaml")
 
-  validates_presence_of :id, :title, :consequence, :criteria
+  validates_presence_of :id, :title, :consequence
   validates_inclusion_of :audience, in: %w[business citizen]
   validates_presence_of :guidance_link_text, if: :guidance_url
   validates_numericality_of :priority, only_integer: true
@@ -75,7 +75,7 @@ private
   def has_criteria
     return unless all_criteria_keys.none?
 
-    errors.add "Action must have at least one criterion"
+    errors.add(:criteria, "can't be blank")
   end
 
   def path_from_url(full_url)
@@ -88,8 +88,8 @@ private
   end
 
   def citizen_action_has_grouping_criteria
-    if audience == "citizen" && grouping_criteria.nil?
-      errors.add(:grouping_criteria, "Can't be empty for citizen actions")
+    if audience == "citizen" && grouping_criteria.blank?
+      errors.add(:grouping_criteria, "can't be empty for citizen actions")
     end
   end
 end

--- a/app/lib/brexit_checker/group.rb
+++ b/app/lib/brexit_checker/group.rb
@@ -1,19 +1,8 @@
 class BrexitChecker::Group
   include ActiveModel::Validations
+  validates_with BrexitChecker::Validators::GroupValidator
 
   GROUPS_PATH = Rails.root.join("app/lib/brexit_checker/groups.yaml")
-
-  validates_inclusion_of :key,
-                         in: %w[visiting-eu
-                                visiting-uk
-                                visiting-ie
-                                living-eu
-                                living-ie
-                                living-uk
-                                working-uk
-                                studying-eu
-                                studying-uk
-                                common-travel-area]
 
   attr_reader :key, :heading, :priority
 

--- a/app/lib/brexit_checker/question.rb
+++ b/app/lib/brexit_checker/question.rb
@@ -5,7 +5,7 @@ class BrexitChecker::Question
 
   validates_presence_of :key, :text
   validates_inclusion_of :type, in: %w[single single_wrapped multiple multiple_grouped]
-  validate { errors.add("Options is not an array") unless options.is_a? Array }
+  validate { errors.add(:options, "is not an array") unless options.is_a? Array }
 
   attr_reader :key,
               :text,

--- a/app/lib/brexit_checker/validators/group_validator.rb
+++ b/app/lib/brexit_checker/validators/group_validator.rb
@@ -1,0 +1,24 @@
+class BrexitChecker::Validators::GroupValidator < ActiveModel::Validator
+  CITIZEN_KEYS = %w[ visiting-eu
+                     visiting-uk
+                     visiting-ie
+                     living-eu
+                     living-ie
+                     living-uk
+                     working-uk
+                     studying-eu
+                     studying-uk
+                     common-travel-area ].freeze
+
+  def validate(record)
+    validate_citizen_group(record)
+  end
+
+private
+
+  def validate_citizen_group(record)
+    unless CITIZEN_KEYS.include? record.key
+      record.errors[:key] << "is not included in the list"
+    end
+  end
+end

--- a/app/lib/brexit_checker/validators/group_validator.rb
+++ b/app/lib/brexit_checker/validators/group_validator.rb
@@ -17,7 +17,7 @@ class BrexitChecker::Validators::GroupValidator < ActiveModel::Validator
 private
 
   def validate_citizen_group(record)
-    unless CITIZEN_KEYS.include? record.key
+    unless CITIZEN_KEYS.include?(record.key)
       record.errors[:key] << "is not included in the list"
     end
   end

--- a/spec/integration/brexit_checker_spec.rb
+++ b/spec/integration/brexit_checker_spec.rb
@@ -58,4 +58,8 @@ RSpec.describe "Brexit checker data integrity" do
 
     expect(possible_criteria.uniq).to match_array possible_criteria
   end
+
+  it "groups.yaml contains valid groups" do
+    expect { BrexitChecker::Group.load_all }.not_to raise_error
+  end
 end

--- a/spec/lib/brexit_checker/action_spec.rb
+++ b/spec/lib/brexit_checker/action_spec.rb
@@ -1,6 +1,51 @@
 require "spec_helper"
 
 RSpec.describe BrexitChecker::Action do
+  describe "validations" do
+    let(:action_missing_attributes) do
+      FactoryBot.build(:brexit_checker_action,
+                       id: nil,
+                       title: nil,
+                       consequence: nil)
+    end
+
+    let(:action_with_invalid_audience) { FactoryBot.build(:brexit_checker_action, audience: "clowns") }
+    let(:action_missing_link_text) { FactoryBot.build(:brexit_checker_action, guidance_url: "/brexity_fun") }
+    let(:action_with_invalid_priority) { FactoryBot.build(:brexit_checker_action, priority: "high") }
+    let(:action_with_missing_criteria) { FactoryBot.build(:brexit_checker_action, criteria: []) }
+    let(:action_with_missing_grouping_criteria) { FactoryBot.build(:brexit_checker_action, :citizen, grouping_criteria: nil) }
+
+    it "id, title, consequence and criteria can't be blank" do
+      message = "Validation failed: Id can't be blank, Title can't be blank, Consequence can't be blank"
+      expect { action_missing_attributes.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "audience can only be business or citizen" do
+      message = "Validation failed: Audience is not included in the list"
+      expect { action_with_invalid_audience.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "guidance links must have text and url" do
+      message = "Validation failed: Guidance link text can't be blank"
+      expect { action_missing_link_text.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "priority must be an integer" do
+      message = "Validation failed: Priority is not a number"
+      expect { action_with_invalid_priority.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "must have criteria" do
+      message = "Validation failed: Criteria can't be blank"
+      expect { action_with_missing_criteria.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "must have grouping criteria if a citizen action" do
+      message = "Validation failed: Grouping criteria can't be empty for citizen actions"
+      expect { action_with_missing_grouping_criteria.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
   describe "factories" do
     it "has a valid default business action factory" do
       action = FactoryBot.build(:brexit_checker_action)

--- a/spec/lib/brexit_checker/criterion_spec.rb
+++ b/spec/lib/brexit_checker/criterion_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 RSpec.describe BrexitChecker::Criterion do
+  describe "validations" do
+    let(:criterion_missing_attributes) { FactoryBot.build(:brexit_checker_criterion, key: nil, text: nil) }
+    it "key and text can't be blank" do
+      message = "Validation failed: Key can't be blank, Text can't be blank"
+      expect { criterion_missing_attributes.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
   describe "factories" do
     it "has a valid default factory" do
       criterion = FactoryBot.build(:brexit_checker_criterion)

--- a/spec/lib/brexit_checker/group_spec.rb
+++ b/spec/lib/brexit_checker/group_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe BrexitChecker::Group do
   let(:group2) { FactoryBot.build(:brexit_checker_group, key: "living-ie") }
   let(:group3) { FactoryBot.build(:brexit_checker_group, key: "studying-uk") }
 
+  describe "validations" do
+    let(:group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, key: "studying-mars") }
+
+    it "validates citizen groups by key" do
+      message = "Validation failed: Key is not included in the list"
+      expect { group_with_invalid_key.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
   describe "factories" do
     it "has a valid default factory" do
       group = FactoryBot.build(:brexit_checker_group)

--- a/spec/lib/brexit_checker/notification_spec.rb
+++ b/spec/lib/brexit_checker/notification_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+RSpec.describe BrexitChecker::Notification do
+  describe "validations" do
+    let(:notification_missing_action_id) { FactoryBot.build(:brexit_checker_notification, action_id: nil) }
+
+    it "action id can't be blank" do
+      message = "Validation failed: Action can't be blank"
+      expect { notification_missing_action_id.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
+  describe "factories" do
+    it "has a valid default factory" do
+      notification = FactoryBot.build(:brexit_checker_notification)
+      expect(notification.valid?).to be(true)
+    end
+  end
+
+  describe "#action" do
+    let(:action) { FactoryBot.build(:brexit_checker_action) }
+    let(:action2) { FactoryBot.build(:brexit_checker_action) }
+    let(:notification) { FactoryBot.build(:brexit_checker_notification, action_id: action.id) }
+
+    before :each do
+      allow(BrexitChecker::Action).to receive(:load_all).and_return([action, action2])
+    end
+
+    it "returns the action relating to that notification" do
+      expect(notification.action).to eq action
+    end
+  end
+
+  describe ".load" do
+    let(:uuid) { "5fe018d7-edb1-4d7a-858e-065e46d0917e" }
+    let(:type) { "addition" }
+    let(:type2) { "content_change" }
+    let(:action_id) { "T092" }
+    let(:date) { "2019-09-09" }
+
+    let(:single_notification_yaml) do
+      <<-YAML
+          - uuid: "#{uuid}"
+            type: "#{type}"
+            action_id: "#{action_id}"
+            date: "#{date}"
+      YAML
+    end
+
+    let(:attrs) { YAML.safe_load(single_notification_yaml).first }
+
+    it "builds a notification from attributes in the yaml" do
+      notification = described_class.load(attrs)
+
+      expect(notification.action_id).to eq(action_id)
+      expect(notification.type).to eq(type)
+      expect(notification.id).to eq(uuid)
+      expect(notification.date).to eq(date)
+    end
+  end
+
+  describe ".find_by_id" do
+    let(:notification) { FactoryBot.build(:brexit_checker_notification) }
+    let(:notification2) { FactoryBot.build(:brexit_checker_notification) }
+
+    before :each do
+      allow(described_class).to receive(:load_all).and_return([notification, notification2])
+    end
+
+    it "returns a group by key" do
+      expect(described_class.find_by_id(notification.id)).to eq notification
+    end
+  end
+end

--- a/spec/lib/brexit_checker/question/option_spec.rb
+++ b/spec/lib/brexit_checker/question/option_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe BrexitChecker::Question::Option do
+  describe "factories" do
+    it "has a valid default factory" do
+      option = FactoryBot.build(:brexit_checker_option)
+      expect(option.valid?).to be(true)
+    end
+  end
+
+  describe "validations" do
+    let(:option_missing_attributes) { FactoryBot.build(:brexit_checker_option, label: nil) }
+
+    it "label can't be blank" do
+      message = "Validation failed: Label can't be blank"
+      expect { option_missing_attributes.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
+  describe ".load_all" do
+    let(:value) { "nationality-uk" }
+    let(:label) { "British" }
+    let(:exclude_if) { "living-uk" }
+    let(:options_yaml) do
+      [
+        {
+          "value" => value,
+          "label" => label,
+          "exclude_if" => exclude_if,
+        },
+      ]
+    end
+
+    let(:options) { described_class.load_all(options_yaml) }
+
+    it "builds an array of options from attributes in the yaml" do
+      expect(options.first.value).to eq(value)
+      expect(options.first.label).to eq(label)
+      expect(options.first.exclude_if).to eq(exclude_if)
+    end
+  end
+end

--- a/spec/lib/brexit_checker/question_spec.rb
+++ b/spec/lib/brexit_checker/question_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+RSpec.describe BrexitChecker::Question do
+  describe "factories" do
+    it "has a valid default factory" do
+      question = FactoryBot.build(:brexit_checker_question)
+      expect(question.valid?).to be(true)
+    end
+  end
+
+  describe "validations" do
+    let(:question_missing_attributes) { FactoryBot.build(:brexit_checker_question, key: nil, text: nil) }
+    let(:question_with_invalid_type) { FactoryBot.build(:brexit_checker_question, type: "bananarama") }
+    let(:question_with_invalid_options) { FactoryBot.build(:brexit_checker_question, options: {}) }
+
+    it "key and text can't be blank" do
+      message = "Validation failed: Key can't be blank, Text can't be blank"
+      expect { question_missing_attributes.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "type must be single, single_wrapped, multiple of multiple_grouped" do
+      message = "Validation failed: Type is not included in the list"
+      expect { question_with_invalid_type.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "options must be an array" do
+      message = "Validation failed: Options is not an array"
+      expect { question_with_invalid_options.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+  end
+
+  describe "building a question from the yaml file" do
+    let(:caption) { "About you and your family" }
+    let(:type) { "single" }
+    let(:options) do
+      [
+        {
+          "value" => "nationality-uk",
+          "label" => "British",
+          "exclude_if" => "living-uk",
+        },
+      ]
+    end
+    let(:key) { "nationality" }
+    let(:text) { "What nationality are you?" }
+
+    let(:question_yaml) do
+      {
+        "caption" => caption,
+        "type" => type,
+        "options" => options,
+        "key" => key,
+        "text" => text,
+      }
+    end
+
+    let(:question) { BrexitChecker::Question.load(question_yaml) }
+
+    it ".load builds a question from attributes in the yaml" do
+      expect(question.caption).to eq(caption)
+      expect(question.type).to eq(type)
+      expect(question.key).to eq(key)
+      expect(question.text).to eq(text)
+    end
+
+    it "#options returns an array of option objects" do
+      expect(question.options.first).to be_an_instance_of(BrexitChecker::Question::Option)
+    end
+
+    it "#options removes an option if the criteria matches the option's exclude_if value " do
+      expect(question.options("living-uk")).to eq([])
+    end
+  end
+
+  describe ".find_by_key" do
+    let(:question) { FactoryBot.build(:brexit_checker_question) }
+    let(:question2) { FactoryBot.build(:brexit_checker_question) }
+
+    before :each do
+      allow(described_class).to receive(:load_all).and_return([question, question2])
+    end
+
+    it "returns a group by key" do
+      expect(described_class.find_by_key(question.key)).to eq question
+    end
+  end
+end


### PR DESCRIPTION
## What

- Adds and extends unit tests for the Brexit checker models.

- Move the validations for the group model into a custom validator to make it easier to extend this model.

[trello](https://trello.com/c/VN5HJYMS/573-tidy-up-checker-in-prep-for-business-groupings)

----

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
