### PR TITLE
Preserve ?continue when redirecting to ?done

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
   def delete
     if params[:continue]
       logout!
-      redirect_if_not_test "#{account_manager_url}/logout?done=1"
+      redirect_if_not_test "#{account_manager_url}/logout?done=#{params[:continue]}"
     elsif params[:done]
       logout!
       redirect_if_not_test "/transition"


### PR DESCRIPTION
We'll use this to pass along extra state, like "continue to the
post-delete page".

---

[Trello card](https://trello.com/c/a9vNNw0Z/395-remove-sign-out-on-nav-after-deleting-account)