### PR TITLE
Notifications for Brexit checker October updates

### DIFF
--- a/app/lib/brexit_checker/notifications.yaml
+++ b/app/lib/brexit_checker/notifications.yaml
@@ -261,3 +261,21 @@ notifications:
     type: addition
     action_id: T120
     date: 2020-10-12
+  - uuid: "cfc24346-a457-4859-863d-86ef25195075"
+    type: addition
+    action_id: T121
+    date: 2020-11-02
+  - uuid: "565704ca-1e9e-4ac4-9225-6001172af5b9"
+    type: content_change
+    action_id: T115
+    date: 2020-11-02
+    note: "Link now points to new guidance on chemical classification, labelling and packaging."
+  - uuid: "16a88af0-aef9-4322-a899-de1f96f25e49"
+    type: content_change
+    action_id: T116
+    date: 2020-11-02
+    note: "Link now points to new guidance on getting approval and product authorisation for biocidal substances."
+  - uuid: "f955e4e7-eb4c-4044-b527-24e7b07308e0"
+    type: addition
+    action_id: S017
+    date: 2020-11-02


### PR DESCRIPTION
This PR adds notifications for the changes added in https://github.com/alphagov/finder-frontend/pull/2280

As per the [guidance](https://docs.google.com/document/d/1YbXLRJ_FkPDvYPC7e4Nkhm054LqFVydn-KX_Th3yFYw/edit#), notifications are required for the following:

T121 - Addition, no change note
T115 - Change, note needed
T116 - Change, note needed

S017 is being treated as a new action, as it was removed and is being reinstated. See [trello](https://trello.com/c/JrxeXfA6/549-action-batch-update-october-x) for context



---
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
