### PR TITLE
DO NOT MERGE Brexit checker - add business groupings to results page

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -201,7 +201,7 @@ private
   helper_method :criteria_keys, :show_business_groupings?
 
   def show_business_groupings?
-    false
+    params[:show_business_groupings] == "true"
   end
 
   def page

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -198,7 +198,11 @@ private
                          BrexitChecker::Criteria::Filter.new.call(keys)
                        end
   end
-  helper_method :criteria_keys
+  helper_method :criteria_keys, :show_business_groupings?
+
+  def show_business_groupings?
+    false
+  end
 
   def page
     @page ||= ParamsCleaner.new(params).fetch(:page, "0").to_i

--- a/app/lib/brexit_checker/action.rb
+++ b/app/lib/brexit_checker/action.rb
@@ -5,12 +5,11 @@ class BrexitChecker::Action
 
   CONFIG_PATH = Rails.root.join("app/lib/brexit_checker/actions.yaml")
 
-  validates_presence_of :id, :title, :consequence
+  validates_presence_of :id, :title, :consequence, :grouping_criteria
   validates_inclusion_of :audience, in: %w[business citizen]
   validates_presence_of :guidance_link_text, if: :guidance_url
   validates_numericality_of :priority, only_integer: true
   validate :has_criteria
-  validate :citizen_action_has_grouping_criteria
 
   attr_reader :id,
               :title,
@@ -84,12 +83,6 @@ private
       url.path
     else
       full_url
-    end
-  end
-
-  def citizen_action_has_grouping_criteria
-    if audience == "citizen" && grouping_criteria.blank?
-      errors.add(:grouping_criteria, "can't be empty for citizen actions")
     end
   end
 end

--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -426,6 +426,8 @@ actions:
     - employ-eu-citizens
     - provide-services-do-business-in-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T007
   priority: 2
   title: Check if you need to change how you do accounting and reporting
@@ -437,6 +439,8 @@ actions:
   criteria:
   - provide-services-do-business-in-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T010
   priority: 5
   title: Check if your existing UK Civil Aviation Authority or EASA certificates and
@@ -452,6 +456,8 @@ actions:
     - aero-space
     - air-passenger-freight
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T011
   priority: 5
   title: Check if you need to change your contracts to broadcast licensed content
@@ -471,6 +477,8 @@ actions:
       - personal-eu-org-provide
       - ip-copyright
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T012
   priority: 5
   title: Check the new rules for parallel exporting IP protected goods from the UK
@@ -492,6 +500,8 @@ actions:
       - ip-patents
       - ip-exhaustion-rights
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T013
   priority: 5
   title: Check contracts relating to EU space programmes with your contracting authority
@@ -502,6 +512,8 @@ actions:
   criteria:
   - aero-space
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T014
   priority: 5
   title: Check if you need to find replacement data or services if you use the Copernicus
@@ -513,6 +525,8 @@ actions:
   criteria:
   - aero-space
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T016
   priority: 5
   title: Find out how to comply with the new UK nuclear safeguards arrangements
@@ -524,6 +538,8 @@ actions:
   criteria:
   - nuclear
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T017
   priority: 5
   title: Register to use the open general export licence to export 'dual use' nuclear
@@ -536,6 +552,8 @@ actions:
   criteria:
   - nuclear
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T018
   priority: 5
   title: Get a licence to import certain nuclear materials into the UK
@@ -549,6 +567,8 @@ actions:
   criteria:
   - nuclear
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T019
   priority: 5
   title: Make sure you have the right authorisations to ship radioactive waste and
@@ -560,6 +580,8 @@ actions:
   criteria:
   - nuclear
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T020
   priority: 5
   title: Check the rules for moving radioactive sources into the UK
@@ -573,6 +595,8 @@ actions:
     - nuclear
     - mining
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T021
   priority: 5
   title: Check what documents you and your employees need to make and operate aircraft
@@ -590,6 +614,8 @@ actions:
     - air-passenger-freight
     - oil-gas-coal
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T022
   priority: 6
   title: Check if you need to change your contract to keep accessing personal data
@@ -606,6 +632,8 @@ actions:
     - personal-eu-org-use
     - personal-eu-org-provide
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T023
   priority: 5
   title: Check the rules you need to follow if you're a broadcaster or provider of
@@ -620,6 +648,8 @@ actions:
     - media
     - digital
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T025
   priority: 5
   title: Get permission to take creative, cultural and sports goods into and out of
@@ -634,6 +664,8 @@ actions:
     - sports
     - culture
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T026
   priority: 5
   title: Appoint a representative in the EU if you run a large UK-based online business
@@ -650,6 +682,8 @@ actions:
     - telecoms
     - personal-eu-org-provide
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T028
   priority: 8
   title: Export fish through the right EU border inspection post and prepare the right
@@ -667,6 +701,8 @@ actions:
     - postal-couriers
     - fish-inc-wholesale
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T032
   priority: 8
   title: Check the rules on moving plants and plant products between the UK and the
@@ -685,6 +721,8 @@ actions:
       - export-to-eu
       - import-from-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-2
 - id: T033
   priority: 8
   title: Get the right certificates of conformity to move fruit and vegetables into
@@ -702,6 +740,8 @@ actions:
       - agriculture-farm
       - food-drink-tobacco
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T034
   priority: 6
   title: Check how to register or label food or drink with a protected name
@@ -716,6 +756,8 @@ actions:
     - agriculture-farm
     - food-drink-tobacco
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T035
   priority: 6
   title: Register as an approved food establishment to export food to the EU
@@ -733,6 +775,8 @@ actions:
       - agriculture-farm
     - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T036
   priority: 6
   title: Check how to label food if you're selling it in the UK or EU
@@ -748,6 +792,8 @@ actions:
     - fish-inc-wholesale
     - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T038
   priority: 5
   title: Check if you can export organic food to the EU, and how to label and trade
@@ -765,6 +811,8 @@ actions:
       - agriculture-farm
     - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T044
   priority: 5
   title: Enrol with the Rural Payments Agency to prepare to export hops to the EU
@@ -779,6 +827,8 @@ actions:
     - food-drink-tobacco
     - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T045
   priority: 6
   title: Print 'GB', 'GBR' or '826' on each egg you're exporting to the EU for people
@@ -791,6 +841,8 @@ actions:
   criteria:
   - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T046
   priority: 6
   title: Check how to mark hatching eggs and boxes of chicks that you're exporting
@@ -803,6 +855,8 @@ actions:
   criteria:
   - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T047
   priority: 6
   title: Get a certificate to export poultry meat to the EU if the meat is printed
@@ -817,6 +871,8 @@ actions:
   criteria:
   - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T050
   priority: 7
   title: Get an International Maritime Organisation (IMO) number if your fishing boat
@@ -832,6 +888,8 @@ actions:
     - marine-transport
     - fish-inc-wholesale
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-3
 - id: T051
   priority: 5
   title: Check what you need to do to land your fish catch at a port in the EU
@@ -845,6 +903,8 @@ actions:
     - marine-transport
     - fish-inc-wholesale
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T052
   priority: 8
   title: Register your chemicals to an organisation based in the EU if you want to
@@ -858,6 +918,8 @@ actions:
   criteria:
   - chemical
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T057
   priority: 4
   title: Check which carbon pricing policies you need to comply with
@@ -890,6 +952,8 @@ actions:
     - digital
     - telecoms
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T059
   priority: 3
   title: Check whether any wood packaging you use meets ISPM15 international standards
@@ -901,6 +965,8 @@ actions:
   criteria:
   - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T063
   priority: 6
   title: Check what documents you need to run bus or coach services in EU countries
@@ -915,6 +981,8 @@ actions:
     - tourism
     - road-passenger-freight
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T065
   priority: 7
   title: Check what documents you need to transport goods through the EU if you’re
@@ -929,6 +997,8 @@ actions:
     - road-passenger-freight
     - haulage-goods-across-eu-borders
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T066
   priority: 5
   title: Check how to get approval to sell vehicles and vehicle parts in the UK and
@@ -945,6 +1015,8 @@ actions:
     - road-passenger-freight
     - motor-trade
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T071
   priority: 8
   title: Get an EORI number that starts with GB to move your goods into or out of
@@ -964,6 +1036,8 @@ actions:
     - haulage-goods-across-eu-borders
     - road-passenger-freight
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T075
   priority: 8
   title: Register for a quicker way to move your goods to the EU, Switzerland, Norway,
@@ -980,6 +1054,8 @@ actions:
     - export-to-eu
     - haulage-goods-across-eu-borders
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T077
   priority: 2
   title: Encourage your employees to check if they need to apply to the EU Settlement
@@ -992,6 +1068,8 @@ actions:
   criteria:
   - employ-eu-citizens
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-4
 - id: T080
   priority: 2
   title: Check the new rules for unregistered design protection in the UK and EU
@@ -1006,6 +1084,8 @@ actions:
     - ip-copyright
     - ip-designs
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T081
   priority: 5
   title: Check what you need to do to continue to work or provide legal services in
@@ -1019,6 +1099,8 @@ actions:
   criteria:
   - legal-service
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T082
   priority: 5
   title: Check what you need to do if you own a UK legal services business
@@ -1030,6 +1112,8 @@ actions:
   criteria:
   - legal-service
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T085
   priority: 1
   title: Get your UK qualification recognised if you want to work in a regulated profession
@@ -1045,6 +1129,8 @@ actions:
     - legal-service
     - construction
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T086
   priority: 5
   title: Check if you need to apply for plant variety rights to market seeds in the
@@ -1062,6 +1148,8 @@ actions:
     - agriculture-farm
     - forestry
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T087
   priority: 8
   title: Check if you need to get a phytosanitary certificate to export plants to
@@ -1078,6 +1166,8 @@ actions:
     - forestry
     - food-drink-tobacco
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T088
   priority: 5
   title: If you buy chemicals from the EU, you will need to register on the new UK
@@ -1093,6 +1183,8 @@ actions:
     - chemical
     - import-from-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T089
   priority: 5
   title: Ask your vet what you need to do before you take your horse or other equine
@@ -1108,6 +1200,8 @@ actions:
     - animal-ex-food
     - sports
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-5
 - id: T090
   priority: 8
   title: Export animals or products of animal origin (POAO) through the right EU or
@@ -1127,6 +1221,8 @@ actions:
     - fish-inc-wholesale
     - agriculture-farm
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T091
   priority: 3
   title: Check guidance on the Kimberly Process Certification Scheme for trading rough
@@ -1139,6 +1235,8 @@ actions:
   criteria:
   - diamond
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T092
   priority: 5
   title: Check the rules on moving timber and timber products between the UK and the
@@ -1151,6 +1249,8 @@ actions:
   criteria:
   - forestry
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T093
   priority: 5
   title: Check if you need new licences for any drug precursor chemicals you import
@@ -1170,6 +1270,8 @@ actions:
       - export-to-eu
       - import-from-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T096
   priority: 2
   title: Check the rules on moving waste between the UK and the EU
@@ -1185,6 +1287,8 @@ actions:
       - import-from-eu
       - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T097
   priority: 2
   title: Check if you need a CITES permit when moving endangered animal or plant species
@@ -1201,6 +1305,8 @@ actions:
     - forestry
     - animal-ex-food
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T098
   priority: 5
   title: Check the rules on making or placing pesticides on the UK market
@@ -1211,6 +1317,8 @@ actions:
   criteria:
   - chemical
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T099
   priority: 9
   title: Decide how you want to make customs declarations and whether you need to
@@ -1225,6 +1333,8 @@ actions:
     - import-from-eu
     - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T100
   priority: 3
   title: Apply for a licence to export cultural objects
@@ -1236,6 +1346,8 @@ actions:
   criteria:
   - culture
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T101
   priority: 5
   title: Register for a licence to export dual-use items to the EU and Channel Islands 
@@ -1255,6 +1367,8 @@ actions:
     - mining
     - non-metal-material
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-6
 - id: T102
   priority: 9
   title: Find out how to export your goods to the UK if you're an overseas business
@@ -1268,6 +1382,8 @@ actions:
     - owns-operates-business-organisation-eu
     - owns-operates-business-organisation-row
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T103
   priority: 8
   title: Check if you need to pay a tariff on the goods you import from 1 January
@@ -1280,6 +1396,8 @@ actions:
   criteria:
   - import-from-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: S038
   priority: 6
   title: Sign up for email updates if you're a UK national living in the EU, Switzerland,
@@ -1340,6 +1458,8 @@ actions:
     - road-passenger-freight
     - motor-trade
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T105
   priority: 4
   title: Check you have the correct EU type approval to continue selling vehicles
@@ -1355,6 +1475,8 @@ actions:
     - road-passenger-freight
     - motor-trade
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: S041
   priority: 9
   title: Check what you need to do to access healthcare in the country you'll be living
@@ -1386,6 +1508,8 @@ actions:
   criteria:
   - export-to-row
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T107
   priority: 1
   title: Apply for Horizon 2020 funding
@@ -1397,6 +1521,8 @@ actions:
   criteria:
   - eu-uk-funding
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T108
   priority: 9
   title: Check how to trade or move goods into, out of, or through Northern Ireland
@@ -1409,6 +1535,8 @@ actions:
   criteria:
   - move-goods-ni
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T109
   priority: 10
   title: Check what you need to do to export to the EU from 1 January 2021
@@ -1418,6 +1546,8 @@ actions:
   criteria:
   - export-to-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T110
   priority: 10
   title: Check what you need to do to import from the EU from 1 January 2021
@@ -1427,6 +1557,8 @@ actions:
   criteria:
   - import-from-eu
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T111
   priority: 2
   title: Check if you need to replace your .eu domain name
@@ -1439,6 +1571,8 @@ actions:
   criteria:
   - eu-domain
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T112
   priority: 9
   title: Register for the UK’s new Import of Products, Animals, Food and Feed System
@@ -1457,6 +1591,8 @@ actions:
       - agriculture-farm
       - food-drink-tobacco
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T113
   priority: 1
   title: Check the rules for reporting unfair trade practices using the UK's new trade
@@ -1470,6 +1606,8 @@ actions:
   criteria:
   - owns-operates-business-organisation-uk
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T114
   priority: 2
   title: Check if there's a trade agreement with any non-EU country you're planning
@@ -1483,6 +1621,8 @@ actions:
     - trade-developing
     - export-to-row
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T115
   priority: 2
   title: Make sure chemicals are classified, labelled and packaged according to GB
@@ -1496,6 +1636,8 @@ actions:
   criteria:
   - chemical
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T116
   priority: 2
   title: Get approval and product authorisations for new biocidal active substances
@@ -1509,6 +1651,8 @@ actions:
   criteria:
   - chemical
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T117
   priority: 5
   title: Contact your regulator if you are a UK lawyer working permanently in the
@@ -1524,6 +1668,8 @@ actions:
     - working-eu
     - legal-service
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T118
   priority: 4
   title: Check the rules for providing online services to the EU, Norway, Iceland
@@ -1538,6 +1684,8 @@ actions:
     - provide-services-do-business-in-eu
     - personal-eu-org-provide
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T119
   priority: 3
   title: Check if you need to update your copyright licenses to satellite broadcast
@@ -1551,6 +1699,8 @@ actions:
     - ip-copyright
     - media
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-1
 - id: T120
   priority: 6
   title: Check if you’ll need a licence to employ workers from the EU, Switzerland,
@@ -1567,6 +1717,8 @@ actions:
     - owns-operates-business-organisation-uk
     - employ-eu-citizens
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7
 - id: T121
   priority: 6
   title: Check what you need to do if your business handles animal feed, or you export
@@ -1581,3 +1733,5 @@ actions:
     - export-to-eu
     - animal-ex-food
   audience: business
+  grouping_criteria:
+  - placeholder-grouping-7

--- a/app/lib/brexit_checker/group.rb
+++ b/app/lib/brexit_checker/group.rb
@@ -4,7 +4,7 @@ class BrexitChecker::Group
 
   GROUPS_PATH = Rails.root.join("app/lib/brexit_checker/groups.yaml")
 
-  attr_reader :key, :heading, :priority
+  attr_reader :key, :heading, :priority, :audience
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/app/lib/brexit_checker/groups.yaml
+++ b/app/lib/brexit_checker/groups.yaml
@@ -1,32 +1,76 @@
 ---
 groups:
-- key: visiting-eu
-  heading: Visiting the EU
-  priority: 9
-- key: visiting-uk
-  heading: Visiting the UK
-  priority: 8
-- key: visiting-ie
-  heading: Visiting Ireland
-  priority: 7
-- key: living-eu
-  heading: Living in the EU
-  priority: 6
-- key: living-ie
-  heading: Living in Ireland
-  priority: 6
-- key: living-uk
-  heading: Living in the UK
-  priority: 6
-- key: working-uk
-  heading: Working in the UK
-  priority: 5
-- key: studying-eu
-  heading: Studying in the EU
-  priority: 4
-- key: studying-uk
-  heading: Studying in the UK
-  priority: 3
-- key: common-travel-area
-  heading: Common Travel Area
-  priority: 1
+### --- Citizen groupings --- ###
+  - key: visiting-eu
+    heading: Visiting the EU
+    priority: 9
+    audience: citizen
+  - key: visiting-uk
+    heading: Visiting the UK
+    priority: 8
+    audience: citizen
+  - key: visiting-ie
+    heading: Visiting Ireland
+    priority: 7
+    audience: citizen
+  - key: living-eu
+    heading: Living in the EU
+    priority: 6
+    audience: citizen
+  - key: living-ie
+    heading: Living in Ireland
+    priority: 6
+    audience: citizen
+  - key: living-uk
+    heading: Living in the UK
+    priority: 6
+    audience: citizen
+  - key: working-uk
+    heading: Working in the UK
+    priority: 5
+    audience: citizen
+  - key: studying-eu
+    heading: Studying in the EU
+    priority: 4
+    audience: citizen
+  - key: studying-uk
+    heading: Studying in the UK
+    priority: 3
+    audience: citizen
+  - key: common-travel-area
+    heading: Common Travel Area
+    priority: 1
+    audience: citizen
+### --- Business groupings --- ###
+  - key: placeholder-grouping-1
+    heading: Placeholder grouping 1
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-2
+    heading: Placeholder grouping 2
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-3
+    heading: Placeholder grouping 3
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-4
+    heading: Placeholder grouping 4
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-5
+    heading: Placeholder grouping 5
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-6
+    heading: Placeholder grouping 6
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-7
+    heading: Placeholder grouping 7
+    priority: 1
+    audience: business
+  - key: placeholder-grouping-8
+    heading: Placeholder grouping 8
+    priority: 1
+    audience: business

--- a/app/lib/brexit_checker/results/group_by_audience.rb
+++ b/app/lib/brexit_checker/results/group_by_audience.rb
@@ -1,35 +1,33 @@
 class BrexitChecker::Results::GroupByAudience
   attr_reader :citizen_actions, :business_actions, :criteria
 
-  def initialize(actions, criteria)
-    @citizen_actions = actions["citizen"]
-    @business_actions = actions["business"]
+  def initialize(criteria)
     @criteria = criteria
   end
 
-  def populate_business_groups
-    return {} if business_actions.blank? || criteria.blank?
+  def populate_business_results(actions)
+    return {} if actions.blank? || criteria.blank?
 
     {
-      actions: business_actions,
-      criteria: business_actions.flat_map(&:all_criteria).uniq & criteria,
+      actions: actions,
+      criteria: actions.flat_map(&:all_criteria).uniq & criteria,
     }
   end
 
-  def populate_citizen_groups
-    return [] if citizen_actions.blank? || criteria.blank?
+  def populate_groups(audience_actions)
+    return {} if audience_actions.blank? || criteria.blank?
 
-    citizen_actions.each_with_object([]) do |action, grouped_actions|
+    audience_actions.each_with_object([]) do |action, grouped_actions|
       next if action.grouping_criteria.empty?
 
       group_key_array(action).each do |key|
         group = BrexitChecker::Group.find_by(key)
-        next if grouped_actions.any? { |actions| actions[:group] == group }
+        next if grouped_actions.any? { |actions| actions[:group].key == group.key }
 
         grouped_actions << {
           group: group,
-          actions: actions_for_group(group, citizen_actions),
-          criteria: criteria_for_group(group, citizen_actions),
+          actions: actions_for_group(group, audience_actions),
+          criteria: criteria_for_group(group, audience_actions),
         }
       end
       sort_by_priority(grouped_actions)

--- a/app/lib/brexit_checker/results/result_presenter.rb
+++ b/app/lib/brexit_checker/results/result_presenter.rb
@@ -16,11 +16,15 @@ class BrexitChecker::Results::ResultPresenter
   end
 
   def business_results
-    grouped_results.populate_business_groups
+    grouped_results.populate_business_results(audience_actions["business"])
   end
 
   def citizen_results_groups
-    grouped_results.populate_citizen_groups
+    grouped_results.populate_groups(audience_actions["citizen"])
+  end
+
+  def business_results_groups
+    grouped_results.populate_groups(audience_actions["business"])
   end
 
 private
@@ -34,6 +38,6 @@ private
   end
 
   def grouped_results
-    BrexitChecker::Results::GroupByAudience.new(audience_actions, criteria)
+    BrexitChecker::Results::GroupByAudience.new(criteria)
   end
 end

--- a/app/lib/brexit_checker/validators/group_validator.rb
+++ b/app/lib/brexit_checker/validators/group_validator.rb
@@ -10,14 +10,31 @@ class BrexitChecker::Validators::GroupValidator < ActiveModel::Validator
                      studying-uk
                      common-travel-area ].freeze
 
+  BUSINESS_KEYS = %w[ placeholder-grouping-1
+                      placeholder-grouping-2
+                      placeholder-grouping-3
+                      placeholder-grouping-4
+                      placeholder-grouping-5
+                      placeholder-grouping-6
+                      placeholder-grouping-7
+                      placeholder-grouping-8].freeze
+
   def validate(record)
-    validate_citizen_group(record)
+    if record.audience.nil?
+      record.errors[:audience] << "can't be blank"
+    else
+      validate_keys(record)
+    end
   end
 
 private
 
-  def validate_citizen_group(record)
-    unless CITIZEN_KEYS.include?(record.key)
+  def keys
+    { "citizen" => CITIZEN_KEYS, "business" => BUSINESS_KEYS }
+  end
+
+  def validate_keys(record)
+    unless keys[record.audience].include?(record.key)
       record.errors[:key] << "is not included in the list"
     end
   end

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -1,10 +1,41 @@
-<section
+<% if show_business_groupings? %>
+  <section class="brexit-checker-audience">
+  <header>
+    <h2 class="govuk-heading-l action-audience__heading">
+      <%= t('brexit_checker.results.audiences.business.heading') %>
+    </h2>
+  </header>
+    <section class="brexit-checker-audience">
+      <% @presenter.business_results_groups.each.with_index do |grouping, group_index| %>
+        <section
+          class="brexit-checker-actions__group"
+          data-analytics-ecommerce
+          data-ecommerce-start-index=<%="#{group_index + 1}"%>
+          data-list-title="Brexit checker results: <%= "#{t('brexit_checker.results.audiences.business.heading')} - #{grouping[:group].heading}" %>"
+          data-search-query
+        >
+          <div class="govuk-grid-row">
+            <%= render 'results_criteria', criteria: grouping[:criteria], heading: grouping[:group].heading %>
+            <div class="govuk-grid-column-two-thirds">
+              <%= render "action_list", {
+                analytics_group: "#{t('brexit_checker.results.audiences.business.heading')} - 1.",
+                actions: grouping[:actions],
+                heading_level: 3
+              } %>
+            </div>
+          </div>
+        </section>
+        <% end %>
+    </section>
+  </section>
+<% else %>
+  <section
   class="brexit-checker-actions"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
   data-list-title="Brexit checker results: <%= t('brexit_checker.results.audiences.business.heading') %>"
   data-search-query
->
+  >
   <section class="brexit-checker-audience">
       <header>
         <h2 class="govuk-heading-l action-audience__heading">
@@ -13,15 +44,16 @@
       </header>
       <section class="brexit-checker-actions__group">
         <div class="govuk-grid-row">
-          <%= render 'results_criteria', criteria: business_results[:criteria] %>
+          <%= render 'results_criteria', criteria: @presenter.business_results[:criteria] %>
           <div class="govuk-grid-column-two-thirds">
             <%= render "action_list", {
               analytics_group: "#{t('brexit_checker.results.audiences.business.heading')} - 1.",
-              actions: business_results[:actions],
+              actions: @presenter.business_results[:actions],
               heading_level: 3
             } %>
           </div>
         </div>
       </section>
   </section>
-</section>
+  </section>
+<% end %>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -84,7 +84,7 @@
       } %>
     <% end %>
 
-    <%= render 'results_business_actions', business_results: @presenter.business_results if @presenter.business_results.any? %>
+    <%= render 'results_business_actions' if @presenter.business_results.any? %>
     <%= render 'results_citizen_actions', citizen_results_groups: @presenter.citizen_results_groups if @presenter.citizen_results_groups.any? %>
     <%= render 'results_with_no_actions', criteria: @presenter.criteria if (@presenter.business_results.empty? && @presenter.citizen_results_groups.empty?) %>
 

--- a/spec/factories/brexit_checker/action.rb
+++ b/spec/factories/brexit_checker/action.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     priority { 5 }
     criteria { %w[construction] }
     audience { "business" }
+    grouping_criteria { %w[placeholder-grouping-1] }
 
     sequence(:id) { |n| "Action#{n}" }
 

--- a/spec/factories/brexit_checker/group.rb
+++ b/spec/factories/brexit_checker/group.rb
@@ -2,7 +2,13 @@ FactoryBot.define do
   factory :brexit_checker_group, class: BrexitChecker::Group do
     key { "living-uk" }
     heading { "You live in the UK" }
+    audience { "citizen" }
     priority { 6 }
     initialize_with { BrexitChecker::Group.new(attributes) }
+
+    trait :business do
+      key { "placeholder-grouping-1" }
+      audience { "business" }
+    end
   end
 end

--- a/spec/lib/brexit_checker/action_spec.rb
+++ b/spec/lib/brexit_checker/action_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BrexitChecker::Action do
     let(:action_missing_link_text) { FactoryBot.build(:brexit_checker_action, guidance_url: "/brexity_fun") }
     let(:action_with_invalid_priority) { FactoryBot.build(:brexit_checker_action, priority: "high") }
     let(:action_with_missing_criteria) { FactoryBot.build(:brexit_checker_action, criteria: []) }
-    let(:action_with_missing_grouping_criteria) { FactoryBot.build(:brexit_checker_action, :citizen, grouping_criteria: nil) }
+    let(:action_with_missing_grouping_criteria) { FactoryBot.build(:brexit_checker_action, grouping_criteria: nil) }
 
     it "id, title, consequence and criteria can't be blank" do
       message = "Validation failed: Id can't be blank, Title can't be blank, Consequence can't be blank"
@@ -40,8 +40,8 @@ RSpec.describe BrexitChecker::Action do
       expect { action_with_missing_criteria.valid? }.to raise_error(ActiveModel::ValidationError, message)
     end
 
-    it "must have grouping criteria if a citizen action" do
-      message = "Validation failed: Grouping criteria can't be empty for citizen actions"
+    it "must have grouping criteria" do
+      message = "Validation failed: Grouping criteria can't be blank"
       expect { action_with_missing_grouping_criteria.valid? }.to raise_error(ActiveModel::ValidationError, message)
     end
   end

--- a/spec/lib/brexit_checker/group_spec.rb
+++ b/spec/lib/brexit_checker/group_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BrexitChecker::Group do
   describe "validations" do
     let(:citizen_group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, key: "studying-mars") }
     let(:business_group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, :business, key: "wonky-shops") }
-    let(:group_missing_audience) { FactoryBot.build(:brexit_checker_group, audience: nil ) }
+    let(:group_missing_audience) { FactoryBot.build(:brexit_checker_group, audience: nil) }
     it "validates citizen groups by key" do
       message = "Validation failed: Key is not included in the list"
       expect { citizen_group_with_invalid_key.valid? }.to raise_error(ActiveModel::ValidationError, message)

--- a/spec/lib/brexit_checker/group_spec.rb
+++ b/spec/lib/brexit_checker/group_spec.rb
@@ -9,11 +9,22 @@ RSpec.describe BrexitChecker::Group do
   let(:group3) { FactoryBot.build(:brexit_checker_group, key: "studying-uk") }
 
   describe "validations" do
-    let(:group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, key: "studying-mars") }
-
+    let(:citizen_group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, key: "studying-mars") }
+    let(:business_group_with_invalid_key) { FactoryBot.build(:brexit_checker_group, :business, key: "wonky-shops") }
+    let(:group_missing_audience) { FactoryBot.build(:brexit_checker_group, audience: nil ) }
     it "validates citizen groups by key" do
       message = "Validation failed: Key is not included in the list"
-      expect { group_with_invalid_key.valid? }.to raise_error(ActiveModel::ValidationError, message)
+      expect { citizen_group_with_invalid_key.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "validates business groups by key" do
+      message = "Validation failed: Key is not included in the list"
+      expect { business_group_with_invalid_key.valid? }.to raise_error(ActiveModel::ValidationError, message)
+    end
+
+    it "must have an audience" do
+      message = "Validation failed: Audience can't be blank"
+      expect { group_missing_audience.valid? }.to raise_error(ActiveModel::ValidationError, message)
     end
   end
 

--- a/spec/lib/brexit_checker/results/group_by_audience_spec.rb
+++ b/spec/lib/brexit_checker/results/group_by_audience_spec.rb
@@ -1,85 +1,63 @@
 require "spec_helper"
 
 describe BrexitChecker::Results::GroupByAudience do
-  describe "#populate_citizen_groups" do
-    let(:living_uk) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk") }
-    let(:visiting_driving) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving") }
-    let(:visiting_bring_pet) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-bring-pet") }
-    let(:visiting_eu) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu") }
-    let(:visiting_ie) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie") }
+  describe "#populate_groups" do
+    context "citizen actions" do
+      let(:living_uk) { FactoryBot.build(:brexit_checker_criterion, key: "living-uk") }
+      let(:visiting_driving) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-driving") }
+      let(:visiting_bring_pet) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-bring-pet") }
+      let(:visiting_eu) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-eu") }
+      let(:visiting_ie) { FactoryBot.build(:brexit_checker_criterion, key: "visiting-ie") }
 
-    let(:action1_criteria) { [{ "all_of" => [living_uk.key] }] }
-    let(:action1) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 1", criteria: action1_criteria, grouping_criteria: %w[living-uk]) }
+      let(:action1_criteria) { [{ "all_of" => [living_uk.key] }] }
+      let(:action1) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 1", criteria: action1_criteria, grouping_criteria: %w[living-uk]) }
 
-    let(:action2_criteria) { [{ "all_of" => [visiting_driving.key] }] }
-    let(:action2) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 2", criteria: action2_criteria, grouping_criteria: %w[visiting-eu]) }
+      let(:action2_criteria) { [{ "all_of" => [visiting_driving.key] }] }
+      let(:action2) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 2", criteria: action2_criteria, grouping_criteria: %w[visiting-eu]) }
 
-    let(:action3_criteria) { [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }] }
-    let(:action3) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie]) }
+      let(:action3_criteria) { [{ "all_of" => [living_uk.key, visiting_bring_pet.key, { "any_of" => [visiting_eu.key, visiting_ie.key] }] }] }
+      let(:action3) { FactoryBot.build(:brexit_checker_action, :citizen, title: "action 3", criteria: action3_criteria, grouping_criteria: %w[visiting-eu visiting-ie]) }
 
-    let(:group_visiting_eu) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU", priority: 9) }
-    let(:group_visiting_ie) { FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland", priority: 7) }
-    let(:group_living_uk) { FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK", priority: 6) }
+      let(:group_visiting_eu) { FactoryBot.build(:brexit_checker_group, key: "visiting-eu", heading: "Visiting the EU", priority: 9) }
+      let(:group_visiting_ie) { FactoryBot.build(:brexit_checker_group, key: "visiting-ie", heading: "Visiting Ireland", priority: 7) }
+      let(:group_living_uk) { FactoryBot.build(:brexit_checker_group, key: "living-uk", heading: "Living in the UK", priority: 6) }
 
-    let(:all_actions) { [action1, action2, action3] }
-    let(:all_criteria) { [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie] }
-    let(:all_groups) { [group_visiting_eu, group_visiting_ie, group_living_uk] }
+      let(:all_actions) { [action1, action2, action3] }
+      let(:all_criteria) { [living_uk, visiting_driving, visiting_bring_pet, visiting_eu, visiting_ie] }
+      let(:all_groups) { [group_visiting_eu, group_visiting_ie, group_living_uk] }
 
-    before :each do
-      allow(BrexitChecker::Action).to receive(:load_all).and_return(all_actions)
-      allow(BrexitChecker::Criterion).to receive(:load_all).and_return(all_criteria)
-      allow(BrexitChecker::Group).to receive(:load_all).and_return(all_groups)
-    end
-
-    context "when citizen actions are provided but there are no criteria" do
-      let(:actions) { { "citizen" => all_actions } }
-      subject { described_class.new(actions, []) }
-      it "returns an empty array" do
-        expect(subject.populate_citizen_groups).to be_empty
+      before :each do
+        allow(BrexitChecker::Action).to receive(:load_all).and_return(all_actions)
+        allow(BrexitChecker::Criterion).to receive(:load_all).and_return(all_criteria)
+        allow(BrexitChecker::Group).to receive(:load_all).and_return(all_groups)
       end
-    end
 
-    context "when criteria are provided but there are no citizen actions" do
-      let(:actions) { { "citizen" => [] } }
-      subject { described_class.new(actions, all_criteria) }
-      it "returns an empty array" do
-        expect(subject.populate_citizen_groups).to be_empty
+      context "when actions are provided but there are no criteria" do
+        let(:actions) { [all_actions] }
+        subject { described_class.new([]) }
+        it "returns an empty hash" do
+          expect(subject.populate_groups(all_actions)).to eq({})
+        end
       end
-    end
 
-    context "when actions are provided that only have a single grouping criterion" do
-      let(:selected_criteria) { [living_uk, visiting_driving] }
-      let(:filtered_actions) { { "citizen" => [action1, action2] } }
-      subject { described_class.new(filtered_actions, selected_criteria) }
-      it "produces an array of group hashes, ordered by priority" do
-        grouped_actions_fixture = [
-          {
-            group: group_visiting_eu,
-            actions: [action2],
-            criteria: [visiting_driving],
-          },
-          {
-            group: group_living_uk,
-            actions: [action1],
-            criteria: [living_uk],
-          },
-        ]
-        expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
+      context "when criteria are provided but there are no citizen actions" do
+        let(:actions) { [] }
+        subject { described_class.new(all_criteria) }
+        it "returns an empty hash" do
+          expect(subject.populate_groups(actions)).to eq({})
+        end
       end
-    end
 
-    context "when actions have multiple grouping criteria" do
-      context "when the user selects ONE of the action's ANY OF criteria" do
-        let(:selected_criteria) { [living_uk, visiting_eu, visiting_bring_pet] }
-        let(:filtered_actions) { { "citizen" => [action1, action3] } }
-        subject { described_class.new(filtered_actions, selected_criteria) }
-
-        it "only shows the groups matching the selected criteria, ordered by priority" do
+      context "when actions are provided that only have a single grouping criterion" do
+        let(:selected_criteria) { [living_uk, visiting_driving] }
+        let(:filtered_actions) { [action1, action2] }
+        subject { described_class.new(selected_criteria) }
+        it "produces an array of group hashes, ordered by priority" do
           grouped_actions_fixture = [
             {
               group: group_visiting_eu,
-              actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_eu],
+              actions: [action2],
+              criteria: [visiting_driving],
             },
             {
               group: group_living_uk,
@@ -87,39 +65,68 @@ describe BrexitChecker::Results::GroupByAudience do
               criteria: [living_uk],
             },
           ]
-          expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
+          expect(subject.populate_groups(filtered_actions)).to eq grouped_actions_fixture
         end
       end
 
-      context "when the user selects ALL of the action's ANY OF criteria" do
-        let(:selected_criteria) { [living_uk, visiting_eu, visiting_ie, visiting_bring_pet] }
-        let(:filtered_actions) { { "citizen" => [action1, action3] } }
-        subject { described_class.new(filtered_actions, selected_criteria) }
+      context "when actions have multiple grouping criteria" do
+        context "when the user selects ONE of the action's ANY OF criteria" do
+          let(:selected_criteria) { [living_uk, visiting_eu, visiting_bring_pet] }
+          let(:filtered_actions) { [action1, action3] }
+          subject { described_class.new(selected_criteria) }
 
-        it "shows all of the groups that have matching criteria, ordered by priority, and duplicates actions " do
-          grouped_actions_fixture = [
-            {
-              group: group_visiting_eu,
-              actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_eu],
-            },
-            {
-              group: group_visiting_ie,
-              actions: [action3],
-              criteria: [living_uk, visiting_bring_pet, visiting_ie],
-            },
-            {
-              group: group_living_uk,
-              actions: [action1],
-              criteria: [living_uk],
-            },
-          ]
-          expect(subject.populate_citizen_groups).to eq grouped_actions_fixture
+          it "only shows the groups matching the selected criteria, ordered by priority" do
+            grouped_actions_fixture = [
+              {
+                group: group_visiting_eu,
+                actions: [action3],
+                criteria: [living_uk, visiting_bring_pet, visiting_eu],
+              },
+              {
+                group: group_living_uk,
+                actions: [action1],
+                criteria: [living_uk],
+              },
+            ]
+            expect(subject.populate_groups(filtered_actions)).to eq grouped_actions_fixture
+          end
+        end
+
+        context "when the user selects ALL of the action's ANY OF criteria" do
+          let(:selected_criteria) { [living_uk, visiting_eu, visiting_ie, visiting_bring_pet] }
+          let(:filtered_actions) { [action1, action3] }
+          subject { described_class.new(selected_criteria) }
+
+          it "shows all of the groups that have matching criteria, ordered by priority, and duplicates actions " do
+            grouped_actions_fixture = [
+              {
+                group: group_visiting_eu,
+                actions: [action3],
+                criteria: [living_uk, visiting_bring_pet, visiting_eu],
+              },
+              {
+                group: group_visiting_ie,
+                actions: [action3],
+                criteria: [living_uk, visiting_bring_pet, visiting_ie],
+              },
+              {
+                group: group_living_uk,
+                actions: [action1],
+                criteria: [living_uk],
+              },
+            ]
+            expect(subject.populate_groups(filtered_actions)).to eq grouped_actions_fixture
+          end
         end
       end
+    end
+
+    context "business actions" do
+      # to be added
     end
   end
-  describe "#populate_business_groups" do
+
+  describe "#populate_business_results" do
     let(:action1) { FactoryBot.build(:brexit_checker_action, criteria: %w[owns-operates-business-organisation automotive]) }
     let(:action2) { FactoryBot.build(:brexit_checker_action, criteria: %w[aero-space]) }
     let(:action3) { FactoryBot.build(:brexit_checker_action, criteria: %w[forestry]) }
@@ -138,21 +145,21 @@ describe BrexitChecker::Results::GroupByAudience do
     end
 
     context "actions are provided but there are no criteria" do
-      let(:result) { described_class.new({ "business" => actions }, []).populate_business_groups }
-      it "returns an empty array" do
-        expect(result).to be_empty
+      let(:result) { described_class.new([]).populate_business_results(actions) }
+      it "returns an empty hash" do
+        expect(result).to eq({})
       end
     end
 
     context "criteria are provided but there are no actions" do
-      let(:result) { described_class.new({}, selected_criteria).populate_business_groups }
-      it "returns an empty array" do
-        expect(result).to be_empty
+      let(:result) { described_class.new(selected_criteria).populate_business_results([]) }
+      it "returns an empty hash" do
+        expect(result).to eq({})
       end
     end
 
     context "actions and criteria are provided" do
-      let(:result) { described_class.new({ "business" => actions }, selected_criteria).populate_business_groups }
+      let(:result) { described_class.new(selected_criteria).populate_business_results(actions) }
 
       it "produces an hash of actions and criteria" do
         expect(result[:actions]).to eq(actions)


### PR DESCRIPTION
## What

- On the Brexit checker results page, we currently group citizen actions by their grouping criteria, but we leave business actions ungrouped. 
- We will soon be adding business groupings to business actions, but content is still being worked on.
- This PR adds the backend work to accommodate the new groups once they're available.

## How

- Adds a grouping criteria attribute to all actions.
- Adds an audience attribute to all groups.
- Adds a `group_business_results?` flag to the controller. Currently the grouping is toggled off.

## Safe to merge?

**No.**

- This PR extends validations so that both citizen and business actions require a grouping criteria. 
- Running `bundle exec rake brexit_checker:convert_csv_to_yaml:actions_from_google_drive` to update an action once this pr is merged, will remove the the placeholder business groupings from actions.yaml. This would make the data fail the extended validations.
- Once the business groupings have been added to the dynamic brexit spread sheet, and those changes have been merged to master, this branch can be rebased onto master to replace placeholder keys with real keys. 

## Testing

To turn business groupings on, add `&show_business_groupings=true` to the end of the query string on the results page of the review app. Once this PR is reviewed, the last commit should be dropped so the groupings can't be activated in this way.

eg. [Review app with business results grouped](https://finder-front-business-g-xwqg2r.herokuapp.com/transition-check/results?c%5B%5D=aero-space&c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=do-not-personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-eu&c%5B%5D=living-uk&c%5B%5D=nationality-uk&show_business_groupings=true)

eg. [Review app with same business results ungrouped](https://finder-front-business-g-xwqg2r.herokuapp.com/transition-check/results?c%5B%5D=aero-space&c%5B%5D=import-from-eu&c%5B%5D=export-to-eu&c%5B%5D=do-not-personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-eu&c%5B%5D=living-uk&c%5B%5D=nationality-uk&show_business_groupings=false)

[Trello](https://trello.com/c/HZWJlnlF/578-add-business-groupings-dev-work-only)

### Business groupings turned off
<img width="810" alt="Screenshot 2020-11-10 at 13 40 44" src="https://user-images.githubusercontent.com/17908089/98681221-5bda6400-235a-11eb-9c2a-576d90d1b899.png">

### Business groupings turned on
<img width="810" alt="Screenshot 2020-11-10 at 13 41 27" src="https://user-images.githubusercontent.com/17908089/98681329-7f9daa00-235a-11eb-9239-83e2cc4a6dc3.png">


---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
