### PR TITLE
Brexit checker: Result presenter

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -49,12 +49,7 @@ class BrexitCheckerController < ApplicationController
       end
     end
 
-    all_actions = BrexitChecker::Action.load_all
-    @criteria = BrexitChecker::Criterion.load_by(criteria_keys)
-    @actions = filter_actions(all_actions, criteria_keys)
-    @audience_actions = @actions.group_by(&:audience)
-    @business_results = grouped_results.populate_business_groups
-    @citizen_results_groups = grouped_results.populate_citizen_groups
+    @presenter = result_presenter
   end
 
   def email_signup; end
@@ -177,10 +172,6 @@ private
     {}
   end
 
-  def grouped_results
-    @grouped_results ||= BrexitChecker::Results::GroupByAudience.new(@audience_actions, @criteria)
-  end
-
   def update_session_tokens(result)
     set_account_session_cookie(
       access_token: result[:access_token],
@@ -211,5 +202,9 @@ private
 
   def page
     @page ||= ParamsCleaner.new(params).fetch(:page, "0").to_i
+  end
+
+  def result_presenter
+    @result_presenter ||= BrexitChecker::Results::ResultPresenter.new(criteria_keys)
   end
 end

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -5,16 +5,6 @@ module BrexitCheckerHelper
     CGI.escape(request.original_url)
   end
 
-  def filter_actions(actions, criteria_keys)
-    filtered = actions.select { |a| a.show?(criteria_keys) }
-    sorted_actions(filtered)
-  end
-
-  def sorted_actions(actions)
-    descending = -1
-    actions.sort_by { |action| [(action.priority * descending), action.title] }
-  end
-
   def persistent_criteria_keys(question_criteria_keys)
     criteria_keys - question_criteria_keys
   end

--- a/app/lib/brexit_checker/results/result_presenter.rb
+++ b/app/lib/brexit_checker/results/result_presenter.rb
@@ -1,0 +1,39 @@
+class BrexitChecker::Results::ResultPresenter
+  attr_reader :criteria_keys
+
+  def initialize(criteria_keys)
+    @criteria_keys = criteria_keys
+  end
+
+  def criteria
+    BrexitChecker::Criterion.load_by(criteria_keys)
+  end
+
+  def actions
+    filtered = BrexitChecker::Action.load_all.select do |a|
+      a.show?(criteria_keys)
+    end
+    sorted_actions(filtered)
+  end
+
+  def sorted_actions(actions)
+    descending = -1
+    actions.sort_by { |action| [(action.priority * descending), action.title] }
+  end
+
+  def business_results
+    grouped_results.populate_business_groups
+  end
+
+  def citizen_results_groups
+    grouped_results.populate_citizen_groups
+  end
+
+  def audience_actions
+    actions.group_by(&:audience)
+  end
+
+  def grouped_results
+    BrexitChecker::Results::GroupByAudience.new(audience_actions, criteria)
+  end
+end

--- a/app/lib/brexit_checker/results/result_presenter.rb
+++ b/app/lib/brexit_checker/results/result_presenter.rb
@@ -6,19 +6,13 @@ class BrexitChecker::Results::ResultPresenter
   end
 
   def criteria
-    BrexitChecker::Criterion.load_by(criteria_keys)
+    @criteria ||= BrexitChecker::Criterion.load_by(criteria_keys)
   end
 
   def actions
-    filtered = BrexitChecker::Action.load_all.select do |a|
-      a.show?(criteria_keys)
-    end
-    sorted_actions(filtered)
-  end
-
-  def sorted_actions(actions)
-    descending = -1
-    actions.sort_by { |action| [(action.priority * descending), action.title] }
+    filtered = all_actions.select { |a| a.show?(criteria_keys) }
+    desc = -1
+    filtered.sort_by { |action| [(action.priority * desc), action.title] }
   end
 
   def business_results
@@ -27,6 +21,12 @@ class BrexitChecker::Results::ResultPresenter
 
   def citizen_results_groups
     grouped_results.populate_citizen_groups
+  end
+
+private
+
+  def all_actions
+    @all_actions ||= BrexitChecker::Action.load_all
   end
 
   def audience_actions

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -1,13 +1,13 @@
 <%
-  action_based_email_link_label = brexit_results_email_link_label(@actions)
-  action_based_title = brexit_results_title(@actions, criteria_keys)
-  action_based_description = brexit_results_description(@actions, criteria_keys)
+  action_based_email_link_label = brexit_results_email_link_label(@presenter.actions)
+  action_based_title = brexit_results_title(@presenter.actions, criteria_keys)
+  action_based_description = brexit_results_description(@presenter.actions, criteria_keys)
 %>
 
 <% content_for :title, action_based_title %>
 <% content_for :head do %>
   <% page_url = request.base_url + request.path %>
-  <meta name="govuk:search-result-count" content="<%= @actions.count %>">
+  <meta name="govuk:search-result-count" content="<%= @presenter.actions.count %>">
   <meta name="robots" content="noindex">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="GOV.UK">
@@ -44,7 +44,7 @@
       <%= render "govuk_publishing_components/components/title", {
         title: action_based_title
       } %>
-      <% unless @actions.any? %>
+      <% unless @presenter.actions.any? %>
         <p class="govuk-body-l">
           <%= action_based_description %>
         </p>
@@ -84,9 +84,9 @@
       } %>
     <% end %>
 
-    <%= render 'results_business_actions', business_results: @business_results if @business_results.any? %>
-    <%= render 'results_citizen_actions', citizen_results_groups: @citizen_results_groups if @citizen_results_groups.any? %>
-    <%= render 'results_with_no_actions', criteria: @criteria if (@business_results.empty? && @citizen_results_groups.empty?) %>
+    <%= render 'results_business_actions', business_results: @presenter.business_results if @presenter.business_results.any? %>
+    <%= render 'results_citizen_actions', citizen_results_groups: @presenter.citizen_results_groups if @presenter.citizen_results_groups.any? %>
+    <%= render 'results_with_no_actions', criteria: @presenter.criteria if (@presenter.business_results.empty? && @presenter.citizen_results_groups.empty?) %>
 
     <% if accounts_enabled? && logged_in? %>
       <% if @results_differ %>
@@ -100,6 +100,6 @@
     <% end %>
 
     <%= render 'share_links' %>
-    <%= render 'print_link' if @business_results.any? || @citizen_results_groups.any? %>
+    <%= render 'print_link' if @presenter.business_results.any? || @presenter.citizen_results_groups.any? %>
   <% end %>
 </div>

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -1,36 +1,6 @@
 require "spec_helper"
 
 describe BrexitCheckerHelper, type: :helper do
-  describe "#filter_actions" do
-    it "filters actions that should be shown" do
-      action1 = instance_double BrexitChecker::Action, show?: true, priority: 1, title: "title"
-      action2 = instance_double BrexitChecker::Action, show?: false, priority: 1, title: "title"
-      expect(action1).to receive(:show?).with([])
-      expect(action2).to receive(:show?).with([])
-      results = filter_actions([action1, action2], [])
-      expect(results).to eq([action1])
-    end
-
-    context "multiple actions with different priorities" do
-      let(:action1) { FactoryBot.build(:brexit_checker_action, priority: 1, title: "a title") }
-      let(:action2) { FactoryBot.build(:brexit_checker_action, priority: 2, title: "a title") }
-      let(:action3) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "a title") }
-      let(:action4) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "b title") }
-      let(:action5) { FactoryBot.build(:brexit_checker_action, priority: 3, title: "c title") }
-      let(:criteria) { action1.criteria }
-
-      it "returns the filtered actions sorted by order of priority" do
-        results = filter_actions([action1, action2, action3], criteria)
-        expect(results).to eq([action3, action2, action1])
-      end
-
-      it "returns the filtered actions sorted by order of priority and then title" do
-        results = filter_actions([action1, action2, action3, action4, action5], criteria)
-        expect(results).to eq([action3, action4, action5, action2, action1])
-      end
-    end
-  end
-
   describe "#persistent_criteria_keys" do
     let(:criteria_keys) { %w[A B C D] }
     let(:question_criteria_keys) { %w[C D] }

--- a/spec/lib/brexit_checker/results/result_presenter_spec.rb
+++ b/spec/lib/brexit_checker/results/result_presenter_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe BrexitChecker::Results::ResultPresenter do
   let(:action) { BrexitChecker::Action }
-  let(:action1) { instance_double action, priority: 1, title: "a", audience: "citizen", show?: true }
-  let(:action2) { instance_double action, priority: 1, title: "b", audience: "citizen", show?: true }
-  let(:action3) { instance_double action, priority: 2, title: "c", audience: "biz", show?: true }
-  let(:action4) { instance_double action, priority: 2, title: "d", audience: "biz", show?: false }
+  let(:action1) { instance_double action, priority: 1, title: "a", show?: true }
+  let(:action2) { instance_double action, priority: 1, title: "b", show?: true }
+  let(:action3) { instance_double action, priority: 2, title: "c", show?: true }
+  let(:action4) { instance_double action, priority: 2, title: "d", show?: false }
   let(:all_actions) { [action1, action2, action3, action4] }
   let(:criteria_keys) { %w[key-one key-two] }
 
@@ -27,16 +27,6 @@ describe BrexitChecker::Results::ResultPresenter do
 
     it "sorts the actions by priority and then title" do
       expect(subject.actions).to eq([action3, action1, action2])
-    end
-  end
-
-  describe "#audience_actions" do
-    it "groups results by audience" do
-      grouped = {
-        "citizen" => [action1, action2],
-        "biz" => [action3],
-      }
-      expect(subject.audience_actions).to eq(grouped)
     end
   end
 end

--- a/spec/lib/brexit_checker/results/result_presenter_spec.rb
+++ b/spec/lib/brexit_checker/results/result_presenter_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+describe BrexitChecker::Results::ResultPresenter do
+  let(:action) { BrexitChecker::Action }
+  let(:action1) { instance_double action, priority: 1, title: "a", audience: "citizen", show?: true }
+  let(:action2) { instance_double action, priority: 1, title: "b", audience: "citizen", show?: true }
+  let(:action3) { instance_double action, priority: 2, title: "c", audience: "biz", show?: true }
+  let(:action4) { instance_double action, priority: 2, title: "d", audience: "biz", show?: false }
+  let(:all_actions) { [action1, action2, action3, action4] }
+  let(:criteria_keys) { %w[key-one key-two] }
+
+  subject { described_class.new(criteria_keys) }
+
+  before :each do
+    allow(BrexitChecker::Action).to receive(:load_all).and_return(all_actions)
+  end
+
+  describe "#actions" do
+    it "returns all actions that should be shown" do
+      all_actions.each do |action|
+        expect(action).to receive(:show?).with(criteria_keys)
+      end
+
+      expect(subject.actions).to include(action1, action2, action3)
+      expect(subject.actions).not_to include(action4)
+    end
+
+    it "sorts the actions by priority and then title" do
+      expect(subject.actions).to eq([action3, action1, action2])
+    end
+  end
+
+  describe "#audience_actions" do
+    it "groups results by audience" do
+      grouped = {
+        "citizen" => [action1, action2],
+        "biz" => [action3],
+      }
+      expect(subject.audience_actions).to eq(grouped)
+    end
+  end
+end


### PR DESCRIPTION
## What

The BrexitChecker controller is getting a bit bloated. The `results` action passes a lot of instance variables to the view. So this PR creates a BrexitChecker::ResultPresenter class to simplify the controller, and the code in general.

- No new functionality is added, just refactoring.
- It feels a bit strange to nesting the presenter class inside lib/brexitchecker/results rather than have it live in /presenters. But that is the pattern of the checker so have left it there for now. 

## Context

We will be soon be adding business groupings to the checker, and it's easier to do that once a few things have been refactored. 

trello: https://trello.com/c/VN5HJYMS/573-tidy-up-checker-in-prep-for-business-groupings

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
