### PR TITLE
Update "UK transition" langauge to "Brexit transition"

### DIFF
--- a/config/locales/en/brexit_checker/account_signup.yml
+++ b/config/locales/en/brexit_checker/account_signup.yml
@@ -5,12 +5,12 @@ en:
       heading: Stay up to date with a GOV.UK account
       proposition: "Create a GOV.UK account to:"
       proposition_list:
-        - get email updates about UK transition changes that may affect you
-        - save your UK transition checker results
+        - get email updates about Brexit transition changes that may affect you
+        - save your Brexit transition checker results
       aim: GOV.UK is trialling accounts to try to improve online public services.
       aim_list:
         - This is separate from other government accounts.
-        - At the moment, you can only use your account with the UK transition checker.
+        - At the moment, you can only use your account with the Brexit transition checker.
       future: "In future, we want to add more features to your account so you can:"
       future_list:
         - see content that’s more tailored to you
@@ -22,7 +22,7 @@ en:
         - an email address
         - a mobile phone
       cta_button: Create a GOV.UK account
-      or: If you’ve already saved your UK transition results,
+      or: If you’ve already saved your Brexit transition results,
       alternative_path_link_text: sign in to your account
       do_not_want_heading: If you do not want a GOV.UK account
       do_not_want_intro: You can


### PR DESCRIPTION
UK civil service has decided that this is the clearest language to
identify the checker, so we're updating that for accounts related pages
here.

Teams working on the checker will handle any required changes across the
rest of the repo