### PR TITLE
Transition checker AB Test 1: Caption on first question

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -3,6 +3,7 @@ class BrexitCheckerController < ApplicationController
 
   include BrexitCheckerHelper
   include BrexitResultsAbTestable
+  include BrexitQuestionsAbTestable
 
   SUBSCRIBER_LIST_GROUP_ID = "5a7c11f2-e737-4531-a0bc-b5f707046607".freeze
 
@@ -16,10 +17,16 @@ class BrexitCheckerController < ApplicationController
   before_action :set_account_session_cookie
   before_action :set_account_variant
 
-  helper_method :subscriber_list_slug, :ab_test_variant, :show_variant?, :account_variant
+  helper_method :subscriber_list_slug, :ab_test_variant, :show_variant?, :account_variant, :brexit_question_variant, :show_brexit_question_variant?,
 
   def show
-    all_questions = BrexitChecker::Question.load_all
+    brexit_question_variant.configure_response(response)
+    all_questions =
+      if show_brexit_question_variant?
+        BrexitChecker::Question.load_all_with_variant
+      else
+        BrexitChecker::Question.load_all
+      end
     @question_index = next_question_index(
       all_questions: all_questions,
       criteria_keys: criteria_keys,

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -17,7 +17,7 @@ class BrexitCheckerController < ApplicationController
   before_action :set_account_session_cookie
   before_action :set_account_variant
 
-  helper_method :subscriber_list_slug, :ab_test_variant, :show_variant?, :account_variant, :brexit_question_variant, :show_brexit_question_variant?,
+  helper_method :subscriber_list_slug, :brexit_urgency_variant, :show_urgency_variant?, :account_variant, :brexit_question_variant, :show_brexit_question_variant?
 
   def show
     brexit_question_variant.configure_response(response)
@@ -45,7 +45,7 @@ class BrexitCheckerController < ApplicationController
   end
 
   def results
-    ab_test_variant.configure_response(response)
+    brexit_urgency_variant.configure_response(response)
 
     if accounts_enabled?
       results_in_account = results_from_account

--- a/app/controllers/concerns/brexit_questions_ab_testable.rb
+++ b/app/controllers/concerns/brexit_questions_ab_testable.rb
@@ -1,0 +1,20 @@
+module BrexitQuestionsAbTestable
+  CUSTOM_DIMENSION = 43
+  TEST_NAME = "TransitionChecker1".freeze
+
+  def brexit_question_variant
+    @brexit_question_variant ||= begin
+      ab_test = GovukAbTesting::AbTest.new(
+        TEST_NAME,
+        dimension: CUSTOM_DIMENSION,
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      ab_test.requested_variant(request.headers)
+    end
+  end
+
+  def show_brexit_question_variant?
+    brexit_question_variant.variant?("B")
+  end
+end

--- a/app/controllers/concerns/brexit_results_ab_testable.rb
+++ b/app/controllers/concerns/brexit_results_ab_testable.rb
@@ -2,8 +2,8 @@ module BrexitResultsAbTestable
   CUSTOM_DIMENSION = 44
   TEST_NAME = "TransitionUrgency5".freeze
 
-  def ab_test_variant
-    @ab_test_variant ||= begin
+  def brexit_urgency_variant
+    @brexit_urgency_variant ||= begin
       ab_test = GovukAbTesting::AbTest.new(
         TEST_NAME,
         dimension: CUSTOM_DIMENSION,
@@ -14,7 +14,7 @@ module BrexitResultsAbTestable
     end
   end
 
-  def show_variant?
-    ab_test_variant.variant?("B")
+  def show_urgency_variant?
+    brexit_urgency_variant.variant?("B")
   end
 end

--- a/app/lib/brexit_checker/question.rb
+++ b/app/lib/brexit_checker/question.rb
@@ -15,8 +15,9 @@ class BrexitChecker::Question
               :type,
               :criteria,
               :detail_text,
-              :detail_title,
-              :caption
+              :detail_title
+
+  attr_accessor :caption
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }
@@ -63,5 +64,11 @@ class BrexitChecker::Question
   def self.load_all
     @load_all = nil if Rails.env.development?
     @load_all ||= YAML.load_file(CONFIG_PATH)["questions"].map { |q| load(q) }
+  end
+
+  def self.load_all_with_variant
+    @load_all = load_all
+    @load_all.first.caption = "First answer some questions about you, then about any business you run"
+    @load_all
   end
 end

--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -4,12 +4,12 @@
 
 <% actions.each.with_index do | action, index | %>
   <div class="govuk-grid-row brexit-checker__action">
-  <% if action.urgent? && show_variant? %>
+  <% if action.urgent? && show_urgency_variant? %>
     <div class="brexit-checker__content-wrapper-urgent">
   <% else %>
     <div class="brexit-checker__content-wrapper">
   <% end %>
-      <% if action.urgent? && show_variant? %>
+      <% if action.urgent? && show_urgency_variant? %>
         <div class="brexit-checker__action-urgent">
         <strong class="govuk-tag brexit-checker__action-urgent-tag"><%= t("brexit_checker.results.urgent") %></strong>
       <% end %>
@@ -65,7 +65,7 @@
           </p>
         </div>
       <% end %>
-      <% if action.urgent? && show_variant? %>
+      <% if action.urgent? && show_urgency_variant? %>
         <%# closing div from .brexit-checker__action-urgent %>
         </div>
       <% end %>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -16,7 +16,7 @@
   <meta property="og:description" content="<%= t('brexit_checker.results.social_media_meta.description') %>">
   <meta name="twitter:card" content="summary">
   <link rel="canonical" href="<%= page_url %>">
-  <%= ab_test_variant.analytics_meta_tag.html_safe %>
+  <%= brexit_urgency_variant.analytics_meta_tag.html_safe %>
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -2,6 +2,7 @@
 <% content_for :head do %>
   <meta name="robots" content="noindex">
   <%= account_variant.analytics_meta_tag.html_safe %>
+  <%= brexit_question_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -123,13 +123,6 @@ Then(/^I (can|cannot) see the "show only transition period results" checkbox$/) 
   end
 end
 
-Given(/^I am in the variant B control group$/) do
-  ab_test_variant = double(:variant, variant_name: "B", analytics_meta_tag: "")
-  allow(ab_test_variant).to receive(:variant?).with("B").and_return(true)
-  allow(ab_test_variant).to receive(:configure_response)
-  allow_any_instance_of(FindersController).to receive(:finder_top_result_variant).and_return(ab_test_variant)
-end
-
 When(/^I view the policy papers and consultations finder$/) do
   topic_taxonomy_has_taxons
   content_store_has_policy_and_engagement_finder

--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -80,4 +80,24 @@ describe BrexitCheckerController, type: :controller do
       end
     end
   end
+
+  context "Testing a new caption for the first question of the checker" do
+    %w[A Z].each do |variant|
+      it "Variant #{variant} shows the control caption" do
+        with_variant TransitionChecker1: variant do
+          get :show
+          assert_select ".govuk-caption-xl", text: "About you and your family"
+          assert_select ".govuk-caption-xl", text: "First answer some questions about you, then about any business you run", count: 0
+        end
+      end
+    end
+
+    it "Variant B shows the alternate caption" do
+      with_variant TransitionChecker1: "B" do
+        get :show
+        assert_select ".govuk-caption-xl", text: "First answer some questions about you, then about any business you run"
+        assert_select ".govuk-caption-xl", text: "About you and your family", count: 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

A new AB test for the Brexit checker

---

### Variant B 

<img width="758" alt="Screenshot 2020-11-11 at 16 17 28" src="https://user-images.githubusercontent.com/17908089/98836295-6ddf0400-2439-11eb-800c-9c7417bd4f0b.png">

### Variant A (Control)

<img width="649" alt="Screenshot 2020-11-11 at 16 18 04" src="https://user-images.githubusercontent.com/17908089/98836355-80593d80-2439-11eb-86a5-0db9934ce75c.png">


## To test

- [Visit Review app](https://finder-front-transition-kbqcqj.herokuapp.com/transition-check/questions)

- [Set a request header](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) with **GOVUK-ABTEST-TransitionChecker1** : B

The urgency AB test is still running and unaffected by this work:

- [Review app on results page](https://finder-front-transition-kbqcqj.herokuapp.com/transition-check/results?c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu-no&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-ie&c%5B%5D=travel-eu-business&c%5B%5D=working-eu&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

- Set a request head with **GOVUK-ABTEST-TransitionUrgency5**: B

[Trello](https://trello.com/c/x9uP89CL/581-ab-test-results-checker-results-page-urgency-messaging)



--- 
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
