### PR TITLE
Use name for date filter title

### DIFF
--- a/app/views/components/_date-filter.html.erb
+++ b/app/views/components/_date-filter.html.erb
@@ -8,9 +8,7 @@
   date_errors_to ||= nil
 %>
 <% if key && name %>
-  <%= render "components/expander", {
-      title: "Date"
-    } do %>
+  <%= render "components/expander", { title: name } do %>
     <div class="app-c-date-filter govuk-!-margin-bottom-0" id="<%= key %>" <% if aria_controls_id %> data-module="enable-aria-controls"<% end %>>
       <%= render "govuk_publishing_components/components/input", {
         label: {
@@ -23,7 +21,7 @@
         hint: "For example, 2005 or 21/11/2014",
         error_message: date_errors_from
       } %>
-  
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: name + " before"


### PR DESCRIPTION
At the moment the title of the date filter is hard coded to the string "Date". This means that if we want to display two date filters, then we end up with two filters both with the word "Date".

I'm not really clear on the consequence for this and whether it was intentional, so it might need some product/frontend approval first.

## [Flood and Coastal Erosion Risk Management Research Reports Finder](https://www-origin.integration.publishing.service.gov.uk/flood-and-coastal-erosion-risk-management-research-reports)

This is the new finder which triggered this work.

### Collapsed

<img width="323" alt="Screenshot 2020-11-16 at 14 48 13" src="https://user-images.githubusercontent.com/510498/99266676-ecadb580-281a-11eb-80e2-f3eb4b15ba73.png">

### Before

<img width="313" alt="Screenshot 2020-11-16 at 14 39 35" src="https://user-images.githubusercontent.com/510498/99266684-f0d9d300-281a-11eb-9c54-12355ded6f77.png">

### After

<img width="330" alt="Screenshot 2020-11-16 at 14 43 57" src="https://user-images.githubusercontent.com/510498/99266694-f3d4c380-281a-11eb-869f-b89ef79cfe9a.png">

## [AAIB Reports](https://www-origin.integration.publishing.service.gov.uk/aaib-reports)

### Before

<img width="328" alt="Screenshot 2020-11-16 at 14 42 56" src="https://user-images.githubusercontent.com/510498/99266768-09e28400-281b-11eb-8a9b-14f4f2697633.png">

### After

<img width="332" alt="Screenshot 2020-11-16 at 14 44 08" src="https://user-images.githubusercontent.com/510498/99266794-0f3fce80-281b-11eb-803d-15582f045e05.png">

[Trello Card](https://trello.com/c/atDp5GQO/2199-3-add-flood-and-coastal-erosion-specialist-document)