### PR TITLE
Remove hidden "Share on" from Brexit checker share links

### DIFF
--- a/app/views/brexit_checker/_share_links.html.erb
+++ b/app/views/brexit_checker/_share_links.html.erb
@@ -1,7 +1,4 @@
 <section class="brexit-checker__share">
-  <% hidden_text = capture do %>
-    <span class="govuk-visually-hidden">Share on</span>
-  <% end %>
   <h2 class="govuk-heading-m">
     <%= I18n.t("brexit_checker.results.share_link_title") %>
   </h2>
@@ -10,27 +7,27 @@
     links: [
       {
         href: "https://www.facebook.com/sharer/sharer.php?u=#{encoded_results_url}",
-        text: hidden_text + "Facebook",
+        text: "Facebook",
         icon: "facebook"
       },
       {
         href: "https://twitter.com/share?url=#{encoded_results_url}",
-        text: hidden_text + "Twitter",
+        text: "Twitter",
         icon: "twitter"
       },
       {
         href: "https://api.whatsapp.com/send?text=#{encoded_results_url}",
-        text: hidden_text + "WhatsApp",
+        text: "WhatsApp",
         icon: "whatsapp"
       },
       {
         href: "mailto:?body=#{encoded_results_url}&subject=#{I18n.t("brexit_checker.results.title")}",
-        text: hidden_text + "Email",
+        text: "Email",
         icon: "email"
       },
       {
         href: "http://www.linkedin.com/shareArticle?url=#{encoded_results_url}",
-        text: hidden_text + "LinkedIn",
+        text: "LinkedIn",
         icon: "linkedin"
       },
     ]


### PR DESCRIPTION
## What 
Remove hidden "Share on" text from Brexit checker share links.

## Why 
The [share links component](https://components.publishing.service.gov.uk/component-guide/share_links) has  "Share on" as visually hidden text by default.
This helps AT users make sense of the links (ie "Share on Facebook" makes more sense than just "Facebook").

The share links on the [Brexit checker results page](https://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=visiting-driving&c%5B%5D=visiting-bring-pet&c%5B%5D=visiting-uk&c%5B%5D=visiting-eu&c%5B%5D=working-ie&c%5B%5D=studying-ie&c%5B%5D=nationality-uk) have an extra "Share on" as part of the share links text. This is causing an issue where hidden content is being repeated e.g. "Share on Share on Facebook".  

<img width="1224" alt="Screenshot 2020-11-17 at 18 28 55" src="https://user-images.githubusercontent.com/7116819/99431591-ec88e500-2902-11eb-86ef-f2efef794bd4.png">



https://trello.com/c/shAQ6AQu/460-social-media-links-repeat-hidden-content-bug

-----

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
