### PR TITLE
[WIP] Put GA tracking in the GOVUK Module

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require live_search
 //= require search-analytics
 //= require taxonomy-select
+//= require ga_cross_domain_form_tracking
 //= require_tree ./modules
 //= require_tree ./components
 

--- a/app/assets/javascripts/ga_cross_domain_form_tracking.js
+++ b/app/assets/javascripts/ga_cross_domain_form_tracking.js
@@ -1,0 +1,25 @@
+/* eslint-env jquery */
+/* global ga */
+
+function attachCrossDomainTrackerToInput (form, trackers) {
+  if (trackers.length) {
+    var existingAction = form.attr('action')
+    var linker = new window.gaplugins.Linker(trackers[0])
+    var trackedAction = linker.decorate(existingAction)
+    form.attr('action', trackedAction)
+  }
+}
+
+window.GOVUK = window.GOVUK || {}
+var GOVUK = window.GOVUK
+GOVUK.attachCrossDomainTrackerToInput = attachCrossDomainTrackerToInput
+
+$(window).on('load', function () {
+  if (window.ga !== undefined && typeof window.ga.getAll === 'function') {
+    var trackers = ga.getAll()
+    var form = $('form#account-signup')
+    if (form.length) {
+      window.GOVUK.attachCrossDomainTrackerToInput(form, trackers)
+    }
+  }
+})

--- a/app/assets/javascripts/ga_cross_domain_form_tracking.js
+++ b/app/assets/javascripts/ga_cross_domain_form_tracking.js
@@ -1,25 +1,24 @@
 /* eslint-env jquery */
 /* global ga */
 
-function attachCrossDomainTrackerToInput (form, trackers) {
-  if (trackers.length) {
-    var existingAction = form.attr('action')
-    var linker = new window.gaplugins.Linker(trackers[0])
-    var trackedAction = linker.decorate(existingAction)
-    form.attr('action', trackedAction)
-  }
-}
+(function(Modules) {
+  'use strict'
 
-window.GOVUK = window.GOVUK || {}
-var GOVUK = window.GOVUK
-GOVUK.attachCrossDomainTrackerToInput = attachCrossDomainTrackerToInput
-
-$(window).on('load', function () {
-  if (window.ga !== undefined && typeof window.ga.getAll === 'function') {
-    var trackers = ga.getAll()
-    var form = $('form#account-signup')
-    if (form.length) {
-      window.GOVUK.attachCrossDomainTrackerToInput(form, trackers)
+  function AttachCrossDomainTrackerToInput () {}
+  AttachCrossDomainTrackerToInput.prototype.start = function($form) {
+    console.log("Object", window.ga)
+    console.log("undefined test", window.ga !== undefined)
+    console.log("getAll is a function", typeof window.ga.getAll === 'function')
+    if (window.ga !== undefined && typeof window.ga.getAll === 'function') {
+      console.log(window.ga.getAll())
+      var trackers = window.ga.getAll()
+      if (trackers.length) {
+        var existingAction = $form.attr('action')
+        var linker = new window.gaplugins.Linker(trackers[0])
+        var trackedAction = linker.decorate(existingAction)
+        $form.attr('action', trackedAction)
+      }
     }
   }
-})
+  Modules.AttachCrossDomainTrackerToInput = AttachCrossDomainTrackerToInput
+})(window.GOVUK.Modules)

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -66,7 +66,7 @@
           <% end %>
         </ul>
 
-        <%= form_tag Services.accounts_api, id: "account-signup" do %>
+        <%= form_tag Services.accounts_api, id: "account-signup", data: { "module": "attach-cross-domain-tracker-to-input" } do %>
           <input type="hidden" name="jwt" value="<%= @account_jwt %>">
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -66,7 +66,7 @@
           <% end %>
         </ul>
 
-        <%= form_tag Services.accounts_api, id: "account-signup", class: "account-signup" do %>
+        <%= form_tag Services.accounts_api, id: "account-signup" do %>
           <input type="hidden" name="jwt" value="<%= @account_jwt %>">
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.cta_button'),

--- a/spec/javascripts/ga_cross_domain_form_tracking_spec.js
+++ b/spec/javascripts/ga_cross_domain_form_tracking_spec.js
@@ -1,16 +1,16 @@
 /* eslint-env jasmine, jquery */
 
 describe('attachCrossDomainTrackerToInput', function () {
-  var form
-  var tracker
   var linker
   var GOVUK = window.GOVUK || {}
+  var form = $('<form method="POST" action="/somewhere" class="account-signup" data-module="attach-cross-domain-tracker-to-input">' +
+                 '<input type="hidden" name="key" value="value" />' +
+                 '<button type="submit">Create a GOV.UK account</button>' +
+               '</form>')
+
+  var crossDomainTracker = new GOVUK.Modules.AttachCrossDomainTrackerToInput()
 
   beforeEach(function () {
-    form = $('<form method="POST" action="/somewhere" class="account-signup">' +
-               '<input type="hidden" name="key" value="value" />' +
-               '<button type="submit">Create a GOV.UK account</button>' +
-             '</form>')
 
     window.ga = {
       getAll: function () {}
@@ -24,7 +24,6 @@ describe('attachCrossDomainTrackerToInput', function () {
       decorate: function () {}
     }
 
-    spyOn(window.ga, 'getAll').and.returnValue([])
     spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
     spyOn(linker, 'decorate').and.returnValue('/somewhere?_ga=abc123')
   })
@@ -33,21 +32,17 @@ describe('attachCrossDomainTrackerToInput', function () {
     form.remove()
   })
 
-  it('leaves the form action unchanged if ga is not present', function () {
-    tracker = []
-    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
-    expect(form.attr('action')).toEqual('/somewhere')
-  })
-
   it('leaves the form action if unchanged there are no trackers in ga', function () {
-    tracker = []
-    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    spyOn(window.ga, 'getAll').and.returnValue([])
+    console.log("THIS SHOULD BE EMPTY", window.ga.getAll())
+    crossDomainTracker.start(form)
     expect(form.attr('action')).toEqual('/somewhere')
   })
 
   it('modifies the form action to append ids from ga to the destination url', function () {
-    tracker = [{ ga_mock: 'foobar' }]
-    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    trackers = [{ga_mock: "abc123"}]
+    spyOn(window.ga, 'getAll').and.returnValue(trackers)
+    crossDomainTracker.start(form)
     expect(form.attr('action')).toEqual('/somewhere?_ga=abc123')
   })
 })

--- a/spec/javascripts/ga_cross_domain_form_tracking_spec.js
+++ b/spec/javascripts/ga_cross_domain_form_tracking_spec.js
@@ -1,0 +1,53 @@
+/* eslint-env jasmine, jquery */
+
+describe('attachCrossDomainTrackerToInput', function () {
+  var form
+  var tracker
+  var linker
+  var GOVUK = window.GOVUK || {}
+
+  beforeEach(function () {
+    form = $('<form method="POST" action="/somewhere" class="account-signup">' +
+               '<input type="hidden" name="key" value="value" />' +
+               '<button type="submit">Create a GOV.UK account</button>' +
+             '</form>')
+
+    window.ga = {
+      getAll: function () {}
+    }
+
+    window.gaplugins = {
+      Linker: function () {}
+    }
+
+    linker = {
+      decorate: function () {}
+    }
+
+    spyOn(window.ga, 'getAll').and.returnValue([])
+    spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
+    spyOn(linker, 'decorate').and.returnValue('/somewhere?_ga=abc123')
+  })
+
+  afterEach(function () {
+    form.remove()
+  })
+
+  it('leaves the form action unchanged if ga is not present', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere')
+  })
+
+  it('leaves the form action if unchanged there are no trackers in ga', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere')
+  })
+
+  it('modifies the form action to append ids from ga to the destination url', function () {
+    tracker = [{ ga_mock: 'foobar' }]
+    GOVUK.attachCrossDomainTrackerToInput(form, tracker)
+    expect(form.attr('action')).toEqual('/somewhere?_ga=abc123')
+  })
+})


### PR DESCRIPTION
@alex-ju and I worked on this one.
It takes the existing tracking code written in this PR, and updates it to proper GOV.UK module standards.

However, in doing so we discovered a strage bug where there `ga` object is being overwritten and not passing the tests.
We suspect this is a race condition with some of the module code not being loaded by the time our x-domain analytics code attempts to fire here.

here's an example output, with console.logs in at various stages of the code initialising.
We then re-run the code after the page has loaded and get a different result... which is suspcious.

I'm leaving this here as a note towards tech debt.

@alex-ju has spotted race condition in other parts of the GA setup, perhaps we can add this as a specific instance when we're unravelling that tech debt.

![image](https://user-images.githubusercontent.com/3694062/99565277-5a94e100-29c3-11eb-8a2b-783d3320b52f.png)
