### PR TITLE
Fix for select element while zoomed

### DIFF
--- a/app/views/finders/_sort_options.html.erb
+++ b/app/views/finders/_sort_options.html.erb
@@ -1,5 +1,5 @@
 <% if local_assigns[:options] %>
-  <div class="govuk-form-group sort-options">
+  <div class="govuk-form-group sort-options gem-c-select">
     <label for="order" class="sort-options__label govuk-label">Sort by</label>
     <select
       class="js-order-results govuk-select sort-options__select"


### PR DESCRIPTION
## What?

While zoomed-in-via-text-only on Firefox the text within the select box cut is off while viewing at 200%.    
(This is in-part due to positioning elements being pixel based not relative)

## Why

[Ticket](https://trello.com/c/aKVL92cP) and [can be seen](https://www.gov.uk/search/all?keywords=help&level_one_taxon=9597c30a-605a-4e36-8bc1-47e5cdae41b3&level_two_taxon=d96e4efc-9c26-4d9b-9fa7-a036b5c11a65&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&public_timestamp%5Bfrom%5D=1%2F1%2F2020&public_timestamp%5Bto%5D=1%2F6%2F2020&order=rele) on live 

I've noticed [this PR from 08/19 implemented the CSS fix ](https://github.com/alphagov/govuk_publishing_components/pull/1018) and this PR builds on this.  I'm aware this introduces a `gem-c-select` class without the use of the actual gem for this element which is tech debt.   However I'm also mindful this might be resolved within this [Design System audit update ticket](https://trello.com/c/Qg72rche) so as a temp solution this could be desirable - this PR could prompt a wider discussion.

# Visuals 

## Before 

![Screenshot 2020-11-24 at 10 29 35](https://user-images.githubusercontent.com/71266765/100082773-90611c00-2e40-11eb-82eb-61db8d34a4e1.png)

## After 

![Screenshot 2020-11-24 at 10 29 25](https://user-images.githubusercontent.com/71266765/100082785-93f4a300-2e40-11eb-81dc-8f9c2950a662.png)
---
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
