### PR TITLE
Remove title URL for S001

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -4,7 +4,6 @@ actions:
   priority: 8
   title: Apply to the EU Settlement Scheme by 30 June 2021 to continue living in the
     UK - you must have arrived in the UK before January 2021
-  title_url: https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status
   consequence: If you do not apply to the scheme, you may not be able to continue
     living or working in the UK as you do now.
   exception: 'You do not need to apply if you have: indefinite leave to enter the


### PR DESCRIPTION
This was a remaining update for https://github.com/alphagov/finder-frontend/pull/2313.

We want to remove as many of the occurrences of "double links" (where an action has both a title link and a guidance link) as possible. 

This action linked to the same guide from both.

https://trello.com/c/kJqzeDpQ/569-batch-update-action-card-november

