### PR TITLE
Update email signup with new design

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -16,10 +16,6 @@ class SignupPresenter
     content_item["title"]
   end
 
-  def body
-    content_item["description"]
-  end
-
   def beta?
     content_item["details"]["beta"]
   end

--- a/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
+++ b/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
@@ -1,3 +1,0 @@
-<% if email_alert_subscription.body %>
-  <meta name="description" content="<%= email_alert_subscription.body %>">
-<% end %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,6 +1,7 @@
-<% content_for :title, @signup_presenter.page_title %>
-<% content_for :head do %>
-  <%= render 'email_alert_subscription_meta', email_alert_subscription: @signup_presenter %>
+<% if @signup_presenter.can_modify_choices? %>
+  <% content_for :title, @signup_presenter.page_title %>
+<% else %>
+  <% content_for :title, t("email_alert_subscriptions.new.title") %>
 <% end %>
 
 <% if @signup_presenter.beta? %>
@@ -9,38 +10,43 @@
 
 <div class="govuk-width-container">
   <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
-    <%= render partial: 'govuk_publishing_components/components/title', locals: {
-      title: @signup_presenter.name,
-      context: "Email alert subscription"
-    } %>
-
     <% if @signup_presenter.can_modify_choices? %>
+      <%= render partial: 'govuk_publishing_components/components/title', locals: {
+        title: @signup_presenter.name,
+      } %>
+
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: nil,
-        heading: @signup_presenter.name,
-        hint_text: "Choose the email alerts you need.",
+        no_hint_text: true,
+        heading: t("email_alert_subscriptions.new.question"),
         items: @signup_presenter.choices_formatted,
-        visually_hide_heading: true
       } %>
-    <% end %>
-    <% if @error_message.present? %>
-      <p class="signup-choices__message"><%= @error_message %></p>
+
+      <% if @error_message.present? %>
+        <p class="signup-choices__message"><%= @error_message %></p>
+      <% end %>
+
+    <% else %>
+
+      <%= render partial: 'govuk_publishing_components/components/title', locals: {
+        title: t("email_alert_subscriptions.new.title"),
+      } %>
+
+      <p class="govuk-body">
+        <%= t("email_alert_subscriptions.new.description") %>
+      </p>
+
+      <p class="govuk-body govuk-!-margin-bottom-8">
+        <strong class="govuk-!-font-weight-bold"><%= @signup_presenter.name %></strong>
+      </p>
     <% end %>
 
     <% @signup_presenter.hidden_choices.each do |hidden_choice| %>
       <%= hidden_field_tag hidden_choice[:name], hidden_choice[:value] %>
     <% end %>
 
-    <% if @signup_presenter.body && !@signup_presenter.can_modify_choices? %>
-      <div class="govspeak-wrapper">
-        <%= render 'govuk_publishing_components/components/govspeak', {} do %>
-          <%= sanitize(@signup_presenter.body) %>
-        <% end %>
-      </div>
-    <% end %>
-
     <%= render "govuk_publishing_components/components/button", {
-      text: "Create subscription",
+      text: "Continue",
       margin_bottom: true
     } %>
   <% end %>

--- a/config/locales/en/email_alert_subscriptions.yml
+++ b/config/locales/en/email_alert_subscriptions.yml
@@ -1,0 +1,7 @@
+en:
+  email_alert_subscriptions:
+    new:
+      title: Get emails from GOV.UK
+      description: "You’ll get emails when we add or update pages about:"
+      question: "What do you want to get emails about?"
+


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

This is to be consistent with the page for content item signups [1],
when there are no modifiable choices. In particular, while some signup
pages may have a description, we have decided these are too inconsistent
to provide any value, so we have removed them altogether. The design also
calls for the removal of the contextual title, and "alert" wording.

## Before

<img width="700" alt="Screenshot 2020-11-24 at 16 10 29" src="https://user-images.githubusercontent.com/9029009/100128392-1ea4c480-2e78-11eb-9966-52e81087c256.png">

<img width="653" alt="Screenshot 2020-11-24 at 16 10 40" src="https://user-images.githubusercontent.com/9029009/100123300-41cc7580-2e72-11eb-979d-db47f807dbf1.png">

## After

<img width="701" alt="Screenshot 2020-11-24 at 17 21 20" src="https://user-images.githubusercontent.com/9029009/100129501-8f001580-2e79-11eb-943a-b50d80ba5322.png">

<img width="662" alt="Screenshot 2020-11-24 at 16 12 03" src="https://user-images.githubusercontent.com/9029009/100123337-4abd4700-2e72-11eb-8485-5a5d807ff8f4.png">



:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.