### PR TITLE
Notifications for Brexit checker November updates

### DIFF
--- a/app/lib/brexit_checker/notifications.yaml
+++ b/app/lib/brexit_checker/notifications.yaml
@@ -279,3 +279,15 @@ notifications:
     type: addition
     action_id: S017
     date: 2020-11-02
+  - uuid: "77562e3e-e4b9-435a-8f16-045eb8b938d5"
+    type: addition
+    action_id: S042
+    date: 2020-11-25
+  - uuid: "79abcb5d-febc-4e29-8265-b1946faec27b"
+    type: addition
+    action_id: T122
+    date: 2020-11-25
+  - uuid: "2f615e3b-be85-4c9d-a58d-fad710c00959"
+    type: addition
+    action_id: T123
+    date: 2020-11-25


### PR DESCRIPTION
This PR adds notifications for the changes added in https://github.com/alphagov/finder-frontend/pull/2313 and https://github.com/alphagov/finder-frontend/pull/2314

As per the [guidance](https://docs.google.com/document/d/1YbXLRJ_FkPDvYPC7e4Nkhm054LqFVydn-KX_Th3yFYw/edit#), notifications are required for the following:

S042 - Addition, no change note
T122 - Addition, no change note
T123 - Addition, no change note

[Trello](https://trello.com/c/kJqzeDpQ/569-batch-update-action-card-november)

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/finder-frontend), after merging.
