### PR TITLE
Use the topical event registry

### DIFF
--- a/app/lib/registries/base_registries.rb
+++ b/app/lib/registries/base_registries.rb
@@ -12,9 +12,7 @@ module Registries
         "organisations" => organisations,
         "manual" => manuals,
         "full_topic_taxonomy" => full_topic_taxonomy,
-        # this isn't called "topical_events" because we don't want the
-        # facet tag to appear automatically
-        "full_topical_events" => full_topical_events,
+        "topical_events" => topical_events,
       }
     end
 
@@ -64,8 +62,8 @@ module Registries
       @manuals ||= ManualsRegistry.new
     end
 
-    def full_topical_events
-      @full_topical_events ||= TopicalEventsRegistry.new
+    def topical_events
+      @topical_events ||= TopicalEventsRegistry.new
     end
   end
 end

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -39,7 +39,7 @@ describe "Healthcheck" do
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
-            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, full_topical_events.",
+            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, topical_events.",
             "status" => "warning",
           },
         },

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -269,46 +269,55 @@ describe FacetsBuilder do
       let(:hash_under_test) do
         {
           "filterable": true,
-          "key": "topical_events",
+          "key": "specialist_sectors",
           "type": "text",
         }
       end
       let(:search_results) do
-        topical_events_search_results.deep_stringify_keys
+        specialist_sector_search_results.deep_stringify_keys
       end
       it "gets the allowed values from the search results" do
-        expect(facet.allowed_values).to eq([{ "label" => "First World War Centenary", "value" => "first-world-war-centenary" },
-                                            { "label" => "Farming", "value" => "farming" },
-                                            { "label" => "Ebola Virus Government Response (EVGR)", "value" => "ebola-virus-government-response" }])
+        expect(facet.allowed_values).to eq([{ "label" => "Import, export and customs for businesses", "value" => "business-tax/import-export" },
+                                            { "label" => "Environmental permits", "value" => "environmental-management/environmental-permits" },
+                                            { "label" => "Tax agent and adviser guidance", "value" => "dealing-with-hmrc/tax-agent-guidance" }])
       end
     end
   end
 
-  def topical_events_search_results
+  def specialist_sector_search_results
     {
       "results": [],
       "facets": {
-        "topical_events": {
-          "options": [{
-            "value": {
-              "title": "First World War Centenary",
-              "slug": "first-world-war-centenary",
+        "specialist_sectors": {
+          "options": [
+            {
+              "value": {
+                "content_id": "4bda0be5-3e65-4cc1-850c-0541e95a40ca",
+                "link": "/topic/business-tax/import-export",
+                "title": "Import, export and customs for businesses",
+                "slug": "business-tax/import-export",
+              },
+              "documents": 1189,
             },
-          },
-                      {
-                        "value": {
-                          "title": "Farming",
-                          "slug": "farming",
-                          "acronym": "Farming",
-                        },
-                      },
-                      {
-                        "value": {
-                          "title": "Ebola Virus Government Response",
-                          "slug": "ebola-virus-government-response",
-                          "acronym": "EVGR",
-                        },
-                      }],
+            {
+              "value": {
+                "content_id": "9d128765-269a-4e90-982c-833a30a352d3",
+                "link": "/topic/environmental-management/environmental-permits",
+                "title": "Environmental permits",
+                "slug": "environmental-management/environmental-permits",
+              },
+              "documents": 950,
+            },
+            {
+              "value": {
+                "content_id": "c3133eb2-4d53-4905-88a2-d2e4547cc41e",
+                "link": "/topic/dealing-with-hmrc/tax-agent-guidance",
+                "title": "Tax agent and adviser guidance",
+                "slug": "dealing-with-hmrc/tax-agent-guidance",
+              },
+              "documents": 868,
+            },
+          ],
         },
       },
     }

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Healthchecks::RegistriesCache do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
-      stub_full_topical_events_registry_request
+      stub_topical_events_registry_request
 
       Registries::BaseRegistries.new.refresh_cache
     end
@@ -38,7 +38,7 @@ RSpec.describe Healthchecks::RegistriesCache do
   context "Registries caches are empty" do
     it "has an OK status" do
       expect(check.status).to eq :warning
-      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, full_topical_events."
+      expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, topical_events."
     end
   end
 end

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Registries::BaseRegistries do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
-      stub_full_topical_events_registry_request
+      stub_topical_events_registry_request
     end
     after { clear_cache }
 
@@ -67,7 +67,7 @@ RSpec.describe Registries::BaseRegistries do
       stub_roles_registry_request
       stub_manuals_registry_request
       stub_organisations_registry_request
-      stub_full_topical_events_registry_request
+      stub_topical_events_registry_request
     end
     after { clear_cache }
 

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -145,7 +145,7 @@ module RegistrySpecHelper
       }.to_json)
   end
 
-  def stub_full_topical_events_registry_request
+  def stub_topical_events_registry_request
     stub_request(:get, "http://search.dev.gov.uk/search.json")
     .with(query: {
       count: 1500,


### PR DESCRIPTION
If we want to hide facets, then we should use the hidden or hidden_clearable facet type. We'd renamed our registry to something non-standard to do this instead. Our code for using the registries to circumvent network calls and heavy queries is reliant on us using the same name for the facet as the registry, so we seemed to be skipping this altogether which is making search slower.

The query to search-api currently includes the [`facet_topical_event:1500`](https://www.gov.uk/api/search.json?count=20&start=0&fields=title%2Clink%2Cdescription_with_highlighting%2Cpublic_timestamp%2Cpopularity%2Ccontent_purpose_supergroup%2Ccontent_store_document_type%2Cformat%2Cis_historic%2Cgovernment_name%2Ccontent_id%2Cparts%2Cpart_of_taxonomy_tree%2Cmanual%2Corganisations%2Cworld_locations%2Ctopical_events&q=Sign+in+guvernament+gateway&reject_link[]=%2Fsearch%2Fall&facet_content_store_document_type=1500%2Corder%3Avalue.title&facet_topical_events=1500%2Corder%3Avalue.title&suggest=spelling_with_highlighting&filter_all_part_of_taxonomy_tree[]&filter_all_part_of_taxonomy_tree[]) key which means that extra queries are run within elasticsearch. We want to avoid this unless we need this.

I switched the facets_builder_spec example to specialist_sectors instead, as topical events will now use the registry. There are few facets where this will work natively from search-api, as we've pulled most of the expanded ones into local registries now. If they don't have a [registry](https://github.com/alphagov/search-api/blob/master/lib/search/registries.rb) configured in search-api, then it's likely that they'll just return slugs in the facet response, which is not sufficient for the facet_builder to use. (The facet builder needs a slug and a title!)

Anyway, this PR will stop us calling facet_topical_event unnecessarily.

Before: https://www.gov.uk/search/all?topical_events%5B%5D=budget-2019 (no facet tag, but we're still making the facet call to search-api)

After: https://finder-front-topical-ev-hwdkpp.herokuapp.com/search/all?topical_events%5B%5D=budget-2019 (facet tag and we're no longer making the facet call to search-api)

