### PR TITLE
Update account/email launch page

### DIFF
--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -1,8 +1,8 @@
-<% if criteria.present? %>
-  <div class="govuk-grid-column-one-third">
-  <% if local_assigns[:heading] %>
-    <h3 class="govuk-heading-m"><%= heading %></h3>
-  <% end %>
+<div class="govuk-grid-column-one-third">
+  <% if criteria.present? %>
+    <% if local_assigns[:heading] %>
+      <h3 class="govuk-heading-m"><%= heading %></h3>
+    <% end %>
     <aside>
       <p class="govuk-body brexit-checker__criteria_explanation">
         <%= t('brexit_checker.results.criteria.list_context') %>
@@ -15,9 +15,9 @@
         <% end %>
       </ul>
     </aside>
-  </div>
-<% else %>
-  <p class="govuk-body">
-    <%= t('brexit_checker.results.criteria.no_answers') %>
-  </p>
-<% end %>
+  <% else %>
+    <p class="govuk-body">
+      <%= t('brexit_checker.results.criteria.no_answers') %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -32,44 +32,43 @@
           text: t('brexit_checker.account_signup.heading'),
           font_size: "xl",
           heading_level: 1,
+          margin_bottom: 6,
         } %>
 
         <p class="govuk-body"><%= t('brexit_checker.account_signup.proposition') %></p>
 
-        <ul class="govuk-list govuk-list--bullet">
-          <% t('brexit_checker.account_signup.proposition_list').each do |prop| %>
-            <li><%= prop %></li>
-          <% end %>
-        </ul>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('brexit_checker.account_signup.email_alerts.heading'),
+          font_size: "m",
+          heading_level: 2,
+        } %>
 
-        <p class="govuk-body"><%= t('brexit_checker.account_signup.aim') %></p>
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          <a class="govuk-link" href="<%= transition_checker_email_signup_path(c: criteria_keys) %>">
+            <%= t('brexit_checker.account_signup.email_alerts.link') %>
+          </a>
+          <%= t('brexit_checker.account_signup.email_alerts.text') %>
+        </p>
+
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('brexit_checker.account_signup.create_account.heading'),
+          font_size: "m",
+          heading_level: 2,
+        } %>
+
+        <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.intro') %></p>
+        <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.text') %></p>
 
         <%= render "govuk_publishing_components/components/inset_text" do %>
-          <% t('brexit_checker.account_signup.aim_list').each do |aim| %>
-            <p class="govuk-body govuk-!-margin-bottom-0"><%= aim %></p>
-          <% end %>
+          <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.aside') %></p>
         <% end %>
 
-        <p class="govuk-body"><%= t('brexit_checker.account_signup.future') %></p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <% t('brexit_checker.account_signup.future_list').each do |future| %>
-            <li><%= future %></li>
-          <% end %>
-        </ul>
-
-        <p class="govuk-body"><%= t('brexit_checker.account_signup.prerequisites') %></p>
-
-        <ul class="govuk-list govuk-list--bullet">
-          <% t('brexit_checker.account_signup.prerequisites_list').each do |prerequisite| %>
-            <li><%= prerequisite %></li>
-          <% end %>
-        </ul>
+        <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.outro') %></p>
 
         <%= form_tag Services.accounts_api, id: "account-signup" do %>
           <input type="hidden" name="jwt" value="<%= @account_jwt %>">
           <%= render "govuk_publishing_components/components/button", {
-            text: t('brexit_checker.account_signup.cta_button'),
+            text: t('brexit_checker.account_signup.create_account.cta_button'),
             margin_bottom: true,
           } %>
         <% end %>
@@ -78,19 +77,6 @@
           <%= t('brexit_checker.account_signup.or') %>
           <a class="govuk-link" href="<%= transition_checker_save_results_confirm_path(c: criteria_keys) %>">
             <%= t('brexit_checker.account_signup.alternative_path_link_text') %></a>.
-        </p>
-
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t('brexit_checker.account_signup.do_not_want_heading'),
-          font_size: "m",
-          heading_level: 2,
-        } %>
-
-        <p class="govuk-body">
-          <%= t('brexit_checker.account_signup.do_not_want_intro') %>
-          <a class="govuk-link" href="<%= transition_checker_email_signup_path(c: criteria_keys) %>">
-            <%= t('brexit_checker.account_signup.do_not_want_link') %></a>
-          <%= t('brexit_checker.account_signup.do_not_want_outro') %>
         </p>
       </div>
     </div>

--- a/config/locales/en/brexit_checker/account_signup.yml
+++ b/config/locales/en/brexit_checker/account_signup.yml
@@ -1,30 +1,19 @@
 en:
   brexit_checker:
     account_signup:
-      title: Stay up to date with a GOV.UK account
-      heading: Stay up to date with a GOV.UK account
-      proposition: "Create a GOV.UK account to:"
-      proposition_list:
-        - get email updates about Brexit transition changes that may affect you
-        - save your Brexit transition checker results
-      aim: GOV.UK is trialling accounts to try to improve online public services.
-      aim_list:
-        - This is separate from other government accounts.
-        - At the moment, you can only use your account with the Brexit transition checker.
-      future: "In future, we want to add more features to your account so you can:"
-      future_list:
-        - see content that’s more tailored to you
-        - get recommendations for services relevant to you
-        - get updates about guidance that might be helpful to you
-        - reuse information you provide between different services
-      prerequisites: "To create an account, you’ll need:"
-      prerequisites_list:
-        - an email address
-        - a mobile phone
-      cta_button: Create a GOV.UK account
-      or: If you’ve already saved your Brexit transition results,
+      title: Choose how you want to stay up to date
+      heading: Choose how you want to stay up to date
+      proposition: There are 2 different ways of signing up to updates.
+      email_alerts:
+        heading: Get email alerts
+        link: Subscribe to get email updates
+        text: about Brexit transition changes that may affect you.
+      create_account:
+        heading: Create a GOV.UK account
+        intro: Save your Brexit transition results and get email updates about changes that may affect you.
+        text: GOV.UK accounts are a trial. In future, we plan to add more features so you can use your account with more services.
+        aside: This is separate from other government accounts (for example your personal tax account or Government Gateway).
+        outro: You’ll need an email address and a mobile phone to create an account.
+        cta_button: Create a GOV.UK account
+      or: If you’ve already saved your UK transition results,
       alternative_path_link_text: sign in to your account
-      do_not_want_heading: If you do not want a GOV.UK account
-      do_not_want_intro: You can
-      do_not_want_link: get alerts and a link to your results
-      do_not_want_outro: instead.

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
   end
 
   def then_i_click_email_alerts_only
-    click_on "get alerts and a link to your results"
+    click_on "Subscribe to get email updates"
   end
 
   def then_i_click_to_subscribe


### PR DESCRIPTION
- change the text and layout on the page where users choose between an email subscription for their checker results, or whether to sign up for an account

Example URL: `/transition-check/save-your-results?c%5B%5D=living-ie`

## Bonus fix

During testing I spotted the problem below, which is fixed in the second commit in this PR.

Before | After
------ | ------
![Screenshot 2020-12-02 at 11 52 54](https://user-images.githubusercontent.com/861310/100869650-3b06b980-3495-11eb-8977-cfe103920df4.png) | ![Screenshot 2020-12-02 at 11 53 07](https://user-images.githubusercontent.com/861310/100869674-40640400-3495-11eb-8edc-62c648562bcd.png)


Trello card: https://trello.com/c/uOsMHhSe/483-what-can-we-do-to-better-serve-users-that-would-sign-up-for-email-but-dont-want-an-account

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
