### PR TITLE
Fix trailing space on link

### DIFF
--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -45,8 +45,7 @@
 
         <p class="govuk-body govuk-!-margin-bottom-6">
           <a class="govuk-link" href="<%= transition_checker_email_signup_path(c: criteria_keys) %>">
-            <%= t('brexit_checker.account_signup.email_alerts.link') %>
-          </a>
+            <%= t('brexit_checker.account_signup.email_alerts.link') %></a>
           <%= t('brexit_checker.account_signup.email_alerts.text') %>
         </p>
 


### PR DESCRIPTION
- with the newline here the link gains a space character in the end of it, which looks weird

![Screenshot 2020-12-02 at 14 33 35](https://user-images.githubusercontent.com/861310/100886157-64cadb00-34ab-11eb-85a2-5f20e27feec0.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
