### PR TITLE
Update content for account signup flow

### DIFF
--- a/config/locales/en/brexit_checker/account_signup.yml
+++ b/config/locales/en/brexit_checker/account_signup.yml
@@ -5,7 +5,7 @@ en:
       heading: Choose how you want to stay up to date
       proposition: There are 2 different ways of signing up to updates.
       email_alerts:
-        heading: Get email alerts
+        heading: Get email updates
         link: Subscribe to get email updates
         text: about Brexit transition changes that may affect you.
       create_account:


### PR DESCRIPTION
The heading should display "Get email updates" rather than "Get email alerts".