### PR TITLE
Set 'secure' flag for session cookie in production

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-FinderFrontend::Application.config.session_store :cookie_store, key: "_finder-frontend_session", expire_after: 15.minutes
+FinderFrontend::Application.config.session_store :cookie_store,
+                                                 key: "_finder-frontend_session",
+                                                 expire_after: 15.minutes,
+                                                 secure: Rails.env.production?


### PR DESCRIPTION
This ensures that the session cookie isn't sent over HTTP.  GOV.UK
upgrades requests to HTTPS, so that won't happen normally.

---

[Trello card](https://trello.com/c/ei6DBtLa/490-make-account-session-cookie-only-available-over-https)