### PR TITLE
Replace with header component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/heading';
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/inset-text';

--- a/app/assets/stylesheets/components/_email-link.scss
+++ b/app/assets/stylesheets/components/_email-link.scss
@@ -3,10 +3,6 @@
   padding: govuk-spacing(4);
   background: govuk-colour('light-grey');
 
-  .govuk-heading-m {
-    margin-bottom: govuk-spacing(2);
-  }
-
   .app-c-email-link__title {
     font-weight: bold;
   }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -236,18 +236,6 @@ mark {
   @include govuk-responsive-margin(4, "bottom");
 }
 
-.result-region-header__counter {
-  @include govuk-font(19);
-  white-space: nowrap;
-  margin-bottom: govuk-spacing(4);
-  display: none;
-
-  @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(2);
-    display: block;
-  }
-}
-
 .sort-options__label {
   @include govuk-responsive-padding(1, "right");
   display: inline-block;
@@ -267,6 +255,13 @@ mark {
 .result-info {
   margin: 0 0 govuk-spacing(4) 0;
   border-bottom: solid 1px govuk-colour("black");
+
+  &__header {    
+    display: none;
+    @include govuk-media-query($from: tablet) {
+      display: block;
+    }
+  }
 
   .govuk-grid-column-two-thirds {
     text-align: left;

--- a/app/assets/stylesheets/views/_brexit_checker_results_page.scss
+++ b/app/assets/stylesheets/views/_brexit_checker_results_page.scss
@@ -81,12 +81,14 @@ $urgency-blue: #0055D2;
   }
 
   .stay-updated__heading {
+    border: 0;
+    height: 0;
     border-top: 1px solid $govuk-border-colour;
-    padding-top: govuk-spacing(6);
     margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
   }
 
-  .stay-updated_description {
+  .stay-updated__description {
     margin-bottom: govuk-spacing(4);
     @include govuk-font(19);
   }

--- a/app/views/brexit_checker/_results_business_actions.html.erb
+++ b/app/views/brexit_checker/_results_business_actions.html.erb
@@ -6,10 +6,13 @@
   data-search-query
 >
   <section class="brexit-checker-audience">
-      <header>
-        <h2 class="govuk-heading-l action-audience__heading">
-          <%= t('brexit_checker.results.audiences.business.heading') %>
-        </h2>
+      <header class="action-audience__heading">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('brexit_checker.results.audiences.business.heading'),
+          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 0
+        } %>
       </header>
       <section class="brexit-checker-actions__group">
         <div class="govuk-grid-row">

--- a/app/views/brexit_checker/_results_citizen_actions.html.erb
+++ b/app/views/brexit_checker/_results_citizen_actions.html.erb
@@ -1,8 +1,11 @@
 <section class="brexit-checker-actions">
-  <header>
-    <h2 class="govuk-heading-l action-audience__heading">
-      <%= t('brexit_checker.results.audiences.citizen.heading') %>
-    </h2>
+  <header class="action-audience__heading">
+     <%= render "govuk_publishing_components/components/heading", {
+          text: t('brexit_checker.results.audiences.citizen.heading'),
+          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 0
+      } %>
   </header>
   <section class="brexit-checker-audience">
     <% citizen_results_groups.each.with_index do |grouping, group_index| %>

--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -1,7 +1,12 @@
-<div class="govuk-grid-column-one-third">
-  <% if criteria.present? %>
+<% if criteria.present? %>
+  <div class="govuk-grid-column-one-third">
     <% if local_assigns[:heading] %>
-      <h3 class="govuk-heading-m"><%= heading %></h3>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: heading,
+        heading_level: 3,
+        font_size: "m",
+        margin_bottom: 4
+      } %>
     <% end %>
     <aside>
       <p class="govuk-body brexit-checker__criteria_explanation">
@@ -15,9 +20,11 @@
         <% end %>
       </ul>
     </aside>
-  <% else %>
+  </div>
+<% else %>
+  <div class="govuk-grid-column-one-third">
     <p class="govuk-body">
       <%= t('brexit_checker.results.criteria.no_answers') %>
     </p>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/brexit_checker/_share_links.html.erb
+++ b/app/views/brexit_checker/_share_links.html.erb
@@ -1,7 +1,9 @@
 <section class="brexit-checker__share">
-  <h2 class="govuk-heading-m">
-    <%= I18n.t("brexit_checker.results.share_link_title") %>
-  </h2>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("brexit_checker.results.share_link_title"),
+    font_size: "m",
+    margin_bottom: 4
+  } %>
   <%= render "govuk_publishing_components/components/share_links", {
     columns: true,
     links: [

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -1,8 +1,11 @@
-<h2 class="govuk-heading-m stay-updated__heading">
-  <%= t("brexit_checker.stay_updated.heading") %>
-</h2>
+<hr class="stay-updated__heading">
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("brexit_checker.stay_updated.heading"),
+  font_size: "m",
+  margin_bottom: 4
+} %>
 
-<p class="stay-updated_description" >
+<p class="stay-updated__description" >
   <%= t("brexit_checker.stay_updated.description") %>
 </p>
 

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -28,7 +28,12 @@
   <main class="govuk-main-wrapper" role="mail">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l"><%= t('brexit_checker.email_signup.sign_up_heading') %></h1>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t('brexit_checker.email_signup.sign_up_heading'),
+          heading_level: 1,
+          font_size: "l",
+          margin_bottom: 6
+        } %>
         <%= t('brexit_checker.email_signup.sign_up_message').html_safe %>
         <ul class="govuk-list govuk-list--bullet">
           <%= t('brexit_checker.email_signup.sign_up_message_criteria').html_safe %>

--- a/app/views/components/_email_link.html.erb
+++ b/app/views/components/_email_link.html.erb
@@ -4,7 +4,11 @@
 %>
 <div class="app-c-email-link">
   <% if link_title %>
-    <h2 class="govuk-heading-m"><%= link_title %></h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: link_title,
+      font_size: "m",
+      margin_bottom: 2
+    } %>
   <% end %>
   <svg class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="21" width="18" viewBox="0 0 18 21">
     <path d="M7.05,19.01C7.05,20.11,7.92,21,9,21c1.08,0,1.95-0.89,1.95-1.99H7.05z M15.73,14.82V9c0-3.25-2.2-5.97-5.18-6.69V1.59C10.56,0.71,9.86,0,9,0C8.14,0,7.44,0.71,7.44,1.59v0.72C4.47,3.03,2.27,5.75,2.27,9v5.82l-2.08,2.12V18h17.62v-1.06L15.73,14.82z"></path>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -37,7 +37,12 @@
     <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets" role="search" aria-label="Search filters">
       <div class="facets__box">
         <div class="facets__header">
-          <h1 class="gem-c-title__text">Filter</h1>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Filter",
+            heading_level: 1,
+            font_size: "xl",
+            margin_bottom: 0
+          } %>
           <button class="app-c-button-as-link facets__return-link js-close-filters" type="button">
             Return to results
           </button>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -16,11 +16,15 @@
   <% if content_item.government? %>
     <%= render 'govuk_publishing_components/components/government_navigation', active: content_item.government_content_section %>
   <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>
-        <h1 class="app-c-search-page-heading">Search<span class="govuk-visually-hidden"> all content</span></h1>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: sanitize("Search <span class='govuk-visually-hidden'>all content</span>"),
+        heading_level: 1,
+        font_size: "xl",
+        margin_bottom: 4
+        } %>
         <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide">
           <%= render "govuk_publishing_components/components/search", {
             aria_controls: "js-search-results-info",

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -54,9 +54,13 @@
         <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
-              <h2 class="result-region-header__counter" id="js-result-count">
-                <%= result_set_presenter.displayed_total %>
-              </h2>
+              <div class="result-info__header">
+                <%= render "govuk_publishing_components/components/heading", {
+                  text: result_set_presenter.displayed_total,
+                  id: "js-result-count",
+                  font_size: "s"
+                  } %>
+              </div>
             </div>
             <div class="govuk-grid-column-two-thirds subscription-links subscription-links--desktop">
               <%= render "govuk_publishing_components/components/subscription-links", signup_links %>

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -1,5 +1,8 @@
 <% label_text = capture do %>
-  <h1>Search GOV.UK</h1>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Search GOV.UK",
+  heading_level: 1,
+} %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/search", {


### PR DESCRIPTION
## What?

Switch out headings to use component gem to improve a11y and adjust visual layouts to match, or closely match, the existing design

## Why?

Paying back debt to for heading elements to use component gem - more consistency, improved a11y (changes to the gem will be cascaded across apps)
[Trello ticket](https://trello.com/c/Qg72rche)

## Visuals 

**Before** (left)      |      **After** (right)

![11](https://user-images.githubusercontent.com/71266765/101390108-3d647b80-38ba-11eb-8113-ced09c2728d7.png)
[Live link #11](http://www.gov.uk/search/all?order=most-viewed)

- Visual change: results numbers are now bold as it's a header
- This element is also hidden on mobile [intentional PR](https://github.com/alphagov/finder-frontend/pull/1804/commits/ef3773b12f50e44bbb6ebc6856fa0ab2c096cadd))

---

![10](https://user-images.githubusercontent.com/71266765/101390110-3d647b80-38ba-11eb-96ae-2458491d8a8f.png)
[Live link #10](http://www.gov.uk/transition-check/results?c%5B%5D=aero-space&c%5B%5D=agriculture-farm&c%5B%5D=import-from-eu&c%5B%5D=eu-domain-no&c%5B%5D=do-not-ip&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-use&c%5B%5D=do-not-employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu-no&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

---

![9](https://user-images.githubusercontent.com/71266765/101390111-3dfd1200-38ba-11eb-8562-cfe086a578aa.png)
[Live link #9](http://www.gov.uk/transition-check/results?c%5B%5D=aero-space&c%5B%5D=agriculture-farm&c%5B%5D=import-from-eu&c%5B%5D=eu-domain-no&c%5B%5D=do-not-ip&c%5B%5D=sell-public-sector&c%5B%5D=sell-public-sector-contracts&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=personal-eu-org-process&c%5B%5D=personal-eu-org-use&c%5B%5D=do-not-employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu-no&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

---

![8](https://user-images.githubusercontent.com/71266765/101390112-3dfd1200-38ba-11eb-8ab7-f39725ff37ca.png)
[Live link #8](http://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=family-eu&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-row)

---

![7](https://user-images.githubusercontent.com/71266765/101390114-3dfd1200-38ba-11eb-8b0a-e60f81a7aff0.png)
[Live link #7](http://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=family-eu&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-row)

---
![6](https://user-images.githubusercontent.com/71266765/101390115-3e95a880-38ba-11eb-9bc4-d452b25eb6ca.png)
[Live link #6](https://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=move-to-eu&c%5B%5D=visiting-driving&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

---
![5](https://user-images.githubusercontent.com/71266765/101390117-3e95a880-38ba-11eb-8394-5561443503f4.png)
[Live link #5](http://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=family-eu&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-row)

---

![4](https://user-images.githubusercontent.com/71266765/101390118-3e95a880-38ba-11eb-99e3-1ad2621bc7fe.png)
[Live link #4](https://www.gov.uk/search?q=)

---

![3](https://user-images.githubusercontent.com/71266765/101390119-3f2e3f00-38ba-11eb-832d-c85434886d47.png)
[Live link #3](http://www.gov.uk/search/all?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0)

---

![2](https://user-images.githubusercontent.com/71266765/101390103-3a698b00-38ba-11eb-81b7-7846c65aec74.png)
[Live link #2](https://www.gov.uk/aaib-reports)
(Mobile only > Filter modal)

---

![1](https://user-images.githubusercontent.com/71266765/101390099-38073100-38ba-11eb-8cfc-0ea5e20116f3.png)
[Live link #1](http://www.gov.uk/transition-check/email-signup?c%5B%5D=aero-space&c%5B%5D=import-from-eu&c%5B%5D=eu-domain&c%5B%5D=ip&c%5B%5D=sell-public-sector&c%5B%5D=eu-uk-funding&c%5B%5D=personal-eu-org&c%5B%5D=employ-eu-citizens&c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=move-to-eu-no&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=travel-eu-business&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk)

---

## Anything else?

- There was also a fix to resolve a visual issue found on [this page](https://www.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=family-eu&c%5B%5D=visiting-driving&c%5B%5D=visiting-ie&c%5B%5D=visiting-eu&c%5B%5D=travel-eu-business-no&)

Before (element outside grid) After (element on right)

![Screenshot 2020-12-07 at 18 54 05](https://user-images.githubusercontent.com/71266765/101393263-b796ff00-38be-11eb-88cb-c3aba6aa3243.png)




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
