### PR TITLE
Update redirect path for accounts sign out

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -45,12 +45,12 @@ class SessionsController < ApplicationController
   def delete
     if params[:continue]
       logout!
-      redirect_with_ga "#{account_manager_url}/logout?done=#{params[:continue]}"
+      redirect_with_ga "#{account_manager_url}/sign-out?done=#{params[:continue]}"
     elsif params[:done]
       logout!
       redirect_with_ga "/transition"
     else
-      redirect_with_ga "#{account_manager_url}/logout?continue=1"
+      redirect_with_ga "#{account_manager_url}/sign-out?continue=1"
     end
   end
 


### PR DESCRIPTION
The account manager has been updated to have a /sign-out route rather than /logout. Although we've put a redirect in place, we should update the path here to save a redirect.

Not to be merged until https://github.com/alphagov/govuk-account-manager-prototype/pull/476 is deployed.

Trello card: https://trello.com/c/CFOt8maS