### PR TITLE
Stop sending group_id to Email Alert API

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -3,8 +3,6 @@ class BrexitCheckerController < ApplicationController
 
   include BrexitCheckerHelper
 
-  SUBSCRIBER_LIST_GROUP_ID = "5a7c11f2-e737-4531-a0bc-b5f707046607".freeze
-
   layout "finder_layout"
 
   protect_from_forgery except: :confirm_email_signup
@@ -184,7 +182,6 @@ private
     {
       "title" => "Get ready for 2021",
       "description" => "[You can view a copy of your results on GOV.UK.](#{Plek.new.website_root}#{path})",
-      "group_id" => SUBSCRIBER_LIST_GROUP_ID,
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,
     }

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -52,7 +52,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
           "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
           "url" => "/transition-check/results?c%5B%5D=nationality-eu",
-          "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
         },
       )
     end
@@ -429,7 +428,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
           "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
           "url" => "/transition-check/results?c%5B%5D=nationality-eu",
-          "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
         },
       )
     end

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
       "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
       "url" => "/transition-check/results?c%5B%5D=nationality-eu",
-      "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
     }
   end
 

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -5,17 +5,6 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::EmailAlertApi
 
-  let(:subscriber_list) do
-    {
-      "title" => "Get ready for 2021",
-      "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
-      "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
-      "url" => "/transition-check/results?c%5B%5D=nationality-eu",
-      "group_id" => BrexitCheckerController::SUBSCRIBER_LIST_GROUP_ID,
-    }
-  end
-
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret!"


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

This isn't used [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1519


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️