### PR TITLE
Stop sending description field for Brexit Checker

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -173,7 +173,6 @@ private
 
     {
       "title" => "Get ready for 2021",
-      "description" => "[You can view a copy of your results on GOV.UK.](#{Plek.new.website_root}#{path})",
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,
     }

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -49,7 +49,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         {
           "title" => "Get ready for 2021",
           "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-          "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
           "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
           "url" => "/transition-check/results?c%5B%5D=nationality-eu",
         },
@@ -429,7 +428,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         {
           "title" => "Get ready for 2021",
           "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-          "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
           "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
           "url" => "/transition-check/results?c%5B%5D=nationality-eu",
         },

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     {
       "title" => "Get ready for 2021",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-      "description" => "[You can view a copy of your results on GOV.UK.](https://www.test.gov.uk/transition-check/results?c%5B%5D=nationality-eu)",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
       "url" => "/transition-check/results?c%5B%5D=nationality-eu",
     }


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Depends on: https://github.com/alphagov/email-alert-frontend/pull/944
https://github.com/alphagov/email-alert-api/pull/1527

This field is no longer used [1].

[1]: https://github.com/alphagov/email-alert-api/pull/1527


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️