### PR TITLE
Log user in if they try to update saved results while logged out

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -78,6 +78,8 @@ class BrexitCheckerController < ApplicationController
   def save_results_email_signup; end
 
   def save_results_apply
+    redirect_to transition_checker_new_session_path(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys), _ga: params[:_ga]) and return unless logged_in?
+
     if params[:email_decision] == "yes"
       update_account_session_cookie_from_oauth_result(
         Services.oidc.update_email_subscription(


### PR DESCRIPTION
I think this situation will arise if the user loads the
`save_results_confirm` page, waits long enough for the session cookie
to expire, and then submits the form.

https://sentry.io/organizations/govuk/issues/2099697511/?project=202224