### PR TITLE
A11y adjustments for the Brexit checker views

### DIFF
--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -6,26 +6,29 @@
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
+<% content_for :breadcrumbs do %>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t('brexit_checker.breadcrumbs.home'),
+          url: "/"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.brexit-home'),
+          url: "/transition"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.results'),
+          url: transition_checker_results_path(c: criteria_keys)
+        }
+      ]
+    } %>
+  </div>
+<% end %>
 <div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: t('brexit_checker.breadcrumbs.home'),
-        url: "/"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
-        url: "/transition"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.results'),
-        url: transition_checker_results_path(c: criteria_keys)
-      }
-    ]
-  } %>
-
-  <main class="govuk-main-wrapper" role="mail">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
@@ -51,5 +54,5 @@
         <% end %>
       </div>
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -6,26 +6,30 @@
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
-<div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: t('brexit_checker.breadcrumbs.home'),
-        url: "/"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
-        url: "/transition"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.results'),
-        url: transition_checker_results_path(c: criteria_keys)
-      }
-    ]
-  } %>
+<% content_for :breadcrumbs do %>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t('brexit_checker.breadcrumbs.home'),
+          url: "/"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.brexit-home'),
+          url: "/transition"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.results'),
+          url: transition_checker_results_path(c: criteria_keys)
+        }
+      ]
+    } %>
+  </div>
+<% end %>
 
-  <main class="govuk-main-wrapper">
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
@@ -79,5 +83,5 @@
         </p>
       </div>
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/brexit_checker/save_results_confirm.html.erb
+++ b/app/views/brexit_checker/save_results_confirm.html.erb
@@ -6,26 +6,30 @@
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
-<div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: t('brexit_checker.breadcrumbs.home'),
-        url: "/"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
-        url: "/transition"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.results'),
-        url: transition_checker_results_path(c: criteria_keys)
-      }
-    ]
-  } %>
+<% content_for :breadcrumbs do %>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t('brexit_checker.breadcrumbs.home'),
+          url: "/"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.brexit-home'),
+          url: "/transition"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.results'),
+          url: transition_checker_results_path(c: criteria_keys)
+        }
+      ]
+    } %>
+  </div>
+<% end %>
 
-  <main class="govuk-main-wrapper">
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
@@ -75,5 +79,5 @@
         <p class="govuk-body"><%= sanitize(t("brexit_checker.confirm_changes.cancel", link: transition_checker_results_path(c: criteria_keys))) %></p>
       </div>
     </div>
-  </main>
+  </div>
 </div>

--- a/app/views/brexit_checker/save_results_email_signup.html.erb
+++ b/app/views/brexit_checker/save_results_email_signup.html.erb
@@ -6,26 +6,30 @@
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
-<div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    collapse_on_mobile: true,
-    breadcrumbs: [
-      {
-        title: t('brexit_checker.breadcrumbs.home'),
-        url: "/"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.brexit-home'),
-        url: "/transition"
-      },
-      {
-        title: t('brexit_checker.breadcrumbs.results'),
-        url: transition_checker_results_path(c: criteria_keys)
-      }
-    ]
-  } %>
+<% content_for :breadcrumbs do %>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t('brexit_checker.breadcrumbs.home'),
+          url: "/"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.brexit-home'),
+          url: "/transition"
+        },
+        {
+          title: t('brexit_checker.breadcrumbs.results'),
+          url: transition_checker_results_path(c: criteria_keys)
+        }
+      ]
+    } %>
+  </div>
+<% end %>
 
-  <main class="govuk-main-wrapper">
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
@@ -65,5 +69,5 @@
         <% end %>
       </div>
     </div>
-  </main>
+  </div>
 </div>


### PR DESCRIPTION
The Brexit checker templates use the `finder_layout` layout file.
This layout file already adds a `<main>` wrapper around the content. 
However, some of the brexit checker views also contain a `<main>` wrapper, which means that on those pages there would be two `main` landmarks, which goes against the rule that the `<main>` element must be unique to the document.

In addition to this, these views also contain breadcrumbs. 
Since breadcrumbs are a navigation element, they should live outside of `<main>`. I updated these views to store the breadcrumbs using `content_for`. This way the breadcrumbs will be placed outside of `<main>` in the layout file.

### Before: two `main` landmarks, breadcrumbs sit inside of `main`
![Screenshot 2020-12-18 at 14 28 17](https://user-images.githubusercontent.com/7116819/102626193-66003700-413e-11eb-9c3c-c3dbe7fb0a95.png)

### After: only one `main` landmark, breadcrumbs sit outside of `main`
![Screenshot 2020-12-18 at 14 31 24](https://user-images.githubusercontent.com/7116819/102626200-67c9fa80-413e-11eb-9148-445abc2025ea.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
