### PR TITLE
Replace show results button with button component on mobile search page

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -57,9 +57,10 @@
           </button>
         </div>
         <div class="facets__footer">
-          <button class="gem-c-button govuk-button js-close-filters js-show-results" type="button">
-            Show <span class="js-result-count"> <%= result_set_presenter.displayed_total %></span>
-          </button>
+          <%= render "govuk_publishing_components/components/button", {
+            text: sanitize("Show <span class=\"js-result-count\">#{result_set_presenter.displayed_total}</span>"),
+            classes: "js-close-filters js-show-results"
+          } %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What
Replaces the button to apply filters for mobile on [the search page](https://www.gov.uk/search/all) with a govuk publishing components [button component](https://components.publishing.service.gov.uk/component-guide/button).

## Why
This is part of a wider piece of work by the govuk accessibility team to ensure that as many of our apps as possible are using up to date, consistent markup. This can be achieved in part by ensuring we make use of our components tooling where possible.

No visual changes.

[Card](https://trello.com/c/9pRq4aIl/567-update-finder-frontend-to-use-form-components)
