### PR TITLE
Improve tests for EmailAlertSignupAPI class

### DIFF
--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -21,8 +21,6 @@ describe EmailAlertSignupAPI do
   let(:applied_filters) { {} }
   let(:facets) { [] }
   let(:subscriber_list_title) { "Subscriber list title" }
-  let(:slug) { "slug" }
-  let(:subscription_url) { "/email/subscriptions/new?topic_id=#{slug}" }
 
   describe "default_attributes" do
     context "no default_attributes or attributes" do
@@ -30,9 +28,10 @@ describe EmailAlertSignupAPI do
         it "returns the url email-alert-api gives back" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {},
-            "slug" => slug,
+            "slug" => "slug",
           )
 
+          subscription_url = "/email/subscriptions/new?topic_id=slug"
           expect(subject.signup_url).to eql subscription_url
           assert_requested(req)
         end
@@ -48,10 +47,9 @@ describe EmailAlertSignupAPI do
         it "will send email_alert_api the default attributes" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => { content_purpose_supergroup: { any: %w[news_and_communications] } },
-            "slug" => "slug",
           )
 
-          expect(subject.signup_url).to eql subscription_url
+          signup_api_wrapper.signup_url
           assert_requested(req)
         end
       end
@@ -88,14 +86,15 @@ describe EmailAlertSignupAPI do
 
     describe "#signup_url" do
       it "returns the url for the subscriber list" do
-        stub_email_alert_api_has_subscriber_list(
+        req = stub_email_alert_api_has_subscriber_list(
           "tags" => {
             format: { any: %w[test-reports] },
             alert_type: { any: %w[first second] },
           },
-          "slug" => "slug",
         )
-        expect(signup_api_wrapper.signup_url).to eql subscription_url
+
+        signup_api_wrapper.signup_url
+        assert_requested(req)
       end
 
       context "with multiple choices selected and a title prefix" do
@@ -105,7 +104,6 @@ describe EmailAlertSignupAPI do
               format: { any: %w[test-reports] },
               alert_type: { any: %w[first second] },
             },
-            "subscription_url" => subscription_url,
           )
 
           signup_api_wrapper.signup_url
@@ -126,7 +124,6 @@ describe EmailAlertSignupAPI do
               format: { any: %w[other-reports test-reports] },
               alert_type: { any: %w[first] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -141,7 +138,6 @@ describe EmailAlertSignupAPI do
               format: { any: %w[test-reports] },
               alert_type: { any: %w[first second] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -158,7 +154,6 @@ describe EmailAlertSignupAPI do
             "tags" => {
               format: { any: %w[test-reports] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -248,7 +243,6 @@ describe EmailAlertSignupAPI do
               alert_type: { any: %w[first second] },
               other_type: { any: %w[third fourth] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -272,7 +266,6 @@ describe EmailAlertSignupAPI do
               alert_type: { any: %w[first] },
               other_type: { any: %w[] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -288,7 +281,6 @@ describe EmailAlertSignupAPI do
               alert_type: { any: %w[first second] },
               other_type: { any: %w[third fourth] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -305,7 +297,6 @@ describe EmailAlertSignupAPI do
             "tags" => {
               format: { any: %w[test-reports] },
             },
-            "slug" => "slug",
           )
 
           signup_api_wrapper.signup_url
@@ -345,10 +336,9 @@ describe EmailAlertSignupAPI do
         "tags" => {
           persons: { any: %w[harry_potter harry john] },
         },
-        "slug" => "slug",
       )
 
-      expect(subject.signup_url).to eql subscription_url
+      subject.signup_url
       assert_requested(req)
     end
   end
@@ -377,9 +367,8 @@ describe EmailAlertSignupAPI do
             taxon_tree: { all: %w[content_id_1 content_id_2] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
-        expect(subject.signup_url).to eql subscription_url
+        subject.signup_url
         assert_requested(req)
       end
     end
@@ -405,9 +394,8 @@ describe EmailAlertSignupAPI do
             content_store_document_type: { any: %w[document_type_1 document_type_2] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
-        expect(subject.signup_url).to eql subscription_url
+        subject.signup_url
         assert_requested(req)
       end
       describe "handling default values" do
@@ -420,9 +408,8 @@ describe EmailAlertSignupAPI do
               content_store_document_type: { any: %w[document_type_1 document_type_2] },
               content_purpose_subgroup: { any: %w[one_thing] },
             },
-            "slug" => "slug",
           )
-          expect(subject.signup_url).to eql subscription_url
+          subject.signup_url
           assert_requested(req)
         end
       end
@@ -448,9 +435,8 @@ describe EmailAlertSignupAPI do
             organisations: { any: %w[content_id_for_death-eaters content_id_for_ministry-of-magic] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
-        expect(subject.signup_url).to eql subscription_url
+        subject.signup_url
         assert_requested(req)
       end
     end
@@ -477,9 +463,8 @@ describe EmailAlertSignupAPI do
             world_locations: { any: %w[content_id_for_location_1 content_id_for_location_2] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
-        expect(subject.signup_url).to eql subscription_url
+        subject.signup_url
         assert_requested(req)
       end
     end
@@ -505,9 +490,8 @@ describe EmailAlertSignupAPI do
             people: { any: %w[content_id_for_albus-dumbledore content_id_for_ron-weasley] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
-        expect(subject.signup_url).to eql subscription_url
+        subject.signup_url
         assert_requested(req)
       end
     end
@@ -534,11 +518,9 @@ describe EmailAlertSignupAPI do
             roles: { any: %w[content_id_for_prime-minister] },
             content_purpose_subgroup: { any: %w[news speeches_and_statements] },
           },
-          "slug" => "slug",
         )
 
-        expect(subject.signup_url).to eql subscription_url
-
+        subject.signup_url
         assert_requested(req)
       end
     end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -24,18 +24,14 @@ describe EmailAlertSignupAPI do
   let(:slug) { "slug" }
   let(:subscription_url) { "/email/subscriptions/new?topic_id=#{slug}" }
 
-  def init_simple_email_alert_api(slug)
-    stub_email_alert_api_has_subscriber_list(
-      "tags" => {},
-      "slug" => slug,
-    )
-  end
-
   describe "default_attributes" do
     context "no default_attributes or attributes" do
       describe "#signup_url" do
         it "returns the url email-alert-api gives back" do
-          req = init_simple_email_alert_api(slug)
+          req = stub_email_alert_api_has_subscriber_list(
+            "tags" => {},
+            "slug" => slug,
+          )
 
           expect(subject.signup_url).to eql subscription_url
           assert_requested(req)

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -85,18 +85,6 @@ describe EmailAlertSignupAPI do
     end
 
     describe "#signup_url" do
-      it "returns the url for the subscriber list" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "tags" => {
-            format: { any: %w[test-reports] },
-            alert_type: { any: %w[first second] },
-          },
-        )
-
-        signup_api_wrapper.signup_url
-        assert_requested(req)
-      end
-
       context "with multiple choices selected and a title prefix" do
         it "asks email-alert-api to find or create the subscriber list" do
           req = stub_email_alert_api_has_subscriber_list(
@@ -224,17 +212,6 @@ describe EmailAlertSignupAPI do
     end
 
     describe "#signup_url" do
-      it "returns the url email-alert-api gives back" do
-        stub_email_alert_api_has_subscriber_list(
-          "tags" => {
-            format: { any: %w[test-reports] },
-            alert_type: { any: %w[first second] },
-          },
-          "slug" => "slug",
-        )
-        expect(signup_api_wrapper.signup_url).to eql subscription_url
-      end
-
       context "with multiple choices selected and a title prefix" do
         it "asks email-alert-api to find or create the subscriber list" do
           req = stub_email_alert_api_has_subscriber_list(

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -200,17 +200,6 @@ describe EmailAlertSignupAPI do
       ]
     end
 
-    before do
-      stub_email_alert_api_has_subscriber_list(
-        "tags" => {
-          format: { any: %w[test-reports] },
-          alert_type: { any: %w[first second] },
-          other_type: { any: %w[third fourth] },
-        },
-        "slug" => "slug",
-      )
-    end
-
     describe "#signup_url" do
       context "with multiple choices selected and a title prefix" do
         it "asks email-alert-api to find or create the subscriber list" do

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -13,14 +13,13 @@ describe EmailAlertSignupAPI do
       applied_filters: applied_filters,
       default_filters: default_filters,
       facets: facets,
-      subscriber_list_title: subscriber_list_title,
+      subscriber_list_title: "title",
     )
   end
 
   let(:default_filters) { {} }
   let(:applied_filters) { {} }
   let(:facets) { [] }
-  let(:subscriber_list_title) { "Subscriber list title" }
 
   describe "default_attributes" do
     context "no default_attributes or attributes" do

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -21,69 +21,63 @@ describe EmailAlertSignupAPI do
   let(:applied_filters) { {} }
   let(:facets) { [] }
 
-  describe "default_attributes" do
+  describe "#signup_url" do
     context "no default_attributes or attributes" do
-      describe "#signup_url" do
-        it "returns the url email-alert-api gives back" do
-          req = stub_email_alert_api_has_subscriber_list(
-            "tags" => {},
-            "slug" => "slug",
-          )
+      it "returns the url email-alert-api gives back" do
+        req = stub_email_alert_api_has_subscriber_list(
+          "tags" => {},
+          "slug" => "slug",
+        )
 
-          subscription_url = "/email/subscriptions/new?topic_id=slug"
-          expect(subject.signup_url).to eql subscription_url
-          assert_requested(req)
-        end
+        subscription_url = "/email/subscriptions/new?topic_id=slug"
+        expect(subject.signup_url).to eql subscription_url
+        assert_requested(req)
       end
     end
 
     context "default attributes provided" do
-      describe "#signup_url" do
-        let(:default_filters) do
-          { "content_purpose_supergroup" => "news_and_communications" }
-        end
+      let(:default_filters) do
+        { "content_purpose_supergroup" => "news_and_communications" }
+      end
 
-        it "will send email_alert_api the default attributes" do
-          req = stub_email_alert_api_has_subscriber_list(
-            "tags" => { content_purpose_supergroup: { any: %w[news_and_communications] } },
-          )
+      it "will send email_alert_api the default attributes" do
+        req = stub_email_alert_api_has_subscriber_list(
+          "tags" => { content_purpose_supergroup: { any: %w[news_and_communications] } },
+        )
 
-          signup_api_wrapper.signup_url
-          assert_requested(req)
-        end
+        signup_api_wrapper.signup_url
+        assert_requested(req)
       end
     end
-  end
 
-  context "with a single facet finder" do
-    let(:default_filters) { { "format" => "test-reports" } }
-    let(:applied_filters) do
-      { "alert_type" => %w[first second] }
-    end
-    let(:facets) do
-      [
-        {
-          "facet_id" => "alert_type",
-          "facet_name" => "alert type",
-          "facet_choices" => [
-            {
-              "key" => "first",
-              "radio_button_name" => "First ABC thing",
-              "topic_name" => "first ABC thing",
-              "prechecked" => false,
-            },
-            {
-              "key" => "second",
-              "radio_button_name" => "Second DEF thing",
-              "topic_name" => "second DEF thing",
-              "prechecked" => false,
-            },
-          ],
-        },
-      ]
-    end
+    context "with a single facet finder" do
+      let(:default_filters) { { "format" => "test-reports" } }
+      let(:applied_filters) do
+        { "alert_type" => %w[first second] }
+      end
+      let(:facets) do
+        [
+          {
+            "facet_id" => "alert_type",
+            "facet_name" => "alert type",
+            "facet_choices" => [
+              {
+                "key" => "first",
+                "radio_button_name" => "First ABC thing",
+                "topic_name" => "first ABC thing",
+                "prechecked" => false,
+              },
+              {
+                "key" => "second",
+                "radio_button_name" => "Second DEF thing",
+                "topic_name" => "second DEF thing",
+                "prechecked" => false,
+              },
+            ],
+          },
+        ]
+      end
 
-    describe "#signup_url" do
       context "with multiple choices selected and a title prefix" do
         it "asks email-alert-api to find or create the subscriber list" do
           req = stub_email_alert_api_has_subscriber_list(
@@ -148,58 +142,56 @@ describe EmailAlertSignupAPI do
         end
       end
     end
-  end
 
-  context "with a multi facet finder" do
-    let(:default_filters) { { "format" => "test-reports" } }
-    let(:applied_filters) do
-      {
-        "alert_type" => %w[first second],
-        "other_type" => %w[third fourth],
-      }
-    end
-    let(:facets) do
-      [
+    context "with a multi facet finder" do
+      let(:default_filters) { { "format" => "test-reports" } }
+      let(:applied_filters) do
         {
-          "facet_id" => "alert_type",
-          "facet_name" => "alert type",
-          "facet_choices" => [
-            {
-              "key" => "first",
-              "radio_button_name" => "First ABC thing",
-              "topic_name" => "first ABC thing",
-              "prechecked" => false,
-            },
-            {
-              "key" => "second",
-              "radio_button_name" => "Second DEF thing",
-              "topic_name" => "second DEF thing",
-              "prechecked" => false,
-            },
-          ],
-        },
-        {
-          "facet_id" => "other_type",
-          "facet_name" => "other type",
-          "facet_choices" => [
-            {
-              "key" => "third",
-              "radio_button_name" => "Third GHI thing",
-              "topic_name" => "third GHI thing",
-              "prechecked" => false,
-            },
-            {
-              "key" => "fourth",
-              "radio_button_name" => "Fourth JKL thing",
-              "topic_name" => "fourth JKL thing",
-              "prechecked" => false,
-            },
-          ],
-        },
-      ]
-    end
+          "alert_type" => %w[first second],
+          "other_type" => %w[third fourth],
+        }
+      end
+      let(:facets) do
+        [
+          {
+            "facet_id" => "alert_type",
+            "facet_name" => "alert type",
+            "facet_choices" => [
+              {
+                "key" => "first",
+                "radio_button_name" => "First ABC thing",
+                "topic_name" => "first ABC thing",
+                "prechecked" => false,
+              },
+              {
+                "key" => "second",
+                "radio_button_name" => "Second DEF thing",
+                "topic_name" => "second DEF thing",
+                "prechecked" => false,
+              },
+            ],
+          },
+          {
+            "facet_id" => "other_type",
+            "facet_name" => "other type",
+            "facet_choices" => [
+              {
+                "key" => "third",
+                "radio_button_name" => "Third GHI thing",
+                "topic_name" => "third GHI thing",
+                "prechecked" => false,
+              },
+              {
+                "key" => "fourth",
+                "radio_button_name" => "Fourth JKL thing",
+                "topic_name" => "fourth JKL thing",
+                "prechecked" => false,
+              },
+            ],
+          },
+        ]
+      end
 
-    describe "#signup_url" do
       context "with multiple choices selected and a title prefix" do
         it "asks email-alert-api to find or create the subscriber list" do
           req = stub_email_alert_api_has_subscriber_list(
@@ -269,224 +261,224 @@ describe EmailAlertSignupAPI do
         end
       end
     end
-  end
 
-  context "when choices have filter_values" do
-    let(:applied_filters) do
-      { "persons" => %w[people_named_harry people_named_john] }
-    end
-    let(:facets) do
-      [
-        {
-          "facet_id" => "persons",
-          "facet_name" => "persons",
-          "facet_choices" => [
-            {
-              "key" => "people_named_harry",
-              "filter_values" => %w[harry_potter harry],
-              "topic_name" => "people named Harry",
-            },
-            {
-              "key" => "people_named_john",
-              "filter_values" => %w[john],
-              "topic_name" => "John",
-            },
-          ],
-        },
-      ]
-    end
-
-    it "asks email-alert-api to find or create the subscriber list" do
-      req = stub_email_alert_api_has_subscriber_list(
-        "tags" => {
-          persons: { any: %w[harry_potter harry john] },
-        },
-      )
-
-      subject.signup_url
-      assert_requested(req)
-    end
-  end
-
-  context "Create link based subscriber lists" do
-    let(:default_filters) do
-      {
-        "content_purpose_subgroup": %w[news speeches_and_statements],
-      }
-    end
-    describe "part_of_taxonomy_tree facet" do
+    context "when choices have filter_values" do
       let(:applied_filters) do
-        { "all_part_of_taxonomy_tree" => %w[content_id_1 content_id_2] }
+        { "persons" => %w[people_named_harry people_named_john] }
       end
       let(:facets) do
         [
           {
-            "facet_id" => "all_part_of_taxonomy_tree",
-            "facet_name" => "Taxon",
+            "facet_id" => "persons",
+            "facet_name" => "persons",
+            "facet_choices" => [
+              {
+                "key" => "people_named_harry",
+                "filter_values" => %w[harry_potter harry],
+                "topic_name" => "people named Harry",
+              },
+              {
+                "key" => "people_named_john",
+                "filter_values" => %w[john],
+                "topic_name" => "John",
+              },
+            ],
           },
         ]
       end
-      it "translates all_part_of_taxonomy_tree to taxon_tree and does not convert values" do
+
+      it "asks email-alert-api to find or create the subscriber list" do
         req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            taxon_tree: { all: %w[content_id_1 content_id_2] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+          "tags" => {
+            persons: { any: %w[harry_potter harry john] },
           },
         )
+
         subject.signup_url
         assert_requested(req)
       end
     end
-    describe "content_store_document_type" do
-      let(:applied_filters) do
-        { "content_store_document_type" => %w[document_type_1 document_type_2] }
+
+    context "Create link based subscriber lists" do
+      let(:default_filters) do
+        { "content_purpose_subgroup": %w[news speeches_and_statements] }
       end
-      let(:facets) do
-        [
-          {
-            "facet_id" => "content_store_document_type",
-            "facet_name" => "Document Type",
-          },
-          {
-            "facet_id" => "organisations",
-            "facet_name" => "Organisations",
-          },
-        ]
-      end
-      it "It does not convert values" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            content_store_document_type: { any: %w[document_type_1 document_type_2] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
-          },
-        )
-        subject.signup_url
-        assert_requested(req)
-      end
-      describe "handling default values" do
-        let(:default_filters) do
-          { "content_purpose_subgroup" => "one_thing" }
+
+      context "part_of_taxonomy_tree facet" do
+        let(:applied_filters) do
+          { "all_part_of_taxonomy_tree" => %w[content_id_1 content_id_2] }
         end
-        it "it converting scalar values to arrays" do
+
+        let(:facets) do
+          [
+            {
+              "facet_id" => "all_part_of_taxonomy_tree",
+              "facet_name" => "Taxon",
+            },
+          ]
+        end
+
+        it "translates all_part_of_taxonomy_tree to taxon_tree and does not convert values" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
-              content_store_document_type: { any: %w[document_type_1 document_type_2] },
-              content_purpose_subgroup: { any: %w[one_thing] },
+              taxon_tree: { all: %w[content_id_1 content_id_2] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
           assert_requested(req)
         end
       end
-    end
-    describe "organisation facet" do
-      let(:applied_filters) do
-        { "organisations" => %w[death-eaters ministry-of-magic] }
-      end
-      let(:facets) do
-        [
-          {
-            "facet_id" => "organisations",
-            "facet_name" => "Organisations",
-          },
-        ]
-      end
-      before :each do
-        stub_organisations_registry_request
-      end
-      it "asks email-alert-api to find or create the subscriber list" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            organisations: { any: %w[content_id_for_death-eaters content_id_for_ministry-of-magic] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
-          },
-        )
-        subject.signup_url
-        assert_requested(req)
-      end
-    end
 
-    describe "world facet" do
-      let(:applied_filters) do
-        { "world_locations" => %w[location_1 location_2] }
-      end
-      let(:facets) do
-        [
-          {
-            "facet_id" => "world_locations",
-            "facet_name" => "world locations",
-          },
-        ]
-      end
-      before :each do
-        stub_worldwide_api_has_locations(%w[location_1 location_2])
-      end
+      context "content_store_document_type" do
+        let(:applied_filters) do
+          { "content_store_document_type" => %w[document_type_1 document_type_2] }
+        end
 
-      it "asks email-alert-api to find or create the subscriber list" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            world_locations: { any: %w[content_id_for_location_1 content_id_for_location_2] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
-          },
-        )
-        subject.signup_url
-        assert_requested(req)
-      end
-    end
-    describe "people facet" do
-      let(:applied_filters) do
-        { "people" => %w[albus-dumbledore ron-weasley] }
-      end
-      let(:facets) do
-        [
-          {
-            "facet_id" => "people",
-            "facet_name" => "people",
-          },
-        ]
-      end
-      before :each do
-        stub_people_registry_request
+        let(:facets) do
+          [
+            {
+              "facet_id" => "content_store_document_type",
+              "facet_name" => "Document Type",
+            },
+            {
+              "facet_id" => "organisations",
+              "facet_name" => "Organisations",
+            },
+          ]
+        end
+
+        it "It does not convert values" do
+          req = stub_email_alert_api_has_subscriber_list(
+            "links" => {
+              content_store_document_type: { any: %w[document_type_1 document_type_2] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+            },
+          )
+          subject.signup_url
+          assert_requested(req)
+        end
+
+        context "handling default values" do
+          let(:default_filters) do
+            { "content_purpose_subgroup" => "one_thing" }
+          end
+
+          it "it converting scalar values to arrays" do
+            req = stub_email_alert_api_has_subscriber_list(
+              "links" => {
+                content_store_document_type: { any: %w[document_type_1 document_type_2] },
+                content_purpose_subgroup: { any: %w[one_thing] },
+              },
+            )
+            subject.signup_url
+            assert_requested(req)
+          end
+        end
       end
 
-      it "asks email-alert-api to find or create the subscriber list" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            people: { any: %w[content_id_for_albus-dumbledore content_id_for_ron-weasley] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
-          },
-        )
-        subject.signup_url
-        assert_requested(req)
+      context "organisation facet" do
+        let(:applied_filters) do
+          { "organisations" => %w[death-eaters ministry-of-magic] }
+        end
+
+        let(:facets) do
+          [{ "facet_id" => "organisations", "facet_name" => "Organisations" }]
+        end
+
+        before :each do
+          stub_organisations_registry_request
+        end
+
+        it "asks email-alert-api to find or create the subscriber list" do
+          req = stub_email_alert_api_has_subscriber_list(
+            "links" => {
+              organisations: { any: %w[content_id_for_death-eaters content_id_for_ministry-of-magic] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+            },
+          )
+          subject.signup_url
+          assert_requested(req)
+        end
       end
-    end
 
-    describe "roles facet" do
-      let(:applied_filters) do
-        { "roles" => %w[prime-minister] }
+      context "world facet" do
+        let(:applied_filters) do
+          { "world_locations" => %w[location_1 location_2] }
+        end
+
+        let(:facets) do
+          [{ "facet_id" => "world_locations", "facet_name" => "world locations" }]
+        end
+
+        before :each do
+          stub_worldwide_api_has_locations(%w[location_1 location_2])
+        end
+
+        it "asks email-alert-api to find or create the subscriber list" do
+          req = stub_email_alert_api_has_subscriber_list(
+            "links" => {
+              world_locations: { any: %w[content_id_for_location_1 content_id_for_location_2] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+            },
+          )
+          subject.signup_url
+          assert_requested(req)
+        end
       end
 
-      let(:facets) do
-        [
-          {
-            "facet_id" => "roles",
-            "facet_name" => "roles",
-          },
-        ]
+      context "people facet" do
+        let(:applied_filters) do
+          { "people" => %w[albus-dumbledore ron-weasley] }
+        end
+
+        let(:facets) do
+          [{ "facet_id" => "people", "facet_name" => "people" }]
+        end
+
+        before :each do
+          stub_people_registry_request
+        end
+
+        it "asks email-alert-api to find or create the subscriber list" do
+          req = stub_email_alert_api_has_subscriber_list(
+            "links" => {
+              people: { any: %w[content_id_for_albus-dumbledore content_id_for_ron-weasley] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+            },
+          )
+          subject.signup_url
+          assert_requested(req)
+        end
       end
 
-      before { stub_roles_registry_request }
+      context "roles facet" do
+        let(:applied_filters) do
+          { "roles" => %w[prime-minister] }
+        end
 
-      it "asks email-alert-api to find or create the subscriber list" do
-        req = stub_email_alert_api_has_subscriber_list(
-          "links" => {
-            roles: { any: %w[content_id_for_prime-minister] },
-            content_purpose_subgroup: { any: %w[news speeches_and_statements] },
-          },
-        )
+        let(:facets) do
+          [
+            {
+              "facet_id" => "roles",
+              "facet_name" => "roles",
+            },
+          ]
+        end
 
-        subject.signup_url
-        assert_requested(req)
+        before { stub_roles_registry_request }
+
+        it "asks email-alert-api to find or create the subscriber list" do
+          req = stub_email_alert_api_has_subscriber_list(
+            "links" => {
+              roles: { any: %w[content_id_for_prime-minister] },
+              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
+            },
+          )
+
+          subject.signup_url
+          assert_requested(req)
+        end
       end
     end
   end

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -300,10 +300,6 @@ describe EmailAlertSignupAPI do
     end
 
     context "Create link based subscriber lists" do
-      let(:default_filters) do
-        { "content_purpose_subgroup": %w[news speeches_and_statements] }
-      end
-
       context "part_of_taxonomy_tree facet" do
         let(:applied_filters) do
           { "all_part_of_taxonomy_tree" => %w[content_id_1 content_id_2] }
@@ -322,7 +318,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               taxon_tree: { all: %w[content_id_1 content_id_2] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
@@ -352,7 +347,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               content_store_document_type: { any: %w[document_type_1 document_type_2] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
@@ -394,7 +388,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               organisations: { any: %w[content_id_for_death-eaters content_id_for_ministry-of-magic] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
@@ -419,7 +412,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               world_locations: { any: %w[content_id_for_location_1 content_id_for_location_2] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
@@ -444,7 +436,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               people: { any: %w[content_id_for_albus-dumbledore content_id_for_ron-weasley] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
           subject.signup_url
@@ -472,7 +463,6 @@ describe EmailAlertSignupAPI do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               roles: { any: %w[content_id_for_prime-minister] },
-              content_purpose_subgroup: { any: %w[news speeches_and_statements] },
             },
           )
 

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -40,7 +40,7 @@ describe EmailAlertSignupAPI do
         { "content_purpose_supergroup" => "news_and_communications" }
       end
 
-      it "will send email_alert_api the default attributes" do
+      it "calls the API" do
         req = stub_email_alert_api_has_subscriber_list(
           "tags" => { content_purpose_supergroup: { any: %w[news_and_communications] } },
         )
@@ -79,7 +79,7 @@ describe EmailAlertSignupAPI do
       end
 
       context "with multiple choices selected and a title prefix" do
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -99,7 +99,7 @@ describe EmailAlertSignupAPI do
             alert_type: %w[first],
           }
         end
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[other-reports test-reports] },
@@ -113,7 +113,7 @@ describe EmailAlertSignupAPI do
       end
 
       context "without a title prefix" do
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -130,7 +130,7 @@ describe EmailAlertSignupAPI do
         let(:facets) { [] }
         let(:default_filters) { { "format" => "test-reports" } }
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -193,7 +193,7 @@ describe EmailAlertSignupAPI do
       end
 
       context "with multiple choices selected and a title prefix" do
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -216,7 +216,7 @@ describe EmailAlertSignupAPI do
           }
         end
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -231,7 +231,7 @@ describe EmailAlertSignupAPI do
       end
 
       context "without a title prefix" do
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -249,7 +249,7 @@ describe EmailAlertSignupAPI do
         let(:facets) { [] }
         let(:default_filters) { { "format" => "test-reports" } }
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "tags" => {
               format: { any: %w[test-reports] },
@@ -287,7 +287,7 @@ describe EmailAlertSignupAPI do
         ]
       end
 
-      it "asks email-alert-api to find or create the subscriber list" do
+      it "calls the API" do
         req = stub_email_alert_api_has_subscriber_list(
           "tags" => {
             persons: { any: %w[harry_potter harry john] },
@@ -299,7 +299,7 @@ describe EmailAlertSignupAPI do
       end
     end
 
-    context "Create link based subscriber lists" do
+    context "with link-based facets" do
       context "part_of_taxonomy_tree facet" do
         let(:applied_filters) do
           { "all_part_of_taxonomy_tree" => %w[content_id_1 content_id_2] }
@@ -314,7 +314,7 @@ describe EmailAlertSignupAPI do
           ]
         end
 
-        it "translates all_part_of_taxonomy_tree to taxon_tree and does not convert values" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               taxon_tree: { all: %w[content_id_1 content_id_2] },
@@ -343,7 +343,7 @@ describe EmailAlertSignupAPI do
           ]
         end
 
-        it "It does not convert values" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               content_store_document_type: { any: %w[document_type_1 document_type_2] },
@@ -358,7 +358,7 @@ describe EmailAlertSignupAPI do
             { "content_purpose_subgroup" => "one_thing" }
           end
 
-          it "it converting scalar values to arrays" do
+          it "converts scalar values to arrays" do
             req = stub_email_alert_api_has_subscriber_list(
               "links" => {
                 content_store_document_type: { any: %w[document_type_1 document_type_2] },
@@ -384,7 +384,7 @@ describe EmailAlertSignupAPI do
           stub_organisations_registry_request
         end
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               organisations: { any: %w[content_id_for_death-eaters content_id_for_ministry-of-magic] },
@@ -408,7 +408,7 @@ describe EmailAlertSignupAPI do
           stub_worldwide_api_has_locations(%w[location_1 location_2])
         end
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               world_locations: { any: %w[content_id_for_location_1 content_id_for_location_2] },
@@ -432,7 +432,7 @@ describe EmailAlertSignupAPI do
           stub_people_registry_request
         end
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               people: { any: %w[content_id_for_albus-dumbledore content_id_for_ron-weasley] },
@@ -449,17 +449,12 @@ describe EmailAlertSignupAPI do
         end
 
         let(:facets) do
-          [
-            {
-              "facet_id" => "roles",
-              "facet_name" => "roles",
-            },
-          ]
+          [{ "facet_id" => "roles", "facet_name" => "roles" }]
         end
 
         before { stub_roles_registry_request }
 
-        it "asks email-alert-api to find or create the subscriber list" do
+        it "calls the API" do
           req = stub_email_alert_api_has_subscriber_list(
             "links" => {
               roles: { any: %w[content_id_for_prime-minister] },


### PR DESCRIPTION
Previously these were hard to maintain [1], due to the amount of
repetition and confusing structure. The commits in this PR are an
attempt to incrementally improve the tests.

[1]: https://github.com/alphagov/finder-frontend/pull/2353


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️