### PR TITLE
Import new actions for 28th December

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -43,9 +43,9 @@ actions:
   consequence: You will be charged for your NHS healthcare if you do not have the
     right insurance.
   guidance_prompt: More information
-  guidance_link_text: 'Healthcare from 2021: citizens of the EU, Norway, Iceland,
-    Liechtenstein and Switzerland visiting the UK'
-  guidance_url: https://www.gov.uk/guidance/healthcare-for-eu-and-efta-citizens-visiting-the-uk
+  guidance_link_text: Healthcare for visitors to the UK from the EU from 1 January
+    2021
+  guidance_url: https://www.gov.uk/guidance/healthcare-for-visitors-to-the-uk-from-the-eu-from-1-january-2021
   criteria:
   - all_of:
     - any_of:
@@ -154,14 +154,15 @@ actions:
   - visiting-ie
 - id: S011
   priority: 9
-  title: Take out appropriate travel insurance with health cover before travelling
-    to the EU
+  title: Check you’ve got an EHIC card or appropriate travel insurance with health
+    cover before travelling to the EU, Switzerland, Norway, Iceland or Liechtenstein
   consequence: You may not have access to free emergency medical treatment and could
-    be charged for your healthcare if you do not get health cover with your travel
-    insurance.
+    be charged for your healthcare if you do not have an EHIC card when visiting an
+    EU country, or appropriate travel insurance when visiting Switzerland, Norway,
+    Iceland or Liechtenstein.
   guidance_prompt: More information
-  guidance_link_text: Foreign travel insurance
-  guidance_url: https://www.gov.uk/guidance/foreign-travel-insurance
+  guidance_link_text: Apply for a free European Health Insurance Card (EHIC)
+  guidance_url: https://www.nhs.uk/using-the-nhs/healthcare-abroad/apply-for-a-free-ehic-european-health-insurance-card/
   criteria:
   - all_of:
     - nationality-uk
@@ -909,10 +910,12 @@ actions:
   priority: 6
   title: Check what documents you need to run bus or coach services in EU countries
   consequence: You may not be able to run bus or coach services in EU countries if
-    you do have the right documents or not request authorisation in time.
+    you do not request authorisation in time or have the right documents.
+  lead_time: It takes up to 6 months to get a special regular international service
+    authorised.
   guidance_prompt: More information
-  guidance_link_text: 'International bus and coach services: operator licences and
-    permits'
+  guidance_link_text: Run international bus or coach services and tours from 1 January
+    2021
   guidance_url: https://www.gov.uk/guidance/run-international-bus-or-coach-services-and-tours-from-1-january-2021
   criteria:
   - any_of:
@@ -1009,15 +1012,18 @@ actions:
 - id: T081
   priority: 5
   title: Check what you need to do to continue to work or provide legal services in
-    the UK, if you're a lawyer with a qualification from the EU, Norway, Iceland or
-    Liechtenstein
+    the UK, if you're a lawyer with a qualification from the EU, Switzerland, Norway,
+    Iceland or Liechtenstein
   consequence: You risk not being able to continue working or providing legal services
     in the UK if you do not prepare.
   guidance_prompt: More information
-  guidance_link_text: EU lawyers in the UK from 1 January 2021
+  guidance_link_text: Lawyers from the EU, Switzerland, Norway, Iceland or Liechtenstein
+    in the UK from 1 January 2021
   guidance_url: https://www.gov.uk/government/publications/eu-lawyers-in-the-uk-from-1-january-2021
   criteria:
-  - legal-service
+  - all_of:
+    - legal-service
+    - working-uk
   audience: business
 - id: T082
   priority: 5
@@ -1280,6 +1286,24 @@ actions:
   criteria:
   - import-from-eu
   audience: business
+- id: S037
+  priority: 9
+  title: Check each country’s entry requirements if you want to work, study or spend
+    more than 90 of any 180 days in the EU, Switzerland, Norway, Iceland or Liechtenstein
+  consequence: You may be refused entry if you do not have the correct visa or work
+    permit.
+  guidance_prompt: More information
+  guidance_link_text: UK nationals visiting the EU
+  guidance_url: https://www.gov.uk/foreign-travel-advice
+  criteria:
+  - any_of:
+    - visiting-eu
+    - studying-eu
+    - move-to-eu
+    - working-eu
+  audience: citizen
+  grouping_criteria:
+  - visiting-eu
 - id: S038
   priority: 6
   title: Sign up for email updates if you're a UK national living in the EU, Switzerland,
@@ -1501,12 +1525,12 @@ actions:
 - id: T117
   priority: 5
   title: Contact your regulator if you are a UK lawyer working permanently in the
-    EU, Norway, Iceland or Liechtenstein
+    EU, Switzerland, Norway, Iceland or Liechtenstein
   consequence: You risk not being able to continue providing legal services in the
     same way if you do not meet new requirements.
   guidance_prompt: More information
-  guidance_link_text: UK laywers practising in the EU, Norway, Iceland or Liechtenstein
-    from 1 January 2021
+  guidance_link_text: UK lawyers practising in the EU, Switzerland, Norway, Iceland
+    or Liechtenstein from 1 January 2021
   guidance_url: https://www.gov.uk/government/publications/uk-lawyers-practising-in-the-eu-norway-iceland-or-liechtenstein-from-1-january-2021/uk-lawyers-practising-in-the-eu-norway-iceland-or-liechtenstein-after-1-january-2021
   criteria:
   - all_of:
@@ -1687,3 +1711,54 @@ actions:
     - consumer-goods
     - retail-wholesale-x-food-drink-motors
   audience: business
+- id: T129
+  priority: 7
+  title: Apply for a Kent Access Permit (KAP) if your HGV is over 7.5 tonnes and you
+    are leaving Great Britain for the EU from the Port of Dover or Eurotunnel
+  consequence: From 1 January 2021, if you do not have a valid permit you will not
+    be able to travel from the Port of Dover or Eurotunnel to the EU, and you may
+    be fined.
+  guidance_prompt: More information
+  guidance_link_text: Apply for a Kent Access Permit
+  guidance_url: https://www.gov.uk/check-hgv-border
+  criteria:
+  - haulage-goods-across-eu-borders
+  audience: business
+- id: S044
+  priority: 2
+  title: Check where you need to pay social security contributions if you’re coming
+    from the EU, Switzerland, Norway, Iceland or Liechtenstein to work in the UK
+  consequence: You risk paying contributions in the wrong country and affecting your
+    entitlement to benefits if you do not complete the correct form.
+  guidance_prompt: More information
+  guidance_link_text: Social security contributions for workers coming to the UK from
+    the EEA or Switzerland from 1 January 2021
+  guidance_url: https://www.gov.uk/guidance/social-security-contributions-for-workers-coming-to-the-uk-from-the-eea-or-switzerland-from-1-january-2021
+  criteria:
+  - all_of:
+    - any_of:
+      - nationality-eu
+      - living-eu
+    - working-uk
+  audience: citizen
+  grouping_criteria:
+  - working-uk
+- id: S045
+  priority: 2
+  title: Check where you need to pay social security contributions if you’re going
+    from the UK to work in the EU, Switzerland, Norway, Iceland or Liechtenstein
+  consequence: You risk paying contributions in the wrong country and affecting your
+    entitlement to benefits if you do not complete the correct form.
+  guidance_prompt: More information
+  guidance_link_text: National Insurance for workers from the UK working in the EEA
+    or Switzerland from 1 January 2021
+  guidance_url: https://www.gov.uk/guidance/national-insurance-for-workers-from-the-uk-working-in-the-eea-or-switzerland-from-1-january-2021
+  criteria:
+  - all_of:
+    - any_of:
+      - nationality-uk
+      - living-uk
+    - working-eu
+  audience: citizen
+  grouping_criteria:
+  - working-eu

--- a/app/lib/brexit_checker/notifications.yaml
+++ b/app/lib/brexit_checker/notifications.yaml
@@ -23,24 +23,44 @@ notifications:
         - visiting-eu
   # End of example block.
   # Add new notifications below 👇
-  - uuid: aa05e643-8d52-40cf-bf67-123eccf10ebc
+  - uuid: 3c1084ae-2e3c-4d0a-89aa-102230accaa6
     type: addition
-    action_id: S035
-    date: '2020-12-23'
-  - uuid: 45ae9772-90bb-4681-b0ad-ed28e714928c
+    action_id: T129
+    date: "2020-12-28"
+  - uuid: 3fd8761e-41e2-474a-b105-84ef2546b7c1
     type: addition
-    action_id: T126
-    date: '2020-12-23'
-  - uuid: 1bfa8383-1d66-4d03-bbb7-0382e753dcfc
+    action_id: S037
+    date: "2020-12-28"
+  - uuid: 031cd676-ea84-46e0-8298-16ff74b0a981
     type: addition
-    action_id: T127
-    date: '2020-12-23'
-  - uuid: aa5c7da3-719d-4e03-a5b5-f0ef81d5b8dc
+    action_id: S044
+    date: "2020-12-28"
+  - uuid: 51666546-3303-4ecb-8a9e-21e7573160c0
     type: addition
-    action_id: T128
-    date: '2020-12-23'
-  - uuid: a6a2558b-1666-451a-84aa-ec540dc4af78
+    action_id: S045
+    date: "2020-12-28"
+  - uuid: 2421ad66-e1bc-4f99-908b-0dec41d957b9
     type: content_change
-    action_id: S009
-    date: '2020-12-23'
-    note: Clarified that you need to contact your vet at least 1 month before travelling to the EU if you want to take your pet or assistance dog with you.
+    action_id: T081
+    date: "2020-12-28"
+    note: "Clarified that this action also applies to lawyers with qualifications from Switzerland."
+  - uuid: 63053034-af75-4875-8296-bf3494b83b10
+    type: content_change
+    action_id: T117
+    date: "2020-12-28"
+    note: "Clarified that the action also applies to UK lawyers working permanently in Switzerland."
+  - uuid: 2938d029-ff67-47a9-aace-7c9637ed5f76
+    type: content_change
+    action_id: S004
+    date: "2020-12-28"
+    note: "Link changed to provide updated guidance on health."
+  - uuid: 798dd12d-8577-43fe-a311-80affcd1dcbf
+    type: content_change
+    action_id: S011
+    date: "2020-12-28"
+    note: "Action updated to clarify you may be charged for healthcare if you do not have an EHIC card when visiting the EU, or appropriate travel insurance when visiting Switzerland, Norway, Iceland or Liechtenstein."
+  - uuid: 398e8da6-b1bd-4568-9f29-bb06d6ab510e
+    type: content_change
+    action_id: T063
+    date: "2020-12-28"
+    note: "Special regular international services will need to be authorised from 1 July 2021. Action updated to clarify that you'll need to apply for authorisation and that this can take up to 6 months."


### PR DESCRIPTION
Imported from the canonical sheet by running:

`govuk-docker-run bundle exec rake brexit_checker:convert_csv_to_yaml:actions_from_google_drive`

The previous notification content has been overwritten - viewing the diff is less helpful than just looking at the file in its
entirety. Notifications were generated by running:

`govuk-docker-run bundle exec rake brexit_checker:configure_notifications NEW_ACTIONS="T129 S037 S044 S045" CHANGED_ACTIONS="T081 T117 S004 S011 T063"` and then filling in the change notes.

New actions:

- S037
- S044
- S045
- T129

Changed actions:

- S004
- S011
- T063
- T081
- T117

Although T081 has new criteria, the content of the action has changed, so we don't need to use any custom configuration to only send a notification to a subset of the affected people.

Change notes have come from the Trello card and has been through content 2i

https://trello.com/c/IYIFwPve/737-batch-update-action-card-28-december

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
