### PR TITLE
Fix invalid groupings

### DIFF
--- a/app/lib/brexit_checker/groups.yaml
+++ b/app/lib/brexit_checker/groups.yaml
@@ -21,6 +21,9 @@ groups:
 - key: working-uk
   heading: Working in the UK
   priority: 5
+- key: working-eu
+  heading: Working in the EU
+  priority: 5
 - key: studying-eu
   heading: Studying in the EU
   priority: 4

--- a/app/lib/brexit_checker/validators/group_validator.rb
+++ b/app/lib/brexit_checker/validators/group_validator.rb
@@ -6,6 +6,7 @@ class BrexitChecker::Validators::GroupValidator < ActiveModel::Validator
                      living-ie
                      living-uk
                      working-uk
+                     working-eu
                      studying-eu
                      studying-uk
                      common-travel-area ].freeze

--- a/spec/lib/brexit_checker/group_spec.rb
+++ b/spec/lib/brexit_checker/group_spec.rb
@@ -49,16 +49,27 @@ RSpec.describe BrexitChecker::Group do
       allow(BrexitChecker::Action).to receive(:load_all).and_return([action1, action2, action3])
     end
 
-    it "retuns an action when a grouping_criteira matches the group key" do
+    it "returns an action when a grouping_criteria matches the group key" do
       expect(group1.actions).to match_array([action1])
     end
 
-    it "retuns multiple actions when multiple grouping_criteira match the group key" do
+    it "returns multiple actions when multiple grouping_criteria match the group key" do
       expect(group2.actions).to match_array([action2, action3])
     end
 
-    it "retuns an empty array when no action's grouping_criteira match the group key" do
+    it "returns an empty array when no action's grouping_criteria match the group key" do
       expect(group3.actions).to match_array([])
+    end
+  end
+
+  describe "live actions" do
+    it "ensure that actions.yaml contains valid groupings" do
+      configured_groupings = BrexitChecker::Action.load_all
+        .select { |action| action.grouping_criteria.present? }
+        .flat_map(&:grouping_criteria).sort.uniq
+      expected_groupings = BrexitChecker::Validators::GroupValidator::CITIZEN_KEYS
+
+      expect(configured_groupings).to match_array(expected_groupings)
     end
   end
 end


### PR DESCRIPTION
New grouping criteria must be configured in [groups.yaml](https://github.com/alphagov/finder-frontend/blob/736bb24164cd76f00710d7c0ea622948c9711a44/app/lib/brexit_checker/groups.yaml) and [group_validator](https://github.com/alphagov/finder-frontend/blob/736bb24164cd76f00710d7c0ea622948c9711a44/app/lib/brexit_checker/validators/group_validator.rb) before being shipped, otherwise things start to error.

This adds a test that validates that actions.yaml only contains groupings that can actually be honoured by the app. This [test failed in Jenkins](https://ci.integration.publishing.service.gov.uk/job/finder-frontend/job/validate-groupings/1/console) proving that we fix the error in the next commit.

The fix in the second commit means that [S045](https://github.com/alphagov/finder-frontend/blob/master/app/lib/brexit_checker/actions.yaml#L1764) will no longer error, because the grouping configuration is now present.

Resolves: https://sentry.io/organizations/govuk/issues/2117074487/?project=202224&query=is%3Aunresolved

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
