### PR TITLE
Update title for Brexit Checker subscriber lists

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -172,7 +172,7 @@ private
     path = transition_checker_results_path(c: criteria_keys)
 
     {
-      "title" => "Get ready for 2021",
+      "title" => "Brexit checker results",
       "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
       "url" => path,
     }

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
 
   let(:subscriber_list) do
     {
-      "title" => "Get ready for 2021",
+      "title" => "Brexit checker results",
       "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
       "tags" => { "brexit_checklist_criteria" => { "any" => %w[nationality-eu] } },
       "url" => "/transition-check/results?c%5B%5D=nationality-eu",


### PR DESCRIPTION
https://trello.com/c/RHB4pu1A/748-change-get-ready-for-2021-to-brexit-checker-results

We will separately update existing list titles in Email Alert API.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️