### PR TITLE
Update template for Brexit checker emails

### DIFF
--- a/app/views/brexit_checker_mailer/change_notification.text.erb
+++ b/app/views/brexit_checker_mailer/change_notification.text.erb
@@ -1,4 +1,4 @@
-<%= t("brexit_checker_mailer.change_notification.#{@notification.type}") %>
+# <%= t("brexit_checker_mailer.change_notification.#{@notification.type}") %>
 
 <% if @action.title_url.present? %>
 [<%= @action.title %>](<%= notification_email_link(@action.title_url, @notification) %>)

--- a/app/views/brexit_checker_mailer/change_notification.text.erb
+++ b/app/views/brexit_checker_mailer/change_notification.text.erb
@@ -11,14 +11,14 @@
 <% if @action.exception.present? %><%= @action.exception %><% end %>
 
 <% if @action.guidance_url.present? %>
-<%= @action.guidance_prompt || t("brexit_checker_mailer.change_notification.guidance_prompt") %>
+<%= @action.guidance_prompt || t("brexit_checker_mailer.change_notification.guidance_prompt") %>:
 [<%= @action.guidance_link_text %>](<%= notification_email_link(@action.guidance_url, @notification)  %>)
 <% end %>
 
-Updated
+Updated:
 <%= Date.parse(@notification.date).strftime("%-d %B %Y") %>
 
 <% if @notification.note.present? %>
-Changes made
+Changes made:
 <%= @notification.note %>
 <% end %>

--- a/config/locales/en/brexit_checker_mailer/change_notification.yml
+++ b/config/locales/en/brexit_checker_mailer/change_notification.yml
@@ -2,6 +2,6 @@ en:
   brexit_checker_mailer:
     change_notification:
       guidance_prompt: Read the guidance
-      title: Your transition period results
+      title: Brexit checker results
       addition: A new action has been added
       content_change: An action has been updated

--- a/config/locales/en/brexit_checker_mailer/change_notification.yml
+++ b/config/locales/en/brexit_checker_mailer/change_notification.yml
@@ -3,5 +3,5 @@ en:
     change_notification:
       guidance_prompt: Read the guidance
       title: Brexit checker results
-      addition: A new action has been added
-      content_change: An action has been updated
+      addition: New action
+      content_change: Updated action


### PR DESCRIPTION
Depends on: https://github.com/alphagov/email-alert-api/pull/1538

Please see the commits for more details.

## Before

<img width="294" alt="Screenshot 2020-12-30 at 17 06 25" src="https://user-images.githubusercontent.com/9029009/103369184-5fb87600-4ac1-11eb-9f77-a61e7fa54291.png">

## After

<img width="312" alt="Screenshot 2020-12-31 at 10 33 36" src="https://user-images.githubusercontent.com/9029009/103406729-ab1b6480-4b53-11eb-9d3a-f8d5e05b53fd.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️