### PR TITLE
Update wording on the brexit email signup page

### DIFF
--- a/config/locales/en/brexit_checker/email_signup.yml
+++ b/config/locales/en/brexit_checker/email_signup.yml
@@ -1,11 +1,11 @@
 en:
   brexit_checker:
     email_signup:
-      title: "How to get ready for new rules in 2021"
+      title: "Get email alerts about your Brexit checker results"
       sign_up_heading: "Get email alerts about your results"
       sign_up_message: |
-        <p class="govuk-body">You're signing up for email updates about changes to your results because of any additional arrangements between the UK and EU.</p>
-        <p class="govuk-body">The emails will tell you what you, your family, or your business should do to prepare for new rules from 1 January 2021.</p>
+        <p class="govuk-body">You're signing up for email updates about changes to your results.</p>
+        <p class="govuk-body">The emails will give you a personalised list of Brexit actions for you, your family and your business.</p>
         <p class="govuk-body">You will only get updates if:</p>
       sign_up_message_criteria:
         <li>there are changes to your results</li>


### PR DESCRIPTION
Updated wording on the Brexit "Get email alerts about your results" page
to reflect the end of the transition period.

Content updates are based on the suggestions made by the Brexit content team here https://docs.google.com/document/d/15UCLGvm73dM5l9wfI4orPd1eyR-MAcy7J9qKOtA-UOU/edit 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
