### PR TITLE
Remove description truncation

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,11 +46,6 @@ class Document
     link
   end
 
-  def truncated_description
-    # This truncates the description at the end of the first sentence
-    description.gsub(/\.\s[A-Z].*/, ".") if description.present?
-  end
-
 private
 
   attr_reader :link, :document_hash

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -11,7 +11,7 @@ class EntryPresenter
   end
 
   def summary
-    @entry.truncated_description if show_summaries
+    @entry.description if show_summaries
   end
 
   def tag(schema)

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -45,7 +45,7 @@ private
   end
 
   def summary_text
-    document.truncated_description if content_item.show_summaries?
+    document.description if content_item.show_summaries?
   end
 
   def subtext

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -152,22 +152,4 @@ describe Document do
       expect(Document.new(document_hash, nil).es_score).to eq 0.005
     end
   end
-
-  describe "#truncated_description" do
-    describe "shows the truncated (first sentence) description when a description is present" do
-      description = "The government has many departments. These departments are part of the government."
-      truncated_description = "The government has many departments."
-
-      let(:with_description_hash) { FactoryBot.build(:document_hash, description_with_highlighting: description) }
-      let(:without_description) { FactoryBot.build(:document_hash, description_with_highlighting: nil) }
-
-      it "should have truncated description" do
-        expect(Document.new(with_description_hash, 1).truncated_description).to eq(truncated_description)
-      end
-
-      it "should not have truncated description" do
-        expect(Document.new(without_description, 1).truncated_description).to eq(nil)
-      end
-    end
-  end
 end

--- a/spec/presenters/entry_presenter_spec.rb
+++ b/spec/presenters/entry_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EntryPresenter do
       FactoryBot.build(:document, description_with_highlighting: "This is the summary. And this is extra.")
     end
     it "displays the truncated description" do
-      expect(EntryPresenter.new(document, true).summary).to eq("This is the summary.")
+      expect(EntryPresenter.new(document, true).summary).to eq("This is the summary. And this is extra.")
     end
     it "returns nil" do
       expect(EntryPresenter.new(document, false).summary).to be nil

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SearchResultPresenter do
         link: {
           text: title,
           path: link,
-          description: "I am a document.",
+          description: "I am a document. I am full of words and that.",
           data_attributes: {
             ecommerce_path: link,
             ecommerce_row: 1,


### PR DESCRIPTION
[Search-api truncates the description](https://github.com/alphagov/search-api/blob/master/lib/search/presenters/highlighted_description.rb#L48) anyway. Truncating it after the first sentence is annoyingly constraining, and leads to people using hyphens instead of full stops to cram in the information that they think is useful.

It would be better to fix bad descriptions than remove the useful context that good descriptions can give users.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
