### PR TITLE
Fix checker/accounts paths redirecting for suspended account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,6 +97,7 @@ private
     accounts_available?
   end
 
+  helper_method :account_feature_flag_enabled?
   def account_feature_flag_enabled?
     Rails.configuration.feature_flag_govuk_accounts
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,15 +83,25 @@ private
   end
 
   def check_accounts_enabled
-    unless accounts_enabled?
+    if account_feature_flag_enabled?
+      redirect_to Services.accounts_api unless accounts_available?
+    else
       render file: Rails.root.join(Rails.root, "public/404.html"), status: :not_found
     end
   end
 
   helper_method :accounts_enabled?
   def accounts_enabled?
-    return false unless Rails.configuration.feature_flag_govuk_accounts
+    return false unless account_feature_flag_enabled?
 
+    accounts_available?
+  end
+
+  def account_feature_flag_enabled?
+    Rails.configuration.feature_flag_govuk_accounts
+  end
+
+  def accounts_available?
     if @check_accounts_available.nil?
       @check_accounts_available = true
       begin

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -143,7 +143,7 @@ private
   end
 
   def set_account_variant
-    return unless accounts_enabled?
+    return unless account_feature_flag_enabled?
     return unless show_signed_in_header? || show_signed_out_header?
 
     account_variant.configure_response(response)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  before_action :check_accounts_enabled
+  before_action :check_accounts_enabled, except: [:delete]
 
   def create
     redirect_with_ga account_manager_url and return if logged_in?

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -8,40 +8,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
     stub_request(:get, Services.accounts_api).to_return(status: 200)
   end
 
-  context "without accounts enabled" do
-    let(:mock_results) { %w[nationality-eu] }
-
-    context "/transition-check/saved-results" do
-      it "returns a 404" do
-        given_i_am_on_the_saved_results_page
-        expect(page.status_code).to eq(404)
-      end
-    end
-
-    context "/transition-check/edit-saved-results" do
-      it "returns a 404" do
-        given_i_am_on_the_edit_saved_results_page
-        expect(page.status_code).to eq(404)
-      end
-    end
-
-    def given_i_am_on_a_question_page
-      visit transition_checker_questions_path
-    end
-
-    def given_i_am_on_the_results_page
-      visit transition_checker_results_path(c: mock_results)
-    end
-
-    def given_i_am_on_the_saved_results_page
-      visit transition_checker_saved_results_path
-    end
-
-    def given_i_am_on_the_edit_saved_results_page
-      visit transition_checker_edit_saved_results_path
-    end
-  end
-
   context "accounts is enabled but not returning JWT" do
     let(:criteria_keys) { %i[nationality-eu] }
 

--- a/spec/requests/account_disabled_spec.rb
+++ b/spec/requests/account_disabled_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+RSpec.describe "When account is disabled", type: :request do
+  before do
+    allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(false)
+  end
+
+  describe "/login" do
+    it "shows the user the 404 page" do
+      get transition_checker_new_session_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/login/callback" do
+    it "shows the user the 404 page" do
+      get transition_checker_new_session_callback_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/logout" do
+    it "shows the user the 404 page" do
+      get transition_checker_end_session_path
+
+      expect(response.body).to eq("Redirecting to #{Services.accounts_api}/sign-out?continue=1")
+    end
+
+    context "With a continue parameter" do
+      it "shows the user the 404 page" do
+        get transition_checker_end_session_path, params: { continue: 1 }
+
+        expect(response.body).to eq("Redirecting to #{Services.accounts_api}/sign-out?done=1")
+      end
+    end
+
+    context "With a done parameter" do
+      it "Redirects user to /transition" do
+        get transition_checker_end_session_path, params: { done: 1 }
+
+        expect(response.body).to eq("Redirecting to /transition")
+      end
+    end
+  end
+
+  describe "/save-your-results" do
+    it "shows the user the 404 page" do
+      get transition_checker_save_results_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/save-your-results/confirm" do
+    it "shows the user the 404 page" do
+      get transition_checker_save_results_confirm_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/save-your-results/email-signup" do
+    it "shows the user the 404 page" do
+      get transition_checker_save_results_email_signup_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/saved-results" do
+    it "shows the user the 404 page" do
+      get transition_checker_saved_results_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "/edit-saved-results" do
+    it "shows the user the 404 page" do
+      get transition_checker_edit_saved_results_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/account_suspended_spec.rb
+++ b/spec/requests/account_suspended_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+
+RSpec.describe "When account is enabled", type: :request do
+  before do
+    allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
+  end
+
+  context "and accounts is returning a 503 error code" do
+    before { stub_request(:get, Services.accounts_api).to_return(status: 503) }
+
+    describe "/login" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_new_session_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/login/callback" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_new_session_callback_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/logout" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_end_session_path
+
+        expect(response.body).to eq("Redirecting to #{Services.accounts_api}/sign-out?continue=1")
+      end
+
+      context "With a continue parameter" do
+        it "redirects a user to the accounts 503 error page" do
+          get transition_checker_end_session_path, params: { continue: 1 }
+
+          expect(response.body).to eq("Redirecting to #{Services.accounts_api}/sign-out?done=1")
+        end
+      end
+
+      context "With a done parameter" do
+        it "redirects a user to /transition" do
+          get transition_checker_end_session_path, params: { done: 1 }
+
+          expect(response.body).to eq("Redirecting to /transition")
+        end
+      end
+    end
+
+    describe "/save-your-results" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_save_results_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/save-your-results/confirm" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_save_results_confirm_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/save-your-results/email-signup" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_save_results_email_signup_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/saved-results" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_saved_results_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+
+    describe "/edit-saved-results" do
+      it "redirects a user to the accounts 503 error page" do
+        get transition_checker_edit_saved_results_path
+
+        expect(response).to redirect_to(Services.accounts_api)
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/LaSdrZyI/459-feature-turn-off-accounts)

https://github.com/alphagov/finder-frontend/pull/2369 focused on what the user could see on the results page, so effectively which journies the user could start after a point where we suspended accounts.

Turned out there were a number of account specific paths that would still be in place if we suspended the account.

We want to be in a position where:
- if we remove the feature flag those paths all correctly 404
- if a user is already on a journey which features one of those paths (so they probably started before we suspended accounts) their journey is halted and we redirect them to the accounts service URL which will, by then be showing a 503 error message explaining why accounts has gone away.

This is part of a wider piece of work to allow us to enable a planned and temporary suspension of accounts should we ever need to for maintainace or in response to an incident.
