### PR TITLE
Update error copy / design for email signup

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/radio

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
 @import 'govuk_publishing_components/components/feedback';
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/heading';

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -58,14 +58,6 @@ mark {
   }
 }
 
-.signup-choices__message {
-  margin-bottom: govuk-spacing(3);
-  padding: govuk-spacing(3);
-  color: $govuk-error-colour;
-  font-weight: bold;
-  border-left: solid 4px $govuk-error-colour;
-}
-
 .live-search-loading-message {
   margin-bottom: govuk-spacing(4);
   display: none;

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -8,7 +8,7 @@ class EmailAlertSubscriptionsController < ApplicationController
     validate_choices!
     redirect_to email_alert_signup_api.signup_url
   rescue MissingFiltersError
-    render_error "Please choose an email alert"
+    render_error "Select at least one option"
   rescue UnprocessableFilterAlertParamsError
     render_error "There was a problem with your chosen filters. Please try again."
   rescue EmailAlertSignupAPI::UnprocessableSubscriberListError

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -15,16 +15,26 @@
         title: @signup_presenter.name,
       } %>
 
+      <% if @error_message.present? %>
+        <%= render "govuk_publishing_components/components/error_summary", {
+          title: "There is a problem",
+          items: [
+            {
+              text: @error_message,
+              href: "#signup-choices-options",
+            }
+          ]
+        } %>
+      <% end %>
+
       <%= render "govuk_publishing_components/components/checkboxes", {
+        id: "signup-choices-options",
         name: nil,
         no_hint_text: true,
         heading: t("email_alert_subscriptions.new.question"),
         items: @signup_presenter.choices_formatted,
+        error: @error_message,
       } %>
-
-      <% if @error_message.present? %>
-        <p class="signup-choices__message"><%= @error_message %></p>
-      <% end %>
 
     <% else %>
 

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -188,6 +188,11 @@ Feature: Filtering documents
     When I use a checkbox filter and another disallowed filter
     Then I can sign up to email alerts for allowed filters
 
+  Scenario: Subscribing to email alerts with missing filters
+    Given a collection of documents exist that can be filtered by checkbox
+    When I do not select any of the filters on the signup page
+    Then I see an error about selecting at least one option
+
   @javascript
   Scenario: Filter documents by keywords and sort by most relevant
     When I view the news and communications finder

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -770,7 +770,7 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
 end
 
 Then("I see an error about selecting at least one option") do
-  expect(page).to have_content("Please choose an email alert")
+  expect(page).to have_content("Select at least one option")
 end
 
 When("I create an email subscription") do

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -736,6 +736,17 @@ When(/^I use a checkbox filter and another disallowed filter$/) do
   end
 end
 
+When("I do not select any of the filters on the signup page") do
+  step("I use a checkbox filter")
+  stub_content_store_has_item("/cma-cases/email-signup", cma_cases_with_multi_facets_signup_content_item)
+
+  within "#subscription-links-footer" do
+    click_link("Get emails")
+  end
+
+  click_on("Continue")
+end
+
 Then(/^I can sign up to email alerts for allowed filters$/) do
   stub_email_alert_api_has_subscriber_list(
     "tags" => {
@@ -756,6 +767,10 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
 
   click_on("Continue")
   expect(page.current_path).to eq("/email/subscriptions/new")
+end
+
+Then("I see an error about selecting at least one option") do
+  expect(page).to have_content("Please choose an email alert")
 end
 
 When("I create an email subscription") do

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -738,7 +738,10 @@ end
 
 Then(/^I can sign up to email alerts for allowed filters$/) do
   stub_email_alert_api_has_subscriber_list(
-    "tags" => { "case_type" => { any: %w[ca98-and-civil-cartels] }, "format" => { any: %w[cma_case] } },
+    "tags" => {
+      "case_type" => { any: %w[competition-disqualification] },
+      "case_state" => { any: %w[open closed] },
+    },
     "subscription_url" => "http://www.rathergood.com",
   )
 
@@ -748,12 +751,11 @@ Then(/^I can sign up to email alerts for allowed filters$/) do
     click_link("Get emails")
   end
 
-  begin
-    click_on("Continue")
-  rescue ActionController::RoutingError
-    expect(page.status_code).to eq(302)
-    expect(page.response_headers["Location"]).to eql("http://www.rathergood.com")
-  end
+  check("Closed")
+  check("Competition disqualification")
+
+  click_on("Continue")
+  expect(page.current_path).to eq("/email/subscriptions/new")
 end
 
 When("I create an email subscription") do


### PR DESCRIPTION
https://trello.com/c/oYRFCtBm/668-iterate-error-content-and-behaviour-for-new-signup-workflow

This also fixes a couple of feature tests. Please see the commits
for more details.

## Before

<img width="475" alt="Screenshot 2021-01-13 at 15 54 11" src="https://user-images.githubusercontent.com/9029009/104482811-4b936f00-55bf-11eb-8fa7-3681f2fdaaf0.png">
<img width="553" alt="Screenshot 2021-01-13 at 15 54 28" src="https://user-images.githubusercontent.com/9029009/104482815-4c2c0580-55bf-11eb-83c3-7307d9d579ca.png">

## After

<img width="610" alt="Screenshot 2021-01-13 at 16 51 45" src="https://user-images.githubusercontent.com/9029009/104483208-c5c3f380-55bf-11eb-8e72-0fb694151536.png">
<img width="508" alt="Screenshot 2021-01-13 at 16 52 15" src="https://user-images.githubusercontent.com/9029009/104483212-c65c8a00-55bf-11eb-8a8b-4c590450fddd.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️