### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,6 @@ library("govuk")
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-finder-frontend")
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
     publishingE2ETests: true,
     brakeman: true,
   )


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
