### PR TITLE
Use correct component reference

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -63,7 +63,7 @@
               </div>
             </div>
             <div class="govuk-grid-column-two-thirds subscription-links subscription-links--desktop">
-              <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
+              <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>
           </div>
           <div id="js-facet-tag-wrapper" class="facet-tags__container" aria-live="assertive">
@@ -86,7 +86,7 @@
         </div>
 
         <div class="subscription-links" id="subscription-links-footer">
-          <%= render "govuk_publishing_components/components/subscription-links", signup_links %>
+          <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- subscription links template has been renamed to match component conventions, updating here to match ahead of a breaking change

...following this change to correct component file names: https://github.com/alphagov/govuk_publishing_components/pull/1848

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
