### PR TITLE
Add a rake task to import actions by batch id

### DIFF
--- a/app/lib/brexit_checker/batched_actions/batch-1.yaml
+++ b/app/lib/brexit_checker/batched_actions/batch-1.yaml
@@ -1,0 +1,153 @@
+---
+actions:
+- id: S001
+  priority: 8
+  title: Apply to the EU Settlement Scheme by 30 June 2021 to continue living in the
+    UK - you must have arrived in the UK by 31 December 2020
+  consequence: If you do not apply to the scheme, you may not be able to continue
+    living or working in the UK as you do now.
+  exception: 'You do not need to apply if you have: indefinite leave to enter the
+    UK, indefinite leave to remain in the UK, British or Irish citizenship (including
+    ‘dual citizenship’).'
+  guidance_prompt: Read the guidance
+  guidance_link_text: Apply to the EU Settlement Scheme (settled and pre-settled status)
+  guidance_url: https://www.gov.uk/settled-status-eu-citizens-families
+  criteria:
+  - all_of:
+    - nationality-eu
+    - living-uk
+  audience: citizen
+  grouping_criteria:
+  - living-uk
+- id: S003
+  priority: 5
+  title: Apply for a permit to join your family member in the UK if they are from
+    the EU, Switzerland, Norway, Iceland or Liechtenstein
+  title_url: https://www.gov.uk/family-permit
+  consequence: You may not be able to join your family member in the UK if you do
+    not have the right permit.
+  criteria:
+  - all_of:
+    - nationality-row
+    - any_of:
+      - living-eu
+      - living-row
+    - join-family-uk-yes
+  audience: citizen
+  grouping_criteria:
+  - living-uk
+- id: S004
+  priority: 5
+  title: Take out appropriate travel insurance with health cover before travelling
+    to the UK
+  consequence: You will be charged for your NHS healthcare if you do not have the
+    right insurance.
+  guidance_prompt: More information
+  guidance_link_text: Healthcare for visitors to the UK from the EU
+  guidance_url: https://www.gov.uk/guidance/healthcare-for-eu-and-efta-citizens-visiting-the-uk
+  criteria:
+  - all_of:
+    - any_of:
+      - nationality-eu
+      - nationality-row
+    - visiting-uk
+  audience: citizen
+  grouping_criteria:
+  - visiting-uk
+- id: S005
+  priority: 5
+  title: Contact your university or college to find out if there are any changes you
+    need to act on to continue studying.
+  consequence: You might not be able to continue your studies or get student finance
+    or benefits if you don't act on any changes.
+  guidance_prompt: More information
+  guidance_link_text: Studying in the UK for EU students
+  guidance_url: https://www.gov.uk/guidance/studying-in-the-uk-guidance-for-eu-students
+  criteria:
+  - all_of:
+    - any_of:
+      - nationality-eu
+      - nationality-row
+      - nationality-ie
+    - studying-uk
+  audience: citizen
+  grouping_criteria:
+  - studying-uk
+- id: S007
+  priority: 5
+  title: Check with your university or college what you must do to continue studying
+    in the EU
+  consequence: There may be changes to your residency, healthcare or tuition fees
+    that you need to act on, or you may not be able to continue studying as before.
+  guidance_prompt: More information
+  guidance_link_text: Continuing your studies in the European Union
+  guidance_url: https://www.gov.uk/guidance/uk-students-in-the-eu-continuing-your-studies
+  criteria:
+  - all_of:
+    - nationality-uk
+    - any_of:
+      - studying-eu
+      - studying-ie
+  audience: citizen
+  grouping_criteria:
+  - studying-eu
+- id: S008
+  priority: 8
+  title: Check your passport’s issue and expiry dates for travel to Europe
+  consequence: You should have at least 6 months left on your UK passport and it needs
+    to be less than 10 years old, or you may not be able to travel.
+  exception: The new rules do not apply when travelling to Ireland.
+  lead_time: Do it before you travel
+  guidance_prompt: More information
+  guidance_link_text: Check a passport for travel to Europe
+  guidance_url: https://www.gov.uk/check-a-passport-travel-europe
+  criteria:
+  - all_of:
+    - nationality-uk
+    - visiting-eu
+  audience: citizen
+  grouping_criteria:
+  - visiting-eu
+- id: S009
+  priority: 8
+  title: Contact your vet at least 1 month before travelling to make sure your pet
+    or assistance dog is able to travel to the EU
+  consequence: If your pet or assistance dog does not have the proper documents, you
+    will not be able to take it with you.
+  lead_time: It takes at least 1 month
+  guidance_prompt: More information
+  guidance_link_text: Pet travel to and from Great Britain
+  guidance_url: https://www.gov.uk/guidance/pet-travel-to-and-from-great-britain
+  criteria:
+  - all_of:
+    - living-uk
+    - any_of:
+      - visiting-eu
+      - visiting-ie
+      - travel-eu-business
+    - visiting-bring-pet
+  audience: citizen
+  grouping_criteria:
+  - visiting-eu
+  - visiting-ie
+- id: S010
+  priority: 5
+  title: Check whether your mobile phone company has changed its mobile roaming charges
+    before travelling to the EU, Switzerland, Norway, Iceland or Liechtenstein
+  consequence: You may be charged for using your mobile device in the EU, Switzerland,
+    Norway, Iceland or Liechtenstein if your operator has reintroduced roaming charges.
+  guidance_prompt: More information
+  guidance_link_text: Visit Europe from 1 January 2021
+  guidance_url: https://www.gov.uk/visit-europe-1-january-2021
+  criteria:
+  - any_of:
+    - all_of:
+      - living-uk
+      - any_of:
+        - visiting-eu
+        - visiting-ie
+    - travel-eu-business
+  audience: citizen
+  grouping_criteria:
+  - visiting-eu
+  - visiting-ie

--- a/app/lib/brexit_checker/convert_csv_to_yaml/actions_processor.rb
+++ b/app/lib/brexit_checker/convert_csv_to_yaml/actions_processor.rb
@@ -1,5 +1,6 @@
 module BrexitChecker
   module ConvertCsvToYaml
+
     class ActionsProcessor
       LOGIC_FIELDS = %w[criteria].freeze
       COMMA_SEPARATED_FIELDS = %w[grouping_criteria].freeze
@@ -17,8 +18,18 @@ module BrexitChecker
                           exception
                           grouping_criteria].freeze
 
+      def initialize(batch = nil)
+        @batch = batch
+      end
+
+      attr_reader :batch
+
       def process(record)
         return unless approved?(record)
+
+        if batch
+          return unless add_to_batch?(record)
+        end
 
         stripped_record = remove_unnecessary_fields(record)
         stripped_record = parse_logic_fields(stripped_record)
@@ -60,6 +71,12 @@ module BrexitChecker
         return unless record["status"]
 
         record["status"].downcase.strip == "approved"
+      end
+
+      def add_to_batch?(record)
+        return unless record["batch"]
+
+        record["batch"].downcase.strip == batch
       end
     end
   end

--- a/lib/tasks/brexit_checker/convert_csv_to_yaml.rake
+++ b/lib/tasks/brexit_checker/convert_csv_to_yaml.rake
@@ -1,5 +1,5 @@
 MISSING_CSV_MESSAGE = "You must provide a path to the CSV file you would like to convert.".freeze
-
+MISSING_BATCH_ID = "You must provide a batch id"
 namespace :brexit_checker do
   namespace :convert_csv_to_yaml do
     desc "Import actions CSV and convert to YAML file"
@@ -23,6 +23,31 @@ namespace :brexit_checker do
       BrexitChecker::ConvertCsvToYaml::GoogleDriveCsvDownloader.new(sheet_id, csv_path).download
 
       Rake::Task["brexit_checker:convert_csv_to_yaml:actions"].invoke(csv_path)
+    end
+
+    ## temporary
+    desc "Import batched actions CSV and convert to YAML file"
+    task :batched_actions, [:csv_path, :batch_id] => :environment do |_, args|
+      raise MISSING_CSV_MESSAGE unless args.csv_path
+      raise MISSING_CSV_MESSAGE unless args.batch_id
+      processor = BrexitChecker::ConvertCsvToYaml::ActionsProcessor.new(args.batch_id)
+      converter = BrexitChecker::ConvertCsvToYaml::Converter.new(processor)
+      yaml_path = "app/lib/brexit_checker/batched_actions/#{args.batch_id}.yaml"
+
+      puts "> Converting #{args.csv_path} to YAML..."
+      converter.convert(args.csv_path, yaml_path, "actions")
+      puts "> #{args.csv_path} has been converted to #{yaml_path}."
+    end
+
+    ## temporary
+    desc "Download batched actions CSV from Google Drive and convert to YAML file"
+    task :batched_actions_from_google_drive, [:batch_id] => :environment do |_, args|
+      raise MISSING_CSV_MESSAGE unless args.batch_id
+      sheet_id = ENV["GOOGLE_SHEET_ID"]
+      csv_path = "tmp/actions_for_#{args.batch_id}.csv"
+      BrexitChecker::ConvertCsvToYaml::GoogleDriveCsvDownloader.new(sheet_id, csv_path).download
+
+      Rake::Task["brexit_checker:convert_csv_to_yaml:batched_actions"].invoke(csv_path, args.batch_id)
     end
 
     desc "Import criteria CSV and convert to YAML file"


### PR DESCRIPTION
- If we add a column to the dynamic spreadsheet for batch id, we could import
by batch id.
- This would write to a new yaml file in /batched_actions.
- We would then manually copy those batched_actions into actions.yaml.
- Would just be a temporary thing whilst there are so many updates flying around.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
