### PR TITLE
Checker actions update

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -63,7 +63,7 @@ actions:
   priority: 5
   title: Contact your university or college to find out if there are any changes you
     need to act on to continue studying.
-  consequence: You might not be able to continue your studies or get student finance
+  consequence: You will not be able to continue your studies or get student finance
     or benefits if you don't act on any changes.
   guidance_prompt: More information
   guidance_link_text: Studying in the UK for EU students
@@ -72,7 +72,6 @@ actions:
   - all_of:
     - any_of:
       - nationality-eu
-      - nationality-row
       - nationality-ie
     - studying-uk
   audience: citizen
@@ -85,7 +84,7 @@ actions:
   consequence: There may be changes to your residency, healthcare or tuition fees
     that you need to act on, or you may not be able to continue studying as before.
   guidance_prompt: More information
-  guidance_link_text: Continuing your studies in the European Union
+  guidance_link_text: Continuing your studies in the EU
   guidance_url: https://www.gov.uk/guidance/uk-students-in-the-eu-continuing-your-studies
   criteria:
   - all_of:
@@ -142,7 +141,7 @@ actions:
   consequence: You may be charged for using your mobile device in the EU, Switzerland,
     Norway, Iceland or Liechtenstein if your operator has reintroduced roaming charges.
   guidance_prompt: More information
-  guidance_link_text: Visit Europe from 1 January 2021
+  guidance_link_text: Visit Europe
   guidance_url: https://www.gov.uk/visit-europe-1-january-2021
   criteria:
   - any_of:
@@ -296,7 +295,7 @@ actions:
   consequence: If you do not allow enough time, you could miss your flight, train
     or ferry.
   guidance_prompt: More information
-  guidance_link_text: Visit Europe from 1 January 2021
+  guidance_link_text: Visit Europe
   guidance_url: https://www.gov.uk/visit-europe-1-january-2021
   criteria:
   - any_of:
@@ -311,10 +310,10 @@ actions:
   priority: 2
   title: Contact the university where you're planning to study to find out if there
     will be any changes to your fees
-  consequence: You may not be able to take up the course if you do not have the correct
+  consequence: You will not be able to take up the course if you do not have the correct
     funding in place.
   guidance_prompt: More information
-  guidance_link_text: Planning to study in the EU
+  guidance_link_text: Study in the EU
   guidance_url: https://www.gov.uk/guidance/study-in-the-european-union
   criteria:
   - all_of:
@@ -346,7 +345,8 @@ actions:
   priority: 5
   title: Exchange your UK licence for a licence issued by the EU country you live
     in
-  consequence: You will not be able to drive in the EU with a UK licence.
+  consequence: You should exchange your UK licence as soon as possible to avoid having
+    to take a test to exchange your licence at a later date
   guidance_prompt: More information
   guidance_link_text: 'Driving in the EU: UK licence holders living in the EU'
   guidance_url: https://www.gov.uk/guidance/driving-in-the-eu-uk-licence-holders-living-in-the-eu
@@ -483,10 +483,9 @@ actions:
   priority: 4
   title: Check if your benefits will be affected if you move to a country in the EU,
     Switzerland, Norway, Iceland or Liechtenstein
-  consequence: Your right to receive some UK benefits will change if you move on or
-    after 1 January 2021.
+  consequence: Your right to receive some benefits will change.
   guidance_prompt: More information
-  guidance_link_text: Benefits and pensions for UK nationals in the EEA or Switzerland
+  guidance_link_text: Benefits and pensions for UK nationals in the EU, EEA or Switzerland
   guidance_url: https://www.gov.uk/guidance/benefits-and-pensions-for-uk-nationals-in-the-eea-or-switzerland
   criteria:
   - move-to-eu
@@ -771,8 +770,8 @@ actions:
   priority: 5
   title: Check the rules you need to follow if you're a broadcaster or provider of
     video-on-demand services in the UK or the EU
-  consequence: You risk not being able to broadcast or provide video-on-demand services
-    if you do not get your business ready.
+  consequence: You will not be able to broadcast or provide video-on-demand services
+    if you do not follow the rules.
   guidance_prompt: More information
   guidance_link_text: Broadcasting and video on-demand services between the UK and
     EU
@@ -928,9 +927,9 @@ actions:
   audience: business
 - id: T044
   priority: 5
-  title: Enrol with the Rural Payments Agency to prepare to export hops to the EU
-  consequence: You will not be able to apply for the correct documents you'll need
-    to export hops to the EU if you do not enrol.
+  title: Enrol with the Rural Payments Agency to export hops to the EU
+  consequence: If you do not enrol, you will not be able to apply for the correct
+    documents to export hops to the EU.
   lead_time: It takes 5 days
   guidance_prompt: More information
   guidance_link_text: Enrol with the Rural Payments Agency
@@ -1399,7 +1398,7 @@ actions:
 - id: T100
   priority: 3
   title: Apply for a licence to export cultural objects
-  consequence: You might not be able to take items such as works of art and historical
+  consequence: You will not be able to take items such as works of art and historical
     objects out of the UK without the correct licence.
   guidance_prompt: More information
   guidance_link_text: Exporting objects of cultural interest
@@ -1414,7 +1413,7 @@ actions:
   title: Register for a licence to export dual-use items to the EU and Channel Islands 
   consequence: You will not be able to export your goods without an export licence.
   guidance_prompt: More information
-  guidance_link_text: Exporting controlled goods from 1 January 2021
+  guidance_link_text: Exporting controlled goods
   guidance_url: https://www.gov.uk/guidance/exporting-controlled-goods-after-eu-exit
   criteria:
   - any_of:
@@ -1440,8 +1439,7 @@ actions:
   audience: business
 - id: T103
   priority: 8
-  title: Check if you need to pay a tariff on the goods you import from 1 January
-    2021
+  title: Check if you need to pay a tariff on the goods you import
   consequence: You risk penalties and your goods not getting through customs if you
     do not pay the correct tariff.
   guidance_prompt: More information
@@ -1527,8 +1525,7 @@ actions:
 - id: T111
   priority: 2
   title: Check if you need to replace your .eu domain name
-  consequence: You may not be able to hold, register or renew a .eu domain name from
-    1 January 2021.
+  consequence: You may not be able to hold, register or renew a .eu domain name.
   guidance_prompt: More information
   guidance_link_text: Registering and renewing .eu domain names in the UK
   guidance_url: https://www.gov.uk/guidance/registering-and-renewing-eu-domain-names-in-the-uk
@@ -1554,7 +1551,7 @@ actions:
   audience: business
 - id: T113
   priority: 1
-  title: Check the rules for reporting unfair trade practices using the UK's new trade
+  title: Check the rules for reporting unfair trade practices using the UK's trade
     remedies service
   consequence: You risk being affected if imported goods are dumped on the UK market
     or are benefiting from subsidies – or if there is a sudden increase in imports
@@ -1568,7 +1565,7 @@ actions:
 - id: T114
   priority: 2
   title: Check if there's a trade agreement with any non-EU country you're planning
-    to trade with from 1 January 2021
+    to trade with
   consequence: You risk disruption to your trading arrangements and unexpected costs.
   guidance_prompt: More information
   guidance_link_text: Existing UK trade agreements with non-EU countries
@@ -1587,14 +1584,14 @@ actions:
   guidance_prompt: More information
   guidance_link_text: Chemicals classification, labelling and packaging (CLP) after
     the transition period
-  guidance_url: https://www.hse.gov.uk/brexit/clp.htm?utm_source=gov.uk&utm_medium=referral&utm_campaign=eu-transition&utm_term=clp&utm_content=checker-tool
+  guidance_url: https://www.hse.gov.uk/chemical-classification/what-to-do/index.htm?utm_source=gov.uk&utm_medium=referral&utm_campaign=eu-transition&utm_term=clp&utm_content=checker-tool
   criteria:
   - chemical
   audience: business
 - id: T116
   priority: 2
   title: Get approval and product authorisations for new biocidal active substances
-    for the GB market from 1 January 2021
+    for the GB market
   consequence: You will not be able to place new biocidal active substances on the
     GB market without approval.
   guidance_prompt: More information
@@ -1623,10 +1620,10 @@ actions:
   priority: 4
   title: Check the rules for providing online services to the EU, Norway, Iceland
     or Liechtenstein
-  consequence: You may be breaking the law if you do not follow the rules in the country
-    you provide online services to.
+  consequence: You will be breaking the law if you do not follow the rules in the
+    country you provide online services to.
   guidance_prompt: More information
-  guidance_link_text: The eCommerce Directive after the transition period
+  guidance_link_text: The eCommerce Directive
   guidance_url: https://www.gov.uk/guidance/the-ecommerce-directive-and-the-uk
   criteria:
   - any_of:
@@ -1706,8 +1703,8 @@ actions:
   audience: business
 - id: T125
   priority: 3
-  title: Check if there are EU funding opportunities you can apply for
-  consequence: You will not be able to apply for EU funding once the current funding
+  title: Check which EU funding opportunities you can continue to apply for
+  consequence: You will only be able to apply for certain EU funding once the funding
     cycle ends.
   guidance_prompt: More information
   guidance_link_text: Getting EU funding
@@ -1762,7 +1759,7 @@ actions:
   title: Apply for a Kent Access Permit (KAP) if your HGV is over 7.5 tonnes and you
     are leaving Great Britain for the EU from the Port of Dover or Eurotunnel
   consequence: From 1 January 2021, if you do not have a valid permit you will not
-    be able to travel from the Port of Dover or Eurotunnel to the EU, and you may
+    be able to travel from the Port of Dover or by Eurotunnel to the EU, and you may
     be fined.
   guidance_prompt: More information
   guidance_link_text: Apply for a Kent Access Permit
@@ -1784,4 +1781,16 @@ actions:
   - any_of:
     - haulage-goods-across-eu-borders
     - road-passenger-freight
+  audience: business
+- id: T131
+  priority: 10
+  title: Check the rules for providing services to the EU, Switzerland, Norway, Iceland
+    and Liechtenstein
+  consequence: You risk not being able to continue providing services if you do not
+    follow the new rules.
+  guidance_prompt: More information
+  guidance_link_text: Rules for selling services to the EU
+  guidance_url: https://www.gov.uk/guidance/providing-services-to-any-country-in-the-eu-iceland-liechtenstein-norway-or-switzerland-after-eu-exit
+  criteria:
+  - provide-services-do-business-in-eu
   audience: business

--- a/app/lib/brexit_checker/notifications.yaml
+++ b/app/lib/brexit_checker/notifications.yaml
@@ -23,94 +23,12 @@ notifications:
         - visiting-eu
   # End of example block.
   # Add new notifications below 👇
-  - uuid: b99cc090-d7b0-4eab-93c2-0d6f83df7f87
+  - uuid: 6e18b271-c4c2-4937-8949-d587453801df
     type: addition
-    action_id: T045
-    date: '2021-01-29'
-    criteria:
-    - all_of:
-      - animal-ex-food
-      - export-to-eu
-  - uuid: ae76f0eb-2096-44b9-8dd3-0f377162e713
-    type: addition
-    action_id: T046
-    date: '2021-01-29'
-    criteria:
-    - all_of:
-      - animal-ex-food
-      - export-to-eu
-  - uuid: e1934fdd-5382-4c38-95be-dbe2752ee533
-    type: addition
-    action_id: T047
-    date: '2021-01-29'
-    criteria:
-    - all_of:
-      - animal-ex-food
-      - export-to-eu
-  - uuid: 5eab1fba-335e-4f2b-b35b-f296b28d3547
-    type: addition
-    action_id: T051
-    date: '2021-01-29'
-  - uuid: d99b394d-286d-4cdc-946c-091bb8239fe1
-    type: addition
-    action_id: S029
-    date: '2021-01-29'
-    criteria:
-    - all_of:
-      - nationality-uk
-      - move-to-eu
-  - uuid: ba26e146-f3a4-4d2e-8e9d-f97042ee1a3b
-    type: addition
-    action_id: T066
-    date: '2021-01-29'
-  - uuid: 356ee51e-3bd1-4e7e-9569-063378fa12fc
-    type: addition
-    action_id: T104
-    date: '2021-01-29'
-  - uuid: 63255c2e-9224-41f0-ace4-0849c168b12e
-    type: addition
-    action_id: T105
-    date: '2021-01-29'
-  - uuid: 4180049e-cdc2-4354-9f2a-6f4cce1ad9d5
-    type: addition
-    action_id: S011
-    date: '2021-01-29'
-    criteria:
-    - all_of:
-      - nationality-uk
-      - studying-eu
-  - uuid: eb3bcd68-fc3c-484c-be45-48a8c16031ca
+    action_id: T131
+    date: '2021-02-04'
+  - uuid: 19d40094-76c2-4e40-a1fb-44dc7fa76a47
     type: content_change
-    action_id: S032
-    date: '2021-01-29'
-    note: "Updated wording of action to reflect that this applies to travelling to Great Britain. Also updated the timeframe to 'at least 1 month'."
-  - uuid: 525a587e-9786-448c-ac23-0e808aade566
-    type: content_change
-    action_id: T038
-    date: '2021-01-29'
-    note: Updated wording of action to reflect that it's about labelling organic food, not other trading rules.
-  - uuid: 1b2b5078-7998-4105-a234-d5d10a1662f3
-    type: content_change
-    action_id: T087
-    date: '2021-01-29'
-    note: "Updated action to link directly to guidance that covers phytosanitary certificates."
-  - uuid: e8181f47-78e1-4483-9194-755795e76d70
-    type: content_change
-    action_id: T096
-    date: '2021-01-29'
-    note: "Updated wording of action to reflect that this applies to Great Britain."
-  - uuid: 9ad7a1d3-e21f-41e3-aa1a-cb9c4b7d14ab
-    type: content_change
-    action_id: T112
-    date: '2021-01-29'
-    note: "Updated wording of action to remove a reference to TRACES, the EU's import system. Also updated the action to link directly to guidance about IPAFFS."
-  - uuid: c5472e5c-a62e-4849-ad4c-6c7a761a6333
-    type: content_change
-    action_id: S029
-    date: '2021-01-29'
-    note: "Updated to cover registering rather than applying to remain living in an EU country"
-  - uuid: fa057928-f659-491e-8dc4-ec3990c16130
-    type: content_change
-    action_id: T063
-    date: '2021-01-29'
-    note: "Updated information for how long it takes to get approval for a bus or coach service."
+    action_id: T115
+    date: '2021-02-04'
+    note: Guidance on chemical classification has been updated


### PR DESCRIPTION
Imported from the spreadsheet. 

Notifications best viewed [not as a diff](https://github.com/alphagov/finder-frontend/blob/cb7a62b110f32cd1b82a940d2196faea237c4e79/app/lib/brexit_checker/notifications.yaml)

Actions:

- [x] S005
- [x] S007
- [x] S010
- [x] S026
- [x] S030
- [x] S040
- [x] T023
- [x] T044
- [x] T100
- [x] T101
- [x] T103
- [x] T111
- [x] T113
- [x] T114
- [x] T115
- [x] T118
- [x] T125
- [x] T129
- [x] T131

There are a couple of extras which have `from 1 January 2021` removed from text.

https://trello.com/c/0FXZnR2N/28-batch-update-action-card-040221

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
