### PR TITLE
Minor update to brexit checker question wording

### DIFF
--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -347,7 +347,7 @@ questions:
         value: export-to-eu
       - label: "Transport goods across EU borders (haulage)"
         value: haulage-goods-across-eu-borders
-      - label: "Provide services or do business in the EU"
+      - label: "Provide services to or do business in the EU"
         value: provide-services-do-business-in-eu
       - label: "Move goods into, out of, or through Northern Ireland"
         value: move-goods-ni


### PR DESCRIPTION
## What

Minor update of wording on **Does your business or organisation do any of the following?** question.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="520" alt="Screenshot 2021-02-09 at 21 42 41" src="https://user-images.githubusercontent.com/17908089/107432409-d4022280-6b1f-11eb-87d7-08d518c92f19.png">
</td>
<td>
<img width="538" alt="Screenshot 2021-02-09 at 21 45 01" src="https://user-images.githubusercontent.com/17908089/107432584-1a578180-6b20-11eb-808c-d83df5254217.png">
</td>
</tr>
</table>

[trello](https://trello.com/c/6ukJatFs/1330-very-small-wording-amend-to-does-your-business-or-organisation-do-any-of-the-following-question)
[review app](https://finder-front-checker-qu-9dyask.herokuapp.com/transition-check/questions?c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&page=19)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
