### PR TITLE
Redirect related to brexit

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -1,4 +1,8 @@
 class RedirectionController < ApplicationController
+  def redirect_brexit
+    redirect_to(finder_path(params[:slug], params: brexit_topic_and_other_params))
+  end
+
   def redirect_covid
     redirect_to(finder_path(params[:slug], params: covid_topic_and_other_params))
   end
@@ -28,6 +32,18 @@ class RedirectionController < ApplicationController
   end
 
 private
+
+  def brexit_topic_and_other_params
+    {
+      keywords: filter_params["keywords"],
+      level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      organisations: filter_params["organisations"],
+      people: filter_params["people"],
+      public_timestamp: filter_params["public_timestamp"],
+      roles: filter_params["roles"],
+      world_locations: filter_params["world_locations"],
+    }.compact
+  end
 
   def covid_topic_and_other_params
     {

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -36,7 +36,7 @@ private
   def brexit_topic_and_other_params
     {
       keywords: filter_params["keywords"],
-      level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      level_one_taxon: ContentItem::BREXIT_CONTENT_ID,
       organisations: filter_params["organisations"],
       people: filter_params["people"],
       public_timestamp: filter_params["public_timestamp"],

--- a/app/lib/email_alert_title_builder.rb
+++ b/app/lib/email_alert_title_builder.rb
@@ -141,7 +141,7 @@ private
   end
 
   def is_brexit?(registry, content_id)
-    registry.is_a?(Registries::TopicTaxonomyRegistry) && content_id == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+    registry.is_a?(Registries::TopicTaxonomyRegistry) && content_id == ContentItem::BREXIT_CONTENT_ID
   end
 
   def ignore_facet?(facet_id)

--- a/app/lib/facets_builder.rb
+++ b/app/lib/facets_builder.rb
@@ -16,21 +16,8 @@ private
 
   attr_reader :content_item, :search_results, :value_hash
 
-  def filters_on_brexit_topic?
-    @value_hash["topic"] == ContentItem::BREXIT_CONTENT_ID
-  end
-
-  def is_related_to_transition_period_checkbox?(facet_hash)
-    facet_hash["key"] == "related_to_brexit" && facet_hash["filter_value"] == ContentItem::BREXIT_CONTENT_ID
-  end
-
   def facet_hashes
-    all_facet_hashes = content_item.raw_facets
-    if filters_on_brexit_topic?
-      all_facet_hashes.reject { |facet_hash| is_related_to_transition_period_checkbox?(facet_hash) }
-    else
-      all_facet_hashes
-    end
+    content_item.raw_facets
   end
 
   def build_facet(facet_hash)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,12 @@ FinderFrontend::Application.routes.draw do
       topical_events.include?("coronavirus-covid-19-uk-government-response")
   }
 
+  get "/*slug" => "redirection#redirect_brexit", constraints: lambda { |request|
+    related_to_brexit = request.params["related_to_brexit"]
+
+    related_to_brexit && related_to_brexit.include?("d6c2de5d-ef90-45d1-82d4-5f2438369eea")
+  }
+
   # Whatever else you do here... keep this at the bottom of the file
   get "/*slug" => "finders#show", as: :finder
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ FinderFrontend::Application.routes.draw do
   get "/*slug" => "redirection#redirect_brexit", constraints: lambda { |request|
     related_to_brexit = request.params["related_to_brexit"]
 
-    related_to_brexit && related_to_brexit.include?("d6c2de5d-ef90-45d1-82d4-5f2438369eea")
+    related_to_brexit && related_to_brexit.include?(ContentItem::BREXIT_CONTENT_ID)
   }
 
   # Whatever else you do here... keep this at the bottom of the file

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -226,14 +226,6 @@ Feature: Filtering documents
     When I view the news and communications finder
     Then the page has a landmark to the search results
 
-  Scenario: "Show only transition period results" checkbox is removed if the topic parameter is set to the transition period Topic.
-    When I view the news and communications finder filtered on the transition period topic
-    Then I cannot see the "show only transition period results" checkbox
-
-  Scenario: "Show only transition period results" checkbox is shown if no topic parameter is set
-    When I view the news and communications finder
-    Then I can see the "show only transition period results" checkbox
-
   Scenario: Email links
     When I view the news and communications finder
     Then I see email and feed sign up links

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -89,17 +89,6 @@
         "preposition": "about"
       },
       {
-        "key": "related_to_brexit",
-        "filter_key": "all_part_of_taxonomy_tree",
-        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-        "name": "Show only transition period results",
-        "short_name": "transition period",
-        "type": "checkbox",
-        "display_as_result_metadata": false,
-        "filterable": true,
-        "preposition": "about"
-      },
-      {
         "key": "organisations",
         "name": "Organisation",
         "short_name": "From",

--- a/features/fixtures/news_and_communications_signup_content_item.json
+++ b/features/fixtures/news_and_communications_signup_content_item.json
@@ -72,12 +72,6 @@
         "facet_id": "level_two_taxon",
         "filter_key": "all_part_of_taxonomy_tree",
         "facet_name": "topics"
-      },
-      {
-        "facet_id": "related_to_brexit",
-        "filter_key": "all_part_of_taxonomy_tree",
-        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-        "facet_name": "topics"
       }
     ]
   }

--- a/features/fixtures/news_and_communications_with_checkboxes.json
+++ b/features/fixtures/news_and_communications_with_checkboxes.json
@@ -79,17 +79,6 @@
         "preposition": "about"
       },
       {
-        "key": "related_to_brexit",
-        "filter_key": "all_part_of_taxonomy_tree",
-        "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-        "name": "Show only transition period results",
-        "short_name": "transition period",
-        "type": "checkbox",
-        "display_as_result_metadata": false,
-        "filterable": true,
-        "preposition": "about"
-      },
-      {
         "key": "organisations",
         "name": "Organisation",
         "short_name": "From",

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -104,25 +104,6 @@ When(/^I view the news and communications finder$/) do
   visit finder_path("search/news-and-communications")
 end
 
-When(/^I view the news and communications finder filtered on the transition period topic$/) do
-  stub_taxonomy_api_request
-  content_store_has_news_and_communications_finder
-  stub_world_locations_api_request
-  stub_all_rummager_api_requests_with_news_and_communication_results
-  stub_people_registry_request
-  stub_organisations_registry_request
-  visit finder_path("search/news-and-communications", topic: "d6c2de5d-ef90-45d1-82d4-5f2438369eea")
-end
-
-Then(/^I (can|cannot) see the "show only transition period results" checkbox$/) do |can_or_cannot|
-  have_clause = have_css(".govuk-checkboxes__label", text: "Show only transition period results")
-  if can_or_cannot == "can"
-    expect(page).to have_clause
-  else
-    expect(page).to_not have_clause
-  end
-end
-
 When(/^I view the policy papers and consultations finder$/) do
   topic_taxonomy_has_taxons
   content_store_has_policy_and_engagement_finder

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -15,7 +15,7 @@ describe EmailAlertSubscriptionsController, type: :controller do
   let(:signup_finder) { cma_cases_signup_content_item }
   let(:taxon_content_id_one) { "magical-education" }
   let(:taxon_content_id_two) { "herbology" }
-  let(:brexit_taxon_id) { "d6c2de5d-ef90-45d1-82d4-5f2438369eea" }
+  let(:brexit_taxon_id) { ContentItem::BREXIT_CONTENT_ID }
   let(:org_slug_one) { "department-of-mysteries" }
   let(:org_slug_two) { "gringots" }
 

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -10,7 +10,7 @@ describe RedirectionController, type: :controller do
       }
       expect(response).to redirect_to finder_path("search/random-finder",
                                                   params: {
-                                                    level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+                                                    level_one_taxon: ContentItem::BREXIT_CONTENT_ID,
                                                   })
     end
 
@@ -29,7 +29,7 @@ describe RedirectionController, type: :controller do
       expect(response).to redirect_to finder_path(
         "any-finder", params: {
           keywords: "one two",
-          level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+          level_one_taxon: ContentItem::BREXIT_CONTENT_ID,
           people: %w[one two],
           organisations: %w[one two],
           world_locations: %w[one two],

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -3,6 +3,42 @@ require "spec_helper"
 describe RedirectionController, type: :controller do
   include TaxonomySpecHelper
 
+  describe "#redirect_brexit" do
+    it "redirects to the same slug with the brexit taxon" do
+      get :redirect_brexit, params: {
+        slug: "search/random-finder",
+      }
+      expect(response).to redirect_to finder_path("search/random-finder",
+                                                  params: {
+                                                    level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+                                                  })
+    end
+
+    it "replaces the brexit param with the brexit taxon, overwriting other taxons" do
+      get :redirect_brexit, params: {
+        "slug" => "any-finder",
+        "keywords" => "one two",
+        "level_one_taxon" => "one",
+        "level_two_taxon" => "two",
+        "people" => %w[one two],
+        "organisations" => %w[one two],
+        "world_locations" => %w[one two],
+        "public_timestamp" => { "from" => "01/01/2014", "to" => "01/01/2014" },
+        "topical_events" => %w[anything],
+      }
+      expect(response).to redirect_to finder_path(
+        "any-finder", params: {
+          keywords: "one two",
+          level_one_taxon: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+          people: %w[one two],
+          organisations: %w[one two],
+          world_locations: %w[one two],
+          public_timestamp: { from: "01/01/2014", to: "01/01/2014" },
+        }
+      )
+    end
+  end
+
   describe "#redirect_covid" do
     it "redirects to the same slug with the coronavirus taxon" do
       get :redirect_covid, params: {

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -8,7 +8,7 @@ describe('remove-filter', function () {
   var removeFilter
   var $checkbox = $(
     '<div data-module="remove-filter">' +
-    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter transition period" data-module="remove-filter-link" data-facet="related_to_brexit" data-value="true" data-track-label="transition period" data-name="">✕</button>' +
+    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter transition period" data-module="remove-filter-link" data-facet="a_check_box" data-value="true" data-track-label="transition period" data-name="">✕</button>' +
   '</div>')
 
   var $oneTextQuery = $(
@@ -64,8 +64,8 @@ describe('remove-filter', function () {
     '<div>' +
       '<input name="public_timestamp[from]" value="" id="public_timestamp[from]" type="text">' +
     '</div>' +
-    '<div id="related_to_brexit">' +
-      '<input type="checkbox" name="related_to_brexit" value="true" data-module="track-click">' +
+    '<div id="a_check_box">' +
+      '<input type="checkbox" name="a_check_box" value="true" data-module="track-click">' +
     '</div>'
 
   beforeEach(function () {
@@ -79,7 +79,7 @@ describe('remove-filter', function () {
   })
 
   it('deselects a selected checkbox', function (done) {
-    var checkbox = $('input[name=related_to_brexit]')[0]
+    var checkbox = $('input[name=a_check_box]')[0]
     checkbox.checked = true
     removeFilter.start($checkbox)
 

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -183,7 +183,6 @@ describe EmailAlertTitleBuilder do
         { "facet_id" => "world_locations", "facet_name" => "world locations" },
         { "facet_id" => "level_one_taxon", "filter_key" => "part_of_taxonomy_tree", "facet_name" => "topics" },
         { "facet_id" => "level_two_taxon", "filter_key" => "part_of_taxonomy_tree", "facet_name" => "topics" },
-        { "facet_id" => "related_to_brexit", "filter_key" => "part_of_taxonomy_tree", "filter_value" => "d6c2de5d-ef90-45d1-82d4-5f2438369eea", "facet_name" => "topics" },
         { "facet_id" => "document_type", "facet_name" => "document types" },
       ]
     end

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -70,16 +70,6 @@ describe FacetsBuilder do
       "allowed_values": [{ "value" => "my_manual" }],
     }
   end
-  let(:related_to_transition_period_facet_hash) do
-    {
-      "key": "related_to_brexit",
-      "filter_key": "all_part_of_taxonomy_tree",
-      "filter_value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
-      "name": "Show only transition period results",
-      "type": "checkbox",
-      "filterable": true,
-    }
-  end
 
   let(:detail_hash) do
     {
@@ -104,44 +94,6 @@ describe FacetsBuilder do
 
   let(:content_item) do
     ContentItem.new(content_item_hash)
-  end
-
-  describe "Remove transition period checkbox filter" do
-    subject(:facets) do
-      FacetsBuilder.new(content_item: content_item, search_results: {}, value_hash: value_hash).facets
-    end
-    let(:detail_hash) do
-      {
-        "details" => {
-          "facets" => [
-            taxon_facet_hash,
-            checkbox_facet_hash,
-            radio_facet_hash,
-            related_to_transition_period_facet_hash,
-          ],
-        },
-      }
-    end
-    context "The page is filtered on the transition period topic" do
-      let(:value_hash) do
-        {
-          "topic" => ContentItem::BREXIT_CONTENT_ID,
-        }
-      end
-      it "contains no related to transition period taxon" do
-        expect(facets).to_not include(an_object_satisfying { |facet| facet.key == "related_to_brexit" })
-      end
-    end
-    context "The page is not filtered on the transition period topic" do
-      let(:value_hash) do
-        {
-          related_to_brexit: ContentItem::BREXIT_CONTENT_ID,
-        }
-      end
-      it "contains a related to transition period taxon" do
-        expect(facets).to include(an_object_satisfying { |facet| facet.key == "related_to_brexit" })
-      end
-    end
   end
 
   describe "facets" do

--- a/spec/lib/parameter_parser/email_alert_parameter_parser_spec.rb
+++ b/spec/lib/parameter_parser/email_alert_parameter_parser_spec.rb
@@ -15,13 +15,11 @@ describe ParameterParser::EmailAlertParameterParser do
   let(:signup_finder) { cma_cases_signup_content_item }
   let(:taxon_content_id_one) { "magical-education" }
   let(:taxon_content_id_two) { "herbology" }
-  let(:brexit_taxon_id) { "d6c2de5d-ef90-45d1-82d4-5f2438369eea" }
 
   before do
     Rails.cache.clear
     topic_taxonomy_has_taxons([
       FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_one, title: "Magical Education"),
-      FactoryBot.build(:level_one_taxon_hash, content_id: brexit_taxon_id, title: "Brexit"),
       FactoryBot.build(:level_one_taxon_hash, content_id: taxon_content_id_two, title: "Herbology"),
     ])
 

--- a/spec/presenters/subscriber_list_params_presenter_spec.rb
+++ b/spec/presenters/subscriber_list_params_presenter_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe SubscriberListParamsPresenter do
         "organisations" => %w[academy-for-social-justice-commissioning accelerated-access-review],
         "people" => %w[sir-philip-jones mark-stanhope],
         "level_one_taxon" => %w[c58fdadd-7743-46d6-9629-90bb3ccc4ef0],
-        "related_to_brexit" => "true",
       }
 
       presenter = described_class.new(signup_finder, params)
@@ -43,7 +42,6 @@ RSpec.describe SubscriberListParamsPresenter do
         "people" => %w[sir-philip-jones mark-stanhope],
         "all_part_of_taxonomy_tree" => %w[
           c58fdadd-7743-46d6-9629-90bb3ccc4ef0
-          d6c2de5d-ef90-45d1-82d4-5f2438369eea
         ],
       )
     end

--- a/spec/routing/redirection_spec.rb
+++ b/spec/routing/redirection_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Redirecting", type: :routing do
         controller: "redirection",
         action: "redirect_brexit",
         slug: "any-old-finder",
-        related_to_brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        related_to_brexit: ContentItem::BREXIT_CONTENT_ID,
       )
     end
 
@@ -33,7 +33,7 @@ RSpec.describe "Redirecting", type: :routing do
         slug: "any-old-finder",
         keywords: "booty",
         organisations: %w[ministry-of-pirates],
-        related_to_brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        related_to_brexit: ContentItem::BREXIT_CONTENT_ID,
       )
     end
   end

--- a/spec/routing/redirection_spec.rb
+++ b/spec/routing/redirection_spec.rb
@@ -1,63 +1,65 @@
 require "spec_helper"
 
-RSpec.describe "Redirecting coronavirus topical event searches", type: :routing do
-  it "sends coronavirus topical event to a redirect (array params)" do
-    expect(
-      get: "/any-old-finder?topical_events[]=coronavirus-covid-19-uk-government-response",
-    ).to route_to(
-      controller: "redirection",
-      action: "redirect_covid",
-      slug: "any-old-finder",
-      topical_events: %w[coronavirus-covid-19-uk-government-response],
-    )
-  end
+RSpec.describe "Redirecting", type: :routing do
+  context "coronavirus topical event searches" do
+    it "sends coronavirus topical event to a redirect (array params)" do
+      expect(
+        get: "/any-old-finder?topical_events[]=coronavirus-covid-19-uk-government-response",
+      ).to route_to(
+        controller: "redirection",
+        action: "redirect_covid",
+        slug: "any-old-finder",
+        topical_events: %w[coronavirus-covid-19-uk-government-response],
+      )
+    end
 
-  it "sends coronavirus topical event to a redirect (string params)" do
-    expect(
-      get: "/any-old-finder?topical_events=coronavirus-covid-19-uk-government-response",
-    ).to route_to(
-      controller: "redirection",
-      action: "redirect_covid",
-      slug: "any-old-finder",
-      topical_events: "coronavirus-covid-19-uk-government-response",
-    )
-  end
+    it "sends coronavirus topical event to a redirect (string params)" do
+      expect(
+        get: "/any-old-finder?topical_events=coronavirus-covid-19-uk-government-response",
+      ).to route_to(
+        controller: "redirection",
+        action: "redirect_covid",
+        slug: "any-old-finder",
+        topical_events: "coronavirus-covid-19-uk-government-response",
+      )
+    end
 
-  it "ignores other topical events" do
-    expect(
-      get: "/any-old-finder?topical_events[]=talk-like-a-pirate-day",
-    ).to route_to(
-      controller: "finders",
-      action: "show",
-      slug: "any-old-finder",
-      topical_events: ["talk-like-a-pirate-day"],
-    )
-  end
+    it "ignores other topical events" do
+      expect(
+        get: "/any-old-finder?topical_events[]=talk-like-a-pirate-day",
+      ).to route_to(
+        controller: "finders",
+        action: "show",
+        slug: "any-old-finder",
+        topical_events: ["talk-like-a-pirate-day"],
+      )
+    end
 
-  it "includes other params too" do
-    expect(
-      get: "/any-old-finder?keywords=bernard&topical_events[]=coronavirus-covid-19-uk-government-response&organisations[]=ministry-of-pirates",
-    ).to route_to(
-      controller: "redirection",
-      action: "redirect_covid",
-      slug: "any-old-finder",
-      keywords: "bernard",
-      organisations: %w[ministry-of-pirates],
-      topical_events: %w[coronavirus-covid-19-uk-government-response],
-    )
-  end
+    it "includes other params too" do
+      expect(
+        get: "/any-old-finder?keywords=bernard&topical_events[]=coronavirus-covid-19-uk-government-response&organisations[]=ministry-of-pirates",
+      ).to route_to(
+        controller: "redirection",
+        action: "redirect_covid",
+        slug: "any-old-finder",
+        keywords: "bernard",
+        organisations: %w[ministry-of-pirates],
+        topical_events: %w[coronavirus-covid-19-uk-government-response],
+      )
+    end
 
-  it "ignores atom feeds" do
-    expect(
-      get: "/any-old-finder.atom?keywords=bernard&topical_events[]=coronavirus-covid-19-uk-government-response&organisations[]=ministry-of-pirates",
-    ).to route_to(
-      format: "atom",
-      controller: "finders",
-      action: "show",
-      slug: "any-old-finder",
-      keywords: "bernard",
-      organisations: %w[ministry-of-pirates],
-      topical_events: %w[coronavirus-covid-19-uk-government-response],
-    )
+    it "ignores atom feeds" do
+      expect(
+        get: "/any-old-finder.atom?keywords=bernard&topical_events[]=coronavirus-covid-19-uk-government-response&organisations[]=ministry-of-pirates",
+      ).to route_to(
+        format: "atom",
+        controller: "finders",
+        action: "show",
+        slug: "any-old-finder",
+        keywords: "bernard",
+        organisations: %w[ministry-of-pirates],
+        topical_events: %w[coronavirus-covid-19-uk-government-response],
+      )
+    end
   end
 end

--- a/spec/routing/redirection_spec.rb
+++ b/spec/routing/redirection_spec.rb
@@ -1,6 +1,43 @@
 require "spec_helper"
 
 RSpec.describe "Redirecting", type: :routing do
+  context "related_to_brexit searches" do
+    it "redirects to the Brexit handler" do
+      expect(
+        get: "/any-old-finder?related_to_brexit=d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      ).to route_to(
+        controller: "redirection",
+        action: "redirect_brexit",
+        slug: "any-old-finder",
+        related_to_brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      )
+    end
+
+    it "doesn't redirect empty params" do
+      expect(
+        get: "/any-old-finder?related_to_brexit=",
+      ).to route_to(
+        controller: "finders",
+        action: "show",
+        slug: "any-old-finder",
+        related_to_brexit: "",
+      )
+    end
+
+    it "includes other params too" do
+      expect(
+        get: "/any-old-finder?keywords=booty&related_to_brexit=d6c2de5d-ef90-45d1-82d4-5f2438369eea&organisations[]=ministry-of-pirates",
+      ).to route_to(
+        controller: "redirection",
+        action: "redirect_brexit",
+        slug: "any-old-finder",
+        keywords: "booty",
+        organisations: %w[ministry-of-pirates],
+        related_to_brexit: "d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+      )
+    end
+  end
+
   context "coronavirus topical event searches" do
     it "sends coronavirus topical event to a redirect (array params)" do
       expect(


### PR DESCRIPTION
This redirects users of the `related_to_brexit` parameter on the news and communications finder to the Brexit topic.

It then removes the old code that made this work.

https://trello.com/c/8Pv2YKzn/1311-retire-show-only-brexit-results-from-finders

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
