### PR TITLE
Submit JWTs to the new account endpoint & pass ID in ?state 

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -41,10 +41,32 @@ class BrexitCheckerController < ApplicationController
     redirect_to email_alert_frontend_signup_path(topic_id: subscriber_list_slug)
   end
 
-  def save_results
-    @account_jwt = account_signup_jwt(criteria_keys, subscriber_list_slug)
-  rescue StandardError
-    redirect_to transition_checker_email_signup_path(c: criteria_keys)
+  def save_results; end
+
+  def save_results_sign_up
+    jwt = account_signup_jwt(criteria_keys, subscriber_list_slug)
+
+    tokens = Rails.cache.fetch("finder-frontend_account_oauth_token") || Services.oidc.tokens!
+
+    response = Services.oidc.submit_jwt(
+      jwt: jwt,
+      access_token: tokens[:access_token],
+      refresh_token: tokens[:refresh_token],
+    )
+
+    Rails.cache.write(
+      "finder-frontend_account_oauth_token",
+      { access_token: response[:access_token], refresh_token: response[:refresh_token] },
+      expires_in: 24.hours,
+    )
+
+    redirect_to transition_checker_new_session_path(
+      redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys),
+      state: response[:result],
+      _ga: params[:_ga],
+    )
+  rescue OidcClient::OAuthFailure
+    head :internal_server_error
   end
 
   def save_results_confirm

--- a/app/controllers/concerns/account_brexit_checker_concern.rb
+++ b/app/controllers/concerns/account_brexit_checker_concern.rb
@@ -7,7 +7,7 @@ module AccountBrexitCheckerConcern
 
   ACCOUNT_AB_CUSTOM_DIMENSION = 42
   ACCOUNT_AB_TEST_NAME = "AccountExperiment"
-  ACCOUNT_ACTIONS = %i[save_results save_results_confirm save_results_email_signup save_results_apply saved_results edit_saved_results].freeze
+  ACCOUNT_ACTIONS = %i[save_results save_results_sign_up save_results_confirm save_results_email_signup save_results_apply saved_results edit_saved_results].freeze
 
   included do
     # this is a false positive which will be fixed by updating rubocop

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,10 @@ class SessionsController < ApplicationController
   def create
     redirect_with_ga account_manager_url and return if logged_in?
 
-    redirect_with_ga Services.oidc.auth_uri(redirect_path: params["redirect_path"])[:uri]
+    redirect_with_ga Services.oidc.auth_uri(
+      redirect_path: params[:redirect_path],
+      state: params[:state],
+    )[:uri]
   end
 
   def callback

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,18 +28,17 @@ class SessionsController < ApplicationController
       return
     end
 
-    tokens = callback[:access_token].token_response
     set_account_session_cookie(
-      sub: callback[:sub],
-      access_token: tokens[:access_token],
-      refresh_token: tokens[:refresh_token],
+      sub: callback[:id_token].sub,
+      access_token: callback[:access_token],
+      refresh_token: callback[:refresh_token],
     )
 
     ephemeral_state =
       update_account_session_cookie_from_oauth_result(
         Services.oidc.get_ephemeral_state(
-          access_token: tokens[:access_token],
-          refresh_token: tokens[:refresh_token],
+          access_token: callback[:access_token],
+          refresh_token: callback[:refresh_token],
         ),
       )
 

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -81,7 +81,6 @@ module BrexitCheckerHelper
       criteria_keys: criteria_keys,
       subscriber_list_slug: subscriber_list_slug,
       post_register_uri: Services.oidc.auth_uri(redirect_path: transition_checker_saved_results_path)[:uri],
-      post_login_uri: Services.oidc.auth_uri(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys))[:uri],
     )
     account_jwt.encode
   end

--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -6,8 +6,8 @@ class BrexitChecker::AccountJwt
     @post_login_uri = post_login_uri
   end
 
-  def encode(key = ecdsa_key, algorithmn = "ES256")
-    JWT.encode payload, key, algorithmn
+  def encode
+    JWT.encode payload, nil, "none"
   end
 
 private
@@ -16,17 +16,10 @@ private
 
   def payload
     {
-      uid: client_oauth_id,
-      key: client_oauth_key_uuid,
-      scopes: scopes,
       attributes: attributes,
       post_register_oauth: post_register_uri,
       post_login_oauth: post_login_uri,
     }
-  end
-
-  def scopes
-    %w[transition_checker]
   end
 
   def attributes
@@ -37,17 +30,5 @@ private
         email_topic_slug: subscriber_list_slug,
       },
     }
-  end
-
-  def client_oauth_id
-    ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID")
-  end
-
-  def client_oauth_key_uuid
-    ENV.fetch("GOVUK_ACCOUNT_JWT_KEY_UUID")
-  end
-
-  def ecdsa_key
-    OpenSSL::PKey::EC.new(ENV.fetch("GOVUK_ACCOUNT_JWT_KEY_PEM"))
   end
 end

--- a/app/lib/brexit_checker/account_jwt.rb
+++ b/app/lib/brexit_checker/account_jwt.rb
@@ -1,9 +1,8 @@
 class BrexitChecker::AccountJwt
-  def initialize(criteria_keys:, subscriber_list_slug:, post_register_uri:, post_login_uri:)
+  def initialize(criteria_keys:, subscriber_list_slug:, post_register_uri:)
     @criteria_keys = criteria_keys
     @subscriber_list_slug = subscriber_list_slug
     @post_register_uri = post_register_uri
-    @post_login_uri = post_login_uri
   end
 
   def encode
@@ -12,13 +11,12 @@ class BrexitChecker::AccountJwt
 
 private
 
-  attr_reader :criteria_keys, :subscriber_list_slug, :post_register_uri, :post_login_uri
+  attr_reader :criteria_keys, :subscriber_list_slug, :post_register_uri
 
   def payload
     {
       attributes: attributes,
       post_register_oauth: post_register_uri,
-      post_login_oauth: post_login_uri,
     }
   end
 

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -127,6 +127,23 @@ class OidcClient
     end
   end
 
+  def submit_jwt(jwt:, access_token:, refresh_token:)
+    response = oauth_request(
+      access_token: access_token,
+      refresh_token: refresh_token,
+      method: :post,
+      uri: jwt_uri,
+      arg: { jwt: jwt },
+    )
+
+    body = response[:result].body
+    if body.empty?
+      raise OAuthFailure
+    else
+      response.merge(result: JSON.parse(body)["id"])
+    end
+  end
+
 private
 
   OK_STATUSES = [200, 204, 404, 410].freeze
@@ -160,20 +177,26 @@ private
   end
 
   def attribute_uri
-    @attribute_uri = URI.parse(userinfo_endpoint).tap do |u|
+    URI.parse(userinfo_endpoint).tap do |u|
       u.path = "/v1/attributes/transition_checker_state"
     end
   end
 
   def email_subscription_uri
-    @email_uri = URI.parse(provider_uri).tap do |u|
+    URI.parse(provider_uri).tap do |u|
       u.path = "/api/v1/transition-checker/email-subscription"
     end
   end
 
   def ephemeral_state_uri
-    @ephemeral_state_uri = URI.parse(provider_uri).tap do |u|
+    URI.parse(provider_uri).tap do |u|
       u.path = "/api/v1/ephemeral-state"
+    end
+  end
+
+  def jwt_uri
+    URI.parse(provider_uri).tap do |u|
+      u.path = "/api/v1/jwt"
     end
   end
 

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -18,8 +18,8 @@ class OidcClient
     @secret = secret
   end
 
-  def auth_uri(redirect_path: nil)
-    nonce = SecureRandom.hex(16)
+  def auth_uri(redirect_path: nil, state: nil)
+    nonce = state || SecureRandom.hex(16)
     state = "#{nonce}:#{redirect_path}"
 
     {
@@ -44,14 +44,16 @@ class OidcClient
   def callback(code, state)
     client.authorization_code = code
     access_token = client.access_token!
-    (nonce, redirect_path, cookie_consent) = state.split(":")
+
+    nonce, redirect_path = state.split(":")
+
     id_token = OpenIDConnect::ResponseObject::IdToken.decode access_token.id_token, discover.jwks
     id_token.verify! client_id: client_id, issuer: discover.issuer, nonce: nonce
+
     {
       access_token: access_token,
       sub: id_token.sub,
       redirect_path: redirect_path,
-      cookie_consent: cookie_consent == "cookies-yes",
     }
   end
 

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -36,7 +36,7 @@ module Services
   end
 
   def self.oidc
-    @oidc ||= OidcClient.new(
+    OidcClient.new(
       accounts_api,
       ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_ID"),
       ENV.fetch("GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"),

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -68,8 +68,7 @@
 
         <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.outro') %></p>
 
-        <%= form_tag Services.accounts_api, id: "account-signup", :"data-module" => "explicit-cross-domain-links" do %>
-          <input type="hidden" name="jwt" value="<%= @account_jwt %>">
+        <%= form_tag transition_checker_save_results_sign_up_path(c: criteria_keys), method: :post, id: "account-signup", :"data-module" => "explicit-cross-domain-links" do %>
           <%= render "govuk_publishing_components/components/button", {
             text: t('brexit_checker.account_signup.create_account.cta_button'),
             margin_bottom: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ FinderFrontend::Application.routes.draw do
     get "/login/callback", to: "sessions#callback", as: :transition_checker_new_session_callback
     get "/logout", to: "sessions#delete", as: :transition_checker_end_session
     get "/save-your-results" => "brexit_checker#save_results", as: :transition_checker_save_results
+    post "/save-your-results/sign-up" => "brexit_checker#save_results_sign_up", as: :transition_checker_save_results_sign_up
     get "/save-your-results/confirm", to: "brexit_checker#save_results_confirm", as: :transition_checker_save_results_confirm
     get "/save-your-results/email-signup", to: "brexit_checker#save_results_email_signup", as: :transition_checker_save_results_email_signup
     post "/save-your-results/confirm", to: "brexit_checker#save_results_apply"

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -327,15 +327,16 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
       end
 
       def log_in
-        access_token = Rack::OAuth2::AccessToken::Bearer.new(
-          access_token: "access-token",
-          refresh_token: "refresh-token",
+        id_token = OpenIDConnect::ResponseObject::IdToken.new(
+          sub: "subject-identifier",
+          iss: "http://account-manager.dev.gov.uk",
+          aud: "test",
+          exp: 0,
+          iat: 0,
         )
 
-        sub = "subject-identifier"
-
-        allow_any_instance_of(OidcClient).to receive(:callback)
-          .and_return({ access_token: access_token, sub: sub })
+        allow_any_instance_of(OidcClient).to receive(:tokens!)
+          .and_return({ access_token: "access-token", refresh_token: "refresh-token", id_token: id_token })
 
         stub_request(:get, "http://account-manager.dev.gov.uk/api/v1/ephemeral-state")
           .with(headers: { "Authorization" => "Bearer access-token" })

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -8,31 +8,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
     stub_request(:get, Services.accounts_api).to_return(status: 200)
   end
 
-  context "accounts is enabled but not returning JWT" do
-    let(:criteria_keys) { %i[nationality-eu] }
-
-    before do
-      allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
-      allow_any_instance_of(BrexitCheckerHelper).to receive(:account_signup_jwt).and_raise
-
-      stub_email_alert_api_creates_subscriber_list(
-        {
-          "title" => "Get ready for 2021",
-          "slug" => "your-get-ready-for-brexit-results-a1a2a3a4a5",
-          "tags" => { "brexit_checklist_criteria" => { "any" => criteria_keys } },
-          "url" => "/transition-check/results?c%5B%5D=nationality-eu",
-        },
-      )
-    end
-
-    context "/transition-check/save-results" do
-      it "redirects to the email signup page" do
-        visit transition_checker_save_results_path(c: criteria_keys)
-        expect(page).to have_content(I18n.t("brexit_checker.email_signup.sign_up_heading"))
-      end
-    end
-  end
-
   context "with accounts enabled" do
     let(:attribute_service_url) { "http://attribute-service" }
 

--- a/spec/features/brexit_checker/email_signup_spec.rb
+++ b/spec/features/brexit_checker/email_signup_spec.rb
@@ -29,8 +29,6 @@ RSpec.feature "Brexit Checker email signup", type: :feature do
     before do
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
       ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret"
-      ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = "fake_key_uuid"
-      ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = AccountSignupHelper.test_ec_key_fixture
       allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
       discovery_response = double(authorization_endpoint: "foo", token_endpoint: "foo", userinfo_endpoint: "foo", end_session_endpoint: "foo")
       allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")
     allow_any_instance_of(OidcClient).to receive(:discover).and_return(discovery_response)
     allow_any_instance_of(OidcClient).to receive(:auth_uri).and_return({ uri: "http://account-mamager/login", state: SecureRandom.hex(16) })
+    allow_any_instance_of(OidcClient).to receive(:tokens!).and_return({ access_token: "access-token", refresh_token: "refresh-token" })
+    allow_any_instance_of(OidcClient).to receive(:submit_jwt).and_return({ access_token: "access-token", refresh_token: "refresh-token", result: "jwt-id" })
     stub_email_subscription_confirmation
     stub_request(:get, Services.accounts_api).to_return(status: 200)
   end
@@ -22,7 +24,8 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
       given_im_on_the_results_page
       then_i_click_to_subscribe
       and_i_am_taken_to_choose_how_to_subscribe_page
-      i_see_a_create_account_button
+      and_i_click_the_create_account_button
+      i_get_redirected_to_sign_up
     end
   end
 
@@ -47,7 +50,8 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
       given_im_on_the_results_page
       then_i_click_to_subscribe
       and_i_am_taken_to_choose_how_to_subscribe_page
-      i_see_a_create_account_button
+      and_i_click_the_create_account_button
+      i_get_redirected_to_sign_up
     end
   end
 
@@ -68,11 +72,15 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     expect(page).to have_current_path(transition_checker_save_results_url(c: %w[nationality-eu]))
   end
 
-  def i_see_a_create_account_button
+  def and_i_click_the_create_account_button
     form = page.find("form#account-signup")
     expect(form.text).to eql("Create a GOV.UK account")
     expect(form["method"]).to eql("post")
-    expect(form["action"]).to eql(Plek.find("account-manager"))
+    click_on I18n.t("brexit_checker.account_signup.create_account.cta_button")
+  end
+
+  def i_get_redirected_to_sign_up
+    expect(page.current_url).to include("&state=jwt-id")
   end
 
   def stub_email_subscription_confirmation

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -8,8 +8,6 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
   before do
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = "Application's OAuth client ID"
     ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET"] = "secret!"
-    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = "fake_key_uuid"
-    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = AccountSignupHelper.test_ec_key_fixture
     allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
     discovery_response = double(authorization_endpoint: "foo", token_endpoint: "foo", userinfo_endpoint: "foo", end_session_endpoint: "foo")
     allow_any_instance_of(OidcClient).to receive(:userinfo_endpoint).and_return("http://attribute-service/oidc/user_info")

--- a/spec/lib/brexit_checker/account_jwt_spec.rb
+++ b/spec/lib/brexit_checker/account_jwt_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 RSpec.describe BrexitChecker::AccountJwt do
-  let(:private_key) { OpenSSL::PKey::EC.new("prime256v1").tap(&:generate_key) }
-  let(:public_key) { OpenSSL::PKey::EC.new(private_key).tap { |k| k.private_key = nil } }
-  let(:oauth_client_id) { "transition-checker-id" }
-  let(:key_uuid) { "38d7dd82-8436-43b5-ae97-e160101cec50" }
   let(:criteria_keys) { %w[hello world] }
   let(:post_register_uri) { "http://www.example.com/register" }
   let(:post_login_uri) { "http://www.example.com/login" }
@@ -19,40 +15,25 @@ RSpec.describe BrexitChecker::AccountJwt do
     ).encode
   end
 
-  before do
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = oauth_client_id
-    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = key_uuid
-    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = private_key.to_pem
-  end
-
-  after do
-    ENV["GOVUK_ACCOUNT_OAUTH_CLIENT_ID"] = nil
-    ENV["GOVUK_ACCOUNT_JWT_KEY_UUID"] = nil
-    ENV["GOVUK_ACCOUNT_JWT_KEY_PEM"] = nil
-  end
-
   it "generates a valid JWT" do
-    payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
+    payload, = JWT.decode(jwt, nil, false)
     expect(payload).to_not be_nil
-    expect(payload["uid"]).to eq(oauth_client_id)
-    expect(payload["key"]).to eq(key_uuid)
-    expect(payload["scopes"]).to eq(%w[transition_checker])
     expect(payload["post_register_oauth"]).to eq(post_register_uri)
     expect(payload["post_login_oauth"]).to eq(post_login_uri)
   end
 
   it "includes the criteria keys" do
-    payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
+    payload, = JWT.decode(jwt, nil, false)
     expect(payload.dig("attributes", "transition_checker_state", "criteria_keys")).to eq(criteria_keys)
   end
 
   it "includes the timestamp" do
-    payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
+    payload, = JWT.decode(jwt, nil, false)
     expect(payload.dig("attributes", "transition_checker_state", "timestamp")).to_not be_nil
   end
 
   it "includes the email topic slug" do
-    payload, = JWT.decode(jwt, public_key, true, { algorithm: "ES256" })
+    payload, = JWT.decode(jwt, nil, false)
     expect(payload.dig("attributes", "transition_checker_state", "email_topic_slug")).to_not be_nil
   end
 end

--- a/spec/lib/brexit_checker/account_jwt_spec.rb
+++ b/spec/lib/brexit_checker/account_jwt_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 RSpec.describe BrexitChecker::AccountJwt do
   let(:criteria_keys) { %w[hello world] }
   let(:post_register_uri) { "http://www.example.com/register" }
-  let(:post_login_uri) { "http://www.example.com/login" }
   let(:subscriber_list_slug) { "test-slug" }
 
   let(:jwt) do
@@ -11,7 +10,6 @@ RSpec.describe BrexitChecker::AccountJwt do
       criteria_keys: criteria_keys,
       subscriber_list_slug: subscriber_list_slug,
       post_register_uri: post_register_uri,
-      post_login_uri: post_login_uri,
     ).encode
   end
 
@@ -19,7 +17,6 @@ RSpec.describe BrexitChecker::AccountJwt do
     payload, = JWT.decode(jwt, nil, false)
     expect(payload).to_not be_nil
     expect(payload["post_register_oauth"]).to eq(post_register_uri)
-    expect(payload["post_login_oauth"]).to eq(post_login_uri)
   end
 
   it "includes the criteria keys" do

--- a/spec/support/account_signup_helper_spec.rb
+++ b/spec/support/account_signup_helper_spec.rb
@@ -1,5 +1,0 @@
-module AccountSignupHelper
-  def self.test_ec_key_fixture
-    OpenSSL::PKey::EC.new("prime256v1").generate_key.export
-  end
-end


### PR DESCRIPTION
**Depends on:** https://github.com/alphagov/govuk-account-manager-prototype/pull/689

---

There are a few parts to this, but I've tried to break it up into independently reviewable commits.

1. The crypto goes away.  This is unnecessary if we're using an authenticated endpoint to submit the token.
2. Allow specifying the OAuth state, which will contain our JWT ID (see https://github.com/alphagov/govuk-account-manager-prototype/pull/684)
3. Remove a confusing instance variable assignment
4. Do a little refactoring to avoid code duplication for the client_credentials auth flow
5. Implement the new JWT journey (see https://github.com/alphagov/govuk-account-manager-prototype/pull/689)

This stuff is all temporary.  It will all be moving to the new account-api app when we set that up.  But by making the change now we can incrementally switch to the new APIs.

---

[Trello card](https://trello.com/c/nfoKVqOK/629-use-the-new-non-posty-jwt-mechanism-in-the-transition-checker)