### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/app/views/brexit_checker/_action_list.html.erb
+++ b/app/views/brexit_checker/_action_list.html.erb
@@ -18,7 +18,7 @@
           <a
             class="govuk-link"
             href="<%= action.title_url %>"
-            data-module="track-click"
+            data-module="gem-track-click"
             data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Action"
             data-track-category="brexit-checker-results"
             data-track-label="<%= action.title_url %>"
@@ -55,7 +55,7 @@
             <a
               href="<%= action.guidance_url %>"
               class="govuk-link govuk-body"
-              data-module="track-click"
+              data-module="gem-track-click"
               data-track-action="<%= "#{analytics_group}#{index + 1}"%> - Guidance"
               data-track-category="brexit-checker-results"
               data-track-label="<%= action.guidance_url %>"

--- a/app/views/brexit_checker/_change_answers_link.html.erb
+++ b/app/views/brexit_checker/_change_answers_link.html.erb
@@ -1,6 +1,6 @@
 <a
   class="govuk-link"
-  data-module="track-click"
+  data-module="gem-track-click"
   data-track-action="ChangeAnswers"
   data-track-category="ChangeAnswersClicked"
   data-track-label="<%= transition_checker_questions_path %>"

--- a/app/views/brexit_checker/_stay_updated.html.erb
+++ b/app/views/brexit_checker/_stay_updated.html.erb
@@ -13,7 +13,7 @@
   text: t("brexit_checker.stay_updated.sign_up"),
   href: path_based_on_account_feature_flag,
   data_attributes: {
-    "module": "track-click",
+    "module": "gem-track-click",
     "track-action": t("brexit_checker.stay_updated.sign_up"),
     "track-category": "StayUpdated",
     "track-label": transition_checker_email_signup_path

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -46,7 +46,7 @@
             text: t('brexit_checker.email_signup.sign_up_button'),
             inline_layout: true,
             data_attributes: {
-              module: "track-click",
+              module: "gem-track-click",
               "track-category": "transition-email-alert",
               "track-action": "subscribe",
             }

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -72,7 +72,7 @@
     <% else %>
       <%= render 'components/email_link', {
         data_attributes: {
-          "module": "track-click",
+          "module": "gem-track-click",
           "track-action": action_based_email_link_label,
           "track-category": "StayUpdated",
           "track-label": transition_checker_email_signup_path

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -24,7 +24,7 @@
     <%= render "govuk_publishing_components/components/back_link", {
       href: back_link_path,
       data_attributes: {
-        module: "track-click",
+        module: "gem-track-click",
         track_category: "brexit-checker-qa",
         track_action: @current_question.key,
         track_label: "back_click",

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -17,7 +17,7 @@
     <% if facets.select(&:filterable?).any? %>
       <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
         data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-        data-module="track-click" data-track-category="filterClicked"
+        data-module="gem-track-click" data-track-category="filterClicked"
         data-track-action="mobile-filter-button" data-track-label="">
         Filter <span class="govuk-visually-hidden"> results</span>
         <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
@@ -25,7 +25,7 @@
     <% end %>
   <% end %>
 
-  <div data-module="track-click" data-track-category="filterClicked"
+  <div data-module="gem-track-click" data-track-category="filterClicked"
       data-track-action="skip-Link" data-track-label="">
     <%= render "govuk_publishing_components/components/skip_link", {
       text: 'Skip to results',

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% if local_assigns[:applied_filters] %>
-  <div class="facet-tags" data-module="track-click">
+  <div class="facet-tags" data-module="gem-track-click">
     <% local_assigns[:applied_filters].each do |applied_filter| %>
       <div class="facet-tags__group">
         <% applied_filter.each do |filter| %>

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -2,7 +2,7 @@
   <meta name="govuk:search-result-count" content="<%= result_set_presenter.total_count %>">
 <% end %>
 
-<div class="finder-results js-finder-results" data-module="track-click">
+<div class="finder-results js-finder-results" data-module="gem-track-click">
   <%= render "govuk_publishing_components/components/document_list", {
     items: local_assigns[:document_list_component_data],
     remove_underline: true

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -45,7 +45,7 @@
         </div>
         <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
           data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-          data-module="track-click" data-track-category="filterClicked"
+          data-module="gem-track-click" data-track-category="filterClicked"
           data-track-action="mobile-filter-button" data-track-label="">
           Filter <span class="govuk-visually-hidden"> results</span>
           <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,7 +1,7 @@
 Then(/^the links on the page have tracking attributes$/) do
   visit finder_path("government/policies/benefits-reform")
 
-  expect(page).to have_selector('.finder-results[data-module="track-click"]')
+  expect(page).to have_selector('.finder-results[data-module="gem-track-click"]')
 
   document_links = page.all(".gem-c-document-list__item-title")
   expect(document_links.count).to be_positive

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -537,7 +537,7 @@ Then(/^The checkbox has the correct tracking data$/) do
   expect(page).to have_css("input[type='checkbox'][data-track-category='filterClicked']")
   expect(page).to have_css("input[type='checkbox'][data-track-action='checkboxFacet']")
   expect(page).to have_css("input[type='checkbox'][data-track-label='Show open cases']")
-  expect(page).to_not have_css("input[type='checkbox'][data-module='track-click']")
+  expect(page).to_not have_css("input[type='checkbox'][data-module='gem-track-click']")
 end
 
 Then(/^I can sort by:$/) do |table|

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -30,7 +30,7 @@ describe('liveSearch', function () {
         document_index: 1
       }
     ],
-    search_results: '<div class="finder-results js-finder-results" data-module="track-click">' +
+    search_results: '<div class="finder-results js-finder-results" data-module="gem-track-click">' +
       '<ol class="gem-c-document-list">' +
         '<li class="gem-c-document-list__item">' +
           '<a data-track-category="navFinderLinkClicked" data-track-action="" data-track-label="" class="gem-c-document-list__item-title" href="aaib-reports/test-report">Test report</a>' +
@@ -400,7 +400,7 @@ describe('liveSearch', function () {
   describe('indexTrackingData', function () {
     var groupedResponse = {
       search_results:
-        '<ul class="finder-results js-finder-results" data-module="track-click">' +
+        '<ul class="finder-results js-finder-results" data-module="gem-track-click">' +
           '<li class="filtered-results__group">' +
             '<h2 class="filtered-results__facet-heading">Primary group</h2>' +
             '<ol class="gem-c-document-list">' +
@@ -521,7 +521,7 @@ describe('liveSearch', function () {
           document_index: 1
         }
       ],
-      search_results: '<div class="finder-results js-finder-results" data-module="track-click">' +
+      search_results: '<div class="finder-results js-finder-results" data-module="gem-track-click">' +
         '<ol class="gem-c-document-list">' +
           '<li class="gem-c-document-list__item">' +
             '<a data-track-category="navFinderLinkClicked" data-track-action="" data-track-label="" class="gem-c-document-list__item-title" href="aaib-reports/test-report">Test report</a>' +
@@ -579,7 +579,7 @@ describe('liveSearch', function () {
           document_index: 1
         }
       ],
-      search_results: '<div class="finder-results js-finder-results" data-module="track-click">' +
+      search_results: '<div class="finder-results js-finder-results" data-module="gem-track-click">' +
         '<ol class="gem-c-document-list">' +
           '<li class="gem-c-document-list__item">' +
             '<a data-track-category="navFinderLinkClicked" data-track-action="" data-track-label="" class="gem-c-document-list__item-title" href="aaib-reports/test-report">Test report</a>' +

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -65,7 +65,7 @@ describe('remove-filter', function () {
       '<input name="public_timestamp[from]" value="" id="public_timestamp[from]" type="text">' +
     '</div>' +
     '<div id="a_check_box">' +
-      '<input type="checkbox" name="a_check_box" value="true" data-module="track-click">' +
+      '<input type="checkbox" name="a_check_box" value="true" data-module="gem-track-click">' +
     '</div>'
 
   beforeEach(function () {


### PR DESCRIPTION
### What

Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
