### PR TITLE
Add a 'None of the above' option to some questions on the Brexit checker

### DIFF
--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -19,6 +19,7 @@ module BrexitCheckerHelper
     { label: option.label,
       text: option.label,
       value: option.value,
+      exclusive: option.exclusive,
       checked: checked,
       hint_text: option.hint_text }
   end

--- a/app/helpers/brexit_checker_helper.rb
+++ b/app/helpers/brexit_checker_helper.rb
@@ -10,7 +10,12 @@ module BrexitCheckerHelper
   end
 
   def format_question_options(options, criteria_keys)
-    options.map { |o| format_question_option(o, criteria_keys) }
+    formatted = options.map { |o| format_question_option(o, criteria_keys) }
+    if formatted.last[:exclusive]
+      penultimate_position = formatted.count - 1
+      formatted.insert(penultimate_position, :or)
+    end
+    formatted
   end
 
   def format_question_option(option, criteria_keys)

--- a/app/lib/brexit_checker/question/option.rb
+++ b/app/lib/brexit_checker/question/option.rb
@@ -3,7 +3,7 @@ class BrexitChecker::Question::Option
 
   validates_presence_of :label
 
-  attr_reader :label, :value, :sub_options, :hint_text, :exclude_if
+  attr_reader :label, :value, :sub_options, :hint_text, :exclude_if, :exclusive
 
   def initialize(attrs)
     attrs.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -92,7 +92,6 @@ questions:
     type: multiple
     caption: About you and your family
     text: 'Where do you plan to travel for leisure and tourism?'
-    hint_text: Select all that apply. If you do not plan to travel, select continue.
     detail_text: |
       <p>The rules for travelling abroad have changed.</p>
       <p>We need to know where you plan to go so we can show you what you need to do before you travel.</p>
@@ -109,6 +108,8 @@ questions:
       - label: To the rest of the world
         value: visiting-row
         exclude_if: living-row
+      - label: None of the above
+        exclusive: true
 
   - key: activities
     criteria:
@@ -120,7 +121,6 @@ questions:
     type: multiple
     caption: About you and your family
     text: 'Do you plan to do either of the following when travelling?'
-    hint_text: "Select all that apply. If neither apply, select continue."
     detail_text: |
       <p>The rules for driving abroad and taking a pet have changed.</p>
       <p>We need to know about your plans so we can show you what you need to do before you travel.</p>
@@ -129,6 +129,8 @@ questions:
         value: visiting-driving
       - label: Take your pet or an assistance dog
         value: visiting-bring-pet
+      - label: None of the above
+        exclusive: true
 
   - key: move-eu
     caption: About you and your family
@@ -355,6 +357,8 @@ questions:
         value: export-to-row
       - label: "Trade with developing countries"
         value: trade-developing
+      - label: None of the above
+        exclusive: true
 
   - key: sector-business-area
     criteria:

--- a/spec/helpers/brexit_checker_helper_spec.rb
+++ b/spec/helpers/brexit_checker_helper_spec.rb
@@ -12,6 +12,39 @@ describe BrexitCheckerHelper, type: :helper do
     end
   end
 
+  describe "#format_question_options" do
+    let(:criteria_keys) { %w[A B C D] }
+    let(:option_A) { FactoryBot.build(:brexit_checker_option, value: criteria_keys.first) }
+    let(:option_Z) { FactoryBot.build(:brexit_checker_option, value: "Z") }
+
+    def build_hash(option, checked)
+      {
+        label: option.label,
+        text: option.label,
+        value: option.value,
+        exclusive: option.exclusive,
+        checked: checked,
+        hint_text: option.hint_text,
+      }
+    end
+
+    it "returns an array of hashes formatted for the checkbox component" do
+      expected = [build_hash(option_A, true), build_hash(option_Z, false)]
+      formatted = format_question_options([option_A, option_Z], criteria_keys)
+      expect(formatted).to eq expected
+    end
+
+    context "when a question has a 'none of the above' option" do
+      let(:exclusive_option) { FactoryBot.build(:brexit_checker_option, value: criteria_keys.first, exclusive: true) }
+
+      it "returns an array of hashes, with an 'or'" do
+        expected = [build_hash(option_A, true), :or, build_hash(exclusive_option, true)]
+        formatted = format_question_options([option_A, exclusive_option], criteria_keys)
+        expect(formatted).to eq expected
+      end
+    end
+  end
+
   describe "#next_question_index" do
     let(:q1) { FactoryBot.build(:brexit_checker_question) }
     let(:q2) { FactoryBot.build(:brexit_checker_question, criteria: [{ "all_of" => %w[a b] }]) }


### PR DESCRIPTION
## What

Add a "None of the above" option to three multiple checkbox questions. 

## Visual changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="579" alt="Screenshot 2021-02-18 at 17 46 06" src="https://user-images.githubusercontent.com/17908089/108398695-3a1e3200-7211-11eb-980d-ddffe51a7fdd.png">
</td>
<td>
<img width="526" alt="Screenshot 2021-02-18 at 17 45 36" src="https://user-images.githubusercontent.com/17908089/108398634-2377db00-7211-11eb-98d3-dcc62a2f3613.png">
</td>
</tr>
<td>
<img width="522" alt="Screenshot 2021-02-18 at 17 47 47" src="https://user-images.githubusercontent.com/17908089/108398902-6e91ee00-7211-11eb-850b-e4a5faf2b6eb.png">
</td>
<td>
<img width="515" alt="Screenshot 2021-02-18 at 17 47 21" src="https://user-images.githubusercontent.com/17908089/108398858-60dc6880-7211-11eb-9cc0-adad1d722168.png">
</td>
<tr>
<td>
<img width="540" alt="Screenshot 2021-02-18 at 17 48 13" src="https://user-images.githubusercontent.com/17908089/108399029-9719e800-7211-11eb-9421-42d5bb47f359.png">
</td>
<td>
<img width="553" alt="Screenshot 2021-02-18 at 17 49 39" src="https://user-images.githubusercontent.com/17908089/108399111-b0229900-7211-11eb-86d4-370c9593e926.png">
</td>
</tr>
<table>

- [Review app](https://finder-front-exclusive--9xx7qi.herokuapp.com/transition-check/questions)
- [Trello](https://trello.com/c/IfaTGHjB/1342-checker-improvement-add-checkbox-with-exclusive-item-component)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
