### PR TITLE
Remove caching / refreshing of access token in JWT flow 

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -46,18 +46,11 @@ class BrexitCheckerController < ApplicationController
   def save_results_sign_up
     jwt = account_signup_jwt(criteria_keys, subscriber_list_slug)
 
-    tokens = Rails.cache.fetch("finder-frontend_account_oauth_token") || Services.oidc.tokens!
+    tokens = Services.oidc.tokens!
 
     response = Services.oidc.submit_jwt(
       jwt: jwt,
       access_token: tokens[:access_token],
-      refresh_token: tokens[:refresh_token],
-    )
-
-    Rails.cache.write(
-      "finder-frontend_account_oauth_token",
-      { access_token: response[:access_token], refresh_token: response[:refresh_token] },
-      expires_in: 24.hours,
     )
 
     redirect_to transition_checker_new_session_path(

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -65,7 +65,7 @@ class OidcClient
     tokens!(id_token_nonce: nonce).merge(redirect_path: redirect_path)
   end
 
-  def get_checker_attribute(access_token:, refresh_token:)
+  def get_checker_attribute(access_token:, refresh_token: nil)
     response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -81,7 +81,7 @@ class OidcClient
     end
   end
 
-  def set_checker_attribute(value:, access_token:, refresh_token:)
+  def set_checker_attribute(value:, access_token:, refresh_token: nil)
     oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -91,7 +91,7 @@ class OidcClient
     )
   end
 
-  def has_email_subscription(access_token:, refresh_token:)
+  def has_email_subscription(access_token:, refresh_token: nil)
     response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -102,7 +102,7 @@ class OidcClient
     response.merge(result: (200..299).include?(response[:result].status))
   end
 
-  def update_email_subscription(slug:, access_token:, refresh_token:)
+  def update_email_subscription(slug:, access_token:, refresh_token: nil)
     oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -112,7 +112,7 @@ class OidcClient
     )
   end
 
-  def get_ephemeral_state(access_token:, refresh_token:)
+  def get_ephemeral_state(access_token:, refresh_token: nil)
     response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -127,7 +127,7 @@ class OidcClient
     end
   end
 
-  def submit_jwt(jwt:, access_token:, refresh_token:)
+  def submit_jwt(jwt:, access_token:, refresh_token: nil)
     response = oauth_request(
       access_token: access_token,
       refresh_token: refresh_token,
@@ -157,6 +157,8 @@ private
     response = Rack::OAuth2::AccessToken::Bearer.new(access_token: access_token_str).public_send(method, *args)
 
     unless OK_STATUSES.include? response.status
+      raise OAuthFailure unless refresh_token
+
       client.refresh_token = refresh_token
       access_token = client.access_token!
 


### PR DESCRIPTION
If we end up with a bad refresh token cached currently we will not
regenerate the tokens at all, and just return an error.  Since
generating tokens is fast, just don't cache.