### PR TITLE
Throw an OAuthFailure from tokens! method

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
         params.require(:code),
         state,
       )
-    rescue Rack::OAuth2::Client::Error
+    rescue OidcClient::OAuthFailure
       head 400
       return
     end

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -32,6 +32,8 @@ class OidcClient
       refresh_token: response[:refresh_token],
       id_token: id_token,
     }.compact
+  rescue Rack::OAuth2::Client::Error
+    raise OAuthFailure
   end
 
   def auth_uri(redirect_path: nil, state: nil)


### PR DESCRIPTION
This ensures that OAuthFailure is the only error exposed outside of
the OidcClient instance.

An exception snuck through the brexit checker controller because it
was doing this:

```ruby
def save_results_sign_up
  tokens = Services.oidc.tokens!
  # ...
rescue OidcClient::OAuthFailure
  # ...
end
```

But that `rescue` block didn't catch the error, as `tokens!` was
raising an `Rack::OAuth2::Client::Error`.

---

[Sentry error](https://sentry.io/organizations/govuk/issues/2234184018/?project=202224&referrer=slack)
