### PR TITLE
Remove two questions from the Brexit checker

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -1478,17 +1478,6 @@ actions:
     - road-passenger-freight
     - motor-trade
   audience: business
-- id: T107
-  priority: 1
-  title: Apply for Horizon 2020 funding
-  consequence: You may miss out on Horizon 2020 funding opportunities if you do not
-    apply.
-  guidance_prompt: More information
-  guidance_link_text: 'Horizon 2020: what it is and how to apply for funding'
-  guidance_url: https://www.gov.uk/guidance/horizon-2020-what-it-is-and-how-to-apply-for-funding#what-horizon-2020-can-do-for-you-as-a-uk-business
-  criteria:
-  - eu-uk-funding
-  audience: business
 - id: T108
   priority: 9
   title: Check the rules on moving goods into, out of, and through Northern Ireland
@@ -1690,17 +1679,6 @@ actions:
       - animal-ex-food
       - agriculture-farm
     - export-to-eu
-  audience: business
-- id: T125
-  priority: 3
-  title: Check which EU funding opportunities you can continue to apply for
-  consequence: You will only be able to apply for certain EU funding once the funding
-    cycle ends.
-  guidance_prompt: More information
-  guidance_link_text: Getting EU funding
-  guidance_url: https://www.gov.uk/guidance/getting-eu-funding
-  criteria:
-  - eu-uk-funding
   audience: business
 - id: T126
   priority: 5

--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -1522,16 +1522,6 @@ actions:
   criteria:
   - import-from-eu
   audience: business
-- id: T111
-  priority: 2
-  title: Check if you need to replace your .eu domain name
-  consequence: You may not be able to hold, register or renew a .eu domain name.
-  guidance_prompt: More information
-  guidance_link_text: Registering and renewing .eu domain names in the UK
-  guidance_url: https://www.gov.uk/guidance/registering-and-renewing-eu-domain-names-in-the-uk
-  criteria:
-  - eu-domain
-  audience: business
 - id: T112
   priority: 9
   title: Register for the UK’s new Import of Products, Animals, Food and Feed System

--- a/app/lib/brexit_checker/criteria.yaml
+++ b/app/lib/brexit_checker/criteria.yaml
@@ -160,10 +160,6 @@ criteria:
   text: You use or rely on exhaustion of rights protection
 - key: do-not-ip
   text: You do not use or rely on intellectual property protection
-- key: do-not-eu-uk-funding
-  text: You do not receive EU or UK government funding
-- key: eu-uk-funding
-  text: You receive EU or UK government funding
 - key: sell-public-sector
   text: You sell products or services to the UK public sector
 - key: sell-public-sector-contracts

--- a/app/lib/brexit_checker/criteria.yaml
+++ b/app/lib/brexit_checker/criteria.yaml
@@ -234,10 +234,6 @@ criteria:
   text: You do not travel to the EU for business
 - key: retired
   text: You are retired or semi-retired
-- key: eu-domain
-  text: You run a website with a .eu domain
-- key: eu-domain-no
-  text: You do not run a website with a .eu domain
 - key: move-to-eu
   text: You plan to move to the EU
 - key: move-to-eu-no

--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -263,21 +263,6 @@ questions:
             value: personal-eu-org-provide
       - label: "No"
         value: do-not-personal-eu-org
-
-  - key: eu-uk-government-funding
-    criteria:
-      - owns-operates-business-organisation-uk
-    caption: About your business
-    type: "single"
-    text: "Do you plan to apply for EU funding?"
-    description: |
-      <p>This includes funding like Horizon 2020.</p>
-    options:
-      - label: "Yes"
-        value: eu-uk-funding
-      - label: "No"
-        value: do-not-eu-uk-funding
-
   - key: public-sector-procurement
     criteria:
       - owns-operates-business-organisation-uk

--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -321,19 +321,6 @@ questions:
             value: ip-exhaustion-rights
       - label: "No"
         value: do-not-ip
-
-  - key: eu-domain
-    caption: About your business
-    criteria:
-      - owns-operates-business-organisation-uk
-    type: "single"
-    text: "Do you run a website with a .eu domain?"
-    options:
-      - label: "Yes"
-        value: eu-domain
-      - label: "No"
-        value: eu-domain-no
-
   - key: business-activity
     criteria:
       - owns-operates-business-organisation-uk

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -138,7 +138,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     answer_question("eu-uk-government-funding", "No")
     answer_question("public-sector-procurement", "No")
     answer_question("intellectual-property", "No")
-    answer_question("eu-domain", "No")
     answer_question("business-activity", "Send or take goods to EU countries (exporting)")
     answer_question("sector-business-area", "Fisheries (including wholesale)")
   end

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -135,7 +135,6 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
     answer_question("business-uk-or-eu", "UK")
     answer_question("employ-eu-citizens", "No")
     answer_question("personal-data", "No")
-    answer_question("eu-uk-government-funding", "No")
     answer_question("public-sector-procurement", "No")
     answer_question("intellectual-property", "No")
     answer_question("business-activity", "Send or take goods to EU countries (exporting)")


### PR DESCRIPTION
## What 

Remove these two questions from the checker:

<table>
<tr>
<td>
<img width="553" alt="Screenshot 2021-02-25 at 15 19 23" src="https://user-images.githubusercontent.com/17908089/109174581-e1084e00-777c-11eb-91d4-23e6f40c938a.png">
</td>
<td>
<img width="579" alt="Screenshot 2021-02-25 at 15 19 10" src="https://user-images.githubusercontent.com/17908089/109174584-e1a0e480-777c-11eb-90a1-838110cba6a3.png">
</td>
</tr>
</table>

- Trello cards:
  [1](https://trello.com/c/lTOFehDi/1377-remove-checker-questions-on-eu-funding-and-running-a-website-with-eu-domain)
  [2](https://trello.com/c/sEdb05R6/1379-batch-update-260221)
- [Review app](https://finder-front-remove-que-gqvsab.herokuapp.com/transition-check/questions)




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
