### PR TITLE
Implement the new account http headers & dev cookie

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -1,4 +1,5 @@
 class BrexitCheckerController < ApplicationController
+  include AccountConcern
   include AccountBrexitCheckerConcern
   include BrexitCheckerHelper
 

--- a/app/controllers/concerns/account_brexit_checker_concern.rb
+++ b/app/controllers/concerns/account_brexit_checker_concern.rb
@@ -50,8 +50,8 @@ module AccountBrexitCheckerConcern
   def oauth_fetch_results_from_account_or_logout
     oauth_do_or_logout do
       Services.oidc.get_checker_attribute(
-        access_token: account_session_cookie_value[:access_token],
-        refresh_token: account_session_cookie_value[:refresh_token],
+        access_token: account_session_header_value[:access_token],
+        refresh_token: account_session_header_value[:refresh_token],
       )
     end
   end
@@ -59,8 +59,8 @@ module AccountBrexitCheckerConcern
   def oauth_fetch_email_subscription_from_account_or_logout
     oauth_do_or_logout do
       Services.oidc.has_email_subscription(
-        access_token: account_session_cookie_value[:access_token],
-        refresh_token: account_session_cookie_value[:refresh_token],
+        access_token: account_session_header_value[:access_token],
+        refresh_token: account_session_header_value[:refresh_token],
       )
     end
   end
@@ -69,8 +69,8 @@ module AccountBrexitCheckerConcern
     oauth_do_or_logout do
       Services.oidc.update_email_subscription(
         slug: slug,
-        access_token: account_session_cookie_value[:access_token],
-        refresh_token: account_session_cookie_value[:refresh_token],
+        access_token: account_session_header_value[:access_token],
+        refresh_token: account_session_header_value[:refresh_token],
       )
     end
   end
@@ -79,14 +79,14 @@ module AccountBrexitCheckerConcern
     oauth_do_or_logout do
       Services.oidc.set_checker_attribute(
         value: { criteria_keys: new_criteria_keys, timestamp: Time.zone.now.to_i },
-        access_token: account_session_cookie_value[:access_token],
-        refresh_token: account_session_cookie_value[:refresh_token],
+        access_token: account_session_header_value[:access_token],
+        refresh_token: account_session_header_value[:refresh_token],
       )
     end
   end
 
   def oauth_do_or_logout
-    return unless account_session_cookie_value
+    return unless account_session_header_value
 
     update_account_session_cookie_from_oauth_result yield
   rescue OidcClient::OAuthFailure

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -43,7 +43,7 @@ module AccountConcern
   end
 
   def logged_in?
-    account_session_cookie_value&.dig(:sub).present?
+    account_session_cookie_value&.dig(:access_token).present?
   end
 
   def handle_disabled
@@ -80,12 +80,9 @@ module AccountConcern
     )
   end
 
-  def set_account_session_cookie(sub: nil, access_token: nil, refresh_token: nil)
-    return unless sub || account_session_cookie_value
-
+  def set_account_session_cookie(access_token: nil, refresh_token: nil)
     cookies.encrypted[ACCOUNT_SESSION_COOKIE_NAME] = {
       value: {
-        sub: sub || account_session_cookie_value&.dig(:sub),
         access_token: access_token || account_session_cookie_value&.dig(:access_token),
         refresh_token: refresh_token || account_session_cookie_value&.dig(:refresh_token),
       }.to_json,

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,6 @@ class SessionsController < ApplicationController
     end
 
     set_account_session_cookie(
-      sub: callback[:id_token].sub,
       access_token: callback[:access_token],
       refresh_token: callback[:refresh_token],
     )

--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -4,32 +4,60 @@ describe BrexitCheckerController, type: :controller do
   include GovukAbTesting::RspecHelpers
   render_views
 
-  context "accounts header AB test setup" do
+  context "accounts header" do
     before do
       allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
       stub_request(:get, Services.accounts_api).to_return(status: 200)
     end
 
-    %w[LoggedIn LoggedOut].each do |variant|
-      it "Variant #{variant} disables the search field" do
-        with_variant AccountExperiment: variant do
-          get :results
-          expect(response.headers["X-Slimmer-Remove-Search"]).to eq("true")
+    it "disables the search field" do
+      get :show
+      assert_equal "true", response.headers["X-Slimmer-Remove-Search"]
+    end
+
+    it "sets the Vary: GOVUK-Account-Session response header" do
+      get :show
+      assert response.headers["Vary"].include? "GOVUK-Account-Session"
+    end
+
+    it "requests the signed-out header" do
+      get :show
+      assert_equal "signed-out", response.headers["X-Slimmer-Show-Accounts"]
+    end
+
+    context "the GOVUK-Account-Session header is set" do
+      it "requests the signed-in header" do
+        request.headers["GOVUK-Account-Session"] = "foo"
+        get :show
+        assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
+      end
+    end
+
+    context "with the LoggedIn A/B variant" do
+      it "requests the signed-in header" do
+        with_variant AccountExperiment: "LoggedIn" do
+          get :show
+          assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
         end
       end
     end
 
-    it "Variant LoggedIn requests the signed-in header" do
-      with_variant AccountExperiment: "LoggedIn" do
-        get :results
-        expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-in")
+    context "with the LoggedOut A/B variant" do
+      it "requests the signed-out header" do
+        with_variant AccountExperiment: "LoggedOut" do
+          get :show
+          assert_equal "signed-out", response.headers["X-Slimmer-Show-Accounts"]
+        end
       end
-    end
 
-    it "Variant LoggedOut requests the signed-out header" do
-      with_variant AccountExperiment: "LoggedOut" do
-        get :results
-        expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-out")
+      context "the GOVUK-Account-Session header is set" do
+        it "requests the signed-in header" do
+          with_variant AccountExperiment: "LoggedOut" do
+            request.headers["GOVUK-Account-Session"] = "foo"
+            get :show
+            assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
+          end
+        end
       end
     end
   end

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -223,6 +223,9 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
                 expect(stub_get_fail).to have_been_made
                 expect(stub_get_success).to have_been_made.twice
+
+                expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
+                expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
               end
             end
           end
@@ -242,6 +245,9 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
               expect(stub_success).to have_been_made.twice
 
               expect(page).to have_current_path(transition_checker_results_path(c: %w[nationality-uk]))
+
+              expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
+              expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
             end
           end
 
@@ -260,6 +266,9 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
               expect(stub_success).to have_been_made
 
               expect(page).to have_current_path(transition_checker_questions_path(c: %w[nationality-uk], page: 0))
+
+              expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
+              expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
             end
           end
 
@@ -318,10 +327,14 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           .to_return(status: 200, body: "{}")
 
         visit transition_checker_new_session_callback_path(state: "state", code: "code")
+
+        @original_account_session_header = page.response_headers["GOVUK-Account-Session"]
+        expect(@original_account_session_header).to_not be_nil
       end
 
       def log_out
-        visit transition_checker_end_session_path
+        visit transition_checker_end_session_path(done: "1")
+        expect(page.response_headers["GOVUK-Account-End-Session"]).to_not be_nil
       end
     end
 

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -76,6 +76,23 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           expect(page).to_not have_content(I18n.t("brexit_checker.results.email_sign_up_title"))
         end
 
+        context "the account header is sent" do
+          before do
+            @original_headers = page.driver.options[:headers]
+            page.driver.options[:headers] ||= {}
+            page.driver.options[:headers].merge!("GOVUK-Account-Session" => @original_account_session_header)
+          end
+
+          after do
+            page.driver.options[:headers] = @original_headers
+          end
+
+          it "reads the new account header" do
+            given_i_am_on_the_results_page
+            expect(page.response_headers["GOVUK-Account-Session"]).to eq(@original_account_session_header)
+          end
+        end
+
         context "the querystring differs to the value in the account" do
           it "shows a link to save the new results" do
             given_i_am_on_the_results_page_with(%w[bring-pet-abroad nationality-eu])


### PR DESCRIPTION
[The RFC](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-134-govuk-wide-session-cookie-and-login.md) proposes our apps switch from managing session cookies to using request & response headers, which Fastly then uses to manage cookies.  And also to set a cookie when running in local dev.

This PR implements that for finder-frontend.  See also [the collections PR](https://github.com/alphagov/collections/pull/2292), which helped my thinking.

---

[Trello card](https://trello.com/c/UgjzCZGP/641-preferentially-use-the-new-cookie-in-the-transition-checker)