### PR TITLE
Check for both HTTP_ and normal-style request header names

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -5,6 +5,7 @@ module AccountConcern
 
   ACCOUNT_SESSION_COOKIE_NAME = :"_finder-frontend_account_session"
 
+  ACCOUNT_SESSION_HEADER_INTERNAL_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
   ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
   ACCOUNT_END_SESSION_HEADER_NAME = "GOVUK-Account-End-Session"
   ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
@@ -63,8 +64,10 @@ module AccountConcern
 
   def fetch_account_session_header
     @account_session_header =
-      if request.headers[ACCOUNT_SESSION_HEADER_NAME]
-        request.headers[ACCOUNT_SESSION_HEADER_NAME]
+      if request.headers[ACCOUNT_SESSION_HEADER_INTERNAL_NAME]
+        request.headers[ACCOUNT_SESSION_HEADER_INTERNAL_NAME]
+      elsif request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
+        request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
       elsif Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
       elsif cookies.encrypted[ACCOUNT_SESSION_COOKIE_NAME]

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -242,7 +242,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
                 expect(stub_get_success).to have_been_made.twice
 
                 expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
-                expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
               end
             end
           end
@@ -264,7 +263,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
               expect(page).to have_current_path(transition_checker_results_path(c: %w[nationality-uk]))
 
               expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
-              expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
             end
           end
 
@@ -285,7 +283,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
               expect(page).to have_current_path(transition_checker_questions_path(c: %w[nationality-uk], page: 0))
 
               expect(page.response_headers["GOVUK-Account-Session"]).to_not be_nil
-              expect(page.response_headers["GOVUK-Account-Session"]).to_not eq(@original_account_session_header)
             end
           end
 


### PR DESCRIPTION
When removing the session cookie entirely, I found that the tests
broke.  I discovered that "GOVUK-Account-Session" is in
`request.headers.to_h.keys`, but
`request.headers["GOVUK-Account-Session"]` doesn't work.  Nor does
`Govuk-Account-Session`, or `HTTP_GOVUK_ACCOUNT_SESSION`.

I don't really understand why, the docs are sparse but look like that
header name should be fine[1].  As a work-around I added the `to_h`,
which does work when the session cookie is turned off.

Then I ran the full testsuite and discovered that the controller specs
had broken!  Looking at `request.headers.to_h.keys` I saw that this
time we did have an `HTTP_GOVUK_ACCOUNT_SESSION`!  So the behaviour of
our controller specs is different to the behaviour of our feature
specs.

I suspect that the feature spec is how things will actually work on
www.gov.uk, as that goes through the full request stack.

[1] https://api.rubyonrails.org/classes/ActionDispatch/Http/Headers.html

---

[Trello card](https://trello.com/c/UgjzCZGP/641-preferentially-use-the-new-cookie-in-the-transition-checker)