### PR TITLE
Set the end-session header in all logout cases

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,11 +52,10 @@ class SessionsController < ApplicationController
   end
 
   def delete
+    logout!
     if params[:continue]
-      logout!
       redirect_with_ga "#{account_manager_url}/sign-out?done=#{params[:continue]}"
     elsif params[:done]
-      logout!
       redirect_with_ga "/transition"
     else
       redirect_with_ga "#{account_manager_url}/sign-out?continue=1"


### PR DESCRIPTION
We were missing a case, which meant logging out from /transition didn't work.

---

[Trello card](https://trello.com/c/UgjzCZGP/641-preferentially-use-the-new-cookie-in-the-transition-checker)