### PR TITLE
Remove account A/B test & old session cookie

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -5,7 +5,11 @@ class BrexitCheckerController < ApplicationController
 
   layout "finder_layout"
 
-  protect_from_forgery except: :confirm_email_signup
+  protect_from_forgery except: %i[
+    confirm_email_signup
+    save_results_sign_up
+    save_results_apply
+  ]
 
   before_action :enable_caching, only: %i[show email_signup confirm_email_signup]
   before_action :enable_caching_unless_accounts, only: %i[results]

--- a/app/controllers/concerns/account_brexit_checker_concern.rb
+++ b/app/controllers/concerns/account_brexit_checker_concern.rb
@@ -88,7 +88,7 @@ module AccountBrexitCheckerConcern
   def oauth_do_or_logout
     return unless account_session_header_value
 
-    update_account_session_cookie_from_oauth_result yield
+    update_account_session_header_from_oauth_result yield
   rescue OidcClient::OAuthFailure
     logout!
   end

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -3,8 +3,6 @@
 module AccountConcern
   extend ActiveSupport::Concern
 
-  ACCOUNT_SESSION_COOKIE_NAME = :"_finder-frontend_account_session"
-
   ACCOUNT_SESSION_HEADER_INTERNAL_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
   ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
   ACCOUNT_END_SESSION_HEADER_NAME = "GOVUK-Account-End-Session"
@@ -12,7 +10,7 @@ module AccountConcern
 
   included do
     before_action :fetch_account_session_header, if: :accounts_enabled?
-    before_action :set_account_session_cookie, if: :accounts_enabled?
+    before_action :set_account_session_header, if: :accounts_enabled?
     before_action :set_account_variant, if: :accounts_enabled?
 
     helper_method :accounts_available?,
@@ -66,11 +64,6 @@ module AccountConcern
         request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
       elsif Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
-      elsif cookies.encrypted[ACCOUNT_SESSION_COOKIE_NAME]
-        legacy_cookie = JSON.parse(cookies.encrypted[ACCOUNT_SESSION_COOKIE_NAME])
-        cookie_value = encode_account_session_header(legacy_cookie["access_token"], legacy_cookie["refresh_token"])
-        response.headers[ACCOUNT_SESSION_HEADER_NAME] = cookie_value
-        cookie_value
       end
   end
 
@@ -101,20 +94,11 @@ module AccountConcern
     )
   end
 
-  def set_account_session_cookie(access_token: nil, refresh_token: nil)
+  def set_account_session_header(access_token: nil, refresh_token: nil)
     new_access_token = access_token || account_session_header_value&.dig(:access_token)
     new_refresh_token = refresh_token || account_session_header_value&.dig(:refresh_token)
 
     return if new_access_token.nil? || new_refresh_token.nil?
-
-    cookies.encrypted[ACCOUNT_SESSION_COOKIE_NAME] = {
-      value: {
-        access_token: new_access_token,
-        refresh_token: new_refresh_token,
-      }.to_json,
-      expires: 15.minutes,
-      secure: Rails.env.production?,
-    }
 
     @account_session_header = encode_account_session_header(new_access_token, new_refresh_token)
     response.headers[ACCOUNT_SESSION_HEADER_NAME] = @account_session_header
@@ -127,8 +111,8 @@ module AccountConcern
     end
   end
 
-  def update_account_session_cookie_from_oauth_result(result)
-    set_account_session_cookie(
+  def update_account_session_header_from_oauth_result(result)
+    set_account_session_header(
       access_token: result[:access_token],
       refresh_token: result[:refresh_token],
     )
@@ -136,7 +120,6 @@ module AccountConcern
   end
 
   def logout!
-    cookies.delete ACCOUNT_SESSION_COOKIE_NAME
     response.headers[ACCOUNT_END_SESSION_HEADER_NAME] = "1"
     @account_session_header = nil
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,13 +28,13 @@ class SessionsController < ApplicationController
       return
     end
 
-    set_account_session_cookie(
+    set_account_session_header(
       access_token: callback[:access_token],
       refresh_token: callback[:refresh_token],
     )
 
     ephemeral_state =
-      update_account_session_cookie_from_oauth_result(
+      update_account_session_header_from_oauth_result(
         Services.oidc.get_ephemeral_state(
           access_token: callback[:access_token],
           refresh_token: callback[:refresh_token],

--- a/app/views/brexit_checker/email_signup.html.erb
+++ b/app/views/brexit_checker/email_signup.html.erb
@@ -3,7 +3,6 @@
   <% unless params[:page] %>
     <meta name="robots" content="noindex">
   <% end %>
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -16,7 +16,6 @@
   <meta property="og:description" content="<%= t('brexit_checker.results.social_media_meta.description') %>">
   <meta name="twitter:card" content="summary">
   <link rel="canonical" href="<%= page_url %>">
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -3,7 +3,6 @@
   <% unless params[:page] %>
     <meta name="robots" content="noindex">
   <% end %>
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/app/views/brexit_checker/save_results_confirm.html.erb
+++ b/app/views/brexit_checker/save_results_confirm.html.erb
@@ -3,7 +3,6 @@
   <% unless params[:page] %>
     <meta name="robots" content="noindex">
   <% end %>
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/app/views/brexit_checker/save_results_email_signup.html.erb
+++ b/app/views/brexit_checker/save_results_email_signup.html.erb
@@ -3,7 +3,6 @@
   <% unless params[:page] %>
     <meta name="robots" content="noindex">
   <% end %>
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <% content_for :breadcrumbs do %>

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, "#{@current_question.text} - #{t('brexit_checker.show.title')}" %>
 <% content_for :head do %>
   <meta name="robots" content="noindex">
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-FinderFrontend::Application.config.session_store :cookie_store,
-                                                 key: "_finder-frontend_session",
-                                                 expire_after: 15.minutes,
-                                                 secure: Rails.env.production?
+FinderFrontend::Application.config.session_store :disabled

--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe BrexitCheckerController, type: :controller do
-  include GovukAbTesting::RspecHelpers
   render_views
 
   context "accounts header" do
@@ -30,34 +29,6 @@ describe BrexitCheckerController, type: :controller do
         request.headers["GOVUK-Account-Session"] = "foo"
         get :show
         assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-      end
-    end
-
-    context "with the LoggedIn A/B variant" do
-      it "requests the signed-in header" do
-        with_variant AccountExperiment: "LoggedIn" do
-          get :show
-          assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-        end
-      end
-    end
-
-    context "with the LoggedOut A/B variant" do
-      it "requests the signed-out header" do
-        with_variant AccountExperiment: "LoggedOut" do
-          get :show
-          assert_equal "signed-out", response.headers["X-Slimmer-Show-Accounts"]
-        end
-      end
-
-      context "the GOVUK-Account-Session header is set" do
-        it "requests the signed-in header" do
-          with_variant AccountExperiment: "LoggedOut" do
-            request.headers["GOVUK-Account-Session"] = "foo"
-            get :show
-            assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
We've now fully switched over to the custom header approach.

---

[Trello card](https://trello.com/c/uHdKokkS/643-switch-from-the-old-cookie-to-the-new-cookie)