### PR TITLE
Change wording/handling of data use question

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -757,7 +757,6 @@ actions:
   guidance_url: https://www.gov.uk/guidance/using-personal-data-in-your-business-or-other-organisation
   criteria:
   - any_of:
-    - personal-eu-org
     - personal-eu-org-process
     - personal-eu-org-use
     - personal-eu-org-provide

--- a/app/lib/brexit_checker/criteria.yaml
+++ b/app/lib/brexit_checker/criteria.yaml
@@ -136,8 +136,6 @@ criteria:
   text: You employ EU citizens
 - key: do-not-employ-eu-citizens
   text: You do not employ EU citizens
-- key: personal-eu-org
-  text: You exchange personal data with EU organisations
 - key: personal-eu-org-process
   text: You process personal data from the EU
 - key: personal-eu-org-use

--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -248,23 +248,21 @@ questions:
     criteria:
       - owns-operates-business-organisation-uk
     caption: About your business
-    type: "single_wrapped"
-    text: "Do you exchange personal data with another organisation in Europe?"
+    type: "multiple"
+    text: "Does your business do any of the following?"
     description: |
-      <p>This includes organisations located in the EU, Norway, Iceland and Liechtenstein.</p>
-      <p>Personal data includes customers’ addresses, staff working hours or information you give to a delivery company.</p>
+      <p>Select any of the following which your business does in the EU. This also includes Norway, Iceland or Liechtenstein.</p>
     options:
-      - label: "Yes"
-        value: personal-eu-org
-        options:
-          - label: Processing personal data from Europe
-            value: personal-eu-org-process
-          - label: Using websites or services hosted in Europe
-            value: personal-eu-org-use
-          - label: Providing digital services available to Europe
-            value: personal-eu-org-provide
-      - label: "No"
+      - label: Store personal data of people in the EU - this includes customer names, email addresses and information you give to a delivery company
+        value: personal-eu-org-process
+      - label: Use websites or services hosted in the EU
+        value: personal-eu-org-use
+      - label: Provide digital services available in the EU
+        value: personal-eu-org-provide
+      - label: None of the above
         value: do-not-personal-eu-org
+        exclusive: true
+
   - key: public-sector-procurement
     criteria:
       - owns-operates-business-organisation-uk

--- a/app/views/brexit_checker/_question_multiple_choice.html.erb
+++ b/app/views/brexit_checker/_question_multiple_choice.html.erb
@@ -4,6 +4,7 @@
   heading: current_question.text,
   description: formatted_description,
   hint_text: current_question.hint_text,
+  no_hint_text: current_question.hint_text.nil?,
   is_page_heading: true,
   items: format_question_options(current_question.options(criteria_keys), criteria_keys)
 } %>


### PR DESCRIPTION
We don't think enough people recognise that this question is for them.

We're going to update the email subscriptions to catch those in the criteria that we've now removed.

There's an additional commit that disables default hint text from the form checkbox component. We want to choose when it's set. More context in the commit.

[Updated question](https://finder-front-data-gathe-uxym7k.herokuapp.com/transition-check/questions?c%5B%5D=owns-operates-business-organisation-uk&c%5B%5D=owns-operates-business-organisation&c%5B%5D=travel-eu-business-no&c%5B%5D=working-uk&c%5B%5D=living-uk&c%5B%5D=nationality-uk&page=14)

https://trello.com/c/NSgSLzOS/1341-review-wording-of-data-sharing-question-in-the-checker

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
