### PR TITLE
Expire dev cookie on logout

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -122,5 +122,13 @@ module AccountConcern
   def logout!
     response.headers[ACCOUNT_END_SESSION_HEADER_NAME] = "1"
     @account_session_header = nil
+
+    if Rails.env.development?
+      cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {
+        value: "",
+        domain: "dev.gov.uk",
+        expires: 1.second.ago,
+      }
+    end
   end
 end


### PR DESCRIPTION
Currently logging out doesn't work in dev mode, which makes testing auth flows a bit awkward.