### PR TITLE
Switch to the account-api email subscription endpoints

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -69,7 +69,7 @@ class BrexitCheckerController < ApplicationController
   def save_results_confirm
     redirect_to transition_checker_results_path(c: criteria_keys) and return if criteria_keys == @saved_results
 
-    @has_email_subscription = oauth_fetch_email_subscription_from_account_or_logout
+    @has_email_subscription = fetch_email_subscription_from_account_or_logout
     redirect_to logged_out_pre_update_results_path unless logged_in?
   end
 
@@ -77,7 +77,7 @@ class BrexitCheckerController < ApplicationController
 
   def save_results_apply
     if params[:email_decision] == "yes"
-      oauth_update_email_subscription_in_account_or_logout subscriber_list_slug
+      update_email_subscription_in_account_or_logout subscriber_list_slug
     end
 
     oauth_update_answers_in_account_or_logout criteria_keys

--- a/app/lib/oidc_client.rb
+++ b/app/lib/oidc_client.rb
@@ -49,27 +49,6 @@ class OidcClient
     )
   end
 
-  def has_email_subscription(access_token:, refresh_token: nil)
-    response = oauth_request(
-      access_token: access_token,
-      refresh_token: refresh_token,
-      method: :get,
-      uri: email_subscription_uri,
-    )
-
-    response.merge(result: (200..299).include?(response[:result].status))
-  end
-
-  def update_email_subscription(slug:, access_token:, refresh_token: nil)
-    oauth_request(
-      access_token: access_token,
-      refresh_token: refresh_token,
-      method: :post,
-      uri: email_subscription_uri,
-      arg: { topic_slug: slug },
-    )
-  end
-
 private
 
   OK_STATUSES = [200, 204, 404, 410].freeze
@@ -107,12 +86,6 @@ private
   def attribute_uri
     URI.parse(userinfo_endpoint).tap do |u|
       u.path = "/v1/attributes/transition_checker_state"
-    end
-  end
-
-  def email_subscription_uri
-    URI.parse(provider_uri).tap do |u|
-      u.path = "/api/v1/transition-checker/email-subscription"
     end
   end
 


### PR DESCRIPTION
These endpoints don't have any use outside of the transition checker,
but by migrating the functionality to account-api we're one step
closer to being able to treat the GOVUK-Account-Session as a black box
in this app.

---

[Trello card](https://trello.com/c/N49KKdOW/666-move-transition-checker-email-management-from-finder-frontend-to-the-new-app)