### PR TITLE
Use GdsApi.account_api

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -5,7 +5,7 @@ require "gds_api/email_alert_api"
 
 module Services
   def self.account_api
-    GdsApi::AccountApi.new(Plek.find("account-api"))
+    GdsApi.account_api
   end
 
   def self.content_store


### PR DESCRIPTION
This fetches the bearer token from the env automatically.

---

[Trello card](https://trello.com/c/Y8z5rsJl/653-move-oauth-sign-in-logic-from-the-transition-checker-to-the-new-app)
