### PR TITLE
Use question description consistently in brexit checker

### DIFF
--- a/app/lib/brexit_checker/questions.yaml
+++ b/app/lib/brexit_checker/questions.yaml
@@ -145,7 +145,8 @@ questions:
           - living-row
     type: single
     text: Do you plan to move to the EU or visit for more than 90 days?
-    hint_text: This includes Switzerland, Norway, Iceland or Liechtenstein but does not include Ireland.
+    description: |
+      <p>This includes Switzerland, Norway, Iceland or Liechtenstein but does not include Ireland.</p>
     options:
       - label: "Yes"
         value: move-to-eu
@@ -172,7 +173,8 @@ questions:
     type: single
     caption: About you and your family
     text: 'Are you a family member of an EU citizen?'
-    hint_text: 'This also includes Switzerland, Norway, Iceland and Liechtenstein.'
+    description: |
+      <p>This also includes Switzerland, Norway, Iceland and Liechtenstein.</p>
     criteria:
       all_of:
         - nationality-row


### PR DESCRIPTION
We currently use a mix of hint elements and 'description' elements (plain paragraphs) to provide additional information for questions. This PR updates two questions to align the approach. This means using hint elements only when for checkboxes where it is essential to remind people using a screen reader to select all answers that apply. For the rest of the questions, we use description to avoid overloading screen reader users with information at each interaction with the form elements.

[Trello card](https://trello.com/c/FEGMorA4)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3062_transition-check_questions_c%5B%5D=visiting-driving c%5B%5D=visiting-eu c%5B%5D=travel-eu-business c%5B%5D=working-uk c%5B%5D=living-uk c%5B%5D=nationality-uk page=7 (1)](https://user-images.githubusercontent.com/788096/111618336-2946e900-87dc-11eb-9f5a-88ee67efd648.png)

</td><td valign="top">

![localhost_3062_transition-check_questions_c%5B%5D=visiting-driving c%5B%5D=visiting-eu c%5B%5D=travel-eu-business c%5B%5D=working-uk c%5B%5D=living-uk c%5B%5D=nationality-uk page=7](https://user-images.githubusercontent.com/788096/111618371-34017e00-87dc-11eb-92d4-99edb57d3343.png)


</td></tr>
<tr><td valign="top">

![localhost_3062_transition-check_questions_c%5B%5D=visiting-driving c%5B%5D=visiting-row c%5B%5D=travel-eu-business c%5B%5D=working-uk c%5B%5D=studying-uk c%5B%5D=living-uk c%5B%5D=nationality-row page=7 (1)](https://user-images.githubusercontent.com/788096/111618385-395ec880-87dc-11eb-8add-a1d92f9eb2cc.png)


</td><td valign="top">

![localhost_3062_transition-check_questions_c%5B%5D=visiting-driving c%5B%5D=visiting-row c%5B%5D=travel-eu-business c%5B%5D=working-uk c%5B%5D=studying-uk c%5B%5D=living-uk c%5B%5D=nationality-row page=7](https://user-images.githubusercontent.com/788096/111618393-3c59b900-87dc-11eb-817f-83a6258ef299.png)


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
