### PR TITLE
Correct header name

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -5,7 +5,7 @@ module AccountConcern
 
   ACCOUNT_SESSION_HEADER_INTERNAL_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
   ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
-  ACCOUNT_END_SESSION_HEADER_NAME = "GOVUK-Account-End-Session"
+  ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
   ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
 
   ATTRIBUTE_NAME = "transition_checker_state"
@@ -67,7 +67,7 @@ module AccountConcern
   end
 
   def logout!
-    response.headers[ACCOUNT_END_SESSION_HEADER_NAME] = "1"
+    response.headers[ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME] = "1"
     @account_session_header = nil
 
     if Rails.env.development?

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -3,7 +3,7 @@
 module AccountConcern
   extend ActiveSupport::Concern
 
-  ACCOUNT_SESSION_HEADER_INTERNAL_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
+  ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
   ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
   ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
   ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
@@ -32,8 +32,8 @@ module AccountConcern
 
   def fetch_account_session_header
     @account_session_header =
-      if request.headers[ACCOUNT_SESSION_HEADER_INTERNAL_NAME]
-        request.headers[ACCOUNT_SESSION_HEADER_INTERNAL_NAME]
+      if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
+        request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
       elsif request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
         request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
       elsif Rails.env.development?

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -4,7 +4,7 @@ module AccountConcern
   extend ActiveSupport::Concern
 
   ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
-  ACCOUNT_SESSION_HEADER_NAME = "GOVUK-Account-Session"
+  ACCOUNT_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-Session"
   ACCOUNT_END_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-End-Session"
   ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
 
@@ -34,8 +34,6 @@ module AccountConcern
     @account_session_header =
       if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
         request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
-      elsif request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
-        request.headers.to_h[ACCOUNT_SESSION_HEADER_NAME]
       elsif Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
       end
@@ -46,7 +44,7 @@ module AccountConcern
   end
 
   def set_account_variant
-    response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_HEADER_NAME].compact.join(", ")
+    response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_RESPONSE_HEADER_NAME].compact.join(", ")
 
     set_slimmer_headers(
       remove_search: true,
@@ -56,7 +54,7 @@ module AccountConcern
 
   def set_account_session_header(govuk_account_session = nil)
     @account_session_header = govuk_account_session if govuk_account_session
-    response.headers[ACCOUNT_SESSION_HEADER_NAME] = @account_session_header
+    response.headers[ACCOUNT_SESSION_RESPONSE_HEADER_NAME] = @account_session_header
 
     if Rails.env.development?
       cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME] = {

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -45,16 +45,8 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
   end
 
   context "the user is logged in" do
-    before do
-      @original_headers = page.driver.options[:headers]
-      @original_account_session_header = "placeholder-session"
-      page.driver.options[:headers] ||= {}
-      page.driver.options[:headers].merge!("GOVUK-Account-Session" => @original_account_session_header)
-    end
-
-    after do
-      page.driver.options[:headers] = @original_headers
-    end
+    before { page.driver.header("GOVUK-Account-Session", "placeholder") }
+    after  { page.driver.header("GOVUK-Account-Session", nil) }
 
     let(:transition_checker_state) { { criteria_keys: criteria_keys, timestamp: 42 } }
     let(:criteria_keys) { %w[nationality-uk] }
@@ -69,7 +61,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
       it "reads the new account header" do
         given_i_am_on_the_results_page
-        expect(page.response_headers["GOVUK-Account-Session"]).to eq(@original_account_session_header)
+        expect(page.response_headers["GOVUK-Account-Session"]).to eq("placeholder")
       end
 
       context "the querystring differs to the value in the account" do


### PR DESCRIPTION
[Trello](https://trello.com/c/6GWYTVMM/681-remove-the-redundant-header-logic-in-finder-frontend-and-account-api)

Now we know more about how rails changes request headers, (see work [we did over on frontend](https://github.com/alphagov/frontend/blob/master/app/controllers/concerns/account_concern.rb#L7)),  we can simplify this code and bring it more into line with other account-using codebases.