### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/app/lib/healthchecks/registries_cache.rb
+++ b/app/lib/healthchecks/registries_cache.rb
@@ -5,8 +5,8 @@ module Healthchecks
     end
 
     def status
-      if in_warning_state?
-        :warning
+      if empty_registries.any?
+        :critical
       else
         :ok
       end
@@ -14,7 +14,7 @@ module Healthchecks
 
     # Optional
     def message
-      if in_warning_state?
+      if empty_registries.any?
         "The following registry caches are empty: #{empty_registries.keys.join(', ')}."
       else
         "OK"
@@ -27,10 +27,6 @@ module Healthchecks
     end
 
   private
-
-    def in_warning_state?
-      empty_registries.any?
-    end
 
     def empty_registries
       @empty_registries ||= registries.select do |_key, registry|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ FinderFrontend::Application.routes.draw do
       )
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    Healthchecks::RegistriesCache,
+  )
+
   root to: redirect("/development") unless Rails.env.test?
   get "/development" => "development#index"
 

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -16,7 +16,7 @@ describe "Healthcheck" do
     end
 
     it "returns an OK status" do
-      get "/healthcheck.json"
+      get "/healthcheck/ready"
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
@@ -34,16 +34,16 @@ describe "Healthcheck" do
       Rails.cache.clear
     end
 
-    it "returns a warning status" do
-      get "/healthcheck.json"
+    it "returns a critical status" do
+      get "/healthcheck/ready"
       expect(JSON.parse(response.body)).to eq(
         "checks" => {
           "registries_have_data" => {
             "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, topical_events.",
-            "status" => "warning",
+            "status" => "critical",
           },
         },
-        "status" => "warning",
+        "status" => "critical",
       )
     end
   end

--- a/spec/lib/healthchecks/registries_cache_spec.rb
+++ b/spec/lib/healthchecks/registries_cache_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Healthchecks::RegistriesCache do
   end
 
   context "Registries caches are empty" do
-    it "has an OK status" do
-      expect(check.status).to eq :warning
+    it "has a critical status" do
+      expect(check.status).to eq :critical
       expect(check.message).to eq "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, topical_events."
     end
   end


### PR DESCRIPTION
Keeping the RegistriesCache check ensures that the app starts with a
"hot" cache, which means it'll respond much more quickly to queries,
so we do want this.

Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
