### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=http://www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck || exit 1
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT/healthcheck/ready || exit 1
 
 CMD foreman run web

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,6 @@ FinderFrontend::Application.routes.draw do
   get "/sign-in", to: proc { [200, {}, %w[OK]] }
   get "/sign-out", to: proc { [200, {}, %w[OK]] }
 
-  get "/healthcheck.json",
-      to: GovukHealthcheck.rack_response(
-        Healthchecks::RegistriesCache,
-      )
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     Healthchecks::RegistriesCache,


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
