### PR TITLE
Fix minor filter bug when switching breakpoints

### DIFF
--- a/app/assets/javascripts/modules/mobile-filters-modal.js
+++ b/app/assets/javascripts/modules/mobile-filters-modal.js
@@ -45,7 +45,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$body.style.top = '-' + window.scrollY + 'px'
     this.$body.style.position = 'fixed'
     this.$focusedElementBeforeOpen = document.activeElement
-    this.$module.style.display = 'block'
+    this.$module.classList.add('facets--visible')
     this.$facetsBox.setAttribute('aria-modal', true)
     this.$facetsBox.setAttribute('tabindex', 0)
     this.$facetsBox.focus()
@@ -62,7 +62,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$body.style.position = ''
     this.$body.style.top = ''
     window.scrollTo(0, parseInt(offsetTop || '0') * -1)
-    this.$module.style.display = 'none'
+    this.$module.classList.remove('facets--visible')
     this.$facetsBox.removeAttribute('aria-modal')
     this.$facetsBox.removeAttribute('tabindex')
     this.$focusedElementBeforeOpen.focus()

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -18,6 +18,10 @@
 .js-enabled .facets {
   @include govuk-media-query($until: tablet) {
     display: none;
+
+    &.facets--visible {
+      display: block;
+    }
   }
 }
 

--- a/spec/javascripts/modules/mobile-filters-modal.spec.js
+++ b/spec/javascripts/modules/mobile-filters-modal.spec.js
@@ -62,7 +62,7 @@ describe('Mobile filters modal', function () {
 
     it('should show the modal', function () {
       var modal = document.querySelector('.facets')
-      expect($(modal).is(':visible')).toBe(true)
+      expect($(modal).hasClass('facets--visible')).toBe(true)
     })
   })
 
@@ -73,7 +73,7 @@ describe('Mobile filters modal', function () {
 
       var modal = document.querySelector('.facets')
       document.querySelector('.js-close-filters').click()
-      expect($(modal).is(':visible')).toBe(false)
+      expect($(modal).hasClass('facets--visible')).toBe(false)
     })
   })
 
@@ -90,7 +90,7 @@ describe('Mobile filters modal', function () {
 
     it('should show the modal', function () {
       var modal = document.querySelector('.facets')
-      expect($(modal).is(':visible')).toBe(true)
+      expect($(modal).hasClass('facets--visible')).toBe(true)
     })
 
     it('should focus the modal', function () {
@@ -104,7 +104,7 @@ describe('Mobile filters modal', function () {
       var modal = document.querySelector('.facets')
       modal.open()
       modal.close()
-      expect($(modal).is(':visible')).toBe(false)
+      expect($(modal).hasClass('facets--visible')).toBe(false)
     })
   })
 


### PR DESCRIPTION
Fixes the issue described in #2446 wherein the filters disappear on desktop when the browser window is resized from desktop to smaller breakpoints and back.

Instead of programatically applying inline styles to the facets, apply a class to toggle visibility on/off. This way we can ensure that the filters are always visible on desktop using CSS media queries.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
