### PR TITLE
Do not consider someone with an empty session logged in

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -33,7 +33,7 @@ module AccountConcern
   def fetch_account_session_header
     @account_session_header =
       if request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
-        request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME]
+        request.headers[ACCOUNT_SESSION_REQUEST_HEADER_NAME].presence
       elsif Rails.env.development?
         cookies[ACCOUNT_SESSION_DEV_COOKIE_NAME]
       end

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -45,7 +45,8 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
   end
 
   context "the user is logged in" do
-    before { page.driver.header("GOVUK-Account-Session", "placeholder") }
+    let(:govuk_account_session) { "placeholder" }
+    before { page.driver.header("GOVUK-Account-Session", govuk_account_session) }
     after  { page.driver.header("GOVUK-Account-Session", nil) }
 
     let(:transition_checker_state) { { criteria_keys: criteria_keys, timestamp: 42 } }
@@ -62,6 +63,15 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
       it "reads the new account header" do
         given_i_am_on_the_results_page
         expect(page.response_headers["GOVUK-Account-Session"]).to eq("placeholder")
+      end
+
+      context "the account header is the empty string" do
+        let(:govuk_account_session) { "" }
+
+        it "doesn't consider the user logged in" do
+          given_i_am_on_the_results_page
+          expect(page.response_headers["GOVUK-Account-Session"]).to be_nil
+        end
       end
 
       context "the querystring differs to the value in the account" do


### PR DESCRIPTION
We have a bug in our CDN config which always sets the
GOVUK-Account-Session request header, even if the cookie isn't set.
Since the `do_or_logout` method checks for nil-ness and not presence,
every request to the Transition Checker results page causes a request
to the account-api, which returns a 401.

Thankfully there's no bad side-effect of this, it just makes the page
a little slower and increases the volume of requests to account-api
unnecessarily.

I noticed that account-api was getting a lot of requests, far more
than we'd expect from the number of account holders we have, and
tracked it down to this.  I'll also update our CDN config to only set
the header if the cookie is set.
