### PR TITLE
Authenticate at level 1, and reauthenticate on 403

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -67,7 +67,7 @@ class BrexitCheckerController < ApplicationController
     redirect_to transition_checker_results_path(c: criteria_keys) and return if criteria_keys == @saved_results
 
     @has_email_subscription = fetch_email_subscription_from_account_or_logout
-    redirect_to logged_out_pre_update_results_path unless logged_in?
+    redirect_to logged_out_pre_update_results_path if must_reauthenticate?
   end
 
   def save_results_email_signup; end
@@ -79,10 +79,10 @@ class BrexitCheckerController < ApplicationController
 
     update_answers_in_account_or_logout criteria_keys
 
-    if logged_in?
-      redirect_to transition_checker_results_path(c: criteria_keys)
-    else
+    if must_reauthenticate?
       redirect_to logged_out_pre_update_results_path
+    else
+      redirect_to transition_checker_results_path(c: criteria_keys)
     end
   end
 

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -145,7 +145,8 @@ module AccountConcern
   end
 
   def transition_checker_new_session_url(**params)
-    "#{base_path}/sign-in?#{params.compact.to_query}"
+    querystring = params.merge(level_of_authentication: "level1").compact.to_query
+    "#{base_path}/sign-in?#{querystring}"
   end
 
   def transition_checker_end_session_url(**params)

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -56,19 +56,7 @@
   </div>
 
   <% if criteria_keys.present? %>
-    <% if logged_in? %>
-      <% if @results_differ %>
-        <%= render 'govuk_publishing_components/components/notice', {
-          title: t('brexit_checker.results.accounts.results_differ.message'),
-          description: sanitize(t('brexit_checker.results.accounts.results_differ.description', link: transition_checker_save_results_confirm_path(c: criteria_keys)))
-        } %>
-      <% elsif @results_saved %>
-        <%= render 'govuk_publishing_components/components/success_alert', {
-          message: t('brexit_checker.results.accounts.results_saved.message'),
-          description: t('brexit_checker.results.accounts.results_saved.description')
-        } %>
-      <% end %>
-    <% else %>
+    <% if must_reauthenticate? %>
       <%= render 'components/email_link', {
         data_attributes: {
           "module": "gem-track-click",
@@ -80,13 +68,25 @@
         link_href: transition_checker_save_results_path(c: criteria_keys),
         link_title: t("brexit_checker.results.email_sign_up_title"),
       } %>
+    <% else %>
+      <% if @results_differ %>
+        <%= render 'govuk_publishing_components/components/notice', {
+          title: t('brexit_checker.results.accounts.results_differ.message'),
+          description: sanitize(t('brexit_checker.results.accounts.results_differ.description', link: transition_checker_save_results_confirm_path(c: criteria_keys)))
+        } %>
+      <% elsif @results_saved %>
+        <%= render 'govuk_publishing_components/components/success_alert', {
+          message: t('brexit_checker.results.accounts.results_saved.message'),
+          description: t('brexit_checker.results.accounts.results_saved.description')
+        } %>
+      <% end %>
     <% end %>
 
     <%= render 'results_business_actions', business_results: @presenter.business_results if @presenter.business_results.any? %>
     <%= render 'results_citizen_actions', citizen_results_groups: @presenter.citizen_results_groups if @presenter.citizen_results_groups.any? %>
     <%= render 'results_with_no_actions', criteria: @presenter.criteria if (@presenter.business_results.empty? && @presenter.citizen_results_groups.empty?) %>
 
-    <% if logged_in? %>
+    <% if !must_reauthenticate? %>
       <% if @results_differ %>
         <%= render 'govuk_publishing_components/components/notice', {
           title: t('brexit_checker.results.accounts.results_differ.message'),

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -19,27 +19,24 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
     context "/transition-check/saved-results" do
       it "redirects to login page" do
         given_i_am_on_the_saved_results_page
-        expect(page).to have_current_path(
-          "#{Plek.find('frontend')}/sign-in?#{CGI.escape('redirect_path=/transition-check/saved-results')}",
-        )
+        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/saved-results" }.to_query
+        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
       end
     end
 
     context "/transition-check/edit-saved-results" do
       it "redirects to login page" do
         given_i_am_on_the_edit_saved_results_page
-        expect(page).to have_current_path(
-          "#{Plek.find('frontend')}/sign-in?#{CGI.escape('redirect_path=/transition-check/edit-saved-results')}",
-        )
+        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/edit-saved-results" }.to_query
+        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
       end
     end
 
     context "/transition-check/save-your-results/confirm" do
       it "redirects to login page" do
         given_i_am_on_the_save_results_confirm_page
-        expect(page).to have_current_path(
-          "#{Plek.find('frontend')}/sign-in?#{CGI.escape('redirect_path=/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu')}",
-        )
+        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu" }.to_query
+        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
       end
     end
   end


### PR DESCRIPTION
If the user gets a 403 response, then they are logged in but not at a
high enough level of authentication.  The straightforward way to
handle this would be to treat it the same as a 401: end the user's
session and redirect them to log in.

But that's not a great user experience.  If they decide they don't
want to set up MFA, and come back, they're no longer able to see their
saved pages any more, because they've been logged out.  Better to keep
the user's session intact, but to put them in a `must_reauthenticate?`
bucket.

`must_reauthenticate?` is essentially the same as `!logged_in?` but
doesn't require actually ending the session.  This is probably a
pattern we'll find useful in other frontend apps.

---

[Trello card](https://trello.com/c/G2uYUDuz/716-check-the-level-of-authentication-when-using-attributes-in-the-account-api)