### PR TITLE
Remove `is_page_heading` param from radio components

### DIFF
--- a/app/views/brexit_checker/_question_single_choice.html.erb
+++ b/app/views/brexit_checker/_question_single_choice.html.erb
@@ -4,6 +4,7 @@
   heading: current_question.text,
   description: formatted_description,
   hint: current_question.hint_text,
-  is_page_heading: true,
+  heading_level: 1,
+  heading_size: 'xl',
   items: format_question_options(current_question.options(criteria_keys), criteria_keys)
 } %>

--- a/app/views/brexit_checker/_question_single_wrapped.html.erb
+++ b/app/views/brexit_checker/_question_single_wrapped.html.erb
@@ -5,7 +5,8 @@
     heading_caption: current_question.caption,
     description: formatted_description,
     hint: current_question.hint_text,
-    is_page_heading: true,
+    heading_level: 1,
+    heading_size: 'xl',
     items: current_question.options.map do |option|
       checkboxes = if option.sub_options.present?
                      render "govuk_publishing_components/components/checkboxes", {


### PR DESCRIPTION
~🙅🏻‍♀️ Do not merge, depends on alphagov/govuk_publishing_components#2051 🙅🏻‍♀️~ no longer an issue, we're up to date on the gem now.


Replace the `is_page_heading` parameter with `heading_level` and `heading_size`.

Changes are being made to remove the `is_page_heading` parameter, and achieve the same result using `heading_level` and/or `heading_size` instead. The reasons behind this are described in more detail in [this issue](https://github.com/alphagov/govuk_publishing_components/issues/1953).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
