### PR TITLE
Fix registry cache update schedule

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,7 +8,7 @@ set :output, error: "log/cron.error.log", standard: "log/cron.log"
 bundler_prefix = ENV.fetch("BUNDLER_PREFIX", "/usr/local/bin/govuk_setenv finder-frontend")
 job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
 
-cache_refresh_schedule = Random.new.rand(45..60)
+cache_refresh_schedule = Random.new.rand(0..60)
 every cache_refresh_schedule.minutes do
   rake "registries:cache_refresh"
 end


### PR DESCRIPTION
At present all the schedules are run once per hour, but they're all clustered between the 45th and 60th minute. It'd be nicer if they were randomly spread out. It's not actually a problem, it just looks a bit untidy on the graphs.

The `every 45.minutes do` line translates into https://crontab.guru/#45_*_*_*_* which means "at the 45th minute", not "every 45 minutes".

https://grafana.production.govuk.digital/dashboard/file/finder-frontend.json?panelId=5&fullscreen&orgId=1&from=now-1d&to=now

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
