### PR TITLE
Fix cache warming schedule again

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,8 +8,8 @@ set :output, error: "log/cron.error.log", standard: "log/cron.log"
 bundler_prefix = ENV.fetch("BUNDLER_PREFIX", "/usr/local/bin/govuk_setenv finder-frontend")
 job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
 
-cache_refresh_schedule = Random.new.rand(0..60)
-every cache_refresh_schedule.minutes do
+random_minute_per_hour = Random.new.rand(0..59)
+every "#{random_minute_per_hour} * * * *" do
   rake "registries:cache_refresh"
 end
 


### PR DESCRIPTION
It turns out that Whenever does something weird when you provide a minutes argument that is less than or equal to 30. It assumes you mean 'every n minutes' whereas for values greater than 30, it assumes you mean 'the nth minute'.

[Whenever specs describing the behaviour](https://github.com/javan/whenever/blob/e916b58f29ea4da76de9ddc5aca8c85a5f29f897/test/unit/cron_test.rb#L17-L19)

So, when the random number generates an 8, whenever generates a schedule like this (edited for brevity):

> 8,16,24,32,40,48,56 * * * * /bin/bash -l -c 'rake registries:cache_refresh'

We'll switch to using raw cron syntax instead. [From the Readme](https://github.com/javan/whenever/blob/e916b58f29ea4da76de9ddc5aca8c85a5f29f897/README.md):

> every '0 0 27-31 * *' do
>  command "echo 'you can use raw cron syntax too'"
> end

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
