### PR TITLE
Remove sticky "show results" button on mobile filters

### DIFF
--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -72,19 +72,12 @@
     }
 
     .facets__content {
-      padding: govuk-spacing(2) govuk-spacing(3) 90px govuk-spacing(3);
+      padding: govuk-spacing(2) govuk-spacing(3) 0;
     }
 
     .facets__footer {
       display: block;
-      position: fixed;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: govuk-colour("white");
-      padding: govuk_spacing(3);
-      border-top: 1px solid $govuk-border-colour;
-      box-shadow: 0 0 5px rgba($govuk-border-colour, .8);
+      margin: govuk_spacing(3);
     }
 
     .facets__return-link {


### PR DESCRIPTION
## What
Restyle the sticky "show results" button on mobile filters to no longer be sticky an sit below the filter options.

## Why
On smaller screens and visually impaired users using browser zoom, this button can take up a lot of the screen and make navigating the filters difficult.

[Card](https://trello.com/c/HV4mr13g/726-update-filters-sticky-button-in-mobile-view-to-no-longer-be-sticky)

[Search page developed against](https://www.gov.uk/search/all?keywords=help&content_purpose_supergroup%5B%5D=services&public_timestamp%5Bfrom%5D=1%2F1%2F2020&public_timestamp%5Bto%5D=1%2F6%2F2020&order=relevance)

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-05-11 at 17 18 31](https://user-images.githubusercontent.com/64783893/117854714-aa24dd00-b281-11eb-8acb-42694fcd9dd0.png) | ![Screenshot 2021-05-11 at 17 18 46](https://user-images.githubusercontent.com/64783893/117854738-af822780-b281-11eb-8720-fa78f33797ba.png) |
| ![Screenshot 2021-05-11 at 17 19 23](https://user-images.githubusercontent.com/64783893/117854764-b6a93580-b281-11eb-8a78-b42102eafea0.png) | ![Screenshot 2021-05-11 at 17 19 32](https://user-images.githubusercontent.com/64783893/117854793-bb6de980-b281-11eb-9af3-7da82ca691ac.png) |




