### PR TITLE
Update travel information priority

### DIFF
--- a/app/lib/brexit_checker/actions.yaml
+++ b/app/lib/brexit_checker/actions.yaml
@@ -96,7 +96,7 @@ actions:
   grouping_criteria:
   - studying-eu
 - id: S008
-  priority: 8
+  priority: 10
   title: Check if you need to renew your passport before you travel to Europe
   consequence: You should have at least 6 months left on your UK passport and it needs
     to be less than 10 years old, or you may not be able to travel.
@@ -156,7 +156,7 @@ actions:
   - visiting-eu
   - visiting-ie
 - id: S011
-  priority: 8
+  priority: 10
   title: Before you travel, make sure you have a valid European Health Insurance Card
     (EHIC) or UK Global Health Insurance Card (GHIC), or travel insurance with health
     cover


### PR DESCRIPTION
We want S008 and S011 to be highlighted as urgent.

https://trello.com/c/fiRpSHr3/1509-add-an-urgency-tag-for-passport-validity-and-healthcare-actions-on-the-brexit-checker-results-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
