### PR TITLE
Add new default option for Research & Statistics Finder

### DIFF
--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -23,15 +23,20 @@ module Filters
           "value" => "statistics_published",
           "label" => "Statistics (published)",
           "filter" => {
-            "content_store_document_type" => %w[statistics national_statistics statistical_data_set official_statistics],
+            "content_store_document_type" => %w[
+              national_statistics
+              official_statistics
+              statistical_data_set
+              statistics
+            ],
           },
         },
         {
           "value" => "upcoming_statistics",
           "label" => "Statistics (upcoming)",
           "filter" => {
-            "release_timestamp" => "from:#{Time.zone.today}",
             "format" => %w[statistics_announcement],
+            "release_timestamp" => "from:#{Time.zone.today}",
           },
         },
         {
@@ -45,7 +50,11 @@ module Filters
           "value" => "research",
           "label" => "Research",
           "filter" => {
-            "content_store_document_type" => %w[research_for_development_output independent_report research],
+            "content_store_document_type" => %w[
+              independent_report
+              research
+              research_for_development_output
+            ],
           },
         },
       ]

--- a/app/models/filters.rb
+++ b/app/models/filters.rb
@@ -3,12 +3,28 @@ module Filters
     def call
       [
         {
+          "value" => "all_research_and_statistics",
+          "label" => "All research and statistics",
+          "filter" => {
+            "content_store_document_type" => %w[
+              independent_report
+              national_statistics
+              official_statistics
+              research
+              research_for_development_output
+              statistical_data_set
+              statistics
+              statistics_announcement
+            ],
+          },
+          "default" => true,
+        },
+        {
           "value" => "statistics_published",
           "label" => "Statistics (published)",
           "filter" => {
             "content_store_document_type" => %w[statistics national_statistics statistical_data_set official_statistics],
           },
-          "default" => true,
         },
         {
           "value" => "upcoming_statistics",

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -253,6 +253,7 @@ Feature: Filtering documents
 
   Scenario: Choosing between document types with a research and statistics facet
     When I view the research and statistics finder
+    Then I should see all research and statistics
     And I select upcoming statistics
     And I click filter results
     Then I should see upcoming statistics

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -37,13 +37,13 @@ Then(/^the ecommerce tracking tags are present$/) do
 end
 
 And "I search for lunch" do
-  stub_rummager_api_request_with_query_param_no_results("lunch")
+  stub_search_api_request_with_query_param_no_results("lunch")
 
   fill_in "Search", with: "lunch"
 end
 
 And "I search for superted" do
-  stub_rummager_api_request_with_query_param_no_results("superted")
+  stub_search_api_request_with_query_param_no_results("superted")
 
   fill_in "Search", with: "superted"
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -1,12 +1,12 @@
 Given(/^a collection of documents exist$/) do
   content_store_has_mosw_reports_finder
-  stub_rummager_api_request
+  stub_search_api_request
   stub_taxonomy_api_request
 end
 
 Given(/^no results$/) do
   content_store_has_mosw_reports_finder_with_no_facets
-  stub_rummager_api_request_with_no_results
+  stub_search_api_request_with_no_results
   stub_taxonomy_api_request
 end
 
@@ -90,7 +90,7 @@ When(/^I view a list of news and communications$/) do
   stub_world_locations_api_request
   stub_people_registry_request
   stub_organisations_registry_request
-  stub_rummager_api_request_with_news_and_communication_results
+  stub_search_api_request_with_news_and_communication_results
   visit finder_path("search/news-and-communications")
 end
 
@@ -98,7 +98,7 @@ When(/^I view the news and communications finder$/) do
   stub_taxonomy_api_request
   content_store_has_news_and_communications_finder
   stub_world_locations_api_request
-  stub_all_rummager_api_requests_with_news_and_communication_results
+  stub_all_search_api_requests_with_news_and_communication_results
   stub_people_registry_request
   stub_organisations_registry_request
   visit finder_path("search/news-and-communications")
@@ -110,8 +110,8 @@ When(/^I view the policy papers and consultations finder$/) do
   stub_organisations_registry_request
   stub_topical_events_registry_request
   stub_world_locations_api_request
-  stub_rummager_api_request_with_policy_papers_results
-  stub_rummager_api_request_with_filtered_policy_papers_results
+  stub_search_api_request_with_policy_papers_results
+  stub_search_api_request_with_filtered_policy_papers_results
 
   visit finder_path("search/policy-papers-and-consultations")
 end
@@ -122,9 +122,9 @@ When(/^I view the research and statistics finder$/) do
   stub_organisations_registry_request
   stub_manuals_registry_request
   stub_world_locations_api_request
-  stub_rummager_api_request_with_research_and_statistics_results
-  stub_rummager_api_request_with_statistics_results
-  stub_rummager_api_request_with_filtered_research_and_statistics_results
+  stub_search_api_request_with_research_and_statistics_results
+  stub_search_api_request_with_statistics_results
+  stub_search_api_request_with_filtered_research_and_statistics_results
   visit finder_path("search/research-and-statistics")
 end
 
@@ -140,9 +140,9 @@ When(/^I view the research and statistics finder with a topic param set$/) do
   stub_organisations_registry_request
   stub_manuals_registry_request
   stub_world_locations_api_request
-  stub_rummager_api_request_with_research_and_statistics_results
-  stub_rummager_api_request_with_statistics_results
-  stub_rummager_api_request_with_filtered_research_and_statistics_results
+  stub_search_api_request_with_research_and_statistics_results
+  stub_search_api_request_with_statistics_results
+  stub_search_api_request_with_filtered_research_and_statistics_results
   visit finder_path("search/research-and-statistics", topic: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0")
 end
 
@@ -158,7 +158,7 @@ When(/^I view the aaib reports finder with a topic param set$/) do
   stub_organisations_registry_request
   stub_manuals_registry_request
   stub_world_locations_api_request
-  stub_rummager_api_request_with_aaib_reports_results
+  stub_search_api_request_with_aaib_reports_results
   visit finder_path("aaib-reports", topic: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0")
 end
 
@@ -191,7 +191,7 @@ When(/^I view the all content finder$/) do
   stub_world_locations_api_request
   stub_people_registry_request
   stub_manuals_registry_request
-  stub_rummager_api_request_with_all_content_results
+  stub_search_api_request_with_all_content_results
 
   visit finder_path("search/all")
 end
@@ -199,7 +199,7 @@ end
 When(/^I view a list of services$/) do
   topic_taxonomy_has_taxons
   content_store_has_services_finder
-  stub_rummager_api_request_with_services_results
+  stub_search_api_request_with_services_results
   stub_people_registry_request
   stub_organisations_registry_request
 
@@ -236,7 +236,7 @@ end
 Given(/^a government finder exists$/) do
   stub_taxonomy_api_request
   content_store_has_government_finder
-  stub_rummager_api_request_with_government_results
+  stub_search_api_request_with_government_results
   stub_organisations_registry_request
 end
 
@@ -278,7 +278,7 @@ end
 Given(/^a collection of documents with bad metadata exist$/) do
   stub_taxonomy_api_request
   content_store_has_mosw_reports_finder
-  stub_rummager_api_request_with_bad_data
+  stub_search_api_request_with_bad_data
 end
 
 Then(/^I can get a list of all documents with good metadata$/) do
@@ -325,7 +325,7 @@ end
 Given(/^a finder with a dynamic filter exists$/) do
   stub_taxonomy_api_request
   content_store_has_mosw_reports_finder
-  stub_rummager_api_request
+  stub_search_api_request
 end
 
 Then(/^I can see filters based on the results$/) do
@@ -349,8 +349,8 @@ end
 Given(/^a finder with paginated results exists$/) do
   stub_taxonomy_api_request
   content_store_has_government_finder_with_10_items
-  stub_rummager_api_request_with_10_government_results
-  stub_rummager_api_request_with_query_param_no_results("xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx")
+  stub_search_api_request_with_10_government_results
+  stub_search_api_request_with_query_param_no_results("xxxxxxxxxxxxxxYYYYYYYYYYYxxxxxxxxxxxxxxx")
 end
 
 Then(/^I can see pagination$/) do
@@ -361,7 +361,7 @@ Then(/^I can see pagination$/) do
 end
 
 Then(/^I can browse to the next page$/) do
-  stub_rummager_api_request_with_10_government_results_page_2
+  stub_search_api_request_with_10_government_results_page_2
   visit finder_path("government/policies/benefits-reform", page: 2)
 
   expect(page).to have_content("Previous page")
@@ -369,7 +369,7 @@ Then(/^I can browse to the next page$/) do
 end
 
 Then(/^I browse to a huge page number and get an appropriate error$/) do
-  stub_rummager_api_request_with_422_response(999_999)
+  stub_search_api_request_with_422_response(999_999)
   visit finder_path("government/policies/benefits-reform", page: 999_999)
 
   expect(page.status_code).to eq(422)
@@ -456,7 +456,7 @@ end
 Given(/^an organisation finder exists$/) do
   stub_taxonomy_api_request
   content_store_has_government_finder
-  stub_rummager_api_request_with_government_results
+  stub_search_api_request_with_government_results
   stub_organisations_registry_request
   stub_people_registry_request
   stub_taxonomy_api_request
@@ -467,7 +467,7 @@ end
 Given(/^an organisation finder exists but a bad breadcrumb path is given$/) do
   stub_taxonomy_api_request
   content_store_has_government_finder
-  stub_rummager_api_request_with_government_results
+  stub_search_api_request_with_government_results
   stub_organisations_registry_request
   stub_people_registry_request
   stub_taxonomy_api_request

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -123,6 +123,7 @@ When(/^I view the research and statistics finder$/) do
   stub_manuals_registry_request
   stub_world_locations_api_request
   stub_rummager_api_request_with_research_and_statistics_results
+  stub_rummager_api_request_with_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
   visit finder_path("search/research-and-statistics")
 end
@@ -140,6 +141,7 @@ When(/^I view the research and statistics finder with a topic param set$/) do
   stub_manuals_registry_request
   stub_world_locations_api_request
   stub_rummager_api_request_with_research_and_statistics_results
+  stub_rummager_api_request_with_statistics_results
   stub_rummager_api_request_with_filtered_research_and_statistics_results
   visit finder_path("search/research-and-statistics", topic: "c58fdadd-7743-46d6-9629-90bb3ccc4ef0")
 end
@@ -795,6 +797,17 @@ end
 Then("I see results with top result") do
   within("#js-results") do
     expect(page.all(".gem-c-document-list__item--highlight").length).to eq(1)
+  end
+end
+
+Then("I should see all research and statistics") do
+  expect(page).to have_text("3 results")
+  within("#js-results") do
+    expect(page.all(".gem-c-document-list__item").size).to eq(3)
+    expect(page).to have_link("Restrictions on usage of spells within school grounds")
+    expect(page).to have_link("New platform at Hogwarts for the express train")
+    expect(page).to have_link("Installation of double glazing at Hogwarts")
+    expect(page).to have_no_link("Proposed changes to magic tournaments")
   end
 end
 

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -30,9 +30,9 @@ Given(/^the all content finder exists$/) do
   stub_organisations_registry_request
   stub_manuals_registry_request
 
-  stub_rummager_api_request_with_organisation_filter_all_content_results
-  stub_rummager_api_request_with_manual_filter_all_content_results
-  stub_rummager_api_request_with_misspelt_query
+  stub_search_api_request_with_organisation_filter_all_content_results
+  stub_search_api_request_with_manual_filter_all_content_results
+  stub_search_api_request_with_misspelt_query
 end
 
 Then(/^I am redirected to the (html|json) all content finder results page$/) do |format|

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -21,7 +21,7 @@ module DocumentHelper
     stub_content_store_has_item("/", "links" => { "level_one_taxons" => [] })
   end
 
-  def stub_rummager_api_request
+  def stub_search_api_request
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(rummager_all_documents_params))
       .to_return(body: all_documents_json)
@@ -37,7 +37,7 @@ module DocumentHelper
       .to_return(body: keyword_search_results)
   end
 
-  def stub_rummager_api_request_with_government_results
+  def stub_search_api_request_with_government_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including({}))
       .to_return(
@@ -45,7 +45,7 @@ module DocumentHelper
       )
   end
 
-  def stub_rummager_api_request_with_query_param_no_results(query)
+  def stub_search_api_request_with_query_param_no_results(query)
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => query))
       .to_return(
@@ -53,25 +53,25 @@ module DocumentHelper
       )
   end
 
-  def stub_rummager_api_request_with_10_government_results
+  def stub_search_api_request_with_10_government_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: rummager_10_documents_params)
       .to_return(body: government_documents_json)
   end
 
-  def stub_rummager_api_request_with_bad_data
+  def stub_search_api_request_with_bad_data
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: rummager_all_documents_params)
       .to_return(body: documents_with_bad_data_json)
   end
 
-  def stub_rummager_api_request_with_10_government_results_page_2
+  def stub_search_api_request_with_10_government_results_page_2
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: rummager_10_documents_page_2_params)
       .to_return(body: government_documents_page_2_json)
   end
 
-  def stub_rummager_api_request_with_news_and_communication_results
+  def stub_search_api_request_with_news_and_communication_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(rummager_newest_news_and_communications_params))
       .to_return(body: newest_news_and_communication_json)
@@ -81,37 +81,37 @@ module DocumentHelper
       .to_return(body: popular_news_and_communication_json)
   end
 
-  def stub_rummager_api_request_with_policy_papers_results
+  def stub_search_api_request_with_policy_papers_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(policy_papers_params))
       .to_return(body: policy_and_engagement_results_json)
   end
 
-  def stub_rummager_api_request_with_all_content_results
+  def stub_search_api_request_with_all_content_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(all_content_params.merge(order: "-public_timestamp")))
       .to_return(body: all_content_results_json)
   end
 
-  def stub_rummager_api_request_with_organisation_filter_all_content_results
+  def stub_search_api_request_with_organisation_filter_all_content_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => "search-term", "filter_organisations" => %w[ministry-of-magic]))
       .to_return(body: filtered_by_organisation_all_content_results_json)
   end
 
-  def stub_rummager_api_request_with_misspelt_query
+  def stub_search_api_request_with_misspelt_query
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => "drving"))
       .to_return(body: spelling_suggestions_json)
   end
 
-  def stub_rummager_api_request_with_manual_filter_all_content_results
+  def stub_search_api_request_with_manual_filter_all_content_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => "search-term", "filter_manual" => %w[how-to-be-a-wizard]))
       .to_return(body: filtered_by_manual_all_content_results_json)
   end
 
-  def stub_rummager_api_request_with_filtered_policy_papers_results
+  def stub_search_api_request_with_filtered_policy_papers_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(policy_papers_params.merge("filter_content_store_document_type" => %w[case_study impact_assessment policy_paper])))
       .to_return(body: policy_and_engagement_results_for_policy_papers_json)
@@ -125,7 +125,7 @@ module DocumentHelper
       .to_return(body: policy_and_engagement_results_for_policy_papers_and_closed_consultations_json)
   end
 
-  def stub_rummager_api_request_with_research_and_statistics_results
+  def stub_search_api_request_with_research_and_statistics_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(
         "filter_content_store_document_type" => %w[
@@ -142,7 +142,7 @@ module DocumentHelper
       .to_return(body: statistics_results_for_statistics_json)
   end
 
-  def stub_rummager_api_request_with_statistics_results
+  def stub_search_api_request_with_statistics_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(
         "filter_content_store_document_type" => %w[
@@ -155,7 +155,7 @@ module DocumentHelper
       .to_return(body: statistics_results_for_statistics_json)
   end
 
-  def stub_rummager_api_request_with_filtered_research_and_statistics_results
+  def stub_search_api_request_with_filtered_research_and_statistics_results
     Timecop.freeze(Time.zone.local("2019-01-01").utc)
     stub_request(:get, "#{Plek.current.find('search')}/search.json")
       .with(query: hash_including(
@@ -165,19 +165,19 @@ module DocumentHelper
       .to_return(body: upcoming_statistics_results_for_statistics_json)
   end
 
-  def stub_rummager_api_request_with_aaib_reports_results
+  def stub_search_api_request_with_aaib_reports_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including({}))
       .to_return(body: %({ "results": [], "total": 0, "start": 0}))
   end
 
-  def stub_all_rummager_api_requests_with_news_and_communication_results
+  def stub_all_search_api_requests_with_news_and_communication_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including({}))
       .to_return(body: newest_news_and_communication_json)
   end
 
-  def stub_rummager_api_request_with_services_results
+  def stub_search_api_request_with_services_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(rummager_alphabetical_services_params))
       .to_return(body: alpabetical_services_json)
@@ -187,19 +187,19 @@ module DocumentHelper
       .to_return(body: popular_services_json)
   end
 
-  def stub_rummager_api_request_with_no_results
+  def stub_search_api_request_with_no_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: rummager_0_documents_params)
       .to_return(body: %({ "results": [], "total": 0, "start": 0}))
   end
 
-  def stub_rummager_api_request_with_422_response(page_number)
+  def stub_search_api_request_with_422_response(page_number)
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: rummager_document_other_page_search_params(page_number))
       .to_return(status: 422)
   end
 
-  def stub_rummager_api_request_with_qa_finder_results
+  def stub_search_api_request_with_qa_finder_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(
         query: hash_including({}),

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -128,7 +128,29 @@ module DocumentHelper
   def stub_rummager_api_request_with_research_and_statistics_results
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(
-        "filter_content_store_document_type" => %w[national_statistics official_statistics statistical_data_set statistics],
+        "filter_content_store_document_type" => %w[
+          independent_report
+          national_statistics
+          official_statistics
+          research
+          research_for_development_output
+          statistical_data_set
+          statistics
+          statistics_announcement
+        ],
+      ))
+      .to_return(body: statistics_results_for_statistics_json)
+  end
+
+  def stub_rummager_api_request_with_statistics_results
+    stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including(
+        "filter_content_store_document_type" => %w[
+          national_statistics
+          official_statistics
+          statistical_data_set
+          statistics
+        ],
       ))
       .to_return(body: statistics_results_for_statistics_json)
   end


### PR DESCRIPTION
The default option for the Research & Statistics Finder was to show only published statistics.

However, some organisations do not publish statistics, in which case users would see no results despite there being research available.

User research done by the Social Mobility Commission showed this was problematic for their users (as they do not publish statistics).

Therefore this adds a new default option that encompasses all documents that can be returned by this finder. The user can then filter the results down using the provided facets.

Whilst doing this, I noticed we still use the term `rummager_api` in the feature tests, despite the name Rummager being dropped several years ago.  I've renamed all affected methods so anyone unfamiliar with the term is not confused.

Trello card: https://trello.com/c/t4EKt4va

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
