### PR TITLE
Remove jQuery from application.js and live_search.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,25 +28,21 @@
 //= require_tree ./modules
 //= require_tree ./components
 
-/* eslint-env jquery */
+var $elementsRequiringJavascript = document.querySelectorAll('.js-required')
 
-jQuery(function ($) {
-  var $form = $('.js-live-search-form')
+for (var i = 0; i < $elementsRequiringJavascript.length; i++) {
+  $elementsRequiringJavascript[i].style.display = 'block'
+}
 
-  var $results = $('.js-live-search-results-block')
+var $form = document.querySelector('.js-live-search-form')
+var $results = document.querySelector('.js-live-search-results-block')
+var $atomAutodiscoveryLink = document.querySelector("link[type='application/atom+xml']")
 
-  var $elementsRequiringJavascript = $('.js-required')
-
-  var $atomAutodiscoveryLink = $("link[type='application/atom+xml']").eq('0')
-
-  $elementsRequiringJavascript.show()
-
-  if ($form.length && $results.length) {
-    // eslint-disable-next-line
-    new GOVUK.LiveSearch({
-      $form: $form,
-      $results: $results,
-      $atomAutodiscoveryLink: $atomAutodiscoveryLink
-    })
-  }
-})
+if ($form && $results && $atomAutodiscoveryLink) {
+  // eslint-disable-next-line no-new
+  new GOVUK.LiveSearch({
+    $form: $form,
+    $results: $results,
+    $atomAutodiscoveryLink: $atomAutodiscoveryLink
+  })
+}

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -356,6 +356,7 @@
     var searchState = this.serializeState(this.state)
     var cachedResultData = this.cache(searchState)
     var liveSearch = this
+
     if (typeof cachedResultData === 'undefined') {
       this.showLoadingIndicator()
       var xhr = new XMLHttpRequest()
@@ -364,12 +365,8 @@
       var done = function (e) {
         if (xhr.readyState === 4 && xhr.status === 200) {
           var response = JSON.parse(e.target.response)
-          var newPath = encodeURI(window.location.pathname + '?' + liveSearch.serializeState(liveSearch.state))
-          window.history.pushState(liveSearch.state, '', newPath)
-          liveSearch.trackingInit()
-          liveSearch.setRelevantResultCustomDimension()
-          liveSearch.trackPageView()
-
+          liveSearch.updateUrl()
+          liveSearch.trackSearch()
           liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
           liveSearch.displayResults(response, searchState)
         } else {
@@ -382,8 +379,21 @@
       xhr.addEventListener('load', done)
       xhr.send()
     } else {
+      this.updateUrl()
+      this.trackSearch()
       this.displayResults(cachedResultData, searchState)
     }
+  }
+
+  LiveSearch.prototype.updateUrl = function () {
+    var newPath = encodeURI(window.location.pathname + '?' + this.serializeState(this.state))
+    window.history.pushState(this.state, '', newPath)
+  }
+
+  LiveSearch.prototype.trackSearch = function () {
+    this.trackingInit()
+    this.setRelevantResultCustomDimension()
+    this.trackPageView()
   }
 
   LiveSearch.prototype.updateLinks = function updateLinks () {

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -1,4 +1,3 @@
-/* eslint-env jquery */
 (function () {
   'use strict'
 
@@ -11,30 +10,41 @@
     this.resultCache = {}
 
     this.$form = options.$form
-    this.$searchSubmitButton = this.$form.find('.gem-c-search__submit')
-    this.$resultsWrapper = this.$form.find('.js-live-search-results-block')
-    this.$suggestionsBlock = this.$form.find('#js-spelling-suggestions')
-    this.$resultsBlock = options.$results.find('#js-results')
-    this.$countBlock = options.$results.find('#js-result-count')
-    this.$mobileResultsCount = this.$form.find('.js-result-count')
-    this.$selectedFilterCount = this.$form.find('.js-selected-filter-count')
-    this.$facetTagBlock = options.$results.find('#js-facet-tag-wrapper')
-    this.$mobileFacetTagBlock = this.$form.find('.js-mobile-facet-tag-block')
-    this.$loadingBlock = options.$results.find('#js-loading-message')
-    this.$sortBlock = options.$results.find('#js-sort-options')
-    this.$paginationBlock = options.$results.find('#js-pagination')
-    this.action = this.$form.attr('action') + '.json'
+    this.$searchSubmitButton = this.$form.querySelector('.gem-c-search__submit')
+    this.$resultsWrapper = this.$form.querySelector('.js-live-search-results-block')
+    this.$suggestionsBlock = this.$form.querySelector('#js-spelling-suggestions')
+    this.$resultsBlock = options.$results.querySelector('#js-results')
+    this.$countBlock = options.$results.querySelector('#js-result-count')
+    this.$mobileResultsCount = this.$form.querySelector('.js-result-count')
+    this.$selectedFilterCount = this.$form.querySelector('.js-selected-filter-count')
+    this.$facetTagBlock = options.$results.querySelector('#js-facet-tag-wrapper')
+    this.$mobileFacetTagBlock = this.$form.querySelector('.js-mobile-facet-tag-block')
+    this.$loadingBlock = options.$results.querySelector('#js-loading-message')
+    this.$sortBlock = options.$results.querySelector('#js-sort-options')
+    this.$paginationBlock = options.$results.querySelector('#js-pagination')
+    this.action = this.$form.getAttribute('action') + '.json'
     this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink
-    this.baseTitle = $("meta[name='govuk:base_title']").attr('content') || document.title
-    this.$resultsCountMetaTag = $("meta[name='govuk:search-result-count']")
-    this.$emailLink = $('a[href*="email-signup"]')
+
+    this.baseTitle = document.querySelector("meta[name='govuk:base_title']")
+    if (this.baseTitle) {
+      this.baseTitle = this.baseTitle.getAttribute('content')
+    } else {
+      this.baseTitle = document.title
+    }
+
+    this.$resultsCountMetaTag = document.querySelector("meta[name='govuk:search-result-count']")
+    this.$emailLinks = document.querySelectorAll('[href*="email-signup"]')
     this.previousSearchTerm = ''
 
-    this.emailSignupHref = this.$emailLink.attr('href')
-    this.$atomLink = $('a[href*=".atom"]')
-    this.atomHref = this.$atomLink.attr('href')
+    if (this.$emailLinks[0]) {
+      this.emailSignupHref = this.$emailLinks[0].getAttribute('href')
+    }
+    this.$atomLinks = document.querySelectorAll('[href*=".atom"]')
+    if (this.$atomLinks[0]) {
+      this.atomHref = this.$atomLinks[0].getAttribute('href')
+    }
     this.bindSortElements()
-    this.getTaxonomyFacet().update()
+    this.getAndUpdateTaxonomyFacet()
 
     if (window.ga) {
       // Use navigator.sendBeacon
@@ -46,72 +56,87 @@
 
     // prevent page refresh on search submit button click
     // instead trigger the AJAX results fetch
-    this.$searchSubmitButton.on('click',
-      function (e) {
+    if (this.$searchSubmitButton) {
+      this.$searchSubmitButton.addEventListener('click', function (e) {
         e.preventDefault()
         this.formChange(e)
-      }.bind(this)
-    )
+      }.bind(this))
+    }
 
     if (GOVUK.support.history()) {
       this.saveState()
 
-      this.$form.on('change', 'input[type=checkbox], input[type=radio], select',
-        function (e) {
-          this.formChange(e)
-        }.bind(this)
-      )
+      this.$form.addEventListener('change', this.formChange.bind(this))
+
       // custom event listener on the form, that fires the update only once
       // when we clear of filters
-      // fired from javascripts/modules/mobile-filters-modal.js:139
-      this.$form.on('customFormChange', this.$form,
-        function (e) {
-          this.formChange(e)
-        }.bind(this)
-      )
+      // fired from javascripts/modules/mobile-filters-modal.js
+      this.$form.addEventListener('customFormChange', this.formChange.bind(this))
 
-      this.$form.on('change keypress', 'input[type=text],input[type=search]',
-        function (e) {
-          var ENTER_KEY = 13
+      this.handleKeyPress = function (e) {
+        var ENTER_KEY = 13
 
-          if (e.keyCode === ENTER_KEY || e.type === 'change') {
-            // cater for jQuery and native events
-            var suppressAnalytics = e.suppressAnalytics || (e.detail && e.detail.suppressAnalytics)
-
-            if (e.currentTarget.value !== this.previousSearchTerm && !suppressAnalytics) {
-              LiveSearch.prototype.fireTextAnalyticsEvent(e)
-            }
-            this.formChange(e)
-            this.previousSearchTerm = e.currentTarget.value
-            e.preventDefault()
+        if (e.keyCode === ENTER_KEY || e.type === 'change') {
+          // cater for jQuery and native events
+          var suppressAnalytics = e.suppressAnalytics || (e.detail && e.detail.suppressAnalytics)
+          if (e.currentTarget.value !== this.previousSearchTerm && !suppressAnalytics) {
+            LiveSearch.prototype.fireTextAnalyticsEvent(e)
           }
-        }.bind(this)
-      )
+          this.formChange(e)
+          this.previousSearchTerm = e.currentTarget.value
+          e.preventDefault()
+        }
+      }
+
+      var inputs = this.$form.querySelectorAll('input[type=text],input[type=search]')
+      for (var i = 0; i < inputs.length; i++) {
+        inputs[i].addEventListener('change', this.handleKeyPress.bind(this))
+        inputs[i].addEventListener('keypress', this.handleKeyPress.bind(this))
+      }
 
       this.indexTrackingData()
 
-      $(window).on('popstate', this.popState.bind(this))
+      document.addEventListener('popstate', this.popState.bind(this))
     } else {
-      this.$form.find('.js-live-search-fallback').show()
+      var fallback = this.$form.querySelector('.js-live-search-fallback')
+      fallback.style.display = 'block'
     }
   }
 
   LiveSearch.prototype.startEnhancedEcommerceTracking = function startEnhancedEcommerceTracking () {
-    this.$resultsWrapper.attr('data-search-query', this.currentKeywords())
-    this.$suggestionsBlock.attr('data-search-query', this.currentKeywords())
+    if (this.$resultsWrapper) {
+      this.$resultsWrapper.setAttribute('data-search-query', this.currentKeywords())
+    }
+    if (this.$suggestionsBlock) {
+      this.$suggestionsBlock.setAttribute('data-search-query', this.currentKeywords())
+    }
     if (GOVUK.Ecommerce) { GOVUK.Ecommerce.start() }
   }
 
-  LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet () {
-    this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: $('.js-taxonomy-select') })
-    return this.taxonomy
+  LiveSearch.prototype.getAndUpdateTaxonomyFacet = function getAndUpdateTaxonomyFacet () {
+    var taxonomySelect = document.querySelector('.js-taxonomy-select')
+    if (taxonomySelect) {
+      this.taxonomy = this.taxonomy || new GOVUK.TaxonomySelect({ $el: taxonomySelect })
+      // return this.taxonomy
+      this.taxonomy.update()
+    }
   }
 
   LiveSearch.prototype.getSerializeForm = function getSerializeForm () {
-    var serialized = this.$form.serializeArray()
-    var filtered = serialized.filter(function (field) {
-      return field.value !== '' && field.name !== 'option-select-filter'
+    var serialized = new FormData(this.$form)
+
+    var filtered = []
+    serialized.forEach(function (value, key) {
+      if (key !== '' && key !== 'option-select-filter' && value !== '') {
+        filtered.push(
+          {
+            name: key,
+            value: value
+          }
+        )
+      }
     })
+
     return filtered
   }
 
@@ -136,7 +161,7 @@
   LiveSearch.prototype.formChange = function formChange (e) {
     var pageUpdated
     if (this.isNewState()) {
-      this.getTaxonomyFacet().update()
+      this.getAndUpdateTaxonomyFacet()
       this.saveState()
       this.updateOrder()
       this.updateLinks()
@@ -144,7 +169,7 @@
       pageUpdated = this.updateResults()
       pageUpdated.done(
         function () {
-          var newPath = window.location.pathname + '?' + $.param(this.state)
+          var newPath = window.location.pathname + '?' + this.serializeState(this.state)
           window.history.pushState(this.state, '', newPath)
           this.trackingInit()
           this.setRelevantResultCustomDimension()
@@ -154,9 +179,24 @@
     }
   }
 
+  LiveSearch.prototype.serializeState = function (state) {
+    var params = []
+    if (!Array.isArray(state)) {
+      var url = Object.keys(state).map(function (k) {
+        return encodeURIComponent(k) + '=' + encodeURIComponent(state[k])
+      }).join('&')
+      params.push(url)
+    } else {
+      for (var i = 0; i < state.length; i++) {
+        params.push(state[i].name + '=' + state[i].value)
+      }
+    }
+    return params.join('&')
+  }
+
   LiveSearch.prototype.setRelevantResultCustomDimension = function setRelevantResultCustomDimension () {
-    var $mostRelevantDocumentLink = $('.js-finder-results').find('.gem-c-document-list__item--highlight')
-    var dimensionValue = $mostRelevantDocumentLink.length ? 'yes' : 'no'
+    var $mostRelevantDocumentLink = this.$form.querySelector('.gem-c-document-list__item--highlight')
+    var dimensionValue = $mostRelevantDocumentLink ? 'yes' : 'no'
     GOVUK.SearchAnalytics.setDimension(83, dimensionValue)
   }
 
@@ -167,17 +207,23 @@
   }
 
   LiveSearch.prototype.trackPageView = function trackPageView () {
-    var newPath = window.location.pathname + '?' + $.param(this.state)
+    var newPath = window.location.pathname + '?' + this.serializeState(this.state)
     GOVUK.SearchAnalytics.trackPageview(newPath)
     GOVUK.SearchAnalytics.trackPageview(newPath, document.title, { trackerName: 'govuk' })
   }
 
   LiveSearch.prototype.trackSpellingSuggestionsImpressions = function trackSpellingSuggestionsImpressions ($suggestions) {
-    var $spellingSuggestionMetaTag = $("meta[name='govuk:spelling-suggestion']")
-    // currently there's ever only one suggestion
-    var spellingSuggestionAvailable = this.$suggestionsBlock.find('a').length > 0
-    var suggestion = spellingSuggestionAvailable ? this.$suggestionsBlock.find('a').data('track-options').dimension81 : ''
-    $spellingSuggestionMetaTag.attr('content', suggestion)
+    var $spellingSuggestionMetaTag = document.querySelector("meta[name='govuk:spelling-suggestion']")
+    if (this.$suggestionsBlock && $spellingSuggestionMetaTag) {
+      // currently there's ever only one suggestion
+      var spellingSuggestionAvailable = this.$suggestionsBlock.querySelector('a')
+      var suggestion = ''
+      if (spellingSuggestionAvailable) {
+        spellingSuggestionAvailable = JSON.parse(spellingSuggestionAvailable.getAttribute('data-track-options'))
+        suggestion = spellingSuggestionAvailable.dimension81
+      }
+      $spellingSuggestionMetaTag.setAttribute('content', suggestion)
+    }
   }
 
   /**
@@ -187,29 +233,28 @@
    * rewrite the appropriate tracking data attribute to delineate the group and document index.
    */
   LiveSearch.prototype.indexTrackingData = function indexTrackingData () {
-    var $groupEls = $('.filtered-results__group')
-    if ($groupEls.length > 0) {
-      $groupEls.each(function (groupIndex) {
-        var $resultEls = $(this).find('.gem-c-document-list__item')
-        $resultEls.each(function (documentIndex) {
-          var $document = $(this)
-          var $documentLink = $document.find('.gem-c-document-list__item-title')
-          var trackingAction = $documentLink.attr('data-track-action')
-          trackingAction = trackingAction.replace(/\.\d+$/, '')
-          trackingAction = [trackingAction, groupIndex + 1, documentIndex + 1].join('.')
-          $documentLink.attr('data-track-action', trackingAction)
-        })
-      })
+    var $groupEls = document.querySelectorAll('.filtered-results__group')
+    for (var g = 0; g < $groupEls.length; g++) {
+      var $resultEls = $groupEls[g].querySelectorAll('.gem-c-document-list__item')
+
+      for (var d = 0; d < $resultEls.length; d++) {
+        var $document = $resultEls[d]
+        var $documentLink = $document.querySelector('.gem-c-document-list__item-title')
+        var trackingAction = $documentLink.getAttribute('data-track-action')
+        trackingAction = trackingAction.replace(/\.\d+$/, '')
+        trackingAction = [trackingAction, g + 1, d + 1].join('.')
+        $documentLink.setAttribute('data-track-action', trackingAction)
+      }
     }
 
-    var $results = $('.js-finder-results')
-    if ($results.length > 0) {
-      var $mostRelevantDocumentLink = $results.find('.gem-c-document-list__item--highlight')
+    var $results = document.querySelector('.js-finder-results')
+    if ($results) {
+      var $mostRelevantDocumentLink = $results.querySelector('.gem-c-document-list__item--highlight')
 
-      if ($mostRelevantDocumentLink.length === 1) {
-        var trackingAction = $mostRelevantDocumentLink.attr('data-track-action')
+      if ($mostRelevantDocumentLink) {
+        trackingAction = $mostRelevantDocumentLink.getAttribute('data-track-action')
         trackingAction += 'r'
-        $mostRelevantDocumentLink.attr('data-track-action', trackingAction)
+        $mostRelevantDocumentLink.setAttribute('data-track-action', trackingAction)
       }
     }
   }
@@ -217,10 +262,10 @@
   LiveSearch.prototype.fireTextAnalyticsEvent = function fireTextAnalyticsEvent (event) {
     var options = {
       transport: 'beacon',
-      label: $(event.target)[0].value
+      label: event.target.value
     }
     var category = 'filterClicked'
-    var action = $('label[for="' + event.target.id + '"]')[0].innerText
+    var action = document.querySelector('label[for="' + event.target.id + '"]').textContent
 
     GOVUK.SearchAnalytics.trackEvent(
       category,
@@ -238,7 +283,7 @@
   }
 
   LiveSearch.prototype.isNewState = function isNewState () {
-    return $.param(this.state) !== $.param(this.getSerializeForm())
+    return this.serializeState(this.state) !== this.serializeState(this.getSerializeForm())
   }
 
   LiveSearch.prototype.updateTitle = function updateTitle () {
@@ -254,19 +299,22 @@
 
   LiveSearch.prototype.updateResultsCountMeta = function updateResultsCountMeta (totalCount) {
     // update search tracking meta data tag with new value
-    this.$resultsCountMetaTag.attr('content', totalCount)
+    if (this.$resultsCountMetaTag) {
+      this.$resultsCountMetaTag.setAttribute('content', totalCount)
+    }
   }
 
   LiveSearch.prototype.updateSortOptions = function updateSortOptions (results, action) {
-    if (action !== $.param(this.state)) { return }
+    if (action !== this.serializeState(this.state)) { return }
     this.updateElement(this.$sortBlock, results.sort_options_markup)
     this.bindSortElements()
   }
 
   LiveSearch.prototype.bindSortElements = function bindSortElements () {
-    this.$orderSelect = this.$form.find('.js-order-results')
-    this.$relevanceOrderOption = this.$orderSelect.find('option[value=' + this.$orderSelect.data('relevance-sort-option') + ']')
-    this.$relevanceOrderOptionIndex = this.$relevanceOrderOption.index()
+    this.$orderSelect = this.$form.querySelector('.js-order-results')
+    if (this.$orderSelect) {
+      this.$relevanceOrderOption = this.$orderSelect.querySelector('option[value=' + this.$orderSelect.getAttribute('data-relevance-sort-option') + ']')
+    }
   }
 
   LiveSearch.prototype.currentKeywords = function currentKeywords () {
@@ -274,7 +322,7 @@
   }
 
   LiveSearch.prototype.updateOrder = function updateOrder () {
-    if (!this.$orderSelect.length) {
+    if (!this.$orderSelect) {
       return
     }
 
@@ -295,23 +343,23 @@
   }
 
   LiveSearch.prototype.selectDefaultSortOption = function selectDefaultSortOption () {
-    var defaultSortOption = this.$orderSelect.data('default-sort-option')
+    var defaultSortOption = this.$orderSelect.getAttribute('data-default-sort-option')
 
-    this.$orderSelect.val(defaultSortOption)
+    this.$orderSelect.value = defaultSortOption
     this.state = this.getSerializeForm()
   }
 
   LiveSearch.prototype.selectRelevanceSortOption = function selectRelevanceSortOption () {
-    var relevanceSortOption = this.$orderSelect.data('relevance-sort-option')
+    var relevanceSortOption = this.$orderSelect.getAttribute('data-relevance-sort-option')
     if (relevanceSortOption) {
-      this.$relevanceOrderOption.removeAttr('disabled')
-      this.$orderSelect.val(relevanceSortOption)
+      this.$relevanceOrderOption.removeAttribute('disabled')
+      this.$orderSelect.value = relevanceSortOption
       this.state = this.getSerializeForm()
     }
   }
 
   LiveSearch.prototype.updateResults = function updateResults () {
-    var searchState = $.param(this.state)
+    var searchState = this.serializeState(this.state)
     var cachedResultData = this.cache(searchState)
     var liveSearch = this
     if (typeof cachedResultData === 'undefined') {
@@ -321,7 +369,7 @@
         data: this.state,
         searchState: searchState
       }).done(function (response) {
-        liveSearch.cache($.param(liveSearch.state), response)
+        liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
         liveSearch.displayResults(response, this.searchState)
       }).error(function () {
         liveSearch.showErrorIndicator()
@@ -334,32 +382,41 @@
   }
 
   LiveSearch.prototype.updateLinks = function updateLinks () {
-    var searchState = '?' + $.param(this.state)
+    var searchState = '?' + this.serializeState(this.state)
     if (typeof (this.emailSignupHref) !== 'undefined' && this.emailSignupHref != null) {
-      this.$emailLink.attr('href', this.emailSignupHref.split('?')[0] + searchState)
+      for (var e = 0; e < this.$emailLinks.length; e++) {
+        this.$emailLinks[e].setAttribute('href', encodeURI(this.emailSignupHref.split('?')[0] + searchState))
+      }
     }
     if (typeof (this.atomHref) !== 'undefined' && this.atomHref != null) {
-      this.$atomLink.attr('href', this.atomHref.split('?')[0] + searchState)
-      this.$atomAutodiscoveryLink.attr('href', this.atomHref.split('?')[0] + searchState)
+      for (var a = 0; a < this.$atomLinks.length; a++) {
+        this.$atomLinks[a].setAttribute('href', encodeURI(this.atomHref.split('?')[0] + searchState))
+      }
+      this.$atomAutodiscoveryLink.setAttribute('href', encodeURI(this.atomHref.split('?')[0] + searchState))
     }
   }
 
   LiveSearch.prototype.showLoadingIndicator = function showLoadingIndicator () {
-    this.$loadingBlock.text('Loading...').show()
+    if (this.$loadingBlock) {
+      this.$loadingBlock.textContent = 'Loading...'
+      this.$loadingBlock.style.display = 'block'
+    }
   }
 
   LiveSearch.prototype.showErrorIndicator = function showErrorIndicator () {
-    this.$loadingBlock.text('Error. Please try modifying your search and trying again.')
+    this.$loadingBlock.textContent = 'Error. Please try modifying your search and trying again.'
   }
 
   LiveSearch.prototype.updateElement = function updateElement (element, content) {
-    element.html(content)
+    if (element) {
+      element.innerHTML = content
+    }
   }
 
   LiveSearch.prototype.displayResults = function displayResults (results, action) {
     // As search is asynchronous, check that the action associated with these results is
     // still the latest to stop results being overwritten by stale data
-    if (action === $.param(this.state)) {
+    if (action === this.serializeState(this.state)) {
       this.updateElement(this.$resultsBlock, results.search_results)
       this.updateElement(this.$facetTagBlock, results.facet_tags)
       this.updateElement(this.$countBlock, results.display_total)
@@ -372,17 +429,21 @@
       this.updateSortOptions(results, action)
       this.updateResultsCountMeta(results.total)
       this.manipulateErrorMessages(results.errors)
-      this.$atomAutodiscoveryLink.attr('href', results.atom_url)
-      this.$loadingBlock.text('').hide()
+      this.$atomAutodiscoveryLink.setAttribute('href', results.atom_url)
+      if (this.$loadingBlock) {
+        this.$loadingBlock.textContent = ''
+        this.$loadingBlock.style.display = 'none'
+      }
     }
   }
 
   LiveSearch.prototype.restoreBooleans = function restoreBooleans () {
-    var that = this
-    this.$form.find('input[type=checkbox], input[type=radio]').each(function (i, el) {
-      var $el = $(el)
-      $el.prop('checked', that.isBooleanSelected($el.attr('name'), $el.attr('value')))
-    })
+    var inputs = this.$form.querySelectorAll('input[type=checkbox], input[type=radio]')
+
+    for (var i = 0; i < inputs.length; i++) {
+      var $el = inputs[i]
+      $el.setAttribute('checked', this.isBooleanSelected($el.getAttribute('name'), $el.value))
+    }
   }
 
   LiveSearch.prototype.isBooleanSelected = function isBooleanSelected (name, value) {
@@ -396,11 +457,12 @@
   }
 
   LiveSearch.prototype.restoreTextInputs = function restoreTextInputs () {
-    var that = this
-    this.$form.find('input[type=text], input[type=search], select').each(function (i, el) {
-      var $el = $(el)
-      $el.val(that.getTextInputValue($el.attr('name'), that.state))
-    })
+    var inputsAndSelects = this.$form.querySelectorAll('input[type=text], input[type=search], select')
+
+    for (var i = 0; i < inputsAndSelects.length; i++) {
+      var $el = inputsAndSelects[i]
+      $el.value = this.getTextInputValue($el.getAttribute('name'), this.state)
+    }
   }
 
   LiveSearch.prototype.getTextInputValue = function getTextInputValue (name, state) {
@@ -414,7 +476,7 @@
   }
 
   LiveSearch.prototype.focusErrorMessagesOnLoad = function ($container) {
-    var $inputWithError = $container.find('input[class*=--error]')
+    var $inputWithError = $container.querySelector('input[class*=--error]') || []
     if ($inputWithError.length) {
       $inputWithError.focus()
     }
@@ -435,32 +497,42 @@
   }
 
   LiveSearch.prototype.renderErrorMessage = function (type, field) {
-    var $input = this.$form.find('input[name*="' + type + '[' + field + ']"]')
-    var errorMessageElement = $('<span />', {
-      id: 'error-' + type,
-      class: 'gem-c-error-message govuk-error-message',
-      html: '<span class="govuk-visually-hidden">Error:</span> Enter a real date'
-    })
+    var $input = this.$form.querySelector('input[name*="' + type + '[' + field + ']"]')
+    var errorMessageElement = document.createElement('span')
+    errorMessageElement.setAttribute('id', 'error-' + type)
+    errorMessageElement.setAttribute('class', 'gem-c-error-message govuk-error-message')
+    errorMessageElement.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Enter a real date'
 
-    // only attach the error message if not present
-    if ($input.siblings('.gem-c-error-message').length === 0) {
-      $input.addClass('govuk-input--error')
-      $input.before(errorMessageElement)
-      $input.parent('.govuk-form-group').addClass('govuk-form-group--error')
-      $input.attr('aria-describedby', $input.attr('aria-describedby') + ' ' + errorMessageElement.attr('id'))
+    var errorMessages = $input.parentNode.querySelectorAll('.gem-c-error-message')
+    if (errorMessages.length === 0) {
+      $input.classList.add('govuk-input--error')
+      $input.insertAdjacentElement('beforebegin', errorMessageElement)
+      var parent = $input.parentNode
+      if (parent.classList.contains('govuk-form-group')) {
+        parent.classList.add('govuk-form-group--error')
+      }
+      $input.setAttribute('aria-describedby', $input.getAttribute('aria-describedby') + ' ' + errorMessageElement.getAttribute('id'))
     }
     $input.focus()
   }
 
   LiveSearch.prototype.removeErrorMessage = function (type, field) {
-    var $input = this.$form.find('input[name*="' + type + '[' + field + ']"]')
+    var $input = this.$form.querySelector('input[name*="' + type + '[' + field + ']"]')
+    if ($input) {
+      // only remove the message if it's present
+      var errorMessages = $input.parentNode.querySelectorAll('.gem-c-error-message')
 
-    // only remove the message if it's present
-    if ($input.siblings('.gem-c-error-message').length > 0) {
-      $input.removeClass('govuk-input--error')
-      $input.siblings('.gem-c-error-message').remove()
-      $input.parent('.govuk-form-group').removeClass('govuk-form-group--error')
-      $input.attr('aria-describedby', '')
+      if (errorMessages.length > 0) {
+        $input.classList.remove('govuk-input--error')
+        for (var x = errorMessages.length - 1; x >= 0; x--) {
+          errorMessages[x].parentNode.removeChild(errorMessages[x])
+        }
+        var inputParent = $input.parentNode
+        if (inputParent.classList.contains('govuk-form-group')) {
+          inputParent.classList.remove('govuk-form-group--error')
+        }
+        $input.setAttribute('aria-describedby', '')
+      }
     }
   }
 

--- a/app/assets/javascripts/taxonomy-select.js
+++ b/app/assets/javascripts/taxonomy-select.js
@@ -1,7 +1,4 @@
-//
-// TaxonomySelect adds interactivity to the topic taxonomy facet.
-//
-
+// TaxonomySelect adds interactivity to the topic taxonomy facet
 (function ($) {
   'use strict'
 
@@ -20,52 +17,59 @@
   }
 
   TaxonomySelect.prototype.$topLevelTaxon = function $topLevelTaxon () {
-    return this.$el.find('#level_one_taxon')
+    return this.$el.querySelector('#level_one_taxon')
   }
 
   TaxonomySelect.prototype.$subTaxon = function $subTaxon () {
-    return this.$el.find('#level_two_taxon')
+    return this.$el.querySelector('#level_two_taxon')
   }
 
   TaxonomySelect.prototype.disableSubTaxonFacet = function disableSubTaxonFacet () {
-    var topLevelTaxonSelected = !!this.$topLevelTaxon().val()
-    this.$subTaxon().attr('disabled', !topLevelTaxonSelected)
+    var topLevelTaxonSelected = !!this.$topLevelTaxon().value
+    if (!topLevelTaxonSelected) {
+      this.$subTaxon().setAttribute('disabled', true)
+    } else {
+      this.$subTaxon().removeAttribute('disabled')
+    }
   }
 
   TaxonomySelect.prototype.showRelevantSubTaxons = function showRelevantSubTaxons () {
-    var taxons = this.options[this.$topLevelTaxon().val()]
-
+    var taxons = this.options[this.$topLevelTaxon().value]
     var subtaxon = this.$subTaxon()
+    var options = subtaxon.querySelectorAll('option')
 
-    subtaxon.find('option').each(function () {
-      if ($(this).val()) { $(this).remove() }
-    })
-
-    subtaxon.append(taxons)
+    for (var o = 0; o < options.length; o++) {
+      if (options[o].value) {
+        options[o].parentNode.removeChild(options[o])
+      }
+    }
+    if (taxons) {
+      for (var i = 0; i < taxons.length; i++) {
+        subtaxon.appendChild(taxons[i])
+      }
+    }
   }
 
   TaxonomySelect.prototype.instantiateOptions = function instantiateOptions () {
     var options = {}
+    var optionElements = this.$subTaxon().querySelectorAll('option')
 
-    this.$subTaxon().find('option').each(function () {
-      var parent = $(this).attr('data-topic-parent')
+    for (var o = 0; o < optionElements.length; o++) {
+      var parent = optionElements[o].getAttribute('data-topic-parent')
 
       options[parent] = options[parent] || []
-      options[parent].push(this)
-    })
-
+      options[parent].push(optionElements[o])
+    }
     return options
   }
 
   TaxonomySelect.prototype.resetSubTaxonValue = function resetSubTaxonValue () {
-    var selected = this.$subTaxon().find(':selected')
-
-    var parentTaxon = this.$topLevelTaxon().val()
-
-    var isOrphanedSubTaxon = selected && selected.attr('data-topic-parent') !== parentTaxon
+    var selected = this.$subTaxon().options[this.$subTaxon().selectedIndex]
+    var parentTaxon = this.$topLevelTaxon().value
+    var isOrphanedSubTaxon = selected && selected.getAttribute('data-topic-parent') !== parentTaxon
 
     if (isOrphanedSubTaxon) {
-      this.$subTaxon().val('')
+      this.$subTaxon().value = ''
     }
   }
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -699,7 +699,7 @@ When(/^I fill in a keyword that should match no results$/) do
 end
 
 And(/^I submit the form$/) do
-  page.execute_script("$('form.js-live-search-form').submit()")
+  page.execute_script("document.querySelector('.js-live-search-form').submit()")
 end
 
 Then(/^The keyword textbox is empty$/) do

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -12,6 +12,7 @@
 #
 src_files:
   - spec/javascripts/vendor/jquery-1.12.4.js
+  - spec/javascripts/vendor/jasmine-ajax-3.4.0.js
   - assets/application.js
 
 # stylesheets

--- a/spec/javascripts/taxonomy_select_spec.js
+++ b/spec/javascripts/taxonomy_select_spec.js
@@ -6,7 +6,7 @@ describe('TaxonomySelect', function () {
 
     $('body').append($facet)
 
-    taxonomySelect = new GOVUK.TaxonomySelect({ $el: $facet })
+    taxonomySelect = new GOVUK.TaxonomySelect({ $el: $facet[0] })
   })
 
   afterEach(function () {
@@ -25,34 +25,34 @@ describe('TaxonomySelect', function () {
     function displayedSubTopicParents () {
       var parents = []
 
-      taxonomySelect.$subTaxon().find('option').each(function () {
-        var option = $(this)
-        if (option.css('display') !== 'none' && option.attr('data-topic-parent')) {
+      var options = taxonomySelect.$subTaxon().querySelectorAll('option')
+      for (var i = 0; i < options.length; i++) {
+        var option = options[i]
+        if (option.style.display !== 'none' && option.getAttribute('data-topic-parent')) {
           parents.push(
-            option.attr('data-topic-parent')
+            option.getAttribute('data-topic-parent')
           )
         }
-      })
-
+      }
       return parents
     }
 
     // User selects easter as the topic
-    taxonomySelect.$topLevelTaxon().val('easter')
+    taxonomySelect.$topLevelTaxon().value = 'easter'
     taxonomySelect.showRelevantSubTaxons()
     expect(displayedSubTopicParents().length).toBe(2) // 2 displayed sub-topics
     expect(displayedSubTopicParents()[0]).toBe('easter')
     expect(displayedSubTopicParents()[1]).toBe('easter')
 
     // They then select christmas
-    taxonomySelect.$topLevelTaxon().val('christmas')
+    taxonomySelect.$topLevelTaxon().value = 'christmas'
     taxonomySelect.showRelevantSubTaxons()
     expect(displayedSubTopicParents().length).toBe(2) // 2 displayed sub-topics
     expect(displayedSubTopicParents()[0]).toBe('christmas')
     expect(displayedSubTopicParents()[1]).toBe('christmas')
 
     // Then halloween!
-    taxonomySelect.$topLevelTaxon().val('halloween')
+    taxonomySelect.$topLevelTaxon().value = 'halloween'
     taxonomySelect.showRelevantSubTaxons()
     expect(displayedSubTopicParents().length).toBe(1) // 1 displayed sub-topic
     expect(displayedSubTopicParents()[0]).toBe('halloween')
@@ -60,31 +60,31 @@ describe('TaxonomySelect', function () {
 
   it('will reset the sub-taxon value on top-level-taxon change', function () {
     // user selects easter as the topic, then easter eggs as a sub topic
-    taxonomySelect.$topLevelTaxon().val('easter')
-    taxonomySelect.$subTaxon().val('easter-eggs')
+    taxonomySelect.$topLevelTaxon().value = 'easter'
+    taxonomySelect.$subTaxon().value = 'easter-eggs'
 
     // user selects christmas as a topic
-    taxonomySelect.$topLevelTaxon().val('christmas')
+    taxonomySelect.$topLevelTaxon().value = 'christmas'
     taxonomySelect.resetSubTaxonValue()
 
-    expect(taxonomySelect.$subTaxon().val()).toBeFalsy()
+    expect(taxonomySelect.$subTaxon().value).toBeFalsy()
   })
 
   it('will disable the sub taxon facet when a top-level taxon is not selected', function () {
     function isSubTaxonDisabled () {
-      return !!taxonomySelect.$subTaxon().attr('disabled')
+      return !!taxonomySelect.$subTaxon().getAttribute('disabled')
     }
 
     // User has not yet selected a top-level topic
     expect(isSubTaxonDisabled()).toBe(true)
 
     // User selects a top-level topic
-    taxonomySelect.$topLevelTaxon().val('christmas')
+    taxonomySelect.$topLevelTaxon().value = 'christmas'
     taxonomySelect.disableSubTaxonFacet()
     expect(isSubTaxonDisabled()).toBe(false)
 
     // User selects default top-level topic again
-    taxonomySelect.$topLevelTaxon().val('')
+    taxonomySelect.$topLevelTaxon().value = ''
     taxonomySelect.disableSubTaxonFacet()
     expect(isSubTaxonDisabled()).toBe(true)
   })

--- a/spec/javascripts/vendor/jasmine-ajax-3.4.0.js
+++ b/spec/javascripts/vendor/jasmine-ajax-3.4.0.js
@@ -1,0 +1,839 @@
+/*
+
+Jasmine-Ajax - v3.4.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+// jshint latedef: nofunc
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    // if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // // CommonJS
+        // var jasmineRequire = require('jasmine-core');
+        // module.exports = factory(root, function() {
+            // return jasmineRequire;
+        // });
+    // } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    // }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+//
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.event = jRequire.AjaxEvent();
+  $ajax.eventBus = jRequire.AjaxEventBus($ajax.event);
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEvent = function() {
+  function now() {
+    return new Date().getTime();
+  }
+
+  function noop() {
+  }
+
+  // Event object
+  // https://dom.spec.whatwg.org/#concept-event
+  function XMLHttpRequestEvent(xhr, type) {
+    this.type = type;
+    this.bubbles = false;
+    this.cancelable = false;
+    this.timeStamp = now();
+
+    this.isTrusted = false;
+    this.defaultPrevented = false;
+
+    // Event phase should be "AT_TARGET"
+    // https://dom.spec.whatwg.org/#dom-event-at_target
+    this.eventPhase = 2;
+
+    this.target = xhr;
+    this.currentTarget = xhr;
+  }
+
+  XMLHttpRequestEvent.prototype.preventDefault = noop;
+  XMLHttpRequestEvent.prototype.stopPropagation = noop;
+  XMLHttpRequestEvent.prototype.stopImmediatePropagation = noop;
+
+  function XMLHttpRequestProgressEvent() {
+    XMLHttpRequestEvent.apply(this, arguments);
+
+    this.lengthComputable = false;
+    this.loaded = 0;
+    this.total = 0;
+  }
+
+  // Extend prototype
+  XMLHttpRequestProgressEvent.prototype = XMLHttpRequestEvent.prototype;
+
+  return {
+    event: function(xhr, type) {
+      return new XMLHttpRequestEvent(xhr, type);
+    },
+
+    progressEvent: function(xhr, type) {
+      return new XMLHttpRequestProgressEvent(xhr, type);
+    }
+  };
+};
+getJasmineRequireObj().AjaxEventBus = function(eventFactory) {
+  function EventBus(source) {
+    this.eventList = {};
+    this.source = source;
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var evt;
+
+    // Event 'readystatechange' is should be a simple event.
+    // Others are progress event.
+    // https://xhr.spec.whatwg.org/#events
+    if (event === 'readystatechange') {
+      evt = eventFactory.event(this.source, event);
+    } else {
+      evt = eventFactory.progressEvent(this.source, event);
+    }
+
+    var eventListeners = this.eventList[event];
+
+    if (eventListeners) {
+      for (var i = 0; i < eventListeners.length; i++) {
+        eventListeners[i].call(this.source, evt);
+      }
+    }
+  };
+
+  return function(source) {
+    return new EventBus(source);
+  };
+};
+
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName].apply(xhr, arguments);
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('readystatechange', wrapProgressEvent(xhr, 'onreadystatechange'));
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory(this);
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+extend(FakeXMLHttpRequest, {
+        UNSENT: 0,
+        OPENED: 1,
+        HEADERS_RECEIVED: 2,
+        LOADING: 3,
+        DONE: 4
+    });
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout', 'responseURL'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1] + '';
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = FakeXMLHttpRequest.OPENED;
+        this.requestHeaders = {};
+        this.eventBus.trigger('readystatechange');
+      },
+
+      setRequestHeader: function(header, value) {
+        if (this.readyState === 0) {
+          throw new Error('DOMException: Failed to execute "setRequestHeader" on "XMLHttpRequest": The object\'s state must be OPENED.');
+        }
+
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = FakeXMLHttpRequest.UNSENT;
+        this.status = 0;
+        this.statusText = "abort";
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: FakeXMLHttpRequest.UNSENT,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+      onreadystatechange: null,
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.eventBus.trigger('loadstart');
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+        if (stub) {
+          stub.handleRequest(this);
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        var resultHeader = null;
+        if (!this.responseHeaders) { return resultHeader; }
+
+        name = name.toLowerCase();
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        if (!this.responseHeaders) { return null; }
+
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+      responseURL: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= FakeXMLHttpRequest.LOADING ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.readyState = FakeXMLHttpRequest.HEADERS_RECEIVED;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.responseURL = response.responseURL || null;
+        this.readyState = FakeXMLHttpRequest.DONE;
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+        if (response.responseJSON) {
+          this.responseText = JSON.stringify(response.responseJSON);
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = FakeXMLHttpRequest.DONE;
+        jasmine.clock().tick(30000);
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function(response) {
+        if (!response) {
+          response = {};
+        }
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.readyState = FakeXMLHttpRequest.DONE;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      },
+
+      startStream: function(options) {
+        if (!options) {
+          options = {};
+        }
+
+        if (this.readyState >= FakeXMLHttpRequest.LOADING) {
+          throw new Error("FakeXMLHttpRequest already loading or finished");
+        }
+
+        this.status = 200;
+        this.responseText = "";
+        this.statusText = "";
+
+        this.responseHeaders = normalizeHeaders(options.responseHeaders, options.contentType);
+        this.readyState = FakeXMLHttpRequest.HEADERS_RECEIVED;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseType = options.responseType || "";
+        this.responseURL = options.responseURL || null;
+        this.readyState = FakeXMLHttpRequest.LOADING;
+        this.eventBus.trigger('readystatechange');
+      },
+
+      streamData: function(data) {
+        if (this.readyState !== FakeXMLHttpRequest.LOADING) {
+          throw new Error("FakeXMLHttpRequest is not loading yet");
+        }
+
+        this.responseText += data;
+        this.responseXML = getResponseXml(this.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        this.response = this.responseValue();
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+      },
+
+      cancelStream: function () {
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = 0;
+        this.statusText = "";
+        this.readyState = FakeXMLHttpRequest.DONE;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('loadend');
+      },
+
+      completeStream: function(status) {
+        if (this.readyState === FakeXMLHttpRequest.DONE) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = status || 200;
+        this.statusText = "";
+        this.readyState = FakeXMLHttpRequest.DONE;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('loadend');
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest !== realAjaxFunction) {
+        throw new Error("Jasmine Ajax was unable to install over a custom XMLHttpRequest. Is Jasmine Ajax already installed?");
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw new Error("MockAjax not installed.");
+      }
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  var RETURN = 0,
+      ERROR = 1,
+      TIMEOUT = 2,
+      CALL = 3;
+
+  var normalizeQuery = function(query) {
+    return query ? query.split('&').sort().join('&') : undefined;
+  };
+
+  var timeoutRequest = function(request) {
+    request.responseTimeout();
+  };
+
+  function RequestStub(url, stubData, method) {
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = (stubData instanceof RegExp) ? stubData : normalizeQuery(stubData);
+    this.method = method;
+  }
+
+  RequestStub.prototype = {
+    andReturn: function(options) {
+      options.status = (typeof options.status !== 'undefined') ? options.status : 200;
+      this.handleRequest = function(request) {
+        request.respondWith(options);
+      };
+    },
+
+    andError: function(options) {
+      if (!options) {
+        options = {};
+      }
+      options.status = options.status || 500;
+      this.handleRequest = function(request) {
+        request.responseError(options);
+      };
+    },
+
+    andTimeout: function() {
+      this.handleRequest = timeoutRequest;
+    },
+
+    andCallFunction: function(functionToCall) {
+      this.handleRequest = function(request) {
+        functionToCall(request);
+      };
+    },
+
+    matches: function(fullUrl, data, method) {
+      var urlMatches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        urlMatches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        urlMatches = this.url === url && this.query === normalizeQuery(query);
+      }
+      var dataMatches = false;
+      if (this.data instanceof RegExp) {
+        dataMatches = this.data.test(data);
+      } else {
+        dataMatches = !this.data || this.data === normalizeQuery(data);
+      }
+      return urlMatches && dataMatches && (!this.method || this.method === method);
+    }
+  };
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));


### PR DESCRIPTION
Part of a wider effort to remove JQuery from GOV.UK

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## application.js

This creates and calls the `live_search` code, originally by passing a jQuery object. This was a small change but it couldn't be done in isolation for this reason.

## live_search.js

Controls the JS on the search pages on gov.uk/search, and related search pages. Used jQuery's Ajax function to dynamically update sections of the page. This has been replaced with `XMLHttpRequest` to allow compatibility with as many browsers as possible. This has involved changing the code slightly in terms of the way callbacks were used to manage the page updates and manually serialising the form data. See commit messages for more specifics.

One part of this code still uses jQuery here: https://github.com/alphagov/finder-frontend/pull/2517/files#diff-fe1355439297aa459f871621b4f95627ea330655c7c6eb08ef10bda7ab66c0feR196 and needs separate work to enable a non-jQuery object to be passed to the modules start code.

## taxonomy_select

Heavily linked to the live_search code. Controls the topic/subtopic select boxes on some searches (e.g. https://www.gov.uk/search/news-and-communications).

## Jasmine tests and IE

Currently all of the `live_search` jasmine tests pass in IE10+, apart from two that create keypress events using a technique not supported by IE10. This can hopefully change to use the GOVUK triggerEvent code when that is updated to allow keyCodes to be passed to it, but this is not a blocking issue for this PR - fixing the tests in IE10+ is a separate issue (several other tests unrelated to this change are also failing).


Trello card: https://trello.com/c/jK6hrK3d/417-remove-jquery-from-finder-frontend