### PR TITLE
Remove JQuery from EnableAriaControls module

### DIFF
--- a/app/assets/javascripts/modules/enable-aria-controls.js
+++ b/app/assets/javascripts/modules/enable-aria-controls.js
@@ -6,12 +6,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GOVUK.Modules.EnableAriaControls = function EnableAriaControls () {
     this.start = function (element) {
-      element.find('[data-aria-controls]').each(enableAriaControls)
-
-      function enableAriaControls () {
-        var controls = $(this).data('aria-controls')
-        if (typeof controls === 'string' && $('#' + controls).length > 0) {
-          $(this).attr('aria-controls', controls)
+      var $controls = element[0].querySelectorAll('[data-aria-controls]')
+      for (var i = 0; i < $controls.length; i++) {
+        var control = $controls[i].getAttribute('data-aria-controls')
+        if (typeof control === 'string' && document.getElementById(control)) {
+          $controls[i].setAttribute('aria-controls', control)
         }
       }
     }


### PR DESCRIPTION
Trello: https://trello.com/c/jK6hrK3d

# What's changed?

Replace [jQuery](https://jquery.com/) code in GOV.UK JavaScript (JS) code with vanilla (plain/normal) JavaScript in the EnableAriaControls module.

# Why?

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

Co-authored-by: Andy Sellick <andy.sellick@digital.cabinet-office.gov.uk>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
