### PR TITLE
If the user has no saved results, skip the comparison table

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -64,10 +64,14 @@ class BrexitCheckerController < ApplicationController
   end
 
   def save_results_confirm
-    redirect_to transition_checker_results_path(c: criteria_keys) and return if criteria_keys == @saved_results
-
-    @has_email_subscription = fetch_email_subscription_from_account_or_logout
-    redirect_to logged_out_pre_update_results_path if must_reauthenticate?
+    if criteria_keys == @saved_results
+      redirect_to transition_checker_results_path(c: criteria_keys)
+    elsif @saved_results.nil?
+      redirect_to transition_checker_save_results_email_signup_path(c: criteria_keys)
+    else
+      @has_email_subscription = fetch_email_subscription_from_account_or_logout
+      redirect_to logged_out_pre_update_results_path if must_reauthenticate?
+    end
   end
 
   def save_results_email_signup; end

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -104,7 +104,7 @@ module AccountConcern
     results_in_account = fetch_results_from_account_or_logout
     redirect_to logged_out_pre_update_results_path and return if must_reauthenticate?
 
-    @saved_results = results_in_account.fetch("criteria_keys", [])
+    @saved_results = results_in_account["criteria_keys"]
   end
 
   def logged_out_pre_saved_results_path(path = transition_checker_saved_results_path)

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
     end
 
     context "/transition-check/save-your-results/confirm" do
-      before { stub_account_api_has_attributes(attributes: %w[transition_checker_state], values: { "transition_checker_state" => transition_checker_state }) }
+      before { stub_account_api_has_attributes(attributes: %w[transition_checker_state], values: { "transition_checker_state" => transition_checker_state }.compact) }
 
       let(:new_criteria_keys) { %w[nationality-eu] }
 
@@ -223,6 +223,15 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         it "redirects back to the results page" do
           given_i_am_on_the_save_results_confirm_page_with(criteria_keys)
           expect(page).to have_current_path(transition_checker_results_path(c: criteria_keys))
+        end
+      end
+
+      context "the user has no results stored in their account" do
+        let(:transition_checker_state) { nil }
+
+        it "skips the comparison table and prompts the user to sign up to email alerts" do
+          given_i_am_on_the_save_results_confirm_page_with(criteria_keys)
+          expect(page).to have_current_path(transition_checker_save_results_email_signup_path(c: criteria_keys))
         end
       end
     end


### PR DESCRIPTION
This is the first step of untangling the special-case sign up
behaviour for the Transition Checker: we need to be able to send the
user to the same place after authenticating, whether they log in to an
existing account or create a new one.

We need to gracefully handle the case where the user has no current
saved results.  To do that, skip the comparison table (because
everything is new), and go straight on to the email sign up page.
