### PR TITLE
Skip the redirect via /sign-in to authenticate a user

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -57,9 +57,8 @@ class BrexitCheckerController < ApplicationController
       },
     ).to_h["state_id"]
     redirect_to transition_checker_new_session_url(
-      redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys),
+      transition_checker_save_results_confirm_path(c: criteria_keys),
       state_id: state_id,
-      _ga: params[:_ga],
     )
   end
 

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -108,11 +108,11 @@ module AccountConcern
   end
 
   def logged_out_pre_saved_results_path(path = transition_checker_saved_results_path)
-    transition_checker_new_session_url(redirect_path: path, _ga: params[:_ga])
+    transition_checker_new_session_url path
   end
 
   def logged_out_pre_update_results_path
-    transition_checker_new_session_url(redirect_path: transition_checker_save_results_confirm_path(c: criteria_keys), _ga: params[:_ga])
+    transition_checker_new_session_url transition_checker_save_results_confirm_path(c: criteria_keys)
   end
 
   def fetch_results_from_account_or_logout
@@ -151,9 +151,14 @@ module AccountConcern
     !logged_in? || @level_of_authentication_is_too_low
   end
 
-  def transition_checker_new_session_url(**params)
-    querystring = params.merge(level_of_authentication: "level1").compact.to_query
-    "#{base_path}/sign-in?#{querystring}"
+  def transition_checker_new_session_url(redirect_path, state_id: nil)
+    uri = GdsApi.account_api.get_sign_in_url(
+      redirect_path: redirect_path,
+      level_of_authentication: "level1",
+      state_id: state_id,
+    ).to_h["auth_uri"]
+    uri += "&_ga=#{params[:_ga]}" if params[:_ga]
+    uri
   end
 
   def transition_checker_end_session_url(**params)

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -18,25 +18,37 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
     context "/transition-check/saved-results" do
       it "redirects to login page" do
+        stub_account_api_get_sign_in_url(
+          redirect_path: "/transition-check/saved-results",
+          level_of_authentication: "level1",
+          auth_uri: "/sign-in?this-is-a-stubbed-url",
+        )
         given_i_am_on_the_saved_results_page
-        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/saved-results" }.to_query
-        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
+        expect(page).to have_current_path("http://www.example.com/sign-in?this-is-a-stubbed-url")
       end
     end
 
     context "/transition-check/edit-saved-results" do
       it "redirects to login page" do
+        stub_account_api_get_sign_in_url(
+          redirect_path: "/transition-check/edit-saved-results",
+          level_of_authentication: "level1",
+          auth_uri: "/sign-in?this-is-a-stubbed-url",
+        )
         given_i_am_on_the_edit_saved_results_page
-        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/edit-saved-results" }.to_query
-        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
+        expect(page).to have_current_path("http://www.example.com/sign-in?this-is-a-stubbed-url")
       end
     end
 
     context "/transition-check/save-your-results/confirm" do
       it "redirects to login page" do
+        stub_account_api_get_sign_in_url(
+          redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu",
+          level_of_authentication: "level1",
+          auth_uri: "/sign-in?this-is-a-stubbed-url",
+        )
         given_i_am_on_the_save_results_confirm_page
-        querystring = { level_of_authentication: "level1", redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu" }.to_query
-        expect(page).to have_current_path("#{Plek.find('frontend')}/sign-in?#{querystring}")
+        expect(page).to have_current_path("http://www.example.com/sign-in?this-is-a-stubbed-url")
       end
     end
   end

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -9,7 +9,12 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
 
   before do
     stub_account_api_create_registration_state(state_id: "jwt-id")
-    stub_account_api_get_sign_in_url(redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu", state_id: "jwt-id")
+    stub_account_api_get_sign_in_url(
+      redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu",
+      state_id: "jwt-id",
+      level_of_authentication: "level1",
+      auth_uri: "/sign-in?this-is-a-stubbed-url",
+    )
     stub_email_subscription_confirmation
   end
 
@@ -41,7 +46,7 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
   end
 
   def i_get_redirected_to_sign_up
-    expect(page.current_url).to include("&state_id=jwt-id")
+    expect(page.current_url).to include("/sign-in?this-is-a-stubbed-url")
   end
 
   def stub_email_subscription_confirmation


### PR DESCRIPTION
The /sign-in endpoint is there because we need something which the
"sign in" link in the header can go to.  But all it's doing is
validating the parameters and then calling the account-api to generate
the *real* sign-in URL.

We don't need to redirect via /sign-in from finder-frontend, because
we can hit account-api directly to generate the URL.  This removes one
redirect from the user's journey, making signing in very slightly
faster.

When this change has been deployed, we can remove the `state_id`
parameter from the frontend `SessionsController` entirely.
