### PR TITLE
Remove JQuery from the expander

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -31,9 +31,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
       this.$toggleButton.click()
     }
 
-    // listen for the change event
-    $module.on('change', 'select, input[type="text"]', this.updateSelectedCount.bind(this))
-
     // Attach listener function to update selected count
     var boundChangeEvents = this.bindChangeEvents.bind(this)
     boundChangeEvents()
@@ -42,6 +39,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
   Expander.prototype.bindChangeEvents = function (e) {
     for (var i = 0; i < this.$allInteractiveElements.length; i++) {
       var $el = this.$allInteractiveElements[i]
+      if ($el.tagName === 'SELECT') {
+        $el.addEventListener('change', this.updateSelectedCount.bind(this))
+      }
+
       // but for inputs we need both change and enter key event
       if ($el.tagName === 'INPUT') {
         $el.addEventListener('change', this.handleInputEvent.bind(this))

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -75,7 +75,10 @@
           var ENTER_KEY = 13
 
           if (e.keyCode === ENTER_KEY || e.type === 'change') {
-            if (e.currentTarget.value !== this.previousSearchTerm && !e.suppressAnalytics) {
+            // cater for jQuery and native events
+            var suppressAnalytics = e.suppressAnalytics || (e.detail && e.detail.suppressAnalytics)
+
+            if (e.currentTarget.value !== this.previousSearchTerm && !suppressAnalytics) {
               LiveSearch.prototype.fireTextAnalyticsEvent(e)
             }
             this.formChange(e)

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -5,11 +5,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   'use strict'
 
   GOVUK.Modules.RemoveFilter = function RemoveFilter () {
-    var onChangeSuppressAnalytics = {
-      type: 'change',
-      suppressAnalytics: true
-    }
-
     this.start = function (element) {
       $(element).on('click', '[data-module="remove-filter-link"]', toggleFilter)
     }
@@ -36,7 +31,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (inputType === 'checkbox') {
         $input.prop('checked', false)
-        window.GOVUK.triggerEvent($input[0], 'change', onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($input[0], 'change', { detail: { suppressAnalytics: true } })
       } else if (inputType === 'text' || inputType === 'search') {
         /* By padding the haystack with spaces, we can remove the
          * first instance of " $needle ", and this will catch it in
@@ -57,9 +52,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var haystack = ' ' + currentVal.trim() + ' '
         var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' '
         var newVal = haystack.replace(needle, ' ').replace(/ {2}/g, ' ').trim()
-        window.GOVUK.triggerEvent($input.val(newVal)[0], 'change', onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($input.val(newVal)[0], 'change', { detail: { suppressAnalytics: true } })
       } else if (elementType === 'OPTION') {
-        window.GOVUK.triggerEvent($('#' + removeFilterFacet).val('')[0], 'change', onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($('#' + removeFilterFacet).val('')[0], 'change', { detail: { suppressAnalytics: true } })
       }
     }
 

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -36,7 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       if (inputType === 'checkbox') {
         $input.prop('checked', false)
-        $input.trigger(onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($input[0], 'change', onChangeSuppressAnalytics)
       } else if (inputType === 'text' || inputType === 'search') {
         /* By padding the haystack with spaces, we can remove the
          * first instance of " $needle ", and this will catch it in
@@ -57,10 +57,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var haystack = ' ' + currentVal.trim() + ' '
         var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' '
         var newVal = haystack.replace(needle, ' ').replace(/ {2}/g, ' ').trim()
-
-        $input.val(newVal).trigger(onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($input.val(newVal)[0], 'change', onChangeSuppressAnalytics)
       } else if (elementType === 'OPTION') {
-        $('#' + removeFilterFacet).val('').trigger(onChangeSuppressAnalytics)
+        window.GOVUK.triggerEvent($('#' + removeFilterFacet).val('')[0], 'change', onChangeSuppressAnalytics)
       }
     }
 


### PR DESCRIPTION
## What

Remove jQuery from the expander file.

## How

I've done this by sort of reverting [this PR](https://github.com/alphagov/finder-frontend/pull/1748). I've moved the listener into both the `select` and `input[type="text"]` parts of the `if / else` loop in order to remove the need for jQuery. I've also removed the jQuery that was triggering the events that it listens for in order to ensure that the bug outlined in that PR remains fixed.

## Why

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
