### PR TITLE
Remove jquery from TrackBrexitQaChoices module

### DIFF
--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -12,14 +12,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function track (element) {
       element.addEventListener('submit', function (event) {
         var eventLabel, options
-        var $submittedForm = event.target
-        var $checkedOptions = $submittedForm.querySelectorAll('input:checked')
-        var questionKey = $submittedForm.getAttribute('data-question-key')
+        var submittedForm = event.target
+        var checkedOptions = submittedForm.querySelectorAll('input:checked')
+        var questionKey = submittedForm.getAttribute('data-question-key')
 
-        if ($checkedOptions.length) {
-          for (var i = 0; i < $checkedOptions.length; i++) {
-            var checkedOptionId = $checkedOptions[i].getAttribute('id')
-            var checkedOptionLabelText = $submittedForm.querySelector('label[for="' + checkedOptionId + '"]')
+        if (checkedOptions.length) {
+          for (var i = 0; i < checkedOptions.length; i++) {
+            var checkedOptionId = checkedOptions[i].getAttribute('id')
+            var checkedOptionLabelText = submittedForm.querySelector('label[for="' + checkedOptionId + '"]')
             var checkedOptionLabel = ''
 
             if (checkedOptionLabelText != null) {
@@ -28,7 +28,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
             eventLabel = checkedOptionLabel.length
               ? checkedOptionLabel
-              : $checkedOptions[i].value
+              : checkedOptions[i].value
 
             options = { transport: 'beacon', label: eventLabel }
 

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -11,24 +11,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     function track (element) {
       element.on('submit', function (event) {
-        var $checkedOption, eventLabel, options
+        var eventLabel, options
         var $submittedForm = event.target
         var $checkedOptions = $submittedForm.querySelectorAll('input:checked')
         var questionKey = $submittedForm.data('question-key')
 
         if ($checkedOptions.length) {
-          $checkedOptions.each(function (index) {
-            $checkedOption = $(this)
-            var checkedOptionId = $checkedOption.attr('id')
+          for (var i = 0; i < $checkedOptions.length; i++) {
+            var checkedOptionId = $checkedOptions[i].getAttribute('id')
             var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
             eventLabel = checkedOptionLabel.length
               ? checkedOptionLabel
-              : $checkedOption.val()
+              : $checkedOptions[i].val()
 
             options = { transport: 'beacon', label: eventLabel }
 
             GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
-          })
+          }
         } else {
           // Skipped questions
           options = { transport: 'beacon', label: 'no choice' }

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -6,11 +6,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GOVUK.Modules.TrackBrexitQaChoices = function () {
     this.start = function (element) {
-      track(element)
+      track(element[0])
     }
 
     function track (element) {
-      element.on('submit', function (event) {
+      element.addEventListener('submit', function (event) {
         var eventLabel, options
         var $submittedForm = event.target
         var $checkedOptions = $submittedForm.querySelectorAll('input:checked')

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -19,7 +19,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if ($checkedOptions.length) {
           for (var i = 0; i < $checkedOptions.length; i++) {
             var checkedOptionId = $checkedOptions[i].getAttribute('id')
-            var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
+            var checkedOptionLabelText = $submittedForm.querySelector('label[for="' + checkedOptionId + '"]')
+            var checkedOptionLabel = ''
+
+            if (checkedOptionLabelText != null) {
+              checkedOptionLabel = checkedOptionLabelText.textContent.replace(/^\s+|\s+$/g, '')
+            }
+
             eventLabel = checkedOptionLabel.length
               ? checkedOptionLabel
               : $checkedOptions[i].value

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -14,7 +14,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var eventLabel, options
         var $submittedForm = event.target
         var $checkedOptions = $submittedForm.querySelectorAll('input:checked')
-        var questionKey = $submittedForm.data('question-key')
+        var questionKey = $submittedForm.getAttribute('data-question-key')
 
         if ($checkedOptions.length) {
           for (var i = 0; i < $checkedOptions.length; i++) {

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -4,8 +4,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (global, GOVUK) {
   'use strict'
 
-  var $ = global.jQuery
-
   GOVUK.Modules.TrackBrexitQaChoices = function () {
     this.start = function (element) {
       track(element)
@@ -14,8 +12,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function track (element) {
       element.on('submit', function (event) {
         var $checkedOption, eventLabel, options
-        var $submittedForm = $(event.target)
-        var $checkedOptions = $submittedForm.find('input:checked')
+        var $submittedForm = event.target
+        var $checkedOptions = $submittedForm.querySelectorAll('input:checked')
         var questionKey = $submittedForm.data('question-key')
 
         if ($checkedOptions.length) {

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             var checkedOptionLabel = $submittedForm.find('label[for="' + checkedOptionId + '"]').text().trim()
             eventLabel = checkedOptionLabel.length
               ? checkedOptionLabel
-              : $checkedOptions[i].val()
+              : $checkedOptions[i].value
 
             options = { transport: 'beacon', label: eventLabel }
 

--- a/spec/javascripts/modules/track-brexit-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-brexit-qa-choices.spec.js
@@ -38,7 +38,7 @@ describe('Brexit QA choices tracker', function () {
   it('tracks checked checkboxes when clicking submit', function () {
     $element.find('input[value="accommodation"]').trigger('click')
     $element.find('input[value="construction"]').trigger('click')
-    $element.find('form').trigger('submit')
+    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
@@ -50,7 +50,7 @@ describe('Brexit QA choices tracker', function () {
 
   it('track events sends value of checkbox when no label is set', function () {
     $element.find('input[value="furniture"]').trigger('click')
-    $element.find('form').trigger('submit')
+    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'furniture' }
@@ -58,7 +58,7 @@ describe('Brexit QA choices tracker', function () {
   })
 
   it('track event triggered when no choice is made', function () {
-    $element.find('form').trigger('submit')
+    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'no choice' }


### PR DESCRIPTION
Trello: https://trello.com/c/jK6hrK3d

# What's changed?

Replace [jQuery](https://jquery.com/) code in GOV.UK JavaScript (JS) code with vanilla (plain/normal) JavaScript in the TrackBrexitQaChoices module.

# Why?

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.


Co-authored-by: @JonathanHallam 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
