### PR TITLE
Use govuk_personalisation's mock_logged_in_session

### DIFF
--- a/spec/controllers/brexit_checker_controller_spec.rb
+++ b/spec/controllers/brexit_checker_controller_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe BrexitCheckerController, type: :controller do
+  include GovukPersonalisation::TestHelpers::Requests
+
   render_views
 
   context "accounts header" do
@@ -20,8 +22,9 @@ describe BrexitCheckerController, type: :controller do
     end
 
     context "the GOVUK-Account-Session header is set" do
+      before { mock_logged_in_session }
+
       it "requests the signed-in header" do
-        request.headers["GOVUK-Account-Session"] = "foo"
         get :show
         assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
       end

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -5,6 +5,7 @@ require "gds_api/test_helpers/email_alert_api"
 RSpec.feature "Brexit Checker accounts", type: :feature do
   include GdsApi::TestHelpers::AccountApi
   include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Features
 
   let(:mock_results) { %w[nationality-eu] }
 
@@ -59,8 +60,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
   context "the user is logged in" do
     let(:govuk_account_session) { "placeholder" }
-    before { page.driver.header("GOVUK-Account-Session", govuk_account_session) }
-    after  { page.driver.header("GOVUK-Account-Session", nil) }
+    before { mock_logged_in_session(govuk_account_session) }
 
     let(:transition_checker_state) { { criteria_keys: criteria_keys, timestamp: 42 } }
     let(:criteria_keys) { %w[nationality-uk] }
@@ -101,7 +101,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
       it "reads the new account header" do
         given_i_am_on_the_results_page
-        expect(page.response_headers["GOVUK-Account-Session"]).to eq("placeholder")
+        expect(page.response_headers["GOVUK-Account-Session"]).to eq(govuk_account_session)
       end
 
       context "the account header is the empty string" do


### PR DESCRIPTION
Version 0.4.0 of the `govuk_personalisation` gem implemented this helper
so we don't need to define it here anymore. We just need to include
`GovukPersonalisation::TestHelpers::Requests` or
`GovukPersonalisation::TestHelpers::Features` instead.

Trello card: https://trello.com/c/HpMFjE5Q/784-add-test-helpers-to-govukpersonalisation

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
