### PR TITLE
Customise metadata descriptions for brexit child taxons

### DIFF
--- a/app/lib/brexit_helper.rb
+++ b/app/lib/brexit_helper.rb
@@ -1,0 +1,27 @@
+module BrexitHelper
+  BREXIT_CHILD_TAXON_IDS = {
+    business: "91cd6143-69d5-4f27-99ff-a52fb0d51c78",
+    individuals: "6555e0bf-c270-4cf9-a0c5-d20b95fab7f1",
+  }.freeze
+
+  def brexit_child_taxon_description
+    child_taxon_descriptions[document.content_id]
+  end
+
+private
+
+  def child_taxon_descriptions
+    {
+      BREXIT_CHILD_TAXON_IDS[:business] => business_description,
+      BREXIT_CHILD_TAXON_IDS[:individuals] => individuals_description,
+    }
+  end
+
+  def business_description
+    I18n.t("finders.brexit_child_taxons.business_description")
+  end
+
+  def individuals_description
+    I18n.t("finders.brexit_child_taxons.individuals_description")
+  end
+end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -1,5 +1,6 @@
 class SearchResultPresenter
   include ActionView::Helpers::SanitizeHelper
+  include BrexitHelper
 
   delegate :title,
            :parts,
@@ -45,6 +46,10 @@ private
   end
 
   def summary_text
+    brexit_child_taxon_description.presence || document_description
+  end
+
+  def document_description
     document.description if content_item.show_summaries?
   end
 

--- a/config/locales/en/finders/search_result_presenter.yml
+++ b/config/locales/en/finders/search_result_presenter.yml
@@ -2,3 +2,6 @@ en:
   finders:
     search_result_presenter:
       first_published_during: "First published during the"
+    brexit_child_taxons:
+      business_description: "Find out how new Brexit rules apply to things like imports, exports, tariffs, providing services and exchanging data with the EU businesses."
+      individuals_description: "Find out how new Brexit rules apply to things like travel to the EU, living, working or studying in the EU and the UK."

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SearchResultPresenter do
       es_score: 0.005,
       combined_score: combined_score,
       original_rank: original_rank,
-      content_id: "content_id",
+      content_id: content_id,
       filter_key: "filter_value",
       index: 1,
     )
@@ -51,19 +51,19 @@ RSpec.describe SearchResultPresenter do
 
   let(:combined_score) { nil }
   let(:original_rank) { nil }
-
+  let(:content_id) { "content_id" }
   let(:is_historic) { false }
   let(:title) { "Investigation into the distribution of road fuels in parts of Scotland" }
   let(:link) { "link-1" }
   let(:description) { "I am a document. I am full of words and that." }
 
   describe "#document_list_component_data" do
-    it "returns a hash of the data we need to show the document" do
-      expected_document = {
+    let(:expected_document) do
+      {
         link: {
           text: title,
           path: link,
-          description: "I am a document. I am full of words and that.",
+          description: description,
           data_attributes: {
             ecommerce_path: link,
             ecommerce_row: 1,
@@ -82,8 +82,21 @@ RSpec.describe SearchResultPresenter do
         subtext: nil,
         parts: [],
       }
+    end
+
+    it "returns a hash of the data we need to show the document" do
       expect(subject.document_list_component_data).to eql(expected_document)
     end
+
+    context "when the document is a brexit child taxon" do
+      let(:content_id) { BrexitHelper::BREXIT_CHILD_TAXON_IDS[:business] }
+      let(:description) { I18n.t("finders.brexit_child_taxons.business_description") }
+
+      it "overwrites the description field" do
+        expect(subject.document_list_component_data).to eql(expected_document)
+      end
+    end
+
     context "has parts" do
       let(:parts) do
         [


### PR DESCRIPTION
### What

Hard code the brexit child taxon metadata descriptions. See commit [message](https://github.com/alphagov/finder-frontend/commit/cd73f8103ae187621a397a51f34052e84d105bcc) for more details.

## Before

<img width="1120" alt="Screenshot 2021-06-11 at 16 54 59" src="https://user-images.githubusercontent.com/17908089/121714506-c9f42e80-cad5-11eb-8a03-b654ec0fea6d.png">

## After

<img width="1106" alt="Screenshot 2021-06-11 at 16 13 53" src="https://user-images.githubusercontent.com/17908089/121714235-8bf70a80-cad5-11eb-8e17-bb8661968154.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

trello: https://trello.com/c/EE9N3eYN/1545-improve-the-meta-descriptions-of-the-landing-page-and-hub-pages