### PR TITLE
Remove jQuery from the remove-filter

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -16,12 +16,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function toggleFilter (e) {
       e.preventDefault()
       e.stopPropagation()
-      var $el = $(e.target)
+      var $el = e.target
 
-      var removeFilterName = $el.data('name')
-      var removeFilterValue = $el.data('value')
-      var removeFilterLabel = $el.data('track-label')
-      var removeFilterFacet = $el.data('facet')
+      var removeFilterName = $el.getAttribute('data-name')
+      var removeFilterValue = $el.getAttribute('data-value')
+      var removeFilterLabel = $el.getAttribute('data-track-label')
+      var removeFilterFacet = $el.getAttribute('data-facet')
 
       var $input = getInput(removeFilterName, removeFilterValue, removeFilterFacet)
       fireRemoveTagTrackingEvent(removeFilterLabel, removeFilterFacet)
@@ -29,9 +29,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     function clearFacet ($input, removeFilterValue, removeFilterFacet) {
-      var elementType = $input.prop('tagName')
-      var inputType = $input.prop('type')
-      var currentVal = $input.val()
+      var elementType = $input.tagName
+      var inputType = $input.type
+      var currentVal = $input.value
 
       if (inputType === 'checkbox') {
         $input.prop('checked', false)

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -66,9 +66,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     function getInput (removeFilterName, removeFilterValue, removeFilterFacet) {
-      var selector = (removeFilterName) ? " input[name='" + removeFilterName + "']" : " [value='" + removeFilterValue + "']"
+      var selector = (removeFilterName) ? "input[name='" + removeFilterName + "']" : "[value='" + removeFilterValue + "']"
+      var element = document.getElementById(removeFilterFacet)
 
-      return $('#' + removeFilterFacet).find(selector)
+      return element.querySelector(selector)
     }
 
     function fireRemoveTagTrackingEvent (filterValue, filterFacet) {

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -6,7 +6,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   GOVUK.Modules.RemoveFilter = function RemoveFilter () {
     this.start = function (element) {
-      $(element).on('click', '[data-module="remove-filter-link"]', toggleFilter)
+      element[0].addEventListener('click', function (e) {
+        if (e.target.getAttribute('data-module') === 'remove-filter-link') {
+          toggleFilter(e)
+        }
+      })
     }
 
     function toggleFilter (e) {

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -34,8 +34,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var currentVal = $input.value
 
       if (inputType === 'checkbox') {
-        $input.prop('checked', false)
-        window.GOVUK.triggerEvent($input[0], 'change', { detail: { suppressAnalytics: true } })
+        $input.checked = false
+        window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
       } else if (inputType === 'text' || inputType === 'search') {
         /* By padding the haystack with spaces, we can remove the
          * first instance of " $needle ", and this will catch it in
@@ -56,9 +56,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var haystack = ' ' + currentVal.trim() + ' '
         var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' '
         var newVal = haystack.replace(needle, ' ').replace(/ {2}/g, ' ').trim()
-        window.GOVUK.triggerEvent($input.val(newVal)[0], 'change', { detail: { suppressAnalytics: true } })
+        $input.value = newVal
+        window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
       } else if (elementType === 'OPTION') {
-        window.GOVUK.triggerEvent($('#' + removeFilterFacet).val('')[0], 'change', { detail: { suppressAnalytics: true } })
+        var element = document.getElementById(removeFilterFacet)
+        element.value = ''
+        window.GOVUK.triggerEvent(element, 'change', { detail: { suppressAnalytics: true } })
       }
     }
 

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -43,8 +43,8 @@ describe('remove-filter', function () {
 
   var $facetTagOne = $(
     '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="aa3a9702-da22-487f-86c1-8334a730e558" data-track-label="A level one taxon" data-name="">✕</button>' +
-      '</div>'
+      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="A level one taxon" data-name="">✕</button>' +
+    '</div>'
   )
 
   var $facetTagTwo = $(
@@ -57,6 +57,10 @@ describe('remove-filter', function () {
     '<select id="level_one_taxon" name="level_one_taxon">' +
       '<option value="">All topics</option>' +
       '<option value="ba3a9702-da22-487f-86c1-8334a730e559">Entering and staying in the UK</option>' +
+    '</select>' +
+    '<select id="level_two_taxon" name="level_two_taxon">' +
+      '<option value="">All topics</option>' +
+      '<option value="bb3a9702-da22-487f-86c1-8334a730e559">Entering and staying in the UK</option>' +
     '</select>' +
     '<div id="keywords">' +
       '<input name="keywords" value="" id="finder-keyword-search" type="text">' +


### PR DESCRIPTION
## What

Remove jQuery from the remove-filter file.

## Why

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

## Trello

https://trello.com/c/jK6hrK3d/417-remove-jquery-from-finder-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
