### PR TITLE
Remove inaccurate error message on Brexit checker

### DIFF
--- a/app/views/brexit_checker/_results_criteria.html.erb
+++ b/app/views/brexit_checker/_results_criteria.html.erb
@@ -21,10 +21,4 @@
       </ul>
     </aside>
   </div>
-<% else %>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-body">
-      <%= t('brexit_checker.results.criteria.no_answers') %>
-    </p>
-  </div>
 <% end %>

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -24,10 +24,6 @@ en:
           What you, your family, or your business can do now to prepare for new rules from 1 January 2021.
       criteria:
         list_context: "Because you said:"
-        no_answers: |
-          You did not answer any of the questions.
-          This is a safe and secure service. We don't store any of your personal information.
-          To change your answers, follow the link below.
       audiences:
         citizen:
           heading: You and your family


### PR DESCRIPTION
## What
Correct a bug that occurs when a user answers checker questions, and they're not required to take any actions. Currently we say the reason they've no actions is because they didn't answer.

## Visual changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="921" alt="Screenshot 2021-06-28 at 22 06 55" src="https://user-images.githubusercontent.com/17908089/123704121-39e81000-d85d-11eb-9439-614780d41dca.png">

</td>
<td>

<img width="979" alt="Screenshot 2021-06-28 at 22 07 09" src="https://user-images.githubusercontent.com/17908089/123704103-348ac580-d85d-11eb-8e4d-a33286986978.png">
</td>
</tr>
<table>

- [Link](https://www.integration.publishing.service.gov.uk/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=join-family-uk-no&c%5B%5D=living-row&c%5B%5D=nationality-row&c%5B%5D=retired) to bug on integration
- [Link](https://finder-front-remove-che-uhzclw.herokuapp.com/transition-check/results?c%5B%5D=does-not-own-operate-business-organisation&c%5B%5D=join-family-uk-no&c%5B%5D=living-row&c%5B%5D=nationality-row&c%5B%5D=retired) to review app
- [Trello](https://trello.com/c/ZAW6eHt6/1622-remove-text-from-no-results-checker-results-page)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
