### PR TITLE
Add ExploreMenuABTestable AB Test module

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -9,7 +9,7 @@ module AbTests::ExploreMenuAbTestable
       dimension: CUSTOM_DIMENSION,
       allowed_variants: ALLOWED_VARIANTS,
       control_variant: "Z",
-      )
+    )
   end
 
   def explore_menu_variant

--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -1,0 +1,26 @@
+module AbTests::ExploreMenuAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def explore_menu_test
+    @explore_menu_test ||= GovukAbTesting::AbTest.new(
+      "ExploreMenuAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+      )
+  end
+
+  def explore_menu_variant
+    explore_menu_test.requested_variant(request.headers)
+  end
+
+  def set_explore_menu_response
+    explore_menu_variant.configure_response(response) if explore_menu_testable?
+  end
+
+  def explore_menu_testable?
+    explore_menu_variant.variant?("B")
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,13 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
-  slimmer_template "header_footer_only"
+  include AbTests::ExploreMenuAbTestable
+
+  before_action :set_explore_menu_response
+
+  helper_method :explore_menu_variant, :explore_menu_testable?
+
+  after_action :set_slimmer_template
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -22,6 +28,16 @@ class ApplicationController < ActionController::Base
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
+  end
+
+protected
+
+  def set_slimmer_template
+    if explore_menu_testable?
+      slimmer_template "header_footer_only_explore_header"
+    else
+      slimmer_template "header_footer_only"
+    end
   end
 
 private

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -107,6 +107,10 @@ class BrexitCheckerController < ApplicationController
 
 private
 
+  def set_slimmer_template
+    slimmer_template "header_footer_only"
+  end
+
   def subscriber_list_slug
     @subscriber_list_slug ||= Services.email_alert_api
       .find_or_create_subscriber_list_cached(subscriber_list_options)

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -12,6 +12,7 @@
       <meta name="robots" content="noindex">
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
+    <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
   </head>
 
   <body class="<%= yield :body_classes %>">

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -6,6 +6,7 @@
     <%= stylesheet_link_tag "application", integrity: false %>
     <%= stylesheet_link_tag "print", media: "print" %>
     <%= javascript_include_tag 'application', integrity: false %>
+    <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
     <% if @content_item %>
       <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
     <% end %>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -3,6 +3,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Search GOV.UK." />
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
 <% end %>
 
 <main id="content" class="search-wrapper search-wrapper--no-search-term">

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -63,6 +63,25 @@ describe FindersController, type: :controller do
           .to_return(status: 200, body: rummager_response, headers: {})
       end
 
+      it "requests the B variant for finders" do
+        with_variant ExploreMenuAbTestable: "B" do
+          get :show, params: { slug: "lunch-finder" }
+
+          expect(response.status).to eq(200)
+        end
+      end
+
+      it "requests the B variant for search pages" do
+        stub_content_store_has_item(
+          "/search/all",
+          all_content_finder,
+        )
+
+        with_variant ExploreMenuAbTestable: "B" do
+          get :show, params: { slug: "search/all" }
+        end
+      end
+
       it "correctly renders a finder page" do
         get :show, params: { slug: "lunch-finder" }
         expect(response.status).to eq(200)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Static has a new header that the GOV.UK Explore team want to AB test as part of their beta. This adds code for Finders and Search (except the Brexit Checker, as it has Sign in links in the header) to show the new header to users in the B group.

See https://github.com/alphagov/static/pull/2515

## Why

Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk, [Jira issue NAV-2838](https://gov-uk.atlassian.net/browse/NAV-2838)

# Visual changes

https://user-images.githubusercontent.com/424772/123961336-239a9b00-d9a8-11eb-95f1-ea9698fdfccb.mov

