### PR TITLE
Use new account email subscription endpoints in the checker

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -4,6 +4,7 @@ module AccountConcern
   extend ActiveSupport::Concern
 
   ATTRIBUTE_NAME = "transition_checker_state"
+  EMAIL_SUBSCRIPTION_NAME = "transition-checker-results"
 
   included do
     include GovukPersonalisation::AccountConcern
@@ -65,12 +66,14 @@ module AccountConcern
   end
 
   def fetch_email_subscription_from_account_or_logout
-    result = do_or_logout { Services.account_api.check_for_email_subscription(govuk_account_session: account_session_header) }
-    result&.fetch("has_subscription", false)
+    result = do_or_logout { Services.account_api.get_email_subscription(name: EMAIL_SUBSCRIPTION_NAME, govuk_account_session: account_session_header) }
+    result.key? "email_subscription"
+  rescue GdsApi::HTTPNotFound
+    false
   end
 
   def update_email_subscription_in_account_or_logout(slug)
-    do_or_logout { Services.account_api.set_email_subscription(govuk_account_session: account_session_header, slug: slug) }
+    do_or_logout { Services.account_api.put_email_subscription(name: EMAIL_SUBSCRIPTION_NAME, govuk_account_session: account_session_header, topic_slug: slug) }
   end
 
   def update_answers_in_account_or_logout(new_criteria_keys)

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -190,7 +190,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         before { stub_find_or_create_subscriber_list(new_criteria_keys) }
 
         context "the user has an email subscription" do
-          before { stub_account_api_has_email_subscription }
+          before { stub_account_api_get_email_subscription(name: "transition-checker-results") }
 
           it "shows a comparison of the result sets" do
             given_i_am_on_the_save_results_confirm_page_with(new_criteria_keys)
@@ -199,7 +199,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           end
 
           it "updates the existing email alert automatically" do
-            stub = stub_account_api_set_email_subscription(slug: "your-get-ready-for-brexit-results-a1a2a3a4a5")
+            stub = stub_account_api_put_email_subscription(name: "transition-checker-results", topic_slug: "your-get-ready-for-brexit-results-a1a2a3a4a5")
             stub_account_api_set_attributes
             given_i_am_on_the_save_results_confirm_page_with(new_criteria_keys)
             click_on I18n.t("brexit_checker.confirm_changes.save_button")
@@ -209,7 +209,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         end
 
         context "the user does not have an email subscription" do
-          before { stub_account_api_does_not_have_email_subscription }
+          before { stub_account_api_get_email_subscription_does_not_exist(name: "transition-checker-results") }
 
           it "prompt the user to sign up to email alerts" do
             given_i_am_on_the_save_results_confirm_page_with(new_criteria_keys)
@@ -219,7 +219,7 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
           context "the user wants email alerts" do
             it "creates an email alert" do
-              stub = stub_account_api_set_email_subscription(slug: "your-get-ready-for-brexit-results-a1a2a3a4a5")
+              stub = stub_account_api_put_email_subscription(name: "transition-checker-results", topic_slug: "your-get-ready-for-brexit-results-a1a2a3a4a5")
               stub_account_api_set_attributes
               given_i_am_on_the_save_results_confirm_page_with(new_criteria_keys)
               click_on I18n.t("brexit_checker.confirm_changes.save_button")


### PR DESCRIPTION
We're retiring the Transition Checker-specific endpoints in favour of
some more general ones which could be used by other apps for other
subscriptions too.  Once this change has been made, the old endpoints
and test helpers can be removed from gds-api-adapters.
