### PR TITLE
Do not send initial attributes to Account Manager to auth

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -47,19 +47,7 @@ class BrexitCheckerController < ApplicationController
   def save_results; end
 
   def save_results_sign_up
-    state_id = Services.account_api.create_registration_state(
-      attributes: {
-        transition_checker_state: {
-          criteria_keys: criteria_keys,
-          timestamp: Time.zone.now.to_i,
-          email_topic_slug: subscriber_list_slug,
-        },
-      },
-    ).to_h["state_id"]
-    redirect_to transition_checker_new_session_url(
-      transition_checker_save_results_confirm_path(c: criteria_keys),
-      state_id: state_id,
-    )
+    redirect_to transition_checker_new_session_url(transition_checker_save_results_confirm_path(c: criteria_keys))
   end
 
   def save_results_confirm

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -8,10 +8,8 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
   include GdsApi::TestHelpers::EmailAlertApi
 
   before do
-    stub_account_api_create_registration_state(state_id: "jwt-id")
     stub_account_api_get_sign_in_url(
       redirect_path: "/transition-check/save-your-results/confirm?c%5B%5D=nationality-eu",
-      state_id: "jwt-id",
       level_of_authentication: "level1",
       auth_uri: "/sign-in?this-is-a-stubbed-url",
     )


### PR DESCRIPTION
We originally went for this approach of passing attributes along to
the Account Manager so that we could still save someone's results and
set up their email subscription if they didn't return to GOV.UK after
signing up.

We have now changed the design of the post-registration confirmation
page to make it clearer that the user does need to return to
GOV.UK (and put a big green button on it), and so we no longer think
that supporting users who don't return is worth the complication.  SO
we're removing it entirely.

---

[Trello card](https://trello.com/c/aEbuS4Tf/884-remove-the-jwt-sign-up-flow)