### PR TITLE
Fix duplicated banner on brexit checker results page.

### DIFF
--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -86,17 +86,8 @@
     <%= render 'results_citizen_actions', citizen_results_groups: @presenter.citizen_results_groups if @presenter.citizen_results_groups.any? %>
     <%= render 'results_with_no_actions', criteria: @presenter.criteria if (@presenter.business_results.empty? && @presenter.citizen_results_groups.empty?) %>
 
-    <% if !must_reauthenticate? %>
-      <% if @results_differ %>
-        <%= render 'govuk_publishing_components/components/notice', {
-          title: t('brexit_checker.results.accounts.results_differ.message'),
-          description: sanitize(t('brexit_checker.results.accounts.results_differ.description', link: transition_checker_save_results_confirm_path(c: criteria_keys)))
-        } %>
-      <% end %>
-    <% else %>
-      <%= render 'stay_updated' %>
-    <% end %>
 
+    <%= render 'stay_updated' if must_reauthenticate? %>
     <%= render 'share_links' %>
     <%= render 'print_link' if @presenter.business_results.any? || @presenter.citizen_results_groups.any? %>
   <% end %>


### PR DESCRIPTION
There is an edge case on the Brexit checker results page, where if the user must NOT reauthenticate (i.e they're already logged in), and their results differ from the ones already stored in their account, the "These results are different from the ones stored in your account" message appears twice. This is due to the same conditions being present in the view at two points, [here](https://github.com/alphagov/finder-frontend/blob/6f9a17f291ddb5fa788bdb2273272e7e50d4fdc3/app/views/brexit_checker/results.html.erb#L72) and [here](https://github.com/alphagov/finder-frontend/blob/6f9a17f291ddb5fa788bdb2273272e7e50d4fdc3/app/views/brexit_checker/results.html.erb#L90).

![image](https://user-images.githubusercontent.com/7116819/124790037-b99f6a00-df42-11eb-8093-fe60384afb76.png)


This removes the second message, so that the notice will only appear once in those specific conditions.

-----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
