### PR TITLE
Add `register` flag to auth URL if the user clicks the green button

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -47,7 +47,8 @@ class BrexitCheckerController < ApplicationController
   def save_results; end
 
   def save_results_sign_up
-    redirect_to transition_checker_new_session_url(transition_checker_save_results_confirm_path(c: criteria_keys))
+    url = transition_checker_new_session_url(transition_checker_save_results_confirm_path(c: criteria_keys))
+    redirect_to("#{url}&register=1")
   end
 
   def save_results_confirm


### PR DESCRIPTION
On the account start page we have a green button to create an account
and a link to sign in to an existing account.

These links do exactly the same thing: they authenticate the user, and
then have the account-manager redirect them back to the Transition
Checker so that their results can be saved.

Previously, the button took the user to the registration page because
we had implemented a non-standard OAuth flow to pass along additional
information to the account-manager.  We've now removed that flow, but
it means that the button and the link go to the same page, despite
saying different things.

So, stick a "register" parameter into the URL.  The account-manager
can pick this up and send the user to the right form.  This is a less
problematic approach than before, as we're no longer passing along the
Transition Checker answers or email signup preferences, just a flag
indicating whether the user should be presented with a sign up or sign
in page.

When we migrate to the Digital Identity auth solution, we can remove
this, as they are going for a single landing page where you enter your
email address and then get routed to the right form.

See also https://github.com/alphagov/govuk-account-manager-prototype/pull/892

---

[Trello card](https://trello.com/c/aEbuS4Tf/884-remove-the-jwt-sign-up-flow)
