### PR TITLE
Add email confirmation reminder to Brexit results

### DIFF
--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -37,6 +37,18 @@
 <% end %>
 
 <div class="govuk-width-container brexit-checker-results-page">
+  <% if show_confirmation_reminder? %>
+    <%= render "govuk_publishing_components/components/notice", {
+      margin_bottom: 0
+    } do %>
+      <p class="govuk-body">
+        <%= sanitize(t("brexit_checker.results.accounts.confirm.intro.#{confirmation_banner_prompt_type}")) %>
+      </p>
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        <a href="<%= "#{Plek.find('account-manager')}/account/confirmation/new" %>" class="govuk-link"><%= t("brexit_checker.results.accounts.confirm.link_text") %></a>
+      </p>
+    <% end %>
+  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", {

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -31,6 +31,11 @@ en:
           heading: Your business or organisation
       print_link: Print your results
       accounts:
+        confirm:
+          intro:
+            set_up: <strong class="govuk-!-font-weight-bold">Confirm your email address</strong> to finish setting up your account and start getting email updates.
+            update: <strong class="govuk-!-font-weight-bold">Confirm your email address</strong> to finish updating your account and email alerts.
+          link_text: Send confirmation email again
         results_differ:
           message: These results are different to the ones saved in your account.
           description: You can <a class="govuk-link" href="%{link}">see what answers you’ve changed and save these results to your account instead.</a>


### PR DESCRIPTION
If a logged in user visits the brexit checker results page and they have not yet confirmed their email address, a banner prompting them to confirm their email will appear. 
This is another step in the efforts to [unbodge the Brexit checker](https://docs.google.com/document/d/1xRdT56CgAF__c_Yjzdy6UuR0LacXIt0EACRonEgbUiM/edit?ts=60eea456#) 😄.

The content of the banner is different depending on whether the user is a new user who hasn't quite completed the account creation process, or if they're an older user who's updated their email address but hasn't confirmed their new email yet. It should all be in line with the changes seen [here](https://github.com/alphagov/frontend/pull/2875) and [here](https://github.com/alphagov/govuk-account-manager-prototype/pull/904).


### What it looks like
Positioned before the `h1` as per [Design System guidance](https://design-system.service.gov.uk/components/notification-banner/#how-it-works):
<img width="388" alt="Screenshot 2021-07-15 at 17 32 13" src="https://user-images.githubusercontent.com/7116819/125824334-84176263-5879-4a41-a35f-a3c47becd483.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
