### PR TITLE
Replace jQuery in module initialisers

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -2,20 +2,19 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none of this JS runs :(
 
 (function (Modules) {
-  function Expander () {}
-
   /* This JavaScript provides two functional enhancements to the expander component:
     1) A count that shows how many items have been used in the expander container
     2) Open/closing of the content
   */
-
-  Expander.prototype.start = function ($module) {
-    this.$module = $module[0] // this is the expander element
+  function Expander ($module) {
+    this.$module = $module
     this.$toggle = this.$module.querySelector('.js-toggle')
     this.$content = this.$module.querySelector('.js-content')
     this.$allInteractiveElements = this.$content.querySelectorAll('select, input[type=text]')
-    this.selectedElements = []
+  }
 
+  Expander.prototype.init = function () {
+    this.selectedElements = []
     var openOnLoad = this.$module.getAttribute('data-open-on-load') === 'true'
 
     this.replaceHeadingSpanWithButton(openOnLoad)

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -2,14 +2,12 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function OptionSelect () {}
-
   /* This JavaScript provides two functional enhancements to option-select components:
     1) A count that shows how many results have been checked in the option-container
     2) Open/closing of the list of checkboxes
   */
-  OptionSelect.prototype.start = function ($module) {
-    this.$optionSelect = $module[0]
+  function OptionSelect ($module) {
+    this.$optionSelect = $module
     this.$options = this.$optionSelect.querySelectorAll("input[type='checkbox']")
     this.$optionsContainer = this.$optionSelect.querySelector('.js-options-container')
     this.$optionList = this.$optionsContainer.querySelector('.js-auto-height-inner')
@@ -17,7 +15,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.hasFilter = this.$optionSelect.getAttribute('data-filter-element') || ''
 
     this.checkedCheckboxes = []
+  }
 
+  OptionSelect.prototype.init = function () {
     if (this.hasFilter.length) {
       var filterEl = document.createElement('div')
       filterEl.innerHTML = this.hasFilter

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -2,7 +2,7 @@ describe('An expander module', function () {
   'use strict'
 
   var $element
-  var expander
+
   /* eslint-disable */
   var html = '\
     <div class="app-c-expander" data-module="expander">\
@@ -19,9 +19,9 @@ describe('An expander module', function () {
 
   describe('in default mode', function () {
     beforeEach(function () {
-      expander = new GOVUK.Modules.Expander()
-      $element = $(html)
-      expander.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
+      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
     })
 
     afterEach(function () {
@@ -29,38 +29,39 @@ describe('An expander module', function () {
     })
 
     it('collapses the content on page load', function () {
-      expect($element.find('.app-c-expander__content').is(':visible')).toBe(false)
+      expect($($element).find('.app-c-expander__content').is(':visible')).toBe(false)
     })
 
     it('replaces the span in the heading with a button and sets correct aria attributes', function () {
-      expect($element.find('.app-c-expander__button').text().trim()).toBe('Organisation')
-      expect($element.find('.app-c-expander__icon').length).toBe(2)
-      expect($element.find('.app-c-expander__heading .app-c-expander__icon').length).toBe(2)
-      expect($element.find('.app-c-expander__button').attr('type')).toBe('button')
-      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('false')
-      expect($element.find('.app-c-expander__button').attr('aria-controls')).toBe('expander-content-2386afad')
+      expect($($element).find('.app-c-expander__button').text().trim()).toBe('Organisation')
+      expect($($element).find('.app-c-expander__icon').length).toBe(2)
+      expect($($element).find('.app-c-expander__heading .app-c-expander__icon').length).toBe(2)
+      expect($($element).find('.app-c-expander__button').attr('type')).toBe('button')
+      expect($($element).find('.app-c-expander__button').attr('aria-expanded')).toBe('false')
+      expect($($element).find('.app-c-expander__button').attr('aria-controls')).toBe('expander-content-2386afad')
     })
 
     it('toggles the content when the button is clicked and updates aria attributes accordingly', function () {
-      var $button = $element.find('.app-c-expander__button')
+      var $button = $($element).find('.app-c-expander__button')
 
       $button.click()
-      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
-      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
+      expect($($element).find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
+      expect($($element).find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
 
       $button.click()
-      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false)
-      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('false')
+      expect($($element).find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false)
+      expect($($element).find('.app-c-expander__button').attr('aria-expanded')).toBe('false')
     })
   })
 
   describe('an expander set to open on load', function () {
     beforeEach(function () {
-      expander = new GOVUK.Modules.Expander()
-      $element = $(html)
-      $element.attr('data-open-on-load', true)
-      $element.find('.js-content').addClass('app-c-expander__content--visible')
-      expander.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
+      $($element).find('.app-c-expander').attr('data-open-on-load', true)
+      $($element).find('.js-content').addClass('app-c-expander__content--visible')
+
+      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
     })
 
     afterEach(function () {
@@ -68,13 +69,13 @@ describe('An expander module', function () {
     })
 
     it('does not collapse the content on page load', function () {
-      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
-      $element.find('.app-c-expander__button').click()
-      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false)
+      expect($($element).find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
+      $element.querySelector('.app-c-expander__button').click()
+      expect($($element).find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(false)
     })
 
     it('sets correct aria attributes on the button', function () {
-      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
+      expect($($element).find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
     })
   })
 
@@ -103,9 +104,9 @@ describe('An expander module', function () {
       </div>'
     /* eslint-enable */
     beforeEach(function () {
-      expander = new GOVUK.Modules.Expander()
-      $element = $(html)
-      expander.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
+      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
     })
 
     afterEach(function () {
@@ -113,15 +114,15 @@ describe('An expander module', function () {
     })
 
     it('shows the number of selecteed items when select options or text inputs have a value', function () {
-      expect($element.find('.js-selected-counter').html()).toBe('3 selected')
+      expect($($element).find('.js-selected-counter').html()).toBe('3 selected')
     })
 
     it('expands the content on page load', function () {
-      expect($element.find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
+      expect($($element).find('.app-c-expander__content').hasClass('app-c-expander__content--visible')).toBe(true)
     })
 
     it('sets correct aria attributes on the button', function () {
-      expect($element.find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
+      expect($($element).find('.app-c-expander__button').attr('aria-expanded')).toBe('true')
     })
   })
 })

--- a/spec/javascripts/components/option-select-spec.js
+++ b/spec/javascripts/components/option-select-spec.js
@@ -90,10 +90,6 @@ describe('An option select component', function () {
       '</div>'
   /* eslint-enable */
 
-  beforeEach(function () {
-    optionSelect = new GOVUK.Modules.OptionSelect()
-  })
-
   afterEach(function () {
     $('body').find('.app-c-option-select').remove()
   })
@@ -102,7 +98,8 @@ describe('An option select component', function () {
     it('instantiates a closed option-select if data-closed-on-load is true', function () {
       var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'))
       $('body').append($closedOnLoadFixture)
-      optionSelect.start($closedOnLoadFixture)
+
+      new GOVUK.Modules.OptionSelect($closedOnLoadFixture[0]).init()
 
       expect($closedOnLoadFixture.find('button').attr('aria-expanded')).toBe('false')
     })
@@ -110,7 +107,8 @@ describe('An option select component', function () {
     it('instantiates an open option-select if data-closed-on-load is false', function () {
       var $openOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=false'))
       $('body').append($openOnLoadFixture)
-      optionSelect.start($openOnLoadFixture)
+
+      new GOVUK.Modules.OptionSelect($openOnLoadFixture[0]).init()
 
       expect($openOnLoadFixture.find('button').attr('aria-expanded')).toBe('true')
       expect($('body').find('.js-options-container').is(':visible')).toBe(true)
@@ -119,50 +117,58 @@ describe('An option select component', function () {
     it('instantiates an open option-select if data-closed-on-load is not present', function () {
       var $openOnLoadFixture = $(optionSelectWithAttrs(''))
       $('body').append($openOnLoadFixture)
-      optionSelect.start($openOnLoadFixture)
+
+      new GOVUK.Modules.OptionSelect($openOnLoadFixture[0]).init()
 
       expect($openOnLoadFixture.find('button').attr('aria-expanded')).toBe('true')
       expect($('body').find('.js-options-container').is(':visible')).toBe(true)
     })
 
     it('sets the height of the options container as part of initialisation', function () {
-      $element = $(html)
-      optionSelect.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
 
-      expect($element.find('.js-options-container').attr('style')).toContain('height')
+      new GOVUK.Modules.OptionSelect($element.querySelector('.app-c-option-select')).init()
+
+      expect($($element).find('.js-options-container').attr('style')).toContain('height')
     })
 
     it('doesn\'t set the height of the options container as part of initialisation if closed-on-load is true', function () {
       var $closedOnLoadFixture = $(optionSelectWithAttrs('data-closed-on-load=true'))
-      optionSelect.start($closedOnLoadFixture)
+
+      new GOVUK.Modules.OptionSelect($closedOnLoadFixture[0]).init()
 
       expect($closedOnLoadFixture.find('.js-options-container').attr('style')).not.toContain('height')
     })
 
     it('replaces the `span.app-c-option-select__title` with a button', function () {
-      $element = $(html)
-      optionSelect.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
 
-      expect($element.find('button')).toBeDefined()
+      new GOVUK.Modules.OptionSelect($element.querySelector('.app-c-option-select')).init()
+
+      expect($($element).find('button')).toBeDefined()
     })
   })
 
   describe('toggleOptionSelect', function () {
     beforeEach(function () {
-      $element = $(html)
-      $('body').append($element)
-      optionSelect.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element)
+      optionSelect.init()
     })
 
     it('calls optionSelect.close() if the optionSelect is currently open', function () {
-      $element.removeClass('js-closed')
+      $($element).removeClass('js-closed')
       spyOn(optionSelect, 'close')
       optionSelect.toggleOptionSelect(jQuery.Event('click'))
       expect(optionSelect.close.calls.count()).toBe(1)
     })
 
     it('calls optionSelect.open() if the optionSelect is currently closed', function () {
-      $element.addClass('js-closed')
+      $($element).addClass('js-closed')
       spyOn(optionSelect, 'open')
       optionSelect.toggleOptionSelect(jQuery.Event('click'))
       expect(optionSelect.open.calls.count()).toBe(1)
@@ -171,27 +177,28 @@ describe('An option select component', function () {
 
   describe('when the open/close button is clicked', function () {
     beforeEach(function () {
-      $element = $(html)
-      $('body').append($element)
-      optionSelect.start($element)
+      $element = document.createElement('div')
+      $element.innerHTML = html
+
+      new GOVUK.Modules.OptionSelect($element).init()
     })
 
     it('closes and opens the option select', function () {
-      var $button = $element.find('button')
+      var $button = $($element).find('button')
       $button.click()
-      expect($element.hasClass('js-closed')).toBe(true)
+      expect($($element).hasClass('js-closed')).toBe(true)
 
       $button.click()
-      expect($element.hasClass('js-closed')).toBe(false)
+      expect($($element).hasClass('js-closed')).toBe(false)
     })
 
     it('updates aria-expanded accordingly', function () {
-      var $button = $element.find('button')
+      var $button = $($element).find('button')
       $button.click()
-      expect($element.find('button').attr('aria-expanded')).toBe('false')
+      expect($($element).find('button').attr('aria-expanded')).toBe('false')
 
       $button.click()
-      expect($element.find('button').attr('aria-expanded')).toBe('true')
+      expect($($element).find('button').attr('aria-expanded')).toBe('true')
     })
   })
 
@@ -201,7 +208,9 @@ describe('An option select component', function () {
     beforeEach(function () {
       $element = $(html)
       $('body').append($element)
-      optionSelect.start($element)
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+      optionSelect.init()
 
       optionSelect.setContainerHeight(100)
       firstCheckbox = optionSelect.$allCheckboxes[0]
@@ -223,7 +232,9 @@ describe('An option select component', function () {
     beforeEach(function () {
       $element = $(html)
       $('body').append($element)
-      optionSelect.start($element)
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+      optionSelect.init()
     })
 
     it('returns all the checkboxes if the container doesn\'t overflow', function () {
@@ -249,6 +260,8 @@ describe('An option select component', function () {
       $element = $(html)
       $('body').append($element)
 
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+
       // Set some visual properties which are done in the CSS IRL
       $checkboxList = $element.find('.js-options-container')
       $checkboxList.css({
@@ -261,7 +274,7 @@ describe('An option select component', function () {
       })
 
       $checkboxListInner = $checkboxList.find(' > .js-auto-height-inner')
-      optionSelect.start($element)
+      optionSelect.init()
     })
 
     it('expands the checkbox-container to fit checkbox list if the list is < 50px larger than the container', function () {
@@ -290,7 +303,9 @@ describe('An option select component', function () {
       $element = $(html)
       var $wrapper = $('<div/>').addClass('wrapper').hide().html($element)
       $('body').append($wrapper)
-      optionSelect.start($element)
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+      optionSelect.init()
     })
 
     afterEach(function () {
@@ -309,7 +324,9 @@ describe('An option select component', function () {
       $element.attr('data-closed-on-load', true)
       var $wrapper = $('<div/>').addClass('wrapper').hide().html($element)
       $('body').append($wrapper)
-      optionSelect.start($element)
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+      optionSelect.init()
     })
 
     afterEach(function () {
@@ -318,7 +335,7 @@ describe('An option select component', function () {
 
     it('sets the height of the container sensibly when the option select is opened', function () {
       $('.wrapper').show()
-      $element.find('button').click()
+      $($element).find('button').click()
 
       var containerHeight = $('.js-options-container').height()
       expect(containerHeight).toBeGreaterThan(200)
@@ -342,7 +359,9 @@ describe('An option select component', function () {
       $element.attr('data-filter-element', filterMarkup)
       $element.find('.gem-c-checkboxes').prepend($(filterSpan))
       $('body').append($element)
-      optionSelect.start($element)
+
+      optionSelect = new GOVUK.Modules.OptionSelect($element[0])
+      optionSelect.init()
 
       jasmine.clock().install()
       $filterInput = document.querySelector('[name="option-select-filter"]')


### PR DESCRIPTION
[Trello](https://trello.com/c/02ot7gbP/482-convert-finder-frontend-module-initialisers-to-not-use-jquery)

# What? 
Replaces jQuery module initialisers with vanilla JavaScript for `expander` and `option-select`. 

See [this PR description](https://github.com/alphagov/govuk_publishing_components/pull/2095) for some nice examples of module initialisation. 

# Why?
We're using an old and unsupported version of jQuery for browser support reasons.

Rather than upgrade, it's far better to remove our dependence.

### Expander

<img width="1072" alt="expander" src="https://user-images.githubusercontent.com/5963488/126612758-2fa94eff-428c-472a-b025-3aca251ff1c2.png">

### Option Select

<img width="1062" alt="option-select" src="https://user-images.githubusercontent.com/5963488/126612783-a6d27409-db9e-4b39-a36f-21d8dba6f0dc.png">

Co-authored-by: Andy Sellick @andysellick

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
