### PR TITLE
Replace jQuery in EnableAriaControls module initialiser

### DIFF
--- a/app/assets/javascripts/modules/enable-aria-controls.js
+++ b/app/assets/javascripts/modules/enable-aria-controls.js
@@ -1,18 +1,20 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (GOVUK) {
-  'use strict'
+(function (Modules) {
+  function EnableAriaControls ($module) {
+    this.$module = $module
+  }
 
-  GOVUK.Modules.EnableAriaControls = function EnableAriaControls () {
-    this.start = function (element) {
-      var $controls = element[0].querySelectorAll('[data-aria-controls]')
-      for (var i = 0; i < $controls.length; i++) {
-        var control = $controls[i].getAttribute('data-aria-controls')
-        if (typeof control === 'string' && document.getElementById(control)) {
-          $controls[i].setAttribute('aria-controls', control)
-        }
+  EnableAriaControls.prototype.init = function () {
+    var $controls = this.$module.querySelectorAll('[data-aria-controls]')
+    for (var i = 0; i < $controls.length; i++) {
+      var control = $controls[i].getAttribute('data-aria-controls')
+      if (typeof control === 'string' && document.getElementById(control)) {
+        $controls[i].setAttribute('aria-controls', control)
       }
     }
   }
-})(window.GOVUK)
+
+  Modules.EnableAriaControls = EnableAriaControls
+})(window.GOVUK.Modules)

--- a/spec/javascripts/modules/enable-aria-controls-spec.js
+++ b/spec/javascripts/modules/enable-aria-controls-spec.js
@@ -1,20 +1,14 @@
-var $ = window.jQuery
-
 describe('aria-controls enabler', function () {
-  'use strict'
-
   var GOVUK = window.GOVUK
   var enableAriaControls
 
-  beforeEach(function () {
-    enableAriaControls = new GOVUK.Modules.EnableAriaControls()
-  })
-
   it('ignores aria-controls if the referenced element isn’t present', function () {
     var $element = $('<div><div data-aria-controls="not-on-page"></div></div>')
-    enableAriaControls.start($element)
 
-    expect($element.find('[aria-controls]').length).toBe(0)
+    enableAriaControls = new GOVUK.Modules.EnableAriaControls($element[0])
+    enableAriaControls.init()
+
+    expect($($element).find('[aria-controls]').length).toBe(0)
   })
 
   it('adds aria-controls attributes if the referenced element is on the page', function () {
@@ -22,10 +16,12 @@ describe('aria-controls enabler', function () {
     $('body').append($referenced)
 
     var $element = $('<div><div data-aria-controls="on-page"></div></div>')
-    enableAriaControls.start($element)
+
+    enableAriaControls = new GOVUK.Modules.EnableAriaControls($element[0])
+    enableAriaControls.init()
 
     expect($('#on-page').length).toBe(1)
-    expect($element.find('[aria-controls="on-page"]').length).toBe(1)
+    expect($($element).find('[aria-controls="on-page"]').length).toBe(1)
 
     $referenced.remove()
   })


### PR DESCRIPTION
[Trello](https://trello.com/c/n8V5lG8F/518-enable-aria-controlsjs-convert-finder-frontend-module-initialisers-to-not-use-jquery)

# What?
Replaces jQuery module initialiser with vanilla JavaScript.

See [this PR description](https://github.com/alphagov/govuk_publishing_components/pull/2095) for some nice examples of module initialisation.

# Why?
We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

Co-authored-by: @andysellick

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
