### PR TITLE
Convert remove-filter.js to use init initialisation approach

### DIFF
--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -1,100 +1,102 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (global, GOVUK) {
+(function (Modules) {
   'use strict'
 
-  GOVUK.Modules.RemoveFilter = function RemoveFilter (element) {
+  function RemoveFilter (element) {
     this.element = element
+  }
 
-    this.init = function () {
-      element.addEventListener('click', function (e) {
-        if (e.target.getAttribute('data-module') === 'remove-filter-link') {
-          toggleFilter(e)
-        }
-      })
-    }
-
-    function toggleFilter (e) {
-      e.preventDefault()
-      e.stopPropagation()
-      var $el = e.target
-
-      var removeFilterName = $el.getAttribute('data-name')
-      var removeFilterValue = $el.getAttribute('data-value')
-      var removeFilterLabel = $el.getAttribute('data-track-label')
-      var removeFilterFacet = $el.getAttribute('data-facet')
-
-      var $input = getInput(removeFilterName, removeFilterValue, removeFilterFacet)
-      fireRemoveTagTrackingEvent(removeFilterLabel, removeFilterFacet)
-      clearFacet($input, removeFilterValue, removeFilterFacet)
-    }
-
-    function clearFacet ($input, removeFilterValue, removeFilterFacet) {
-      var elementType = $input.tagName
-      var inputType = $input.type
-      var currentVal = $input.value
-
-      if (inputType === 'checkbox') {
-        $input.checked = false
-        window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
-      } else if (inputType === 'text' || inputType === 'search') {
-        /* By padding the haystack with spaces, we can remove the
-         * first instance of " $needle ", and this will catch it in
-         * the middle of the haystack, at the ends, and when the
-         * needle is the haystack; without needing to consider these
-         * boundary conditions explicitly.
-         *
-         * The only caveat is that the matched needle needs replacing
-         * with " ", to avoid merging adjacent keywords when it was in
-         * the middle of the string, eg:
-         *
-         * needle = "beta"
-         * haystack = "alpha beta gamma"
-         *
-         * Just removing " beta " from the haystack would result in
-         * "alphagamma", which is wrong.
-         */
-        var haystack = ' ' + currentVal.trim() + ' '
-        var needle = ' ' + decodeEntities(removeFilterValue.toString()) + ' '
-        var newVal = haystack.replace(needle, ' ').replace(/ {2}/g, ' ').trim()
-        $input.value = newVal
-        window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
-      } else if (elementType === 'OPTION') {
-        var element = document.getElementById(removeFilterFacet)
-        element.value = ''
-        window.GOVUK.triggerEvent(element, 'change', { detail: { suppressAnalytics: true } })
+  RemoveFilter.prototype.init = function () {
+    this.element.addEventListener('click', function (e) {
+      if (e.target.getAttribute('data-module') === 'remove-filter-link') {
+        this.toggleFilterHandler(e)
       }
-    }
+    }.bind(this))
+  }
 
-    function getInput (removeFilterName, removeFilterValue, removeFilterFacet) {
-      var selector = (removeFilterName) ? "input[name='" + removeFilterName + "']" : "[value='" + removeFilterValue + "']"
+  RemoveFilter.prototype.toggleFilterHandler = function (e) {
+    e.preventDefault()
+    e.stopPropagation()
+    var $el = e.target
+
+    var removeFilterName = $el.getAttribute('data-name')
+    var removeFilterValue = $el.getAttribute('data-value')
+    var removeFilterLabel = $el.getAttribute('data-track-label')
+    var removeFilterFacet = $el.getAttribute('data-facet')
+
+    var $input = this.getInput(removeFilterName, removeFilterValue, removeFilterFacet)
+    this.fireRemoveTagTrackingEvent(removeFilterLabel, removeFilterFacet)
+    this.clearFacet($input, removeFilterValue, removeFilterFacet)
+  }
+
+  RemoveFilter.prototype.clearFacet = function ($input, removeFilterValue, removeFilterFacet) {
+    var elementType = $input.tagName
+    var inputType = $input.type
+    var currentVal = $input.value
+
+    if (inputType === 'checkbox') {
+      $input.checked = false
+      window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
+    } else if (inputType === 'text' || inputType === 'search') {
+      /* By padding the haystack with spaces, we can remove the
+       * first instance of " $needle ", and this will catch it in
+       * the middle of the haystack, at the ends, and when the
+       * needle is the haystack; without needing to consider these
+       * boundary conditions explicitly.
+       *
+       * The only caveat is that the matched needle needs replacing
+       * with " ", to avoid merging adjacent keywords when it was in
+       * the middle of the string, eg:
+       *
+       * needle = "beta"
+       * haystack = "alpha beta gamma"
+       *
+       * Just removing " beta " from the haystack would result in
+       * "alphagamma", which is wrong.
+       */
+      var haystack = ' ' + currentVal.trim() + ' '
+      var needle = ' ' + this.decodeEntities(removeFilterValue.toString()) + ' '
+      var newVal = haystack.replace(needle, ' ').replace(/ {2}/g, ' ').trim()
+      $input.value = newVal
+      window.GOVUK.triggerEvent($input, 'change', { detail: { suppressAnalytics: true } })
+    } else if (elementType === 'OPTION') {
       var element = document.getElementById(removeFilterFacet)
-
-      return element.querySelector(selector)
-    }
-
-    function fireRemoveTagTrackingEvent (filterValue, filterFacet) {
-      var category = 'facetTagRemoved'
-      var action = filterFacet
-      var label = filterValue
-
-      GOVUK.SearchAnalytics.trackEvent(
-        category,
-        action,
-        { label: label }
-      )
-
-      GOVUK.SearchAnalytics.trackEvent(
-        category,
-        action,
-        { label: label, trackerName: 'govuk' }
-      )
-    }
-
-    function decodeEntities (string) {
-      return string
-        .replace(/&quot;/g, '"')
+      element.value = ''
+      window.GOVUK.triggerEvent(element, 'change', { detail: { suppressAnalytics: true } })
     }
   }
-})(window, window.GOVUK)
+
+  RemoveFilter.prototype.getInput = function (removeFilterName, removeFilterValue, removeFilterFacet) {
+    var selector = (removeFilterName) ? "input[name='" + removeFilterName + "']" : "[value='" + removeFilterValue + "']"
+    var element = document.getElementById(removeFilterFacet)
+
+    return element.querySelector(selector)
+  }
+
+  RemoveFilter.prototype.fireRemoveTagTrackingEvent = function (filterValue, filterFacet) {
+    var category = 'facetTagRemoved'
+    var action = filterFacet
+    var label = filterValue
+
+    GOVUK.SearchAnalytics.trackEvent(
+      category,
+      action,
+      { label: label }
+    )
+
+    GOVUK.SearchAnalytics.trackEvent(
+      category,
+      action,
+      { label: label, trackerName: 'govuk' }
+    )
+  }
+
+  RemoveFilter.prototype.decodeEntities = function (string) {
+    return string
+      .replace(/&quot;/g, '"')
+  }
+
+  Modules.RemoveFilter = RemoveFilter
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/remove-filter.js
+++ b/app/assets/javascripts/modules/remove-filter.js
@@ -4,9 +4,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (global, GOVUK) {
   'use strict'
 
-  GOVUK.Modules.RemoveFilter = function RemoveFilter () {
-    this.start = function (element) {
-      element[0].addEventListener('click', function (e) {
+  GOVUK.Modules.RemoveFilter = function RemoveFilter (element) {
+    this.element = element
+
+    this.init = function () {
+      element.addEventListener('click', function (e) {
         if (e.target.getAttribute('data-module') === 'remove-filter-link') {
           toggleFilter(e)
         }

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -5,53 +5,52 @@ describe('remove-filter', function () {
 
   var GOVUK = window.GOVUK
   var timeout = 500
-  var removeFilter
   var $checkbox = $(
     '<div data-module="remove-filter">' +
     '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter transition period" data-module="remove-filter-link" data-facet="a_check_box" data-value="true" data-track-label="transition period" data-name="">✕</button>' +
-  '</div>')
+  '</div>')[0]
 
   var $oneTextQuery = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-track-label="Education" data-name="keywords">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $multipleTextQueries = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-track-label="the" data-name="keywords">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $quotedTextQuery = $(
     '<div data-module="remove-filter">' +
       '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fi&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fi&quot;" data-facet="keywords" data-value="&amp;quot;fi&amp;quot;" data-name="keywords">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $quotedTextQuerySpaces = $(
     '<div data-module="remove-filter">' +
       '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fee fi fo&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fee fi fo&quot;" data-facet="keywords" data-value="&amp;quot;fee fi fo&amp;quot;" data-name="keywords">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $dropdown = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $facetTagOne = $(
     '<div data-module="remove-filter">' +
       '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="A level one taxon" data-name="">✕</button>' +
     '</div>'
-  )
+  )[0]
 
   var $facetTagTwo = $(
     '<div data-module="remove-filter">' +
      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-track-label="Sub taxon" data-name="">✕</button>' +
    '</div>'
-  )
+  )[0]
 
   var $facets =
     '<select id="level_one_taxon" name="level_one_taxon">' +
@@ -74,7 +73,6 @@ describe('remove-filter', function () {
 
   beforeEach(function () {
     $(document.body).append($facets)
-    removeFilter = new GOVUK.Modules.RemoveFilter()
     spyOn(GOVUK.SearchAnalytics, 'trackEvent')
   })
 
@@ -85,7 +83,7 @@ describe('remove-filter', function () {
   it('deselects a selected checkbox', function (done) {
     var checkbox = $('input[name=a_check_box]')[0]
     checkbox.checked = true
-    removeFilter.start($checkbox)
+    new GOVUK.Modules.RemoveFilter($checkbox).init()
 
     expect(checkbox.checked).toBe(true)
 
@@ -100,7 +98,7 @@ describe('remove-filter', function () {
   it('clears the text search field if removing all text queries', function (done) {
     var searchField = $('input[name=keywords]')[0]
     searchField.value = 'education'
-    removeFilter.start($oneTextQuery)
+    new GOVUK.Modules.RemoveFilter($oneTextQuery).init()
 
     expect(searchField.value).toContain('education')
 
@@ -115,7 +113,7 @@ describe('remove-filter', function () {
   it('removes one text query from the text search field if there are multiple', function (done) {
     var searchField = $('input[name=keywords]')[0]
     searchField.value = 'therefore the search term'
-    removeFilter.start($multipleTextQueries)
+    new GOVUK.Modules.RemoveFilter($multipleTextQueries).init()
 
     expect(searchField.value).toContain('the')
 
@@ -130,7 +128,7 @@ describe('remove-filter', function () {
   it('removes text queries with quotes from the text search field', function (done) {
     var searchField = $('input[name=keywords]')[0]
     searchField.value = 'fee "fi" fo fum'
-    removeFilter.start($quotedTextQuery)
+    new GOVUK.Modules.RemoveFilter($quotedTextQuery).init()
 
     expect(searchField.value).toContain('"fi"')
 
@@ -145,7 +143,7 @@ describe('remove-filter', function () {
   it('removes text queries with multiple words inside quotes from the text search field', function (done) {
     var searchField = $('input[name=keywords]')[0]
     searchField.value = '"fee fi fo" fum'
-    removeFilter.start($quotedTextQuerySpaces)
+    new GOVUK.Modules.RemoveFilter($quotedTextQuerySpaces).init()
 
     expect(searchField.value).toContain('"fee fi fo"')
 
@@ -162,7 +160,7 @@ describe('remove-filter', function () {
     dropdown.value = 'ba3a9702-da22-487f-86c1-8334a730e559'
     var selectedValue = dropdown.options[dropdown.selectedIndex].value
 
-    removeFilter.start($dropdown)
+    new GOVUK.Modules.RemoveFilter($dropdown).init()
 
     expect(selectedValue).toEqual('ba3a9702-da22-487f-86c1-8334a730e559')
 
@@ -176,7 +174,7 @@ describe('remove-filter', function () {
 
   describe('Clicking the "x" button in facet tags', function () {
     it('triggers a google analytics custom event', function () {
-      removeFilter.start($facetTagOne)
+      new GOVUK.Modules.RemoveFilter($facetTagOne).init()
 
       triggerRemoveFilterClick($facetTagOne)
 
@@ -186,8 +184,8 @@ describe('remove-filter', function () {
     })
 
     it('triggers a google analytics custom event when second facet tag removed', function () {
-      removeFilter.start($facetTagOne)
-      removeFilter.start($facetTagTwo)
+      new GOVUK.Modules.RemoveFilter($facetTagOne).init()
+      new GOVUK.Modules.RemoveFilter($facetTagTwo).init()
 
       triggerRemoveFilterClick($facetTagOne)
       triggerRemoveFilterClick($facetTagTwo)
@@ -200,5 +198,6 @@ describe('remove-filter', function () {
 })
 
 function triggerRemoveFilterClick (element) {
-  element.find('button[data-module=remove-filter-link]').trigger('click')
+  var button = element.querySelector('button[data-module=remove-filter-link]')
+  window.GOVUK.triggerEvent(button, 'click')
 }

--- a/spec/javascripts/modules/remove-filter-spec.js
+++ b/spec/javascripts/modules/remove-filter-spec.js
@@ -1,58 +1,55 @@
-var $ = window.jQuery
-
 describe('remove-filter', function () {
   'use strict'
 
   var GOVUK = window.GOVUK
   var timeout = 500
-  var $checkbox = $(
-    '<div data-module="remove-filter">' +
-    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter transition period" data-module="remove-filter-link" data-facet="a_check_box" data-value="true" data-track-label="transition period" data-name="">✕</button>' +
-  '</div>')[0]
+  var facets
 
-  var $oneTextQuery = $(
-    '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-track-label="Education" data-name="keywords">✕</button>' +
-    '</div>'
-  )[0]
+  function createRemoveFilter (innerHTML) {
+    var filter = document.createElement('div')
+    filter.classList.add('remove-filter')
+    filter.innerHTML = innerHTML
+    return filter
+  }
 
-  var $multipleTextQueries = $(
-    '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-track-label="the" data-name="keywords">✕</button>' +
-    '</div>'
-  )[0]
+  function triggerRemoveFilterClick (element) {
+    var button = element.querySelector('button[data-module=remove-filter-link]')
+    window.GOVUK.triggerEvent(button, 'click')
+  }
 
-  var $quotedTextQuery = $(
-    '<div data-module="remove-filter">' +
-      '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fi&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fi&quot;" data-facet="keywords" data-value="&amp;quot;fi&amp;quot;" data-name="keywords">✕</button>' +
-    '</div>'
-  )[0]
+  var checkboxFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications" class="remove-filter" role="button" aria-label="Remove filter transition period" data-module="remove-filter-link" data-facet="a_check_box" data-value="true" data-track-label="transition period" data-name="">✕</button>'
+  )
 
-  var $quotedTextQuerySpaces = $(
-    '<div data-module="remove-filter">' +
-      '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fee fi fo&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fee fi fo&quot;" data-facet="keywords" data-value="&amp;quot;fee fi fo&amp;quot;" data-name="keywords">✕</button>' +
-    '</div>'
-  )[0]
+  var oneTextQueryFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter education" data-module="remove-filter-link" data-facet="keywords" data-value="education" data-track-label="Education" data-name="keywords">✕</button>'
+  )
 
-  var $dropdown = $(
-    '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>' +
-    '</div>'
-  )[0]
+  var multipleTextQueriesFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications?[]=education" class="remove-filter" role="button" aria-label="Remove filter the" data-module="remove-filter-link" data-facet="keywords" data-value="the" data-track-label="the" data-name="keywords">✕</button>'
+  )
 
-  var $facetTagOne = $(
-    '<div data-module="remove-filter">' +
-      '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="A level one taxon" data-name="">✕</button>' +
-    '</div>'
-  )[0]
+  var quotedTextQueryFilter = createRemoveFilter(
+    '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fi&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fi&quot;" data-facet="keywords" data-value="&amp;quot;fi&amp;quot;" data-name="keywords">✕</button>'
+  )
 
-  var $facetTagTwo = $(
-    '<div data-module="remove-filter">' +
-     '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-track-label="Sub taxon" data-name="">✕</button>' +
-   '</div>'
-  )[0]
+  var quotedTextQuerySpacesFilter = createRemoveFilter(
+    '<button type="button" class="facet-tag__remove" aria-label="Remove filter &amp;quot;fee fi fo&amp;quot;" data-module="remove-filter-link" data-track-label="&quot;fee fi fo&quot;" data-facet="keywords" data-value="&amp;quot;fee fi fo&amp;quot;" data-name="keywords">✕</button>'
+  )
 
-  var $facets =
+  var dropdownFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter Entering and staying in the UK" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="Entering and staying in the UK" data-name="">✕</button>'
+  )
+
+  var facetTagOneFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_one_taxon" data-value="ba3a9702-da22-487f-86c1-8334a730e559" data-track-label="A level one taxon" data-name="">✕</button>'
+  )
+
+  var facetTagTwoFilter = createRemoveFilter(
+    '<button href="/search/news-and-communications?[][]=level_one_taxon&amp;[][]=ba3a9702-da22-487f-86c1-8334a730e559&amp;[][]=level_two_taxon&amp;[][]" class="remove-filter" role="button" aria-label="Remove filter" data-module="remove-filter-link" data-facet="level_two_taxon" data-value="bb3a9702-da22-487f-86c1-8334a730e559" data-track-label="Sub taxon" data-name="">✕</button>'
+  )
+
+  var facetsHTML =
     '<select id="level_one_taxon" name="level_one_taxon">' +
       '<option value="">All topics</option>' +
       '<option value="ba3a9702-da22-487f-86c1-8334a730e559">Entering and staying in the UK</option>' +
@@ -72,22 +69,25 @@ describe('remove-filter', function () {
     '</div>'
 
   beforeEach(function () {
-    $(document.body).append($facets)
+    facets = document.createElement('div')
+    facets.innerHTML = facetsHTML
+    document.body.appendChild(facets)
     spyOn(GOVUK.SearchAnalytics, 'trackEvent')
   })
 
   afterEach(function () {
+    document.body.removeChild(facets)
     GOVUK.SearchAnalytics.trackEvent.calls.reset()
   })
 
   it('deselects a selected checkbox', function (done) {
-    var checkbox = $('input[name=a_check_box]')[0]
+    var checkbox = facets.querySelector('input[name=a_check_box]')
     checkbox.checked = true
-    new GOVUK.Modules.RemoveFilter($checkbox).init()
+    new GOVUK.Modules.RemoveFilter(checkboxFilter).init()
 
     expect(checkbox.checked).toBe(true)
 
-    triggerRemoveFilterClick($checkbox)
+    triggerRemoveFilterClick(checkboxFilter)
 
     setTimeout(function () {
       expect(checkbox.checked).toBe(false)
@@ -96,13 +96,13 @@ describe('remove-filter', function () {
   })
 
   it('clears the text search field if removing all text queries', function (done) {
-    var searchField = $('input[name=keywords]')[0]
+    var searchField = facets.querySelector('input[name=keywords]')
     searchField.value = 'education'
-    new GOVUK.Modules.RemoveFilter($oneTextQuery).init()
+    new GOVUK.Modules.RemoveFilter(oneTextQueryFilter).init()
 
     expect(searchField.value).toContain('education')
 
-    triggerRemoveFilterClick($oneTextQuery)
+    triggerRemoveFilterClick(oneTextQueryFilter)
 
     setTimeout(function () {
       expect(searchField.value).toEqual('')
@@ -111,13 +111,13 @@ describe('remove-filter', function () {
   })
 
   it('removes one text query from the text search field if there are multiple', function (done) {
-    var searchField = $('input[name=keywords]')[0]
+    var searchField = facets.querySelector('input[name=keywords]')
     searchField.value = 'therefore the search term'
-    new GOVUK.Modules.RemoveFilter($multipleTextQueries).init()
+    new GOVUK.Modules.RemoveFilter(multipleTextQueriesFilter).init()
 
     expect(searchField.value).toContain('the')
 
-    triggerRemoveFilterClick($multipleTextQueries)
+    triggerRemoveFilterClick(multipleTextQueriesFilter)
 
     setTimeout(function () {
       expect(searchField.value).toEqual('therefore search term')
@@ -126,13 +126,13 @@ describe('remove-filter', function () {
   })
 
   it('removes text queries with quotes from the text search field', function (done) {
-    var searchField = $('input[name=keywords]')[0]
+    var searchField = facets.querySelector('input[name=keywords]')
     searchField.value = 'fee "fi" fo fum'
-    new GOVUK.Modules.RemoveFilter($quotedTextQuery).init()
+    new GOVUK.Modules.RemoveFilter(quotedTextQueryFilter).init()
 
     expect(searchField.value).toContain('"fi"')
 
-    triggerRemoveFilterClick($quotedTextQuery)
+    triggerRemoveFilterClick(quotedTextQueryFilter)
 
     setTimeout(function () {
       expect(searchField.value).toEqual('fee fo fum')
@@ -141,13 +141,13 @@ describe('remove-filter', function () {
   })
 
   it('removes text queries with multiple words inside quotes from the text search field', function (done) {
-    var searchField = $('input[name=keywords]')[0]
+    var searchField = facets.querySelector('input[name=keywords]')
     searchField.value = '"fee fi fo" fum'
-    new GOVUK.Modules.RemoveFilter($quotedTextQuerySpaces).init()
+    new GOVUK.Modules.RemoveFilter(quotedTextQuerySpacesFilter).init()
 
     expect(searchField.value).toContain('"fee fi fo"')
 
-    triggerRemoveFilterClick($quotedTextQuerySpaces)
+    triggerRemoveFilterClick(quotedTextQuerySpacesFilter)
 
     setTimeout(function () {
       expect(searchField.value).toEqual('fum')
@@ -156,15 +156,15 @@ describe('remove-filter', function () {
   })
 
   it('sets default state for dropdown', function (done) {
-    var dropdown = $('select[name=level_one_taxon]')[0]
+    var dropdown = facets.querySelector('select[name=level_one_taxon]')
     dropdown.value = 'ba3a9702-da22-487f-86c1-8334a730e559'
     var selectedValue = dropdown.options[dropdown.selectedIndex].value
 
-    new GOVUK.Modules.RemoveFilter($dropdown).init()
+    new GOVUK.Modules.RemoveFilter(dropdownFilter).init()
 
     expect(selectedValue).toEqual('ba3a9702-da22-487f-86c1-8334a730e559')
 
-    triggerRemoveFilterClick($dropdown)
+    triggerRemoveFilterClick(dropdownFilter)
 
     setTimeout(function () {
       expect(dropdown.options[dropdown.selectedIndex].value).toEqual('')
@@ -174,9 +174,9 @@ describe('remove-filter', function () {
 
   describe('Clicking the "x" button in facet tags', function () {
     it('triggers a google analytics custom event', function () {
-      new GOVUK.Modules.RemoveFilter($facetTagOne).init()
+      new GOVUK.Modules.RemoveFilter(facetTagOneFilter).init()
 
-      triggerRemoveFilterClick($facetTagOne)
+      triggerRemoveFilterClick(facetTagOneFilter)
 
       expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_one_taxon', {
         label: 'A level one taxon'
@@ -184,11 +184,11 @@ describe('remove-filter', function () {
     })
 
     it('triggers a google analytics custom event when second facet tag removed', function () {
-      new GOVUK.Modules.RemoveFilter($facetTagOne).init()
-      new GOVUK.Modules.RemoveFilter($facetTagTwo).init()
+      new GOVUK.Modules.RemoveFilter(facetTagOneFilter).init()
+      new GOVUK.Modules.RemoveFilter(facetTagTwoFilter).init()
 
-      triggerRemoveFilterClick($facetTagOne)
-      triggerRemoveFilterClick($facetTagTwo)
+      triggerRemoveFilterClick(facetTagOneFilter)
+      triggerRemoveFilterClick(facetTagTwoFilter)
 
       expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith('facetTagRemoved', 'level_two_taxon', {
         label: 'Sub taxon'
@@ -196,8 +196,3 @@ describe('remove-filter', function () {
     })
   })
 })
-
-function triggerRemoveFilterClick (element) {
-  var button = element.querySelector('button[data-module=remove-filter-link]')
-  window.GOVUK.triggerEvent(button, 'click')
-}


### PR DESCRIPTION
Trello: https://trello.com/c/DdSnmUQy/522-convert-finder-frontend-module-initialisers-in-remove-filterjs-to-not-use-jquery

This replaces the jQuery start initialisation pattern in the module to use the non-jQuery init approach, to help us remove jQuery. It then refactors the module organisation to be the standard GOV.UK approach. Finally it does some clean-up in the tests and removes the jQuery from that too.

This is easiest reviewed commit by commit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
