### PR TITLE
Convert track-brexit-qa-choices.js to use init initialisation approach

### DIFF
--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -1,46 +1,47 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (global, GOVUK) {
+(function (Modules) {
   'use strict'
 
-  GOVUK.Modules.TrackBrexitQaChoices = function (element) {
-    this.init = function () {
-      track(element)
-    }
+  function TrackBrexitQaChoices (element) {
+    this.element = element
+  }
 
-    function track (element) {
-      element.addEventListener('submit', function (event) {
-        var eventLabel, options
-        var submittedForm = event.target
-        var checkedOptions = submittedForm.querySelectorAll('input:checked')
-        var questionKey = submittedForm.getAttribute('data-question-key')
+  TrackBrexitQaChoices.prototype.init = function () {
+    this.element.addEventListener('submit', this.submitHandler.bind(this))
+  }
 
-        if (checkedOptions.length) {
-          for (var i = 0; i < checkedOptions.length; i++) {
-            var checkedOptionId = checkedOptions[i].getAttribute('id')
-            var checkedOptionLabelText = submittedForm.querySelector('label[for="' + checkedOptionId + '"]')
-            var checkedOptionLabel = ''
+  TrackBrexitQaChoices.prototype.submitHandler = function () {
+    var eventLabel, options
+    var checkedOptions = this.element.querySelectorAll('input:checked')
+    var questionKey = this.element.getAttribute('data-question-key')
 
-            if (checkedOptionLabelText != null) {
-              checkedOptionLabel = checkedOptionLabelText.textContent.replace(/^\s+|\s+$/g, '')
-            }
+    if (checkedOptions.length) {
+      for (var i = 0; i < checkedOptions.length; i++) {
+        var checkedOptionId = checkedOptions[i].getAttribute('id')
+        var checkedOptionLabelText = this.element.querySelector('label[for="' + checkedOptionId + '"]')
+        var checkedOptionLabel = ''
 
-            eventLabel = checkedOptionLabel.length
-              ? checkedOptionLabel
-              : checkedOptions[i].value
-
-            options = { transport: 'beacon', label: eventLabel }
-
-            GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
-          }
-        } else {
-          // Skipped questions
-          options = { transport: 'beacon', label: 'no choice' }
-
-          GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
+        if (checkedOptionLabelText != null) {
+          checkedOptionLabel = checkedOptionLabelText.textContent.replace(/^\s+|\s+$/g, '')
         }
-      })
+
+        eventLabel = checkedOptionLabel.length
+          ? checkedOptionLabel
+          : checkedOptions[i].value
+
+        options = { transport: 'beacon', label: eventLabel }
+
+        GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
+      }
+    } else {
+      // Skipped questions
+      options = { transport: 'beacon', label: 'no choice' }
+
+      GOVUK.SearchAnalytics.trackEvent('brexit-checker-qa', questionKey, options)
     }
   }
-})(window, window.GOVUK)
+
+  Modules.TrackBrexitQaChoices = TrackBrexitQaChoices
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-brexit-qa-choices.js
+++ b/app/assets/javascripts/modules/track-brexit-qa-choices.js
@@ -4,9 +4,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (global, GOVUK) {
   'use strict'
 
-  GOVUK.Modules.TrackBrexitQaChoices = function () {
-    this.start = function (element) {
-      track(element[0])
+  GOVUK.Modules.TrackBrexitQaChoices = function (element) {
+    this.init = function () {
+      track(element)
     }
 
     function track (element) {

--- a/spec/javascripts/modules/track-brexit-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-brexit-qa-choices.spec.js
@@ -2,29 +2,26 @@ var $ = window.jQuery
 
 describe('Brexit QA choices tracker', function () {
   var GOVUK = window.GOVUK || {}
-  var tracker
   var $element
 
   beforeEach(function () {
     spyOn(GOVUK.SearchAnalytics, 'trackEvent')
 
     $element = $(
-      '<div>' +
-        '<form onsubmit="event.preventDefault()" data-question-key="question-key">' +
-          '<div>' +
-            '<input name="sector_business_area[]" id="construction" type="checkbox" value="construction">' +
-            '<label for="construction">Construction label</label>' +
-          '</div>' +
-          '<div>' +
-            '<input name="sector_business_area[]" id="accommodation" type="checkbox" value="accommodation">' +
-            '<label for="accommodation">Accommodation label</label>' +
-          '</div>' +
-          '<div>' +
-            '<input name="sector_business_area[]" type="checkbox" value="furniture">' +
-          '</div>' +
-          '<button type="submit">Next</button>' +
-        '</form>' +
-      '</div>'
+      '<form onsubmit="event.preventDefault()" data-question-key="question-key">' +
+        '<div>' +
+          '<input name="sector_business_area[]" id="construction" type="checkbox" value="construction">' +
+          '<label for="construction">Construction label</label>' +
+        '</div>' +
+        '<div>' +
+          '<input name="sector_business_area[]" id="accommodation" type="checkbox" value="accommodation">' +
+          '<label for="accommodation">Accommodation label</label>' +
+        '</div>' +
+        '<div>' +
+          '<input name="sector_business_area[]" type="checkbox" value="furniture">' +
+        '</div>' +
+        '<button type="submit">Next</button>' +
+      '</form>'
     )
 
     new GOVUK.Modules.TrackBrexitQaChoices($element[0]).init()
@@ -37,7 +34,7 @@ describe('Brexit QA choices tracker', function () {
   it('tracks checked checkboxes when clicking submit', function () {
     $element.find('input[value="accommodation"]').trigger('click')
     $element.find('input[value="construction"]').trigger('click')
-    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
+    window.GOVUK.triggerEvent($element[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
@@ -49,7 +46,7 @@ describe('Brexit QA choices tracker', function () {
 
   it('track events sends value of checkbox when no label is set', function () {
     $element.find('input[value="furniture"]').trigger('click')
-    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
+    window.GOVUK.triggerEvent($element[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'furniture' }
@@ -57,7 +54,7 @@ describe('Brexit QA choices tracker', function () {
   })
 
   it('track event triggered when no choice is made', function () {
-    window.GOVUK.triggerEvent($element.find('form')[0], 'submit')
+    window.GOVUK.triggerEvent($element[0], 'submit')
 
     expect(GOVUK.SearchAnalytics.trackEvent).toHaveBeenCalledWith(
       'brexit-checker-qa', 'question-key', { transport: 'beacon', label: 'no choice' }

--- a/spec/javascripts/modules/track-brexit-qa-choices.spec.js
+++ b/spec/javascripts/modules/track-brexit-qa-choices.spec.js
@@ -27,8 +27,7 @@ describe('Brexit QA choices tracker', function () {
       '</div>'
     )
 
-    tracker = new GOVUK.Modules.TrackBrexitQaChoices()
-    tracker.start($element)
+    new GOVUK.Modules.TrackBrexitQaChoices($element[0]).init()
   })
 
   afterEach(function () {


### PR DESCRIPTION
Trello: https://trello.com/c/bqbkGp0E/523-convert-finder-frontend-module-initialisers-in-track-brexit-qa-choicesjs-to-not-use-jquery

This replaces the jQuery start initialisation pattern in the module to use the non-jQuery init approach, to help us remove jQuery. It then refactors the module organisation to be the standard GOV.UK approach and adjusts the tests accordingly.

This is easiest reviewed commit by commit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
