### PR TITLE
Make mobile-filters-modal use init

### DIFF
--- a/app/assets/javascripts/modules/mobile-filters-modal.js
+++ b/app/assets/javascripts/modules/mobile-filters-modal.js
@@ -2,10 +2,8 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function MobileFiltersModal () { }
-
-  MobileFiltersModal.prototype.start = function ($module) {
-    this.$module = $module[0]
+  function MobileFiltersModal ($module) {
+    this.$module = $module
     this.$facetsBox = this.$module.querySelector('.facets__box')
     this.$closeTriggers = this.$module.querySelectorAll('.js-close-filters')
     this.$showResultsButton = this.$module.querySelector('.js-show-results')
@@ -17,7 +15,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.clearFilters = this.handleClearFilters.bind(this)
     this.$module.ModalFocus = this.handleModalFocus.bind(this)
     this.$module.boundKeyDown = this.handleKeyDown.bind(this)
+  }
 
+  MobileFiltersModal.prototype.init = function () {
     var $triggerElement = document.querySelector(
       '[data-toggle="mobile-filters-modal"][data-target="' + this.$module.id + '"]'
     )

--- a/spec/javascripts/modules/mobile-filters-modal.spec.js
+++ b/spec/javascripts/modules/mobile-filters-modal.spec.js
@@ -43,8 +43,13 @@ describe('Mobile filters modal', function () {
     '</form>'
 
     document.body.appendChild(container)
-    var element = $('[data-module="mobile-filters-modal"]')
-    new GOVUK.Modules.MobileFiltersModal().start(element)
+
+    container.addEventListener('submit', function (e) {
+      e.preventDefault()
+    })
+
+    var element = $('[data-module="mobile-filters-modal"]')[0]
+    new GOVUK.Modules.MobileFiltersModal(element).init()
   })
 
   afterEach(function () {


### PR DESCRIPTION
This is part of a wider effort to remove jQuery from our applications because we're using an unsupported version. The publishing components gem knows the different between `start` and `init` and will now pass the module a JS object rather than a jQ one.

Trello - https://trello.com/c/uuYzo3hc/519-convert-finder-frontend-module-initialisers-in-mobile-filters-modaljs-to-not-use-jquery

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
