### PR TITLE
replace start with init for ecommerce in live search

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -99,7 +99,7 @@
   LiveSearch.prototype.startEnhancedEcommerceTracking = function startEnhancedEcommerceTracking () {
     this.$resultsWrapper.attr('data-search-query', this.currentKeywords())
     this.$suggestionsBlock.attr('data-search-query', this.currentKeywords())
-    if (GOVUK.Ecommerce) { GOVUK.Ecommerce.start() }
+    if (GOVUK.Ecommerce) { GOVUK.Ecommerce.init() }
   }
 
   LiveSearch.prototype.getTaxonomyFacet = function getTaxonomyFacet () {


### PR DESCRIPTION
As it turns out init is defined on the [Ecommerce variable in publishing components](https://github.com/alphagov/govuk_publishing_components/blob/e3b952e0365c8174da7ed7e8e964951bd3cbc074/app/assets/javascripts/govuk_publishing_components/analytics/ecommerce.js#L12) so this should be fine.

This is part of a wider effort to remove jQuery from the stack because the version we're using is outdated

Trello - https://trello.com/c/pATsfsuD/524-convert-finder-frontend-module-initialisers-in-livesearchjs-to-not-use-jquery

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
