### PR TITLE
Fix Explore header being applied to Brexit pages

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -12,6 +12,8 @@ class BrexitCheckerController < ApplicationController
 
   before_action :enable_caching, only: %i[show email_signup confirm_email_signup results]
 
+  after_action :set_slimmer_template
+
   helper_method :subscriber_list_slug
 
   def show


### PR DESCRIPTION
We should exclude the Brexit pages from the Explore Super Menu AB Test as they need to keep the Sign In link.

https://trello.com/c/xjU0uYAt/459-fix-sign-in-link-on-brexit-pages, [Jira issue NAV-3111](https://gov-uk.atlassian.net/browse/NAV-3111)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
