### PR TITLE
Return A/B response headers for all variants

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -17,10 +17,10 @@ module AbTests::ExploreMenuAbTestable
   end
 
   def set_explore_menu_response
-    explore_menu_variant.configure_response(response) if explore_menu_testable?
+    explore_menu_variant.configure_response(response)
   end
 
-  def explore_menu_testable?
+  def explore_menu_variant_b?
     explore_menu_variant.variant?("B")
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_explore_menu_response
 
-  helper_method :explore_menu_variant, :explore_menu_testable?
+  helper_method :explore_menu_variant, :explore_menu_variant_b?
 
   after_action :set_slimmer_template
 
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def set_slimmer_template
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "header_footer_only_explore_header"
     else
       slimmer_template "header_footer_only"

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -6,7 +6,7 @@
     <%= stylesheet_link_tag "application", integrity: false %>
     <%= stylesheet_link_tag "print", media: "print" %>
     <%= javascript_include_tag 'application', integrity: false %>
-    <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+    <%= explore_menu_variant.analytics_meta_tag.html_safe %>
     <% if @content_item %>
       <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
     <% end %>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -3,7 +3,7 @@
 <% content_for :extra_headers do %>
   <meta name="description"
         content="Search GOV.UK." />
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <main id="content" class="search-wrapper search-wrapper--no-search-term">

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -63,22 +63,36 @@ describe FindersController, type: :controller do
           .to_return(status: 200, body: rummager_response, headers: {})
       end
 
-      it "requests the B variant for finders" do
-        with_variant ExploreMenuAbTestable: "B" do
+      it "should render the default header for variant A of the explore menu A/B test" do
+        with_variant ExploreMenuAbTestable: "A", assert_meta_tag: true do
           get :show, params: { slug: "lunch-finder" }
 
           expect(response.status).to eq(200)
+          assert_response_is_cached_by_variant("ExploreMenuAbTestable")
+          expect(response.headers["X-Slimmer-Template"]).to eq("header_footer_only")
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "A", 47)
         end
       end
 
-      it "requests the B variant for search pages" do
-        stub_content_store_has_item(
-          "/search/all",
-          all_content_finder,
-        )
+      it "should render the explore header for variant B of the explore menu A/B test" do
+        with_variant ExploreMenuAbTestable: "B", assert_meta_tag: true do
+          get :show, params: { slug: "lunch-finder" }
 
-        with_variant ExploreMenuAbTestable: "B" do
-          get :show, params: { slug: "search/all" }
+          expect(response.status).to eq(200)
+          assert_response_is_cached_by_variant("ExploreMenuAbTestable")
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "B", 47)
+          expect(response.headers["X-Slimmer-Template"]).to eq("header_footer_only_explore_header")
+        end
+      end
+
+      it "should render the default header for variant Z of the explore menu A/B test" do
+        with_variant ExploreMenuAbTestable: "Z", assert_meta_tag: true do
+          get :show, params: { slug: "lunch-finder" }
+
+          expect(response.status).to eq(200)
+          assert_response_is_cached_by_variant("ExploreMenuAbTestable")
+          assert_page_tracked_in_ab_test("ExploreMenuAbTestable", "Z", 47)
+          expect(response.headers["X-Slimmer-Template"]).to eq("header_footer_only")
         end
       end
 


### PR DESCRIPTION
## What

Sets the `Vary` header to be returned whatever the variant being view is.

Tests have been updated to check that this is working correctly, with checks for the Vary header, the meta tag and the correct Slimmer template header.

## Why
The `Vary` header was only being returned for the "B" variant - which makes it tricky for Fastly to know how to cache the pages correctly. This has been updated to always pass the `Vary` header back to Fastly regardless of the variant.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
