### PR TITLE
Prevent proposition menu links apeparing on explore menu AB variant

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,7 +13,7 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
 
-  <% if content_item.government? %>
+  <% if content_item.government? && explore_menu_variant_b? == false %>
     <%= render 'govuk_publishing_components/components/government_navigation', active: content_item.government_content_section %>
   <% end %>
   <div class="govuk-grid-row">


### PR DESCRIPTION
## What
Prevents proposition menu links from appearing in the markup if the "B" variant of the explore AB test is active on the [topical events page](https://www.gov.uk/government/topical-events).

## Why
Fixes a visual bug on this view.

## Visual changes

| Before | After|
| --- | --- |
| <img width="1104" alt="Screenshot 2021-08-11 at 10 46 14" src="https://user-images.githubusercontent.com/64783893/129015032-4ebcb21c-0769-4728-b49b-e8c5a5dac41c.png"> | ![Screenshot 2021-08-11 at 11 33 51](https://user-images.githubusercontent.com/64783893/129015063-01b16151-fc2d-49a7-9c63-f086e26cac45.png) |