### PR TITLE
Swap to `gem_layout`

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 $govuk-use-legacy-font: false;
@@ -9,7 +9,6 @@ $govuk-use-legacy-font: false;
 // https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components
 // for guidance
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/back-link';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
 
-  slimmer_template "header_footer_only"
+  slimmer_template "gem_layout"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -60,7 +60,7 @@ class BrexitCheckerController < ApplicationController
       slimmer_template "gem_layout_account_manager_no_nav"
       render :save_results_initial
     else
-      slimmer_template "header_footer_only_old_header"
+      slimmer_template "gem_layout_full_width_old_header"
     end
   end
 
@@ -148,6 +148,6 @@ private
   end
 
   def set_template
-    slimmer_template "header_footer_only_old_header"
+    slimmer_template "gem_layout_full_width_old_header"
   end
 end

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -23,11 +23,6 @@
           <%= yield %>
         </div>
       </main>
-      <% unless @omit_feedback_footer %>
-        <div class="govuk-width-container">
-          <%= render 'govuk_publishing_components/components/feedback' %>
-        </div>
-      <% end %>
     </div>
   </body>
 </html>

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -15,7 +15,6 @@
   <body class="mainstream <%= yield :body_classes %>">
     <div id="wrapper" class="govuk-width-container">
       <%= yield %>
-      <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### What

Update `finder-frontend` to use the Design System-based page layout

### Why

Benefits include performance improvements, accessibility improvements, and consistency with other applications.

### Checklist
Things to be addressed before merging this PR
- [x] https://github.com/alphagov/govuk_publishing_components/pull/2294 (example page: https://finder-front-swap-to-ge-qw2ad7.herokuapp.com/transition-check/questions) 
- [x] https://github.com/alphagov/govuk_publishing_components/pull/2296 (example page: https://finder-front-swap-to-ge-qw2ad7.herokuapp.com/search/policy-papers-and-consultations)

