### PR TITLE
Remove jQuery wrapping of element for module start

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       unicorn (>= 5.4, < 5.9)
     govuk_personalisation (0.6.0)
       rails (~> 6)
-    govuk_publishing_components (25.3.1)
+    govuk_publishing_components (25.4.0)
       govuk_app_config
       kramdown
       plek

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -195,7 +195,7 @@
   }
 
   LiveSearch.prototype.trackingInit = function trackingInit () {
-    GOVUK.modules.start($(this.$resultsWrapper)) // this still needs to pass a jQuery object until we update the modules code
+    GOVUK.modules.start(this.$resultsWrapper)
     this.indexTrackingData()
     this.startEnhancedEcommerceTracking()
   }


### PR DESCRIPTION
Trello: https://trello.com/c/pATsfsuD/524-convert-finder-frontend-module-initialisers-in-livesearchjs-to-not-use-jquery

This change removes jQuery from this script, it is dependent on
govuk_publishing_components having released https://github.com/alphagov/govuk_publishing_components/pull/2260

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
