### PR TITLE
Remove jQuery from taxonomy-select

### DIFF
--- a/app/assets/javascripts/taxonomy-select.js
+++ b/app/assets/javascripts/taxonomy-select.js
@@ -1,9 +1,7 @@
-// TaxonomySelect adds interactivity to the topic taxonomy facet
-(function ($) {
-  'use strict'
+window.GOVUK = window.GOVUK || {};
 
-  window.GOVUK = window.GOVUK || {}
-  var GOVUK = window.GOVUK
+(function (GOVUK) {
+  'use strict'
 
   function TaxonomySelect (options) {
     this.$el = options.$el
@@ -74,4 +72,4 @@
   }
 
   GOVUK.TaxonomySelect = TaxonomySelect
-})(jQuery)
+})(window.GOVUK)


### PR DESCRIPTION
This last reference to jQuery seems to have not been caught in https://github.com/alphagov/finder-frontend/pull/2517

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
