### PR TITLE
Set Transition Checker to use old style header

### DIFF
--- a/app/controllers/brexit_checker_controller.rb
+++ b/app/controllers/brexit_checker_controller.rb
@@ -84,7 +84,7 @@ class BrexitCheckerController < ApplicationController
 private
 
   def set_slimmer_template
-    slimmer_template "header_footer_only"
+    slimmer_template "header_footer_only_old_header"
   end
 
   def subscriber_list_slug


### PR DESCRIPTION
We will be setting the Explore Super Menu Header as the default across GOV.UK, so we need to switch the Brexit landing page to use a specific template from Static that has a header with the Sign in link. This is temporary, while we work on design iterations to add the Accounts related links.

Depends on alphagov/static#2595

Related https://github.com/alphagov/collections/pull/2531

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
