### PR TITLE
Remove `government_navigation` component

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,9 +13,6 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
 
-  <% if content_item.government? && explore_menu_variant_b? == false %>
-    <%= render 'govuk_publishing_components/components/government_navigation', active: content_item.government_content_section %>
-  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -38,8 +38,7 @@ Feature: Filtering documents
 
   Scenario: Visit a government finder
     Given a government finder exists
-    Then I can see the government header
-    And I can see documents which are marked as being in history mode
+    Then I can see documents which are marked as being in history mode
 
   Scenario: Filters document with bad metadata
     Given a collection of documents with bad metadata exist

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -240,11 +240,6 @@ Given(/^a government finder exists$/) do
   stub_organisations_registry_request
 end
 
-Then(/^I can see the government header$/) do
-  visit finder_path("government/policies/benefits-reform")
-  expect(page).to have_css("#proposition-menu")
-end
-
 Then(/^I should see a blue banner$/) do
   expect(page).to have_css(".gem-c-inverse-header")
   expect(page).to have_content("Education, training and skills")
@@ -252,6 +247,7 @@ Then(/^I should see a blue banner$/) do
 end
 
 Then(/^I can see documents which are marked as being in history mode$/) do
+  visit finder_path("government/policies/benefits-reform")
   expect(page).to have_css(".published-by", count: 5)
   expect(page).to have_content("2005 to 2010 Labour government")
 end


### PR DESCRIPTION
## What
Removes the [government navigation component][gnc].

## Why

The list of links isn't needed as the navigation header is being rolled out.

---


The government navigation is no longer needed with the rollout of the
navigation header.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


[gnc]: https://components.publishing.service.gov.uk/component-guide/government_navigation
