### PR TITLE
Remove email confirmation banner from brexit checker results page

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -19,22 +19,17 @@ module AccountConcern
     # rubocop:enable Rails/LexicallyScopedActionFilter
 
     helper_method :must_reauthenticate?
-    helper_method :show_confirmation_reminder?
-    helper_method :confirmation_banner_prompt_type
   end
 
   def pre_results
     result = do_or_logout do
       Services.account_api.get_attributes(
         govuk_account_session: account_session_header,
-        attributes: [ATTRIBUTE_NAME, "email_verified", "has_unconfirmed_email"],
+        attributes: [ATTRIBUTE_NAME],
       )
     end
 
     return if must_reauthenticate?
-
-    @user_email_verified = result&.dig("values", "email_verified")
-    @user_has_unconfirmed_email = result&.dig("values", "has_unconfirmed_email")
 
     results_in_account = result&.dig("values", ATTRIBUTE_NAME) || {}
 
@@ -133,21 +128,5 @@ module AccountConcern
 
   def base_path
     Rails.env.production? ? Plek.new.website_root : Plek.find("frontend")
-  end
-
-  def show_confirmation_reminder?
-    return false unless logged_in?
-
-    !@user_email_verified || @user_has_unconfirmed_email
-  end
-
-  def confirmation_banner_prompt_type
-    return "update" if confirmed_user_changed_email?
-
-    "set_up"
-  end
-
-  def confirmed_user_changed_email?
-    @user_email_verified && @user_has_unconfirmed_email
   end
 end

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -37,18 +37,6 @@
 <% end %>
 
 <div class="govuk-width-container brexit-checker-results-page">
-  <% if show_confirmation_reminder? %>
-    <%= render "govuk_publishing_components/components/notice", {
-      margin_bottom: 0
-    } do %>
-      <p class="govuk-body">
-        <%= sanitize(t("brexit_checker.results.accounts.confirm.intro.#{confirmation_banner_prompt_type}")) %>
-      </p>
-      <p class="govuk-body govuk-!-margin-bottom-0">
-        <a href="<%= "#{Plek.find('account-manager')}/account/confirmation/new" %>" class="govuk-link"><%= t("brexit_checker.results.accounts.confirm.link_text") %></a>
-      </p>
-    <% end %>
-  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/title", {

--- a/config/locales/en/brexit_checker/results.yml
+++ b/config/locales/en/brexit_checker/results.yml
@@ -31,11 +31,6 @@ en:
           heading: Your business or organisation
       print_link: Print your results
       accounts:
-        confirm:
-          intro:
-            set_up: <strong class="govuk-!-font-weight-bold">Confirm your email address</strong> to finish setting up your account and start getting email updates.
-            update: <strong class="govuk-!-font-weight-bold">Confirm your email address</strong> to finish updating your account and email alerts.
-          link_text: Send confirmation email again
         results_differ:
           message: These results are different to the ones saved in your account.
           description: You can <a class="govuk-link" href="%{link}">see what answers you’ve changed and save these results to your account instead.</a>

--- a/spec/features/brexit_checker/accounts_spec.rb
+++ b/spec/features/brexit_checker/accounts_spec.rb
@@ -68,7 +68,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
     context "the user's session is invalid" do
       before do
-        stub_account_api_unauthorized_has_attributes(attributes: %w[transition_checker_state email_verified has_unconfirmed_email])
         stub_account_api_unauthorized_has_attributes(attributes: %w[transition_checker_state])
       end
 
@@ -82,7 +81,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
     context "the user is authenticated at too low a level" do
       before do
-        stub_account_api_forbidden_has_attributes(attributes: %w[transition_checker_state email_verified has_unconfirmed_email])
         stub_account_api_forbidden_has_attributes(attributes: %w[transition_checker_state])
       end
 
@@ -97,17 +95,12 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
     context "/transition-check/results" do
       before do
         stub_account_api_has_attributes(
-          attributes: %w[transition_checker_state email_verified has_unconfirmed_email],
+          attributes: %w[transition_checker_state],
           values: {
             "transition_checker_state" => transition_checker_state,
-            "email_verified" => email_verified,
-            "has_unconfirmed_email" => has_unconfirmed_email,
           },
         )
       end
-
-      let(:email_verified) { true }
-      let(:has_unconfirmed_email) { false }
 
       it "doesn't show the normal call-to-action" do
         given_i_am_on_the_results_page
@@ -132,40 +125,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
         it "shows a link to save the new results" do
           given_i_am_on_the_results_page_with(%w[bring-pet-abroad nationality-eu])
           expect(page).to have_content(I18n.t("brexit_checker.results.accounts.results_differ.message"))
-        end
-      end
-
-      context "the user does not need to confirm their email address" do
-        it "does not show a reminder to confirm their email address" do
-          given_i_am_on_the_results_page
-
-          expect(page).to_not have_content(strip_tags(I18n.t("brexit_checker.results.accounts.confirm.intro.set_up")))
-          expect(page).to_not have_content(strip_tags(I18n.t("brexit_checker.results.accounts.confirm.intro.update")))
-          expect(page).to_not have_link(I18n.t("brexit_checker.results.accounts.confirm.link_text", href: "#{Plek.find('account-manager')}/account/confirmation/new"))
-        end
-      end
-
-      context "the user has not finished setting up their account" do
-        let(:email_verified) { false }
-        let(:has_unconfirmed_email) { false }
-
-        it "reminds them to confirm their email address" do
-          given_i_am_on_the_results_page
-
-          expect(page).to have_content(strip_tags(I18n.t("brexit_checker.results.accounts.confirm.intro.set_up")))
-          expect(page).to have_link(I18n.t("brexit_checker.results.accounts.confirm.link_text", href: "#{Plek.find('account-manager')}/account/confirmation/new"))
-        end
-      end
-
-      context "the user has changed the email address on their account, but has not confirmed it yet" do
-        let(:email_verified) { true }
-        let(:has_unconfirmed_email) { true }
-
-        it "reminds them to confirm their email address" do
-          given_i_am_on_the_results_page
-
-          expect(page).to have_content(strip_tags(I18n.t("brexit_checker.results.accounts.confirm.intro.update")))
-          expect(page).to have_link(I18n.t("brexit_checker.results.accounts.confirm.link_text", href: "#{Plek.find('account-manager')}/account/confirmation/new"))
         end
       end
 
@@ -202,14 +161,10 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
           attributes: %w[transition_checker_state],
           values: { "transition_checker_state" => transition_checker_state },
         )
-        stub_account_api_has_attributes(
-          attributes: %w[transition_checker_state email_verified has_unconfirmed_email],
-          values: { "transition_checker_state" => transition_checker_state },
-        )
 
         given_i_am_on_the_saved_results_page
 
-        expect(stub).to have_been_made
+        expect(stub).to have_been_made.twice
 
         expect(page).to have_current_path(transition_checker_results_path(c: %w[nationality-uk]))
       end
@@ -239,7 +194,6 @@ RSpec.feature "Brexit Checker accounts", type: :feature do
 
     context "/transition-check/save-your-results/confirm" do
       before do
-        stub_account_api_has_attributes(attributes: %w[transition_checker_state email_verified has_unconfirmed_email], values: { "transition_checker_state" => transition_checker_state }.compact)
         stub_account_api_has_attributes(attributes: %w[transition_checker_state], values: { "transition_checker_state" => transition_checker_state }.compact)
         stub_find_or_create_subscriber_list(new_criteria_keys)
       end


### PR DESCRIPTION
We've migrated to Digital Identity now, who don't allow unconfirmed
email addresses.
