### PR TITLE
Disable GOV.UK account creation during migration

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/title';
+@import 'govuk_publishing_components/components/warning-text';
 
 @import 'components/*';
 @import 'finder_frontend';

--- a/app/views/brexit_checker/save_results.html.erb
+++ b/app/views/brexit_checker/save_results.html.erb
@@ -65,14 +65,9 @@
           <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.aside') %></p>
         <% end %>
 
-        <p class="govuk-body"><%= t('brexit_checker.account_signup.create_account.outro') %></p>
-
-        <%= form_tag transition_checker_save_results_sign_up_path(c: criteria_keys), method: :post, id: "account-signup", :"data-module" => "explicit-cross-domain-links" do %>
-          <%= render "govuk_publishing_components/components/button", {
-            text: t('brexit_checker.account_signup.create_account.cta_button'),
-            margin_bottom: true,
-          } %>
-        <% end %>
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: t('brexit_checker.account_signup.create_account.migration_warning')
+        } %>
 
         <p class="govuk-body">
           <%= t('brexit_checker.account_signup.or') %>

--- a/config/locales/en/brexit_checker/account_signup.yml
+++ b/config/locales/en/brexit_checker/account_signup.yml
@@ -15,5 +15,6 @@ en:
         aside: This is separate from other government accounts (for example your personal tax account or Government Gateway).
         outro: You’ll need an email address and a mobile phone to create an account.
         cta_button: Create a GOV.UK account
+        migration_warning: You cannot create a GOV.UK account between 9am on 25th October and 5pm on 27th October. This is because we’re making changes to how the account works.
       or: If you’ve already saved your UK transition results,
       alternative_path_link_text: sign in to your account

--- a/spec/features/brexit_checker/save_results_spec.rb
+++ b/spec/features/brexit_checker/save_results_spec.rb
@@ -20,8 +20,6 @@ RSpec.feature "Brexit Checker create GOV.UK Account", type: :feature do
     given_im_on_the_results_page
     then_i_click_to_subscribe
     and_i_am_taken_to_choose_how_to_subscribe_page
-    and_i_click_the_create_account_button
-    i_get_redirected_to_sign_up
   end
 
   def given_im_on_the_results_page


### PR DESCRIPTION
We're planning to migrate the GOV.UK account to use Digital Identity's
auth service. During this time users will be unable to create new GOV.UK
accounts, so temporarily remove the button and replace it with a warning.

Once the migration is complete we can revert this PR and make any
further changes needed for the switchover.

This is ready for review but we're leaving it in a draft state so we don't 
accidentally merge and deploy before we start the migration.

[Trello card](https://trello.com/c/Ln4RoFA6/1085-brexit-checker-downtime)

The new page:
![image](https://user-images.githubusercontent.com/6362602/138416232-fc0d9e74-dce6-49a8-a79b-88d4dfc266ac.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
