### PR TITLE
Update how users see a change in return results (search filter)

### DIFF
--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -84,7 +84,7 @@
       text-decoration: none;
       @supports (display: grid) {
         justify-self: end;
-        align-self: center;
+        align-self: start;
       }
     }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -248,13 +248,6 @@ mark {
   margin: 0 0 govuk-spacing(4) 0;
   border-bottom: solid 1px govuk-colour("black");
 
-  &__header {
-    display: none;
-    @include govuk-media-query($from: tablet) {
-      display: block;
-    }
-  }
-
   .govuk-grid-column-two-thirds {
     text-align: left;
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -14,35 +14,26 @@
         label_text: label_text
       } %>
     </div>
-    <% if facets.select(&:filterable?).any? %>
-      <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
-        data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-        data-module="gem-track-click" data-track-category="filterClicked"
-        data-track-action="mobile-filter-button" data-track-label="">
-        Filter <span class="govuk-visually-hidden"> results</span>
-        <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
-      </button>
-    <% end %>
   <% end %>
-
-  <div data-module="gem-track-click" data-track-category="filterClicked"
-      data-track-action="skip-Link" data-track-label="">
-    <%= render "govuk_publishing_components/components/skip_link", {
-      text: 'Skip to results',
-      href: '#js-results'}
-    %>
-  </div>
 
   <% if facets.select(&:filterable?).any? %>
     <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets" role="search" aria-label="Search filters">
       <div class="facets__box">
         <div class="facets__header">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Filter",
-            heading_level: 1,
-            font_size: "xl",
-            margin_bottom: 0
-          } %>
+          <div>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Filter",
+              heading_level: 1,
+              font_size: "xl",
+              margin_bottom: 2
+            } %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: sanitize("<span class=\"js-result-count govuk-!-font-weight-regular\">#{result_set_presenter.displayed_total}</span>"),
+              heading_level: 2,
+              font_size: "s",
+              margin_bottom: 0
+            } %>
+          </div>
           <button class="app-c-button-as-link facets__return-link js-close-filters" type="button">
             Return to results
           </button>
@@ -58,7 +49,7 @@
         </div>
         <div class="facets__footer">
           <%= render "govuk_publishing_components/components/button", {
-            text: sanitize("Show <span class=\"js-result-count\">#{result_set_presenter.displayed_total}</span>"),
+            text: sanitize("Show search results"),
             classes: "js-close-filters js-show-results"
           } %>
         </div>

--- a/app/views/finders/_filter_button.html.erb
+++ b/app/views/finders/_filter_button.html.erb
@@ -1,0 +1,7 @@
+<button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
+  data-toggle="mobile-filters-modal" data-target="facet-wrapper"
+  data-module="gem-track-click" data-track-category="filterClicked"
+  data-track-action="mobile-filter-button" data-track-label="">
+  Filter <span class="govuk-visually-hidden"> results</span>
+  <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
+</button>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -40,13 +40,6 @@
           >
           <%= render 'spelling_suggestion' %>
         </div>
-        <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
-          data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-          data-module="gem-track-click" data-track-category="filterClicked"
-          data-track-action="mobile-filter-button" data-track-label="">
-          Filter <span class="govuk-visually-hidden"> results</span>
-          <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
-        </button>
       <% elsif topic_finder?(filter_params) %>
         <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'govuk-link topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -58,10 +58,28 @@
                 <%= render "govuk_publishing_components/components/heading", {
                   text: result_set_presenter.displayed_total,
                   id: "js-result-count",
-                  font_size: "s"
+                  font_size: "s",
+                  margin_bottom: 2,
                   } %>
+
+                <% if content_item.all_content_finder? %>
+                  <%= render partial: 'filter_button'%>
+                <% elsif !content_item.all_content_finder? %>
+                  <% if facets.select(&:filterable?).any? %>
+                    <%= render partial: 'filter_button'%>
+                  <% end %>
+                <% end %>
+
+                <div data-module="gem-track-click" data-track-category="filterClicked"
+                    data-track-action="skip-Link" data-track-label="">
+                  <%= render "govuk_publishing_components/components/skip_link", {
+                    text: 'Skip to results',
+                    href: '#js-results'}
+                  %>
+                </div>
               </div>
             </div>
+
             <div class="govuk-grid-column-two-thirds subscription-links subscription-links--desktop">
               <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>


### PR DESCRIPTION
## What

- Display *No. of results* label on mobile (remove media query) and displayed above the 'filter' button
- On filter overlay (mobile) display *No. of results* label below the 'Filter' `h1`
- On filter overlay (mobile) remove the number of results text from the submit button so the button text now just reads 'Show search results'

## Why

- Small improvement to GOV.UK Search
- Especially after making the Search button on the filter screen (in mobile) no longer sticky.
- Also, addresses an issue, though not a WCAG fail, with information changing on the page automatically after a user interaction.
- More info about this can be found in the following ticket: https://trello.com/c/1c8oQKhJ

## Visuals

| Before (all_content_finder)  | After (all_content_finder) |
|---|---|
| <img src="https://user-images.githubusercontent.com/87758239/139134217-5668b43b-8f0a-4c23-a791-9630284adaf3.png" width="350" > | <img src="https://user-images.githubusercontent.com/87758239/139134206-ebd53e9c-9dcf-4e65-8756-68c70dabf2bd.png" width="350"> |
| | |
| <img src="https://user-images.githubusercontent.com/87758239/139134214-eb3bc2de-4610-41dd-b4d6-4f7b7c47ba58.png" width="350" > | <img src="https://user-images.githubusercontent.com/87758239/139134200-c9cb0587-2430-4c60-85b8-0ac3d2a19a60.png" width="350"> |

| Before (!all_content_finder)  | After (!all_content_finder) |
|---|---|
| <img src="https://user-images.githubusercontent.com/87758239/139135141-3ea2983c-feae-4c6f-854b-470cccd98042.png" width="350" > | <img src="https://user-images.githubusercontent.com/87758239/139135130-496de813-e108-4e09-bea4-63ef45f67321.png" width="350"> |
| | |
| <img src="https://user-images.githubusercontent.com/87758239/139135137-d22447bc-9fce-4674-a352-3a637cc10480.png" width="350" > | <img src="https://user-images.githubusercontent.com/87758239/139135127-b2eae5f6-868a-4b57-bc3c-01636a53245a.png" width="350"> |

## How to test

- https://www.gov.uk/search/all (all_content_finder)
- https://www.gov.uk/search/services (!all_content_finder)

## Anything else
- In the 'filter' overlay view I have marked up the no. of results (e.g. 520,927 results or 7,615 services), which is displayed below the main 'Filter' title (`h1`) with a `h2` since this is how no. of results is formatted on larger screens.
- I've also moved the skip link component to sit below the newly repositioned 'filter' button (so the tab order is the same as it currently is).