### PR TITLE
Add notice to indicate closure of the checker

### DIFF
--- a/app/views/brexit_checker/_retirement_callout.html.erb
+++ b/app/views/brexit_checker/_retirement_callout.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/notice", {
+  title: t("brexit_checker.retirement.title"),
+  description: t("brexit_checker.retirement.description").html_safe
+} %>

--- a/app/views/brexit_checker/results.html.erb
+++ b/app/views/brexit_checker/results.html.erb
@@ -39,6 +39,8 @@
 <div class="govuk-width-container brexit-checker-results-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= render partial: "retirement_callout" %>
+
       <%= render "govuk_publishing_components/components/title", {
         title: action_based_title
       } %>

--- a/app/views/brexit_checker/show.html.erb
+++ b/app/views/brexit_checker/show.html.erb
@@ -35,6 +35,8 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <%= render partial: "retirement_callout" %>
+
       <form
         action="<%= transition_checker_questions_path %>"
         method="get"

--- a/config/locales/en/brexit_checker/retirement.yml
+++ b/config/locales/en/brexit_checker/retirement.yml
@@ -1,0 +1,7 @@
+en:
+  brexit_checker:
+    retirement:
+      title: "The Brexit checker will be removed on 30 November 2021"
+      description: >
+        <p class="govuk-body">From 30 November you will no longer be able to use the Brexit checker or see your results.</p>
+        <p class="govuk-body">You can continue to find out how Brexit affects you, your business and your family by visiting <a href="/brexit">gov.uk/brexit</a><p>

--- a/spec/features/brexit_checker/question_results_spec.rb
+++ b/spec/features/brexit_checker/question_results_spec.rb
@@ -152,6 +152,7 @@ RSpec.feature "Brexit Checker workflow", type: :feature do
 
   def then_i_should_see_the_results_page
     expect(page).to have_content I18n.t!("brexit_checker.results.title")
+    expect(page).to have_text("The Brexit checker will be removed")
   end
 
   def then_i_should_see_the_no_results_page

--- a/spec/support/brexit_checker_helper.rb
+++ b/spec/support/brexit_checker_helper.rb
@@ -3,6 +3,7 @@ module BrexitCheckerHelper
     question = BrexitChecker::Question.find_by_key(key)
     expect(page).to have_content(question.text)
     expect(page).to have_content(question.caption)
+    expect(page).to have_text("The Brexit checker will be removed")
     options.each { |o| find_field(o).click }
     click_on "Continue"
   end


### PR DESCRIPTION
This will be displayed on all question pages and the results page. This is a bit invasive, but it's important to flag, because people will have to think about their options if they want to keep getting Brexit emails.

![Screenshot 2021-11-09 at 09 53 45](https://user-images.githubusercontent.com/773037/140902395-3b692750-fbd2-43bb-a1f1-c059e66dd2ff.png)
![Screenshot 2021-11-09 at 09 53 40](https://user-images.githubusercontent.com/773037/140902411-86e8af0f-38b1-4dc7-8b6f-3cc430175c89.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
