### PR TITLE
Restore full width blue header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
 
-  slimmer_template "gem_layout"
+  slimmer_template "gem_layout_full_width"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.


### PR DESCRIPTION
## What

Changes the default layout to be `gem_layout_full_width`.

## WHy

Because the blue header is hidden behind a query string (for example, `?parent=%2Fbrexit&topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea`) it's easily missed when checking things - and the blue header had been mistakenly constrained to a fixed width layout.

This changes the template requested from Static to the full width version. The search results are already [contained inside an element with a `.width-container` class][1], so this doesn't affect rest of the the page's layout.

[1]: https://github.com/alphagov/finder-frontend/blob/e83059d079691e2b37b2e1da761b4155c854adac/app/views/finders/show.html.erb#L37

## Visual changes

Before:
![image](https://user-images.githubusercontent.com/1732331/141973085-bfccfb9a-b126-4c9b-9c1b-2f88200c72f6.png)

After:

![image](https://user-images.githubusercontent.com/1732331/141973512-9c64c04e-efbe-4731-b188-e8d2882341f9.png)

