### PR TITLE
Honour Content Store TTL

### DIFF
--- a/app/lib/registries/full_topic_taxonomy_registry.rb
+++ b/app/lib/registries/full_topic_taxonomy_registry.rb
@@ -65,7 +65,7 @@ module Registries
     end
 
     def fetch_taxon(base_path = "/")
-      Services.cached_content_item(base_path)
+      Services.cached_content_item(base_path).to_h
     end
   end
 end

--- a/app/lib/registries/topic_taxonomy_registry.rb
+++ b/app/lib/registries/topic_taxonomy_registry.rb
@@ -61,7 +61,7 @@ module Registries
     end
 
     def fetch_taxon(base_path = "/")
-      Services.cached_content_item(base_path)
+      Services.cached_content_item(base_path).to_h
     end
   end
 end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -15,7 +15,7 @@ module Services
   def self.cached_content_item(base_path)
     Rails.cache.fetch("finder-frontend_content_items#{base_path}", expires_in: 5.minutes) do
       GovukStatsd.time("content_store.fetch_request_time") do
-        content_store.content_item(base_path).to_h
+        content_store.content_item(base_path)
       end
     end
   end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -6,7 +6,7 @@ class ContentItem
   end
 
   def self.from_content_store(base_path)
-    content_item_hash = Services.cached_content_item(base_path)
+    content_item_hash = Services.cached_content_item(base_path).to_h
     new(content_item_hash)
   end
 


### PR DESCRIPTION
Content Store provides a TTL in the Cache-Control response header which frontend apps should respect.

This ensures that this app honours the cache TTL provided by Content Store. There is a 5 minute TTL on the `FindersController` which I have left as-is, since we want content in search to be fresh and the current TTL provided by Content Store is 30 minutes.

This partially implements RFC 144.

Links:
* Content Store TTL: https://github.com/alphagov/content-store/blob/9661e2047f2167f87066fbb6ef38da71668a1327/app/controllers/content_items_controller.rb#L14
* RFC 144: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-144-consistent-cache-expiry.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
