### PR TITLE
Remove height on filter menu

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -18,6 +18,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   OptionSelect.prototype.init = function () {
+    var SETTINGS = {
+      breakpoint: {
+        desktop: 769
+      }
+    }
+
+    // Returns what screen size the window is currently. Returns a string of
+    // either `desktop` or `mobile`
+    this.windowSize = function () {
+      return document.documentElement.clientWidth >= SETTINGS.breakpoint.desktop ? 'desktop' : 'mobile'
+    }
+
     if (this.hasFilter.length) {
       var filterEl = document.createElement('div')
       filterEl.innerHTML = this.hasFilter
@@ -212,7 +224,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   OptionSelect.prototype.setContainerHeight = function setContainerHeight (height) {
-    this.$optionsContainer.style.height = height + 'px'
+    // Only apply inline height should the user be on desktop
+    if (this.windowSize() === 'desktop') {
+      this.$optionsContainer.style.height = height + 'px'
+    }
   }
 
   OptionSelect.prototype.isCheckboxVisible = function isCheckboxVisible (option) {

--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -84,8 +84,6 @@
 
 .app-c-option-select__container {
   position: relative;
-  max-height: 200px;
-  overflow-y: auto;
   overflow-x: hidden;
   background-color: govuk-colour("white");
 
@@ -129,7 +127,9 @@
   }
 
   .app-c-option-select__container {
-    height: 200px;
+    @include govuk-media-query($from: tablet) {
+      height: 200px;
+    }
   }
 
   [data-closed-on-load="true"] .app-c-option-select__container {


### PR DESCRIPTION
## What 

Remove `height` from filter menu on mobile

## Why

On mobile this height limit restricts the viewport of this section and whats visible. This leads to a potentially difficult experience for mobile users, this fix removes this so the user can scroll naturally

## Visuals

Before: 

https://user-images.githubusercontent.com/71266765/153610573-1f688c44-b606-4a8e-9af7-0e394341085e.mov

After:

https://user-images.githubusercontent.com/71266765/153607934-80d3a07e-7eaa-4512-8dd8-b69bc8a542f0.mov

### Desktop

https://user-images.githubusercontent.com/71266765/153608061-0ab11b80-516c-403a-b249-6e0a907f1ab7.mov

## Anything else

Desktop `max-height` has been removed

### Testing 

https://www.gov.uk/administrative-appeals-tribunal-decisions
https://finder-front-filter-men-i3xnrn.herokuapp.com/