### PR TITLE
Remove cache key checks from readiness probe

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,7 @@ Rails.application.routes.draw do
   get "/sign-in", to: proc { [200, {}, %w[OK]] }
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
-    Healthchecks::RegistriesCache,
-  )
+  get "/healthcheck/ready", to: proc { [200, {}, [JSON.generate({ status: :ok })]] }
 
   root to: redirect("/development") unless Rails.env.test?
   get "/development" => "development#index"

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -2,54 +2,10 @@ require "spec_helper"
 require "json"
 
 describe "Healthcheck" do
-  before do
-    Rails.cache.clear
-  end
-
-  after do
-    Rails.cache.clear
-  end
-
   context "when everything is fine", type: :request do
-    before do
-      fill_registries
-    end
-
     it "returns an OK status" do
       get "/healthcheck/ready"
-      expect(JSON.parse(response.body)).to eq(
-        "checks" => {
-          "registries_have_data" => {
-            "message" => "OK",
-            "status" => "ok",
-          },
-        },
-        "status" => "ok",
-      )
+      expect(JSON.parse(response.body)).to eq("status" => "ok")
     end
-  end
-
-  context "when registries have no data", type: :request do
-    before do
-      Rails.cache.clear
-    end
-
-    it "returns a critical status" do
-      get "/healthcheck/ready"
-      expect(JSON.parse(response.body)).to eq(
-        "checks" => {
-          "registries_have_data" => {
-            "message" => "The following registry caches are empty: world_locations, all_part_of_taxonomy_tree, part_of_taxonomy_tree, people, roles, organisations, manual, full_topic_taxonomy, topical_events.",
-            "status" => "critical",
-          },
-        },
-        "status" => "critical",
-      )
-    end
-  end
-
-  def fill_registries
-    cache_keys = Registries::BaseRegistries.new.all.values.map(&:cache_key)
-    cache_keys.each { |key| Rails.cache.write(key, cached: "data") }
   end
 end


### PR DESCRIPTION
Resolves #2732

This will enable Finder Frontend to serve requests before its cache is warm. The readiness probe should only check
the hard dependencies of the application (ie are required to serve all requests). This allows the application to degrade gracefully when external dependencies fails, and prevents a cascading failure when those dependencies fail.

I've left the Cache check class in as I'd like to reuse it to export cache status as Prometheus metrics.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
