### PR TITLE
Use Internal Worldwide API

### DIFF
--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -43,7 +43,15 @@ module Registries
     end
 
     def fetch_locations_from_worldwide_api
-      Services.worldwide_api.world_locations.with_subsequent_pages.to_a
+      GdsApi::Worldwide.new(worldwide_api_endpoint).world_locations.with_subsequent_pages.to_a
+    end
+
+    def worldwide_api_endpoint
+      if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
+        Plek.new.website_root
+      else
+        Plek.find("whitehall-frontend")
+      end
     end
   end
 end


### PR DESCRIPTION
FinderFrontend will use the internal /api/world-locations
API rather than going out of the VPC and then back in.

This removes an oddity - and also removes the need for
finder-frontend to provide basic authentication when accessing
the API at www-origin.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
