### PR TITLE
Revert "Use Internal Worldwide API"

### DIFF
--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -43,15 +43,7 @@ module Registries
     end
 
     def fetch_locations_from_worldwide_api
-      GdsApi::Worldwide.new(worldwide_api_endpoint).world_locations.with_subsequent_pages.to_a
-    end
-
-    def worldwide_api_endpoint
-      if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
-        Plek.new.website_root
-      else
-        Plek.find("whitehall-frontend")
-      end
+      Services.worldwide_api.world_locations.with_subsequent_pages.to_a
     end
   end
 end


### PR DESCRIPTION
After discussing with @kevindew we have decided to continue consuming these APIs via the public endpoint rather than using an internal endpoint.

The reasoning is that we prefer all requests to frontend applications to go through Fastly and router. This is particularly useful because Fastly caches requests to the APIs, and we have seen an incident in the past where these APIs could not handle high volumes of requests (and so require caching). We believe these APIs should probably not be served by frontend apps, and instead should be served by a different backend service, but this is out of scope of the replatforming project.

Reverts alphagov/finder-frontend#2738