### PR TITLE
Fix overlapping tag text with button 'x' when increasing font size

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -165,13 +165,13 @@ mark {
 
   display: table-cell;
   position: relative;
-  padding: 5px;
+  padding: govuk-em(5, 16px);
   border: 1px solid govuk-colour("dark-grey");
-  border-radius: 5px;
+  border-radius: govuk-em(5, 16px);
   background-color: govuk-colour("light-grey");
 
   .js-enabled & {
-    padding: 8px 7px 7px 23px;
+    padding: govuk-em(8, 16px) govuk-em(8, 16px) govuk-em(8, 16px) govuk-em(24, 16px);
   }
 }
 
@@ -180,7 +180,7 @@ mark {
   margin-left: 0;
 
   .js-enabled & {
-    margin-left: 5px;
+    margin-left: govuk-em(5, 16px);
   }
 }
 
@@ -191,8 +191,8 @@ mark {
   left: 0;
   width: 100%;
   height: 100%;
-  padding: 8px;
-  border-radius: 5px;
+  padding: govuk-em(8, 16px);
+  border-radius: govuk-em(5, 16px);
   font-weight: bold;
   @include govuk-font(16, $weight: bold);
   text-align: left;


### PR DESCRIPTION
## What
Fix overlapping tag text with button 'x' when increasing font size (visible in Firefox)

https://trello.com/c/gZvzb6od/1137-search-filter-tags-overlapping-with-x-when-increasing-font-size

https://finder-front-fix-overla-qjsopk.herokuapp.com/search/all?keywords=help&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=news_and_communications&order=relevance

## Why

- Not a strict WCAG fail because everything is still readable enough, related to 1.4.4
- This tags might get less readable to some people

## Visual changes
<table role="table">
<thead>
<tr>
<th>Before (zoom 200%)</th>
<th>After (zoom 200%)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159296118-d855f3ea-0781-4654-8478-f3136b9c4a17.png"><img src="https://user-images.githubusercontent.com/87758239/159296118-d855f3ea-0781-4654-8478-f3136b9c4a17.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159296105-dd173411-c7e8-4c2e-88e3-a0e679011a03.png"><img src="https://user-images.githubusercontent.com/87758239/159296105-dd173411-c7e8-4c2e-88e3-a0e679011a03.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>

<table role="table">
<thead>
<tr>
<th>Before (no zoom)</th>
<th>After (no zoom)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159296150-89dbe5e8-0dcc-4155-8aab-73bad984bb05.png"><img src="https://user-images.githubusercontent.com/87758239/159296150-89dbe5e8-0dcc-4155-8aab-73bad984bb05.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/159296131-da57006f-232a-4a0f-ade6-d016631b8988.png"><img src="https://user-images.githubusercontent.com/87758239/159296131-da57006f-232a-4a0f-ade6-d016631b8988.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</table>