### PR TITLE
Revert `slimmer_template` change

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::Template
 
-  slimmer_template "gem_layout_full_width"
+  slimmer_template "gem_layout"
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.


### PR DESCRIPTION
## What 

This change reverts this: https://github.com/alphagov/finder-frontend/pull/2684 by changing the `application_controller.rb`'s `slimmer_template` back to `gem_layout` from `gem_layout_full_width`.

## Why

When the Coronavirus banner was removed with this change https://github.com/alphagov/static/pull/2719, the template being set to `gem_layout_full_width` caused the blue bar to disappear on all search pages.

[Trello](https://trello.com/c/WUaR9m4Q/859-investigate-missing-blue-bar-on-finder-frontend-pages)

## Screenshots

| Before | After |
|---|---|
|![Screenshot 2022-04-20 at 16 30 33](https://user-images.githubusercontent.com/44037625/164271753-26ae5315-b652-4e6b-96a3-c01f9e90e801.png)|![Screenshot 2022-04-20 at 16 31 17](https://user-images.githubusercontent.com/44037625/164271779-5bcdb401-94fb-45b0-8b7a-fd561076df0e.png)|
|![Screenshot 2022-04-20 at 16 30 52](https://user-images.githubusercontent.com/44037625/164271801-145461e0-8a50-49d3-aaf7-b5ed5ed206fa.png)|![Screenshot 2022-04-20 at 16 31 40](https://user-images.githubusercontent.com/44037625/164271820-bbbd2bc7-f6e4-439c-9588-80de88216ea9.png)|
|![Screenshot 2022-04-20 at 16 54 41](https://user-images.githubusercontent.com/44037625/164272373-e43ddeb4-3330-4499-9152-0a6722a519dc.png)|![Screenshot 2022-04-20 at 16 54 50](https://user-images.githubusercontent.com/44037625/164272407-cfde0a83-ed22-41b7-ad96-30cd2d5a913a.png)|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
