### PR TITLE
Topic finder pages use the full width layout 

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -6,6 +6,8 @@ class FindersController < ApplicationController
   end
 
   def show
+    slimmer_template "gem_layout_full_width" if i_am_a_topic_page_finder
+
     respond_to do |format|
       format.html do
         raise UnsupportedContentItem unless content_item.is_finder?


### PR DESCRIPTION
## What

Add a line of code which replaces the default value of `slimmer_template` (`gem_layout`) to `gem_layout_full_width` only
 if the page is a topic finder page.

## Why

On topic finder pages, a different styling is used for the page header. The header is wrapper in a banner which gives the text a blue background (so that it is differentiated from standard finder pages). The background is intended to be as wide as the page but it is currently being constrained by the layout. This was not previously seen before as the layout when this header style change was made for topic pages because the layout being used at that time for all finder pages was  `gem_layout_full_width` (because an emergency banner was being deployed on the pages). After this banner was removed, the gem layout was restored to the 'regular' width so that the blue bar below the navigation bar (which is present on gem_layout but not present on `gem_layout_full_width`) was restored on all finder pages. This change means that the correct layout will be used on the correct type of finder page.

## Visual Changes

### Before

![Screenshot 2022-05-06 at 12 44 08](https://user-images.githubusercontent.com/3727504/167125243-1c5a535c-e9b9-4b9a-9d0e-ba637096e2d4.png)


![Screenshot 2022-05-06 at 12 41 01](https://user-images.githubusercontent.com/3727504/167124956-65cadf87-8365-4741-ad1c-0251389c2f59.png)

### After
 
![Screenshot 2022-05-06 at 12 40 21](https://user-images.githubusercontent.com/3727504/167125285-ec0155eb-9f74-42f9-b474-0cbab91ed4b4.png)

![Screenshot 2022-05-06 at 12 41 21](https://user-images.githubusercontent.com/3727504/167124922-71bd67c8-6b51-401f-88d4-67769962737f.png)


[Relevant Trello Card](https://trello.com/c/ehmV9NDk/975-bug-finder-pages-are-missing-padding-on-blue-header), [Jira issue NAV-5358](https://gov-uk.atlassian.net/browse/NAV-5358)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
