### PR TITLE
Add hover state for search page filter types

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -178,6 +178,9 @@ mark {
 .facet-tag__text {
   display: inline-block;
   margin-left: 0;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
 
   .js-enabled & {
     margin-left: govuk-em(5, 16px);
@@ -205,6 +208,10 @@ mark {
   .js-enabled & {
     display: inline-block;
     border: 1px solid transparent;
+
+    &:hover {
+      background: govuk-colour("mid-grey");
+    }
 
     &:focus {
       -webkit-box-shadow: inset 0 0 0 2px;


### PR DESCRIPTION
## What

https://trello.com/c/LhCn70vH/1292-add-hover-state-for-finder-frontend-search-page-filter-options

Add a hover state for search page filter types.

## Why

Fix WCAG [1.4.13 Content on Hover or Focus](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus) (Level AA)... TBC

## Visual changes

https://finder-frontend-2793.herokuapp.com/search/all?keywords=parliament&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=relevance

<table role="table">
<thead>
<tr>
<th>Before (hover only)</th>
<th>After (hover only)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169845874-67eb5689-821e-4ce4-96a0-d8c32939e99e.png"><img src="https://user-images.githubusercontent.com/87758239/169845874-67eb5689-821e-4ce4-96a0-d8c32939e99e.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169845913-f79580c1-3d18-4080-8343-4d742dc1ca4a.png"><img src="https://user-images.githubusercontent.com/87758239/169845913-f79580c1-3d18-4080-8343-4d742dc1ca4a.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

<table role="table">
<thead>
<tr>
<th>Before (focus and hover)</th>
<th>After (focus and hover)</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169846212-a8aff746-f3ec-4f88-bc9c-c6b8a5077b33.png"><img src="https://user-images.githubusercontent.com/87758239/169846212-a8aff746-f3ec-4f88-bc9c-c6b8a5077b33.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169846253-83d86a5f-7480-46cd-b05f-688c6ecb2efc.png"><img src="https://user-images.githubusercontent.com/87758239/169846253-83d86a5f-7480-46cd-b05f-688c6ecb2efc.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## Anything else

The colour contrast ratio between the hover state background colour `govuk-colour("mid-grey")` and colour `#000` is **10.07**.