### PR TITLE
Create `/search/latest` endpoint

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -7,6 +7,16 @@ class RedirectionController < ApplicationController
     redirect_to(finder_path(params[:slug], params: covid_topic_and_other_params))
   end
 
+  def redirect_latest
+    redirect_params = {
+      order: "updated-newest",
+    }
+    redirect_params[:organisations] = params[:departments] if params[:departments]
+    redirect_params[:topical_events] = params[:topical_events] if params[:topical_events]
+    redirect_params[:world_locations] = params[:world_locations] if params[:world_locations]
+    redirect_to(finder_path("search/all", params: redirect_params))
+  end
+
   def advanced_search
     conversion_hash =
       {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   post "/*slug/email-signup" => "email_alert_subscriptions#create", as: :email_alert_subscriptions
 
   get "/search/advanced" => "redirection#advanced_search"
+  get "/search/latest" => "redirection#redirect_latest"
 
   get "/*slug" => "redirection#redirect_covid", constraints: lambda { |request|
     topical_events = request.params["topical_events"]

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -105,4 +105,39 @@ describe RedirectionController, type: :controller do
       end
     end
   end
+
+  describe "#redirect_latest" do
+    it "redirects to /search/all retaining topical events" do
+      get :redirect_latest, params: {
+        topical_events: %w[magic-competition],
+      }
+      expect(response).to redirect_to finder_path("search/all",
+                                                  params: {
+                                                    order: "updated-newest",
+                                                    topical_events: %w[magic-competition],
+                                                  })
+    end
+
+    it "redirects to /search/all retaining world locations" do
+      get :redirect_latest, params: {
+        world_locations: %w[hogwarts],
+      }
+      expect(response).to redirect_to finder_path("search/all",
+                                                  params: {
+                                                    order: "updated-newest",
+                                                    world_locations: %w[hogwarts],
+                                                  })
+    end
+
+    it "redirects to /search/all replacing departments with organisations" do
+      get :redirect_latest, params: {
+        departments: %w[department-of-magic],
+      }
+      expect(response).to redirect_to finder_path("search/all",
+                                                  params: {
+                                                    order: "updated-newest",
+                                                    organisations: %w[department-of-magic],
+                                                  })
+    end
+  end
 end


### PR DESCRIPTION
, [Jira issue PP-792](https://gov-uk.atlassian.net/browse/PP-792)We are retiring `/government/latest` from being rendered in Whitehall.

Finder Frontend's `/search/all` finder provides the same search response, so we are redirecting `/government/latest` to this finder.

However there is a mismatch in the query string parameters used between the two applications. Therefore we need to redirect any queries containing `departments` to match the expectation of the finder (`organisations`).

Additionally, we need to add a default search order to see the latest documents instead of the most relevant documents.

[Trello card](https://trello.com/c/93adHMBQ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
