### PR TITLE
Remove button component's JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak


### PR DESCRIPTION
## What

Stops the button component's JavaScript from being included in finder frontend's JavaScript.

## Why

This is now included in Static's JavaScript (https://github.com/alphagov/static/pull/2820), so can be removed from this app.

## Visual changes

None.

---

## Search page examples to sanity check:

- https://finder-frontend-pr-2820.herokuapp.com/search/all
- https://finder-frontend-pr-2820.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-2820.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-2820.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-2820.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-2820.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-2820.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-2820.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
