### PR TITLE
Don't error 500 on invalid params

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -8,13 +8,12 @@ class RedirectionController < ApplicationController
   end
 
   def redirect_latest
-    redirect_params = {
-      order: "updated-newest",
-    }
-    redirect_params[:organisations] = params[:departments] if params[:departments]
-    redirect_params[:topical_events] = params[:topical_events] if params[:topical_events]
-    redirect_params[:world_locations] = params[:world_locations] if params[:world_locations]
-    redirect_to(finder_path("search/all", params: redirect_params))
+    redirect_params = params.slice(:departments, :topical_events, :world_locations)
+                            .permit(departments: [], topical_events: [], world_locations: [])
+                            .transform_keys { |k| k == "departments" ? "organisations" : k }
+                            .compact
+
+    redirect_to(finder_path("search/all", params: { order: "updated-newest" }.merge(redirect_params)))
   end
 
   def advanced_search

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -139,5 +139,13 @@ describe RedirectionController, type: :controller do
                                                     organisations: %w[department-of-magic],
                                                   })
     end
+
+    it "copes with incorrect types being passed as parameters" do
+      get :redirect_latest, params: {
+        departments: { "wrong": %w[department-of-magic] },
+      }
+      expect(response).to redirect_to finder_path("search/all",
+                                                  params: { order: "updated-newest" })
+    end
   end
 end


### PR DESCRIPTION
This is to fix an issue where we're seeing error alerts in Sentry due to
a client input issue.

A client is requesting:

/search/latest?departments%5B%5D/government/organisations/department-for-business-energy-and-industrial-strategy&page=1

(note the lack of equals following `departments%5B%5D`)

This causes Rails to misinterpret the request and raise an exception of: ActionController::UnfilteredParameters

This commit changes the behaviour of the code so that it will only
accept input that is in an array format. Thus if a user inputs anything
strange the parameter will be rejected and thus the server won't error.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
