### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,11 @@ $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 $govuk-use-legacy-font: false;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import "reset";
 
 // see /component-guide for sass imports and


### PR DESCRIPTION
## What

Prevent the font from being included in Finder-frontend's stylesheet.

## Why

We should be serving the font files from Static so they're cached across the entirety of GOVUK - so the font shouldn't be included in Finder-frontend's stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from Static means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from Static, instead of Finder-frontend.

Before (the font paths contains `finder-frontend`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/181037319-666ab623-31a4-4e1d-85e5-3d1654876c26.png">


After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/1732331/181037342-34cc0ec4-e976-4eb6-b860-53ab6e4f625e.png">


---

## Search page examples to sanity check:

- https://finder-frontend-pr-2832.herokuapp.com/search/all
- https://finder-frontend-pr-2832.herokuapp.com/search/research-and-statistics
- https://finder-frontend-pr-2832.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-2832.herokuapp.com/drug-device-alerts
- https://finder-frontend-pr-2832.herokuapp.com/find-eu-exit-guidance-business
- https://finder-frontend-pr-2832.herokuapp.com/find-eu-exit-guidance-business?keywords=eori&order=relevance
- https://finder-frontend-pr-2832.herokuapp.com/find-eu-exit-guidance-business?sector_business_area%5B%5D=aerospace&order=topic
- https://finder-frontend-pr-2832.herokuapp.com/uk-nationals-living-eu

[Other finders](https://live-stuff.herokuapp.com/finders)
