### PR TITLE
Fix search ecommerce and result click tracking

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -366,9 +366,9 @@
         if (xhr.readyState === 4 && xhr.status === 200) {
           var response = JSON.parse(e.target.response)
           liveSearch.updateUrl()
-          liveSearch.trackSearch()
           liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
           liveSearch.displayResults(response, searchState)
+          liveSearch.trackSearch()
         } else {
           liveSearch.showErrorIndicator()
         }
@@ -380,8 +380,8 @@
       xhr.send()
     } else {
       this.updateUrl()
-      this.trackSearch()
       this.displayResults(cachedResultData, searchState)
+      this.trackSearch()
     }
   }
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -106,6 +106,10 @@
   LiveSearch.prototype.startEnhancedEcommerceTracking = function startEnhancedEcommerceTracking () {
     if (this.$resultsWrapper) {
       this.$resultsWrapper.setAttribute('data-search-query', this.currentKeywords())
+      var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
+      if (sortedBy) {
+        this.$resultsWrapper.setAttribute('data-ecommerce-variant', sortedBy.options[sortedBy.selectedIndex].text)
+      }
     }
     if (this.$suggestionsBlock) {
       this.$suggestionsBlock.setAttribute('data-search-query', this.currentKeywords())

--- a/app/views/finders/_facet_tags.html.erb
+++ b/app/views/finders/_facet_tags.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% if local_assigns[:applied_filters] %>
-  <div class="facet-tags" data-module="gem-track-click">
+  <div class="facet-tags">
     <% local_assigns[:applied_filters].each do |applied_filter| %>
       <div class="facet-tags__group">
         <% applied_filter.each do |filter| %>

--- a/app/views/finders/_filter_button.html.erb
+++ b/app/views/finders/_filter_button.html.erb
@@ -1,7 +1,9 @@
 <button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
-  data-toggle="mobile-filters-modal" data-target="facet-wrapper"
-  data-module="gem-track-click" data-track-category="filterClicked"
-  data-track-action="mobile-filter-button" data-track-label="">
-  Filter <span class="govuk-visually-hidden"> results</span>
-  <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
+  data-toggle="mobile-filters-modal"
+  data-target="facet-wrapper"
+  data-track-category="filterClicked"
+  data-track-action="mobile-filter-button"
+  data-track-label="">
+    Filter <span class="govuk-visually-hidden"> results</span>
+    <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
 </button>

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -2,7 +2,7 @@
   <meta name="govuk:search-result-count" content="<%= result_set_presenter.total_count %>">
 <% end %>
 
-<div class="finder-results js-finder-results" data-module="gem-track-click">
+<div class="finder-results js-finder-results">
   <%= render "govuk_publishing_components/components/document_list", {
     items: local_assigns[:document_list_component_data],
     remove_underline: true

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -50,6 +50,7 @@
         <% unless result_set_presenter.sort_option.nil? %>
           data-ecommerce-variant="<%= result_set_presenter.sort_option[:data_track_label] %>"
         <% end %>
+        data-module="gem-track-click"
         >
         <div id="js-search-results-info" data-module="remove-filter" class="result-info">
           <div class="govuk-grid-row">
@@ -69,6 +70,14 @@
                     <%= render partial: 'filter_button'%>
                   <% end %>
                 <% end %>
+
+                <div data-track-category="filterClicked"
+                    data-track-action="skip-Link" data-track-label="">
+                  <%= render "govuk_publishing_components/components/skip_link", {
+                    text: 'Skip to results',
+                    href: '#js-results'}
+                  %>
+                </div>
               </div>
             </div>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -100,7 +100,7 @@
           <%= render "search_results", result_set_presenter.search_results_content %>
         </div>
 
-        <div id="js-pagination" data-module="gem-track-click">
+        <div id="js-pagination">
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
         </div>
 

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,7 +1,7 @@
 Then(/^the links on the page have tracking attributes$/) do
   visit finder_path("government/policies/benefits-reform")
 
-  expect(page).to have_selector('.finder-results[data-module="gem-track-click"]')
+  expect(page).to have_selector('.js-live-search-results-block[data-module="gem-track-click"]')
 
   document_links = page.all(".gem-c-document-list__item-title")
   expect(document_links.count).to be_positive


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Apply fixes so that tracking works after search parameters are changed and parts of the page have been dynamically updated. See individual commits for details.

## Why
Tracking was working fine on initial page load but stopped working after a second search.

## Visual changes
None.

Trello card: https://trello.com/c/a9GavpZp/87-fix-missing-ua-search-finder-event-clicks-after-applying-filters-or-changing-the-search-term
