### PR TITLE
Move skip link on search page

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -17,6 +17,14 @@
   <% end %>
 
   <% if facets.select(&:filterable?).any? %>
+    <div data-module="gem-track-click" data-track-category="filterClicked"
+        data-track-action="skip-Link" data-track-label="">
+      <%= render "govuk_publishing_components/components/skip_link", {
+        text: 'Skip to results',
+        href: '#js-results'}
+      %>
+    </div>
+
     <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets" role="search" aria-label="Search filters">
       <div class="facets__box">
         <div class="facets__header">

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -69,14 +69,6 @@
                     <%= render partial: 'filter_button'%>
                   <% end %>
                 <% end %>
-
-                <div data-module="gem-track-click" data-track-category="filterClicked"
-                    data-track-action="skip-Link" data-track-label="">
-                  <%= render "govuk_publishing_components/components/skip_link", {
-                    text: 'Skip to results',
-                    href: '#js-results'}
-                  %>
-                </div>
               </div>
             </div>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Moving the skip link on the search pages to be before the search filters instead of after them. This is intended to allow keyboard users to skip to search results without having to tab through the filters.

Have left it after the main search box rather than before, on the assumption that users will want to access that even if they don't want to access the filters.

## Why
Was moved unintentionally as part of this change https://github.com/alphagov/finder-frontend/pull/2667

Fixes https://github.com/alphagov/finder-frontend/issues/2841

## Visual changes

Before | After
------ | ------
![Screenshot 2022-08-03 at 09 54 14](https://user-images.githubusercontent.com/861310/182567404-de9b3254-dacb-487a-b33c-23cdc1251892.png) | ![Screenshot 2022-08-03 at 09 53 57](https://user-images.githubusercontent.com/861310/182567427-f5502c08-543b-4866-b4d3-fbc49c8cfecf.png)
