### PR TITLE
Re-add tracking to next and previous pagination link clicks

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -99,7 +99,7 @@
           <%= render "search_results", result_set_presenter.search_results_content %>
         </div>
 
-        <div id="js-pagination">
+        <div id="js-pagination" data-module="gem-track-click">
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
         </div>
 


### PR DESCRIPTION
The data-module was removed when .gem-c-pagination was replaced with .govuk-pagination in the govuk_publishing_components gem[1].

This caused smokey tests to fail [2] when Finder Frontend was bumped to govuk_publishing_components 30.0.0 [3].

The tests were failing due to ‘Step: [FAIL] Then the "contentsClicked" event is reported’. This commit adds data-module="gem-track-click" and the contentsClicked event now fires as expected.



<img width="549" alt="Screenshot 2022-08-03 at 10 42 55" src="https://user-images.githubusercontent.com/5963488/182578687-2cfc4db8-7a34-4eac-ac38-6da845356783.png">



[1](dbcc697#diff-faf8d214f3533285c10c2c77f2ea3db12f3c22463bb53a2e3587a4494fc79bc1L7)

[2](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=Smokey+loop+for+apps%2Ffinder_frontend&scroll=299)

[3](alphagov/finder-frontend#2838)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
