### PR TITLE
Fix OIM capitialisation issue

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -153,7 +153,11 @@ private
   def label_for_metadata_key(facets, key)
     facet = metadata_facets(facets).find { |f| f.key == key }
 
-    facet.short_name || facet.key.humanize
+    if format == "oim_project"
+      facet.short_name || facet.name
+    else
+      facet.short_name || facet.key.humanize
+    end
   end
 
   def get_metadata_label(key, tag)


### PR DESCRIPTION
## What

A [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5042464) has been received from the team that has published a project page for the Office for the Internal Market (OIM).

We need so ensure that all instances of the organisations abbreviation - OIM - appear as they are held in the relevant content item(s) when rendered by `finder-frontend`. There should be no instances of `Oim` being rendered on the published document if it appears as `OIM` in the content item.

### An OIM content item

The content item below shows `OIM Project type` and `OIM Project state`. However, in the rendered document (see Before screenshot below) these show as `Oim project type` and `Oim project state`.

<img width="706" alt="Screenshot 2022-08-26 at 12 45 24" src="https://user-images.githubusercontent.com/44037625/186908187-b926c471-95c9-4ba6-9899-d1370ce69048.png">

## Why

The organisation wants to see the data as stored in the content item(s) and not have this data converted or changed in any way.

## Rendered content item(s)

| Before | After |
| --- | --- |
|<img width="1028" alt="Screenshot 2022-08-26 at 12 43 43" src="https://user-images.githubusercontent.com/44037625/186907929-bc2fcbaf-ada3-4004-9138-87e74b97e80d.png">|<img width="1028" alt="Screenshot 2022-08-26 at 12 44 13" src="https://user-images.githubusercontent.com/44037625/186907994-33368b71-569a-4a3c-8816-df738938944d.png">|

- [Trello](https://trello.com/c/gSZFfTcC/189-scope-fix-on-finder-frontend-app-for-oim)
- [Zendesk](https://govuk.zendesk.com/agent/tickets/5042464)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
