### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,46 +4,11 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Security updates
-      - dependency-name: brakeman
-        dependency-type: direct
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      - dependency-name: gds-api-adapters
-        dependency-type: direct
-      - dependency-name: rubocop-govuk
-        dependency-type: direct
-      - dependency-name: slimmer
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: factory_bot
-        dependency-type: direct
-      - dependency-name: jasmine-browser-runner
-        dependency-type: direct
-      - dependency-name: jasmine-core
-        dependency-type: direct
-      - dependency-name: rails
-        dependency-type: direct
-      - dependency-name: rspec-rails
-        dependency-type: direct
-      - dependency-name: sassc-rails
-        dependency-type: direct
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Internal packages
-      - dependency-name: stylelint-config-gds
-        dependency-type: direct
-      # Framework packages
-      - dependency-name: standardx
-        dependency-type: direct
-      - dependency-name: stylelint
-        dependency-type: direct
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2