### PR TITLE
Enable Static proxy for development

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     },
+    "GOVUK_PROXY_STATIC_ENABLED": {
+      "value": "true"
+    },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://www.gov.uk/api"
     },

--- a/startup.sh
+++ b/startup.sh
@@ -6,6 +6,7 @@ bundle check || bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  GOVUK_PROXY_STATIC_ENABLED=true \
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \


### PR DESCRIPTION
This sets the GOVUK_PROXY_STATIC_ENABLED env var to enable the proxy to Static in production. This is so the application continues, when Static changes to use relative URLs for assets. See https://github.com/alphagov/govuk_app_config/pull/261 and https://github.com/alphagov/govuk-puppet/pull/11801

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
