### PR TITLE
Fix Plek URL for Static in development

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {
-      "value": "assets.digital.cabinet-office.gov.uk"
+      "value": "https://assets.publishing.service.gov.uk"
     },
     "PLEK_SERVICE_SEARCH_URI": {
       "value": "https://www.gov.uk/api"

--- a/startup.sh
+++ b/startup.sh
@@ -9,7 +9,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_PROXY_STATIC_ENABLED=true \
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk} \
   PLEK_SERVICE_WHITEHALL_FRONTEND_URI=https://www.gov.uk \
   bundle exec rails s -p 3062
 else


### PR DESCRIPTION
This updates the URLs to use the asset domain and use HTTPS. This
is required for the Static proxy to correctly forward request.
