### PR TITLE
Add enhanced ecommerce tracking

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -52,6 +52,8 @@
       window.ga('set', 'transport', 'beacon')
     }
 
+    this.Ga4EcommerceTracking(true)
+
     this.focusErrorMessagesOnLoad(this.$form)
 
     // prevent page refresh on search submit button click
@@ -115,6 +117,22 @@
       this.$suggestionsBlock.setAttribute('data-search-query', this.currentKeywords())
     }
     if (GOVUK.Ecommerce) { GOVUK.Ecommerce.start() }
+
+    this.Ga4EcommerceTracking(false)
+  }
+
+  LiveSearch.prototype.Ga4EcommerceTracking = function (isNewPage) {
+    if (GOVUK.analyticsGA4 && GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker) {
+      var consentCookie = GOVUK.getConsentCookie()
+
+      if (consentCookie && consentCookie.settings) {
+        GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(isNewPage)
+      } else {
+        window.addEventListener('cookie-consent', function () {
+          GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(isNewPage)
+        })
+      }
+    }
   }
 
   LiveSearch.prototype.getAndUpdateTaxonomyFacet = function getAndUpdateTaxonomyFacet () {

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -44,6 +44,7 @@
         role="region"
         aria-label="<%= content_item.title %> search results"
         data-analytics-ecommerce
+        data-ga4-ecommerce
         data-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
         data-list-title="<%= content_item.title %>"
         data-search-query="<%= result_set_presenter.user_supplied_keywords %>"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds:

- `ga4-enhanced-ecommerce-tracker` to the `data-module` attribute on the DOM element wrapping the search results so that our `Ga4EnhancedEcommerceTracker` tracking module can be used
- The necessary JS to start tracking every time the search results are updated via filtering or sorting

## Why
This change has been made as part of our migration to GA4.

## Visual changes

N/A
