### PR TITLE
Update GA4 naming conventions

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -122,14 +122,14 @@
   }
 
   LiveSearch.prototype.Ga4EcommerceTracking = function (isNewPage) {
-    if (GOVUK.analyticsGA4 && GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker) {
+    if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4EcommerceTracker) {
       var consentCookie = GOVUK.getConsentCookie()
 
       if (consentCookie && consentCookie.settings) {
-        GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(isNewPage)
+        GOVUK.analyticsGa4.Ga4EcommerceTracker.init(isNewPage)
       } else {
         window.addEventListener('cookie-consent', function () {
-          GOVUK.analyticsGA4.Ga4EnhancedEcommerceTracker.init(isNewPage)
+          GOVUK.analyticsGa4.Ga4EcommerceTracker.init(isNewPage)
         })
       }
     }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR updates the GA4 variable names to coincide with the naming convention updates in the `govuk_publishing_components` gem (PR #2987).

## Why
The `govuk_publishing_components` gem has updated its GA4 naming conventions and this needs to be reflected in this application so that non-existent variables aren't being targeted.

## Visual Changes
N/A