### PR TITLE
Replace Plek.current

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def absolute_url_for(path)
-    URI.join(Plek.current.website_root, path)
+    URI.join(Plek.new.website_root, path)
   end
 end

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -3,7 +3,7 @@ class EntryPresenter
            :path,
            to: :entry
 
-  WEBSITE_ROOT = Plek.current.website_root.gsub(/https?:\/\//, "")
+  WEBSITE_ROOT = Plek.new.website_root.gsub(/https?:\/\//, "")
 
   def initialize(entry, show_summaries)
     @entry = entry

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -15,7 +15,7 @@ module DocumentHelper
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::Worldwide
 
-  SEARCH_ENDPOINT = "#{Plek.current.find('search')}/search.json".freeze
+  SEARCH_ENDPOINT = "#{Plek.find('search')}/search.json".freeze
 
   def stub_taxonomy_api_request
     stub_content_store_has_item("/", "links" => { "level_one_taxons" => [] })
@@ -157,7 +157,7 @@ module DocumentHelper
 
   def stub_search_api_request_with_filtered_research_and_statistics_results
     Timecop.freeze(Time.zone.local("2019-01-01").utc)
-    stub_request(:get, "#{Plek.current.find('search')}/search.json")
+    stub_request(:get, "#{Plek.find('search')}/search.json")
       .with(query: hash_including(
         "filter_format" => %w[statistics_announcement],
         "filter_release_timestamp" => "from:2019-01-01",

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -1,6 +1,6 @@
 module RummagerUrlHelper
   def rummager_url(params)
-    "#{Plek.current.find('search')}/search.json?#{params.to_query}"
+    "#{Plek.find('search')}/search.json?#{params.to_query}"
   end
 
   def mosw_search_params

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -48,7 +48,7 @@ describe FindersController, type: :controller do
           { max_age: 900, public: true },
         )
 
-        url = "#{Plek.current.find('search')}/search.json"
+        url = "#{Plek.find('search')}/search.json"
 
         stub_request(:get, url)
           .with(
@@ -127,7 +127,7 @@ describe FindersController, type: :controller do
           "suggested_queries": []
         })
 
-        stub = stub_request(:get, "#{Plek.current.find('search')}/search.json")
+        stub = stub_request(:get, "#{Plek.find('search')}/search.json")
           .with(
             query: {
               count: 10,
@@ -150,7 +150,7 @@ describe FindersController, type: :controller do
       it "renders the users malicious input escaped" do
         stub_content_store_has_item("/lunch-finder", lunch_finder)
 
-        stub_request(:get, /\A#{Plek.current.find('search')}\/search.json/)
+        stub_request(:get, /\A#{Plek.find('search')}\/search.json/)
           .to_return(status: 200, body: rummager_response, headers: {})
 
         get :show, params: { slug: "lunch-finder", keywords: "<script>alert(0)</script>" }
@@ -323,7 +323,7 @@ describe FindersController, type: :controller do
   end
 
   def search_api_request(query: {})
-    stub_request(:get, "#{Plek.current.find('search')}/search.json")
+    stub_request(:get, "#{Plek.find('search')}/search.json")
       .with(
         query: {
           count: 10,

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -189,7 +189,7 @@ describe FacetsBuilder do
         facet_people: "1500,examples:0,order:value.title",
       }
     end
-    let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+    let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
 
     let(:detail_hash) do
       {

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Registries::ManualsRegistry do
       count: 1500,
     }
   end
-  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Registries::OrganisationsRegistry do
       "order" => "title",
     }
   end
-  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Registries::PeopleRegistry do
       facet_people: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Registries::RolesRegistry do
       facet_roles: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.current.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do


### PR DESCRIPTION
`Plek.current` was marked as deprecated in alphagov/plek#94. This replaces all uses of `Plek.current` to stop deprecation warnings from filling up the logs with:

"Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."

[Trello](https://trello.com/c/vdnZ4cBq/233-replace-plekcurrent)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
