### PR TITLE
Replace govuk-content-schema-test-helpers with govuk_schemas in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ group :test do
   gem "climate_control"
   gem "cucumber-rails", require: false
   gem "factory_bot"
-  gem "govuk-content-schema-test-helpers"
   gem "launchy"
   gem "rails-controller-testing"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,8 +180,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_ab_testing (2.4.2)
     govuk_app_config (4.9.0)
       logstasher (~> 2.1)
@@ -476,7 +474,6 @@ DEPENDENCIES
   factory_bot
   gds-api-adapters
   google-apis-drive_v3
-  govuk-content-schema-test-helpers
   govuk_ab_testing
   govuk_app_config
   govuk_publishing_components

--- a/spec/support/content_helper.rb
+++ b/spec/support/content_helper.rb
@@ -1,18 +1,7 @@
 # Include this module to get access to the GOVUK Content Schema examples in the
 # tests.
-#
-# By default, the govuk-content-schemas repository is expected to be located
-# at ../govuk-content-schemas. This can be overridden with the
-# GOVUK_CONTENT_SCHEMAS_PATH environment variable, for example:
-#
-#   $ GOVUK_CONTENT_SCHEMAS_PATH=/some/dir/govuk-content-schemas bundle exec rake
-#
+require "govuk_schemas/example"
 require "gds_api/test_helpers/content_store"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "frontend"
-  config.project_root = Rails.root
-end
 
 module GovukContentSchemaExamples
   extend ActiveSupport::Concern
@@ -22,8 +11,7 @@ module GovukContentSchemaExamples
 
     # Returns a hash representing an finder content item from govuk-content-schemas
     def govuk_content_schema_example(name, format = "finder")
-      string = GovukContentSchemaTestHelpers::Examples.new.get(format, name)
-      JSON.parse(string)
+      GovukSchemas::Example.find(format, example_name: name)
     end
   end
 end


### PR DESCRIPTION
govuk-content-schema-test-helpers is deprecated, replace use in tests with govuk_schemas

https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
