### PR TITLE
Fix referrer bug

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -52,7 +52,7 @@
       window.ga('set', 'transport', 'beacon')
     }
 
-    this.Ga4EcommerceTracking(true)
+    this.Ga4EcommerceTracking()
 
     this.focusErrorMessagesOnLoad(this.$form)
 
@@ -118,18 +118,18 @@
     }
     if (GOVUK.Ecommerce) { GOVUK.Ecommerce.start() }
 
-    this.Ga4EcommerceTracking(false)
+    this.Ga4EcommerceTracking(this.previousSearchUrl)
   }
 
-  LiveSearch.prototype.Ga4EcommerceTracking = function (isNewPage) {
+  LiveSearch.prototype.Ga4EcommerceTracking = function (referrer) {
     if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4EcommerceTracker) {
       var consentCookie = GOVUK.getConsentCookie()
 
       if (consentCookie && consentCookie.settings) {
-        GOVUK.analyticsGa4.Ga4EcommerceTracker.init(isNewPage)
+        GOVUK.analyticsGa4.Ga4EcommerceTracker.init(referrer)
       } else {
         window.addEventListener('cookie-consent', function () {
-          GOVUK.analyticsGa4.Ga4EcommerceTracker.init(isNewPage)
+          GOVUK.analyticsGa4.Ga4EcommerceTracker.init(referrer)
         })
       }
     }
@@ -378,6 +378,7 @@
     var searchState = this.serializeState(this.state)
     var cachedResultData = this.cache(searchState)
     var liveSearch = this
+    this.previousSearchUrl = window.location.href
 
     if (typeof cachedResultData === 'undefined') {
       this.showLoadingIndicator()


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR fixes a GA4 analytics bug relating to `page_views`.

When a user is on a search results page and applies a new filter or sort option, the URL of the page changes and this needs to be reflected in the `page_view.referrer` property that is pushed to the `dataLayer`. Currently, the  `page_view.referrer` property is not updating when a dynamic update has been triggered (e.g. by applying a filter). To address this, the `location` of the page is stored in a `referrer` variable before any dynamic updates have been triggered and it is ultimately passed to `GOVUK.analyticsGa4.Ga4EcommerceTracker.init()` as part of an object (namely `dynamicPageViewData.referrer`).

In addition to the `dynamicPageViewData.referrer` property, a `dynamicPageViewData.dynamic` property is also passed in order to enable PA's to differentiate between a fresh page load and a dynamic page update.

The `referrer` and `dynamic` values have been passed as properties on an object because this removes a reliance on the parameters being passed in the correct order and, if additional properties need to be passed in future, it can be easily extended.

## Why
Without these fixes, PA's will be unable to:

- Track user journeys accurately when filters or sorting options have been added, changed, or removed
- Differentiate between fresh page loads (e.g. by clicking a link or using the pagination) and dynamic page updates

## Visual changes
None.

## N.B.
Related PR - https://github.com/alphagov/govuk_publishing_components/pull/3032

As this PR changes how parameters are passed to `GOVUK.analyticsGa4.Ga4EcommerceTracker.init()`, these changes are breaking.