### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
     ffi (1.15.5)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -27,7 +27,7 @@ module Services
   end
 
   def self.rummager
-    GdsApi::Search.new(Plek.find("search"))
+    GdsApi::Search.new(Plek.find("search-api"))
   end
 
   def self.email_alert_api

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -15,7 +15,7 @@ module DocumentHelper
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::Worldwide
 
-  SEARCH_ENDPOINT = "#{Plek.find('search')}/search.json".freeze
+  SEARCH_ENDPOINT = "#{Plek.find('search-api')}/search.json".freeze
 
   def stub_taxonomy_api_request
     stub_content_store_has_item("/", "links" => { "level_one_taxons" => [] })
@@ -157,7 +157,7 @@ module DocumentHelper
 
   def stub_search_api_request_with_filtered_research_and_statistics_results
     Timecop.freeze(Time.zone.local("2019-01-01").utc)
-    stub_request(:get, "#{Plek.find('search')}/search.json")
+    stub_request(:get, "#{Plek.find('search-api')}/search.json")
       .with(query: hash_including(
         "filter_format" => %w[statistics_announcement],
         "filter_release_timestamp" => "from:2019-01-01",

--- a/features/support/rummager_url_helper.rb
+++ b/features/support/rummager_url_helper.rb
@@ -1,6 +1,6 @@
 module RummagerUrlHelper
   def rummager_url(params)
-    "#{Plek.find('search')}/search.json?#{params.to_query}"
+    "#{Plek.find('search-api')}/search.json?#{params.to_query}"
   end
 
   def mosw_search_params

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -48,7 +48,7 @@ describe FindersController, type: :controller do
           { max_age: 900, public: true },
         )
 
-        url = "#{Plek.find('search')}/search.json"
+        url = "#{Plek.find('search-api')}/search.json"
 
         stub_request(:get, url)
           .with(
@@ -127,7 +127,7 @@ describe FindersController, type: :controller do
           "suggested_queries": []
         })
 
-        stub = stub_request(:get, "#{Plek.find('search')}/search.json")
+        stub = stub_request(:get, "#{Plek.find('search-api')}/search.json")
           .with(
             query: {
               count: 10,
@@ -150,7 +150,7 @@ describe FindersController, type: :controller do
       it "renders the users malicious input escaped" do
         stub_content_store_has_item("/lunch-finder", lunch_finder)
 
-        stub_request(:get, /\A#{Plek.find('search')}\/search.json/)
+        stub_request(:get, /\A#{Plek.find('search-api')}\/search.json/)
           .to_return(status: 200, body: rummager_response, headers: {})
 
         get :show, params: { slug: "lunch-finder", keywords: "<script>alert(0)</script>" }
@@ -323,7 +323,7 @@ describe FindersController, type: :controller do
   end
 
   def search_api_request(query: {})
-    stub_request(:get, "#{Plek.find('search')}/search.json")
+    stub_request(:get, "#{Plek.find('search-api')}/search.json")
       .with(
         query: {
           count: 10,

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -189,7 +189,7 @@ describe FacetsBuilder do
         facet_people: "1500,examples:0,order:value.title",
       }
     end
-    let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
+    let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
 
     let(:detail_hash) do
       {

--- a/spec/lib/registries/base_registries_spec.rb
+++ b/spec/lib/registries/base_registries_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Registries::BaseRegistries do
 
       # should not request anything further over the network
       described_class.new.ensure_warm_cache
-      assert_not_requested :get, "http://search.dev.gov.uk/search.json"
+      assert_not_requested :get, "http://search-api.dev.gov.uk/search.json"
     end
   end
 

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Registries::ManualsRegistry do
       count: 1500,
     }
   end
-  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Registries::OrganisationsRegistry do
       "order" => "title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Registries::PeopleRegistry do
       facet_people: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Registries::RolesRegistry do
       facet_roles: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search')}/search.json?#{rummager_params.to_query}" }
+  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
 
   describe "when rummager is available" do
     before do

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe Search::Query do
   def stub_search
-    stub_request(:get, %r{#{Plek.find("search")}/search.json})
+    stub_request(:get, %r{#{Plek.find("search-api")}/search.json})
   end
 
   def stub_batch_search
-    stub_request(:get, %r{#{Plek.find("search")}/batch_search.json})
+    stub_request(:get, %r{#{Plek.find("search-api")}/batch_search.json})
   end
 
   let(:content_item) do

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -1,6 +1,6 @@
 module RegistrySpecHelper
   def stub_people_registry_request
-    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json")
         .with(query: {
           count: 0,
           facet_people: "1500,examples:0,order:value.title",
@@ -58,7 +58,7 @@ module RegistrySpecHelper
   end
 
   def stub_roles_registry_request
-    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json")
         .with(query: {
           count: 0,
           facet_roles: "1500,examples:0,order:value.title",
@@ -83,7 +83,7 @@ module RegistrySpecHelper
   end
 
   def stub_organisations_registry_request
-    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json")
     .with(query: {
       count: 1500,
       fields: %w[slug title acronym content_id],
@@ -121,7 +121,7 @@ module RegistrySpecHelper
   end
 
   def stub_manuals_registry_request
-    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json")
       .with(query: {
         filter_document_type: %w[manual service_manual_homepage service_manual_guide],
         fields: %w[title],
@@ -146,7 +146,7 @@ module RegistrySpecHelper
   end
 
   def stub_topical_events_registry_request
-    stub_request(:get, "http://search.dev.gov.uk/search.json")
+    stub_request(:get, "http://search-api.dev.gov.uk/search.json")
     .with(query: {
       count: 1500,
       fields: %w[slug title],


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.