### PR TITLE
Remove publishing e2e tests from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,7 @@
 library("govuk")
 
 node {
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-finder-frontend")
   govuk.buildProject(
-    publishingE2ETests: true,
     brakeman: true,
   )
 }


### PR DESCRIPTION
[This commit removes the E2E tests from this app's CI pipeline. Once merged, the Jenkins CI server will no longer kick off a run of the publishing-e2e-tests job when new PRs are opened.

This change is the first step in the overall decommissioning process, and will be applied to every application currently running the E2E tests.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️