### PR TITLE
Implement redirects from Whitehall finder paths

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -12,7 +12,10 @@ class FindersController < ApplicationController
       format.html do
         raise UnsupportedContentItem unless content_item.is_finder?
 
-        transform_legacy_publication_params_and_redirect if legacy_params_present? && content_item.base_path == "/search/all"
+        if legacy_params_present?
+          transform_legacy_announcement_params_and_redirect if content_item.base_path == "/search/news-and-communications"
+          transform_legacy_publication_params_and_redirect if content_item.base_path == "/search/all"
+        end
 
         show_page_variables
       end
@@ -213,6 +216,19 @@ private
     given_params = params.keys.map(&:to_sym)
 
     (legacy_params & given_params).any?
+  end
+
+  def transform_legacy_announcement_params_and_redirect
+    base_path = "/search/news-and-communications"
+    query_string = legacy_finder_query_params.to_query
+
+    redirect_path = if query_string.empty?
+                      base_path
+                    else
+                      "#{base_path}?#{query_string}"
+                    end
+
+    redirect_to redirect_path and return
   end
 
   def transform_legacy_publication_params_and_redirect

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -322,6 +322,111 @@ describe FindersController, type: :controller do
     end
   end
 
+  describe "with legacy query parameters for publications" do
+    before do
+      search_api_request
+      stub_content_store_has_item("/search/all", all_content_finder)
+
+      @default_params = { slug: "search/all" }
+    end
+
+    describe "when a non-default finder is needed" do
+      it "redirects to official-documents finder for command_and_act_papers" do
+        expect(get(:show, params: @default_params.merge(official_document_status: "command_and_act_papers"))).to redirect_to("/official-documents")
+      end
+
+      it "redirects to official-documents finder with parameters for command_papers" do
+        expect(get(:show, params: @default_params.merge(official_document_status: "command_papers"))).to redirect_to("/official-documents?content_store_document_type=command_papers")
+      end
+
+      it "redirects to official-documents finder with parameters for act_papers" do
+        expect(get(:show, params: @default_params.merge(official_document_status: "act_papers"))).to redirect_to("/official-documents?content_store_document_type=act_papers")
+      end
+
+      it "redirects to policy-papers-and-consultations finder with parameters for consultations" do
+        expect(get(:show, params: @default_params.merge(publication_type: "consultations"))).to redirect_to("/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations")
+      end
+
+      it "redirects to policy-papers-and-consultations finder with parameters for closed-consultations" do
+        expect(get(:show, params: @default_params.merge(publication_type: "closed-consultations"))).to redirect_to("/search/policy-papers-and-consultations?content_store_document_type=closed_consultations")
+      end
+
+      it "redirects to policy-papers-and-consultations finder with parameters for open-consultations" do
+        expect(get(:show, params: @default_params.merge(publication_type: "open-consultations"))).to redirect_to("/search/policy-papers-and-consultations?content_store_document_type=open_consultations")
+      end
+
+      it "redirects to transparency-and-freedom-of-information-releases finder with parameters for foi-releases" do
+        expect(get(:show, params: @default_params.merge(publication_type: "foi-releases"))).to redirect_to("/search/transparency-and-freedom-of-information-releases?content_store_document_type=foi_release")
+      end
+
+      it "redirects to transparency-and-freedom-of-information-releases finder with parameters for transparency-data" do
+        expect(get(:show, params: @default_params.merge(publication_type: "transparency-data"))).to redirect_to("/search/transparency-and-freedom-of-information-releases?content_store_document_type=transparency")
+      end
+
+      it "redirects to transparency-and-freedom-of-information-releases finder with parameters for corporate-reports" do
+        expect(get(:show, params: @default_params.merge(publication_type: "corporate-reports"))).to redirect_to("/search/transparency-and-freedom-of-information-releases?content_store_document_type=corporate_report")
+      end
+
+      it "redirects to guidance-and-regulation finder for guidance" do
+        expect(get(:show, params: @default_params.merge(publication_type: "guidance"))).to redirect_to("/search/guidance-and-regulation")
+      end
+
+      it "redirects to guidance-and-regulation finder for regulations" do
+        expect(get(:show, params: @default_params.merge(publication_type: "regulations"))).to redirect_to("/search/guidance-and-regulation")
+      end
+
+      it "redirects to policy-papers-and-consultations finder with parameters for corporate-reports" do
+        expect(get(:show, params: @default_params.merge(publication_type: "policy-papers"))).to redirect_to("/search/policy-papers-and-consultations?content_store_document_type=policy_papers")
+      end
+
+      it "redirects to services finder for forms" do
+        expect(get(:show, params: @default_params.merge(publication_type: "forms"))).to redirect_to("/search/services")
+      end
+
+      it "redirects to research-and-statistics finder with parameters for corporate-reports" do
+        expect(get(:show, params: @default_params.merge(publication_type: "research-and-analysis"))).to redirect_to("/search/research-and-statistics?content_store_document_type=research")
+      end
+
+      it "redirects to research-and-statistics finder for statistics" do
+        expect(get(:show, params: @default_params.merge(publication_type: "statistics"))).to redirect_to("/search/research-and-statistics")
+      end
+    end
+
+    describe "when there are legacy parameters present" do
+      it "strips out all from taxons parameter" do
+        expect(get(:show, params: @default_params.merge(taxons: %w[all]))).to redirect_to("/search/all")
+      end
+
+      it "strips out all from subtaxons parameter" do
+        expect(get(:show, params: @default_params.merge(subtaxons: %w[all]))).to redirect_to("/search/all")
+      end
+
+      it "strips out all from departments parameter" do
+        expect(get(:show, params: @default_params.merge(departments: %w[all]))).to redirect_to("/search/all")
+      end
+
+      it "replaces departments with organisations parameter" do
+        expect(get(:show, params: @default_params.merge(departments: %w[cabinet-office]))).to redirect_to("/search/all?organisations%5B%5D=cabinet-office")
+      end
+    end
+
+    it "redirects a request using both a non-default finder and has legacy parameters" do
+      expected_query_string = {
+        content_store_document_type: %w[open_consultations closed_consultations],
+        level_one_taxon: "education",
+        level_two_taxon: "schools",
+        organisations: %w[cabinet-office hm-revenue-and-customs],
+      }.to_query
+
+      expect(get(:show, params: @default_params.merge(
+        publication_type: "consultations",
+        departments: %w[cabinet-office hm-revenue-and-customs],
+        taxons: %w[education],
+        subtaxons: %w[schools],
+      ))).to redirect_to("/search/policy-papers-and-consultations?#{expected_query_string}")
+    end
+  end
+
   def search_api_request(query: {})
     stub_request(:get, "#{Plek.find('search-api')}/search.json")
       .with(


### PR DESCRIPTION
These redirects used to be rendered by Whitehall, but were removed in https://github.com/alphagov/whitehall/pull/6950.

As Whitehall Frontend is being retired, we need to bring these into another application.  The previous routes are already being redirected to Finder Frontend (`/search/all` for publications and `/search/news-and-communications` for announcements), so are best processed here.

This replicates the behaviour in an identical way to Whitehall, the commit messages link to the redirect code before it was removed.

[Trello card](https://trello.com/c/Drb1H01H/383-bug-fix-redirects-from-whitehall-rendered-finders), [Jira issue PP-892](https://gov-uk.atlassian.net/browse/PP-892)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
