### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "google-apis-drive_v3"
 gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "rest-client"
 gem "sassc-rails"
 gem "slimmer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,11 +230,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
@@ -479,6 +476,7 @@ DEPENDENCIES
   govuk_test
   launchy
   listen
+  mail (~> 2.7.1)
   pry-byebug
   rails (= 7.0.4)
   rails-controller-testing


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
