### PR TITLE
Remove disused account_api stub.

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,13 +1,8 @@
-require "gds_api/account_api"
 require "gds_api/content_store"
 require "gds_api/search"
 require "gds_api/email_alert_api"
 
 module Services
-  def self.account_api
-    GdsApi.account_api
-  end
-
   def self.content_store
     GdsApi::ContentStore.new(Plek.find("content-store"))
   end


### PR DESCRIPTION
Finder Frontend no longer makes any calls to Account API. The last usage was removed in fea96b0.

This means we'll have one fewer API user bearer token to manage (and they're currently manually rotated, so eliminating one of them is a win).