### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "google-apis-drive_v3"
 gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "rest-client"
 gem "sassc-rails"
 gem "slimmer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,6 @@ DEPENDENCIES
   govuk_test
   launchy
   listen
-  mail (~> 2.8.0)
   pry-byebug
   rails (= 7.0.4)
   rails-controller-testing


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
