### PR TITLE
Change mobile search filters modal to a regular 'in page' component

### DIFF
--- a/app/assets/javascripts/modules/mobile-filters-modal.js
+++ b/app/assets/javascripts/modules/mobile-filters-modal.js
@@ -2,104 +2,46 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function MobileFiltersModal ($module) {
-    this.$module = $module
-    this.$facetsBox = this.$module.querySelector('.facets__box')
-    this.$closeTriggers = this.$module.querySelectorAll('.js-close-filters')
-    this.$showResultsButton = this.$module.querySelector('.js-show-results')
-    this.$clearFiltersTrigger = this.$module.querySelector('.js-clear-selected-filters')
-    this.$body = document.querySelector('body')
-
-    this.$module.open = this.handleOpen.bind(this)
-    this.$module.close = this.handleClose.bind(this)
-    this.$module.clearFilters = this.handleClearFilters.bind(this)
-    this.$module.ModalFocus = this.handleModalFocus.bind(this)
-    this.$module.boundKeyDown = this.handleKeyDown.bind(this)
+  function MobileFiltersModal (module) {
+    this.module = module
+    this.triggerElement = document.querySelector('[data-toggle="mobile-filters-modal"][data-target="' + this.module.id + '"]')
+    this.clearFiltersTrigger = this.module.querySelector('.js-clear-selected-filters')
+    this.module.toggle = this.handleToggle.bind(this)
+    this.module.open = this.handleOpen.bind(this)
+    this.module.close = this.handleClose.bind(this)
+    this.module.clearFilters = this.handleClearFilters.bind(this)
   }
 
   MobileFiltersModal.prototype.init = function () {
-    var $triggerElement = document.querySelector(
-      '[data-toggle="mobile-filters-modal"][data-target="' + this.$module.id + '"]'
-    )
-    if ($triggerElement) {
-      $triggerElement.addEventListener('click', this.$module.open)
+    if (this.triggerElement) {
+      this.triggerElement.addEventListener('click', this.module.toggle)
+      this.triggerElement.setAttribute('aria-controls', this.module.id)
+      this.triggerElement.setAttribute('aria-expanded', 'false')
     }
 
-    if (this.$closeTriggers) {
-      for (var t = 0; t < this.$closeTriggers.length; t++) {
-        this.$closeTriggers[t].addEventListener('click', this.$module.close)
-      }
-    }
-
-    if (this.$clearFiltersTrigger) {
-      this.$clearFiltersTrigger.addEventListener('click', this.$module.clearFilters)
+    if (this.clearFiltersTrigger) {
+      this.clearFiltersTrigger.addEventListener('click', this.module.clearFilters)
     }
   }
 
-  MobileFiltersModal.prototype.handleOpen = function (event) {
-    if (event) {
-      event.preventDefault()
-    }
-    // when our support browser matrix is above iOS 13
-    // we can use overflow: hidden on the <body> and remove position: fixed
-    this.$body.style.top = '-' + window.scrollY + 'px'
-    this.$body.style.position = 'fixed'
-    this.$focusedElementBeforeOpen = document.activeElement
-    this.$module.classList.add('facets--visible')
-    this.$facetsBox.setAttribute('aria-modal', true)
-    this.$facetsBox.setAttribute('tabindex', 0)
-    this.$facetsBox.focus()
+  MobileFiltersModal.prototype.handleToggle = function (event) {
+    event.preventDefault()
 
-    document.addEventListener('keydown', this.$module.boundKeyDown, true)
+    if (this.module.classList.contains('facets--visible')) {
+      this.module.close()
+    } else {
+      this.module.open()
+    }
   }
 
-  MobileFiltersModal.prototype.handleClose = function (event) {
-    if (event) {
-      event.preventDefault()
-    }
-
-    var offsetTop = this.$body.style.top
-    this.$body.style.position = ''
-    this.$body.style.top = ''
-    window.scrollTo(0, parseInt(offsetTop || '0') * -1)
-    this.$module.classList.remove('facets--visible')
-    this.$facetsBox.removeAttribute('aria-modal')
-    this.$facetsBox.removeAttribute('tabindex')
-    this.$focusedElementBeforeOpen.focus()
-
-    document.removeEventListener('keydown', this.$module.boundKeyDown, true)
+  MobileFiltersModal.prototype.handleOpen = function () {
+    this.triggerElement.setAttribute('aria-expanded', 'true')
+    this.module.classList.add('facets--visible')
   }
 
-  MobileFiltersModal.prototype.handleModalFocus = function () {
-    this.$facetsBox.focus()
-  }
-
-  // while open, prevent tabbing to outside the dialogue
-  // and listen for ESC key to close the dialogue
-  MobileFiltersModal.prototype.handleKeyDown = function (event) {
-    var KEY_TAB = 9
-    var KEY_ESC = 27
-
-    switch (event.keyCode) {
-      case KEY_TAB:
-        if (event.shiftKey) {
-          if (document.activeElement === this.$facetsBox) {
-            event.preventDefault()
-            this.$showResultsButton.focus()
-          }
-        } else {
-          if (document.activeElement === this.$showResultsButton) {
-            event.preventDefault()
-            this.$facetsBox.focus()
-          }
-        }
-        break
-      case KEY_ESC:
-        this.$module.close()
-        break
-      default:
-        break
-    }
+  MobileFiltersModal.prototype.handleClose = function () {
+    this.triggerElement.setAttribute('aria-expanded', 'false')
+    this.module.classList.remove('facets--visible')
   }
 
   MobileFiltersModal.prototype.handleClearFilters = function (event) {
@@ -108,26 +50,29 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
     // reset all selects, uncheck checkboxes, clear text input values
     // and remove the selected count on each facet
-    var $elements = this.$module.querySelectorAll('input, select, .js-selected-counter')
-    var $form = document.querySelector('.js-live-search-form')
+    var elements = this.module.querySelectorAll('input, select, .js-selected-counter')
+    var form = document.querySelector('.js-live-search-form')
     var customEvent = document.createEvent('HTMLEvents')
     customEvent.initEvent('customFormChange', true, false)
-    for (var i = 0; i < $elements.length; i++) {
-      var $el = $elements[i]
-      var tagName = $el.tagName
+    for (var i = 0; i < elements.length; i++) {
+      var el = elements[i]
+      var tagName = el.tagName
       switch (tagName) {
         case 'INPUT':
-          if ($el.type === 'checkbox' && $el.checked === true) {
-            $el.checked = false
-          } else if ($el.type === 'text' && $el.value !== '') {
-            $el.value = ''
+          if (el.type === 'checkbox' && el.checked === true) {
+            el.checked = false
+          } else if (el.type === 'text' && el.value !== '') {
+            el.value = ''
           }
           break
         case 'SELECT':
-          $el.selectedIndex = null
+          el.selectedIndex = null
           break
         case 'DIV':
-          $el.parentNode.removeChild($el)
+          el.parentNode.removeChild(el)
+          break
+        case 'SPAN':
+          el.parentNode.removeChild(el)
           break
         default:
           break
@@ -135,7 +80,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
     // fire a single custom change event on the form once all filters have been cleared
     // so that we only fetch new search-api data once
-    $form.dispatchEvent(customEvent)
+    form.dispatchEvent(customEvent)
   }
 
   Modules.MobileFiltersModal = MobileFiltersModal

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -3,10 +3,29 @@
 
   .js-enabled & {
     display: inline-block;
+    margin-left: govuk-spacing(3);
     margin-bottom: govuk-spacing(4);
     text-decoration: none;
 
     @include govuk-typography-weight-bold;
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+
+    position: relative;
+  }
+
+  &[aria-expanded="false"] ~ .mobile-filters-expander__icon--down {
+    display: block;
+
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+  }
+
+  &[aria-expanded="true"] ~ .mobile-filters-expander__icon--up {
+    display: block;
+
     @include govuk-media-query($from: tablet) {
       display: none;
     }
@@ -47,37 +66,24 @@
 @include govuk-media-query($until: tablet) {
   .js-enabled {
     .facets__box {
-      position: fixed;
-      z-index: 1000;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      margin: 0;
-      padding: 0;
-      overflow-y: auto;
-      background: govuk-colour("white");
+      border-left: 5px solid #b1b4b6;
+      padding-left: govuk-spacing(2);
+      margin-bottom: govuk-spacing(3);
     }
 
     .facets__header {
-      padding: govuk-spacing(3) 0 govuk-spacing(2);
+      padding: 0 0 govuk-spacing(3) 0;
       border-bottom: 1px solid $govuk-border-colour;
-      margin: 0 govuk-spacing(3) 0 govuk-spacing(3);
       @supports (display: grid) {
         display: grid;
         grid-auto-flow: column;
       }
     }
 
-    .facets__content {
-      padding: govuk-spacing(2) govuk-spacing(3) 0;
-    }
-
     .facets__footer {
       display: block;
-      margin: govuk_spacing(3);
+      margin-top: govuk_spacing(3);
+      margin-bottom: govuk_spacing(3);
     }
 
     .facets__return-link {
@@ -98,4 +104,14 @@
       display: block;
     }
   }
+}
+
+.mobile-filters-expander__icon {
+  display: none;
+  position: absolute;
+  top: -2px;
+  left: -8px;
+  width: 25px;
+  height: 25px;
+  fill: #0b0c0c;
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -40,6 +40,8 @@ mark {
 }
 
 .filter-form {
+  position: relative;
+
   .js-enabled & .button__wrapper {
     display: none;
   }

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -11,11 +11,11 @@
 %>
 <% if title %>
   <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load } do %>
-    <h2 class="app-c-expander__heading">
+    <h3 class="app-c-expander__heading">
       <span class="app-c-expander__title js-toggle"><%= title %></span>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
-    </h2>
+    </h3>
     <div class="app-c-expander__content js-content <%= 'app-c-expander__content--visible' if open_on_load %>" id="<%= content_id %>">
       <%= yield %>
     </div>

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -33,11 +33,11 @@
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
   <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >
-  <h2 class="app-c-option-select__heading js-container-heading">
+  <h3 class="app-c-option-select__heading js-container-heading">
     <span class="app-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
-  </h2>
+  </h3>
   <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>" tabindex="-1">
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,4 +1,11 @@
 <div class="filter-form">
+  <% if content_item.all_content_finder? %>
+    <%= render partial: 'filter_button'%>
+  <% elsif !content_item.all_content_finder? %>
+    <% if facets.select(&:filterable?).any? %>
+      <%= render partial: 'filter_button'%>
+    <% end %>
+  <% end %>
   <% if !content_item.all_content_finder? %>
     <div id="keywords" role="search" aria-label="<%= content_item.title %>">
       <% label_text = capture do %>
@@ -27,24 +34,16 @@
 
     <div id="facet-wrapper" data-module="mobile-filters-modal" class="facets" role="search" aria-label="Search filters">
       <div class="facets__box">
+        <h2 class='govuk-visually-hidden'>Filter</h2>
         <div class="facets__header">
           <div>
             <%= render "govuk_publishing_components/components/heading", {
-              text: "Filter",
-              heading_level: 1,
-              font_size: "xl",
-              margin_bottom: 2
-            } %>
-            <%= render "govuk_publishing_components/components/heading", {
               text: sanitize("<span class=\"js-result-count govuk-!-font-weight-regular\">#{result_set_presenter.displayed_total}</span>"),
-              heading_level: 2,
+              heading_level: 3,
               font_size: "s",
               margin_bottom: 0
             } %>
           </div>
-          <button class="app-c-button-as-link facets__return-link js-close-filters" type="button">
-            Return to results
-          </button>
         </div>
         <div class="facets__content">
           <%= render facets.select(&:filterable?) %>
@@ -56,11 +55,14 @@
           </button>
         </div>
         <div class="facets__footer">
-          <%= render "govuk_publishing_components/components/button", {
-            text: sanitize("Show search results"),
-            classes: "js-close-filters js-show-results"
+        <%= render "govuk_publishing_components/components/button", {
+            text: "Go to search results",
+            href: "#js-results",
+            data_attributes: {
+              module: "govuk-skip-link",
+            }
           } %>
-        </div>
+      </div>
       </div>
     </div>
   <% end %>

--- a/app/views/finders/_filter_button.html.erb
+++ b/app/views/finders/_filter_button.html.erb
@@ -1,4 +1,4 @@
-<button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"
+<button class="app-c-button-as-link app-mobile-filters-link js-toggle-mobile-filters"
   data-toggle="mobile-filters-modal"
   data-target="facet-wrapper"
   data-track-category="filterClicked"
@@ -7,3 +7,5 @@
     Filter <span class="govuk-visually-hidden"> results</span>
     <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
 </button>
+<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"></path></svg>
+<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"></path></svg>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -64,14 +64,6 @@
                   margin_bottom: 2,
                   } %>
 
-                <% if content_item.all_content_finder? %>
-                  <%= render partial: 'filter_button'%>
-                <% elsif !content_item.all_content_finder? %>
-                  <% if facets.select(&:filterable?).any? %>
-                    <%= render partial: 'filter_button'%>
-                  <% end %>
-                <% end %>
-
                 <div data-track-category="filterClicked"
                     data-track-action="skip-Link" data-track-label="">
                   <%= render "govuk_publishing_components/components/skip_link", {

--- a/spec/javascripts/modules/mobile-filters-modal.spec.js
+++ b/spec/javascripts/modules/mobile-filters-modal.spec.js
@@ -7,16 +7,13 @@ describe('Mobile filters modal', function () {
     container = document.createElement('div')
     container.innerHTML =
     '<form method="get" class="js-live-search-form">' +
-    '<button class="app-c-button-as-link app-mobile-filters-link js-show-mobile-filters"' +
+    '<button class="app-c-button-as-link app-mobile-filters-link js-toggle-mobile-filters"' +
       'data-toggle="mobile-filters-modal" data-target="facet-wrapper">Filter' +
     '</button>' +
     '<div id="facet-wrapper" data-module="mobile-filters-modal" class="facets">' +
       '<div class="facets__box">' +
         '<div class="facets__header">' +
-          '<h1 class="gem-c-title__text">Filter</h1>' +
-          '<button class="app-c-button-as-link facets__return-link js-close-filters" type="button">' +
-            'Return to results' +
-          '</button>' +
+          '<h2 class="gem-c-title__text">Filter</h2>' +
         '</div>' +
         '<div class="facets__content">' +
           '<select>' +
@@ -34,9 +31,9 @@ describe('Mobile filters modal', function () {
           '</button>' +
         '</div>' +
         '<div class="facets__footer">' +
-          '<button class="gem-c-button govuk-button js-close-filters" type="button">' +
-            'Show <span class="js-result-count">9<span>' +
-          '</button>' +
+          '<a class="gem-c-button govuk-button" role="button" data-module="govuk-button govuk-skip-link" draggable="false" href="#js-results" data-govuk-button-module-started="true" data-govuk-skip-link-module-started="true">' +
+            'Go to search results' +
+          '</a>' +
         '</div>' +
       '</div>' +
     '</div>' +
@@ -58,26 +55,21 @@ describe('Mobile filters modal', function () {
 
   describe('open button', function () {
     beforeEach(function () {
-      document.querySelector('.js-show-mobile-filters').click()
+      document.querySelector('.js-toggle-mobile-filters').click()
     })
 
     afterEach(function () {
-      document.querySelector('.js-close-filters').click()
+      document.querySelector('.js-toggle-mobile-filters').click()
     })
 
     it('should show the modal', function () {
       var modal = document.querySelector('.facets')
       expect($(modal).hasClass('facets--visible')).toBe(true)
     })
-  })
 
-  describe('close button', function () {
     it('should hide the modal', function () {
-      document.querySelector('.js-show-mobile-filters').click()
-      document.querySelector('.js-close-filters').click()
-
       var modal = document.querySelector('.facets')
-      document.querySelector('.js-close-filters').click()
+      document.querySelector('.js-toggle-mobile-filters').click()
       expect($(modal).hasClass('facets--visible')).toBe(false)
     })
   })
@@ -96,11 +88,6 @@ describe('Mobile filters modal', function () {
     it('should show the modal', function () {
       var modal = document.querySelector('.facets')
       expect($(modal).hasClass('facets--visible')).toBe(true)
-    })
-
-    it('should focus the modal', function () {
-      var modalFocused = document.querySelector('.facets__box')
-      expect(modalFocused).toBeTruthy()
     })
   })
 
@@ -122,6 +109,25 @@ describe('Mobile filters modal', function () {
       expect($(modal).find('input[type="text"]')
         .filter(function () { return $(this).val() }).length).toBe(0)
       expect($(modal).find('select').val()).toBe('')
+    })
+  })
+
+  describe('accessibility', function () {
+    it('should add aria-expanded="false" on load to the Filter button', function () {
+      var button = document.querySelector('.js-toggle-mobile-filters')
+      expect(button.getAttribute('aria-expanded')).toEqual('false')
+    })
+
+    it('should set aria-expanded to true when clicking the Filter button', function () {
+      var button = document.querySelector('.js-toggle-mobile-filters')
+      button.click()
+      expect(button.getAttribute('aria-expanded')).toEqual('true')
+    })
+
+    it('should add aria-controls on load to the Filter button', function () {
+      var button = document.querySelector('.js-toggle-mobile-filters')
+      expect(button.getAttribute('aria-controls')).toEqual('facet-wrapper')
+      expect(document.querySelector('#facet-wrapper')).not.toEqual(null)
     })
   })
 })


### PR DESCRIPTION
## What

- Changes the Filters on mobile from being a modal/popup, to a regular "In Page" element thats visibility is triggered by a `<button>` styled as a link.
- Fixes a bug where the amount of filters you selected would not disappear after clicking "Clear all filters". This was because `<span>` was not included in elements to remove in the JS code for this.
- Fixes a visual bug where on Desktop/Tablet, the Topic and Subtopics filters had a `min-width` which would make them spill over onto the search results.

## Why
- The filters change was needed as part of our accessibility fixes.


## Testing

To test, you don't need any local static. You can just use `../startup.sh --live`. Then navigate to http://127.0.0.1:3062/search/all and reduce your screen size until it's a mobile view.

Accessibility wise, I have tested the keyboard functionality, MacOS VoiceOver, Android Talkback, JAWS, NVDA, Lighthouse, WebAim WAVE, navigating at 400% zoom, the behaviour when JavaScript is disabled, and checked the heading structure with headingsMap.

## Visual Changes

### Before - Mobile Filters
https://user-images.githubusercontent.com/8880610/219028588-90215c3a-a271-44fe-82dd-3827611d7d92.mov

### After - Mobile Filters

https://user-images.githubusercontent.com/8880610/219028825-f43558c7-69c5-4f81-8e06-8e8444823432.mov

## Before - Visual Bug
<img width="672" alt="image" src="https://user-images.githubusercontent.com/8880610/219028991-0f812d1a-07ee-4d04-8ee3-bcf4031b982d.png">

## After - Visual Bug

<img width="671" alt="image" src="https://user-images.githubusercontent.com/8880610/219029163-45dd6140-2476-468c-a015-ca27a341cbbc.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

This is a draft PR for an accessibility fix, the code will change quite a bit and we cleaned up before it is ready for a PR.