### PR TITLE
Add option to remove top border on first list item

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -50,6 +50,10 @@ class ResultSetPresenter
     presenter[:options].find { |o| o[:selected] }
   end
 
+  def has_sort_options
+    sort_presenter.to_hash.blank? ? true : false
+  end
+
 private
 
   attr_reader :metadata_presenter_class, :sort_presenter, :total, :documents, :facets, :content_item

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -5,7 +5,8 @@
 <div class="finder-results js-finder-results">
   <%= render "govuk_publishing_components/components/document_list", {
     items: local_assigns[:document_list_component_data],
-    remove_underline: true
+    remove_underline: true,
+    remove_top_border_from_first_child: result_set_presenter.has_sort_options
   } %>
 </div>
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -53,7 +53,7 @@
         <% end %>
         data-module="gem-track-click"
         >
-        <div id="js-search-results-info" data-module="remove-filter" class="result-info">
+        <div id="js-search-results-info" data-module="remove-filter" class="result-info <%= "govuk-!-margin-bottom-0" if result_set_presenter.has_sort_options %>">
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <div class="result-info__header">


### PR DESCRIPTION
## What
https://trello.com/c/dhg330gw/1785-remove-grey-top-border-on-the-top-item-on-the-list-on-specialist-finders

On specialist finder pages (or finder pages where no sort options are rendered) a double border is seen since no sort options are displayed (see _before_ screenshot below). The border on the first document list item should be removed. On the main search results page https://www.gov.uk/search/all?keywords=parliament&order=relevance the top border on the first document list item is necessary to visually separate the sort options from the document list.

For any specialist finder pages (or finder pages with no sort options) it should be true.

- Add option `remove_top_border_from_first_child` to remove the top border from the first item of the document list
- Amend spacing when there are no sort options for consistent item spacing

**Review URL(s)**

- https://finder-frontend-pr-2994.herokuapp.com/aaib-reports
- https://finder-frontend-pr-2994.herokuapp.com/search/all (unchanged)

## Why
On some finder pages e.g. [Air Accidents Investigation Branch reports](https://www.gov.uk/aaib-reports) a double border can be seen when no sort options are present.

The option `remove_top_border_from_first_child` will remove the top border from the first item only.

## Visual Changes
### Before (Air Accidents Investigation Branch reports)
<img src="https://user-images.githubusercontent.com/87758239/215546610-f0f0b186-cfd8-4693-aec6-424c4caab343.png" width="660" style="max-width: 100%;">

### After (Air Accidents Investigation Branch reports)
<img src="https://user-images.githubusercontent.com/87758239/216602420-b051976e-f2ac-497a-be06-44bb08d7bdef.png" width="660" style="max-width: 100%;">

<img src="https://user-images.githubusercontent.com/87758239/216602439-c2a49ec6-c300-4bdd-bad2-9f6dce93f02c.png" width="660" style="max-width: 100%;">