### PR TITLE
Add research banner for UKMCAB

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/document-list";
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/metadata";
 @import "govuk_publishing_components/components/phase-banner";

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -295,6 +295,10 @@ mark {
   }
 }
 
+.gem-c-intervention {
+  margin-bottom: 0;
+}
+
 .app-c-button-as-link {
   padding: 0;
   border-width: 0;

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,4 +1,6 @@
 class FindersController < ApplicationController
+  include ResearchBannerHelper
+
   layout "finder_layout"
 
   before_action do
@@ -11,6 +13,8 @@ class FindersController < ApplicationController
     respond_to do |format|
       format.html do
         raise UnsupportedContentItem unless content_item.is_finder?
+
+        @show_banner = show_banner?(request.path)
 
         if legacy_params_present?
           transform_legacy_announcement_params_and_redirect if content_item.base_path == "/search/news-and-communications"

--- a/app/helpers/research_banner_helper.rb
+++ b/app/helpers/research_banner_helper.rb
@@ -1,0 +1,7 @@
+module ResearchBannerHelper
+  UKMCAB_FINDER = "/uk-market-conformity-assessment-bodies".freeze
+
+  def show_banner?(path)
+    UKMCAB_FINDER == path
+  end
+end

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,6 +13,15 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
 
+  <% if @show_banner %>
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve the UKMCAB service",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: "https://forms.office.com/e/ptRdu5Ci3s",
+      new_tab: true,
+    } %>
+  <% end %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>

--- a/spec/helpers/research_banner_helper_spec.rb
+++ b/spec/helpers/research_banner_helper_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe ResearchBannerHelper, type: :helper do
+  include ResearchBannerHelper
+
+  context "for the UKMCAB finder" do
+    subject(:subject) { show_banner?("/uk-market-conformity-assessment-bodies") }
+
+    it "should display the banner" do
+      expect(subject).to be_truthy
+    end
+  end
+
+  context "for other finders" do
+    subject(:subject) { show_banner?("/lunch-finder") }
+
+    it "should not display the banner" do
+      expect(subject).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Adds banner to `/uk-market-conformity-assessment-bodies` UKMCAB finder that links to their external form.

[Trello](https://trello.com/c/o36muRbv/1602-banner-request-ukmcab-landing-page-m)

## Screenshots

### Before

![www gov uk_uk-market-conformity-assessment-bodies(iPhone SE)](https://user-images.githubusercontent.com/424772/217303524-fa94479f-f7b5-4f80-9c21-b18a9a8bb3a0.png)

![www gov uk_uk-market-conformity-assessment-bodies(iPad Air)](https://user-images.githubusercontent.com/424772/217303552-0325bd8a-68d1-4105-be8a-5c4ab8bedfc2.png)

### After

![localhost_3062_uk-market-conformity-assessment-bodies(iPhone SE)](https://user-images.githubusercontent.com/424772/217303571-8364eb9d-6f76-4e38-b1c3-08a9ce75dc2f.png)

![localhost_3062_uk-market-conformity-assessment-bodies(iPad Air)](https://user-images.githubusercontent.com/424772/217303585-208350fa-4279-4708-85d8-9de99ac008bb.png)
