### PR TITLE
Add ga4 ecommerce attribute

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -96,6 +96,7 @@ private
     return {} unless @include_ecommerce
 
     {
+      ga4_ecommerce_path: link,
       ecommerce_path: link,
       ecommerce_row: 1,
       ecommerce_index: document.index,

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe ResultSetPresenter do
             description: "document_description",
             data_attributes: {
               ecommerce_path: "/path/to/doc",
+              ga4_ecommerce_path: "/path/to/doc",
               ecommerce_row: 1,
               ecommerce_index: 1,
               track_category: "navFinderLinkClicked",

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe SearchResultPresenter do
           path: link,
           description: "I am a document. I am full of words and that.",
           data_attributes: {
+            ga4_ecommerce_path: link,
             ecommerce_path: link,
             ecommerce_row: 1,
             ecommerce_index: 1,
@@ -106,6 +107,7 @@ RSpec.describe SearchResultPresenter do
               path: "#{link}/part-path",
               description: "Part description",
               data_attributes: {
+                ga4_ecommerce_path: "#{link}/part-path",
                 ecommerce_path: "#{link}/part-path",
                 ecommerce_row: 1,
                 ecommerce_index: 1,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds a `data-ga4-ecommerce-path` attribute to individual search results in addition to the pre-existing `data-ecommerce-path` attribute.

## Why
This attribute has been added in order to improve the naming conventions of the data attributes that we use for GA4 tracking and it reduces the risk of the GA4 data attributes from being removed accidentally. It does not replace the `data-ecommerce-path` attribute as that would break the UA tracking.

## Visual changes
None.