### PR TITLE
Fix space not being read in visually hidden text

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,5 +1,20 @@
 $app-colour-true-black: #000000;
 
+.app-visually-hidden {
+  // The current .govuk-visually-hidden uses absolute positioning. This has the
+  // unintended consequence of removing any necessary whitespace before and
+  // after the visually hidden element, and potentially making screen reader
+  // announcements unintelligble. To fix this, insert a space character before
+  // and after the visually hidden element.
+  &:before {
+    content: "\00a0";
+  }
+
+  &:after {
+    content: "\00a0";
+  }
+}
+
 .metadata-summary {
   @include govuk-font(19);
   margin-bottom: govuk-spacing(6);

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -26,7 +26,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>
       <%= render "govuk_publishing_components/components/heading", {
-        text: sanitize("Search <span class='govuk-visually-hidden'>all content</span>"),
+        text: sanitize("Search <span class='govuk-visually-hidden app-visually-hidden'>all content</span>"),
         heading_level: 1,
         font_size: "xl",
         margin_bottom: 4


### PR DESCRIPTION
## What
On the GOV.UK search results page, the H1 contains the word "Search" followed by the visually hidden text, "all content". However, JAWS and NVDA on Chrome, Edge and IE11 announce it as  "searchall content", with the space character prior to the visually hidden text not announced. 

`.govuk-visually-hidden` uses `position: absolute` as a fallback for older browsers that don't support `clip-path`. The bug arises from the fact that when the visually hidden element taken out of the page flow with absolute positioning, the space before the text gets removed as the element is no longer relative to the rest of the page. The removal of the space can be seen visually in modern browsers, and by inspecting the accessibility tree: the value of the visually hidden content in the accessibility tree is "all content" (no whitespace), but without `position: absolute` it is " all content". 

## Why 
This came up in user research, with the user saying that it was challenging to understand the JAWS announcement of the GOV.UK search page results heading. This is also a known issue which has previously been reported to JAWS: alphagov/reported-bugs#51. An equivalent bug also happens when the visually hidden text appears _before_ the visible text, for instance on gov.uk/travel-advice. Here, JAWS announces the heading as "Countries starting withA" (although for some reason NVDA interprets the space correctly here). 

## The fix
To fix this, insert a space character using pseudo elements before and after the visually hidden text. This tests well in all screen readers, regardless of whether the whitespace is before the visually hidden text ("Search _all content_"), after the visually hidden text ("_Countries starting with_ A") or where the heading text is only made up visually hidden text ("_Navigation menu_"). The only slight issue I found is that Mac VoiceOver in Safari explicitly announces the inserted spare characters when navigating by headings - but this is unlikely to block any users and the user numbers for Mac VoiceOver are small compared to other assistive technologies. 

This fix only addresses the issue in one place but we should also add it to the headings on gov.uk/travel-advice, or otherwise contribute the fix upstream to the GOV.UK Design System.

### Before (JAWS 2023)
<img width="300" alt="Search all content is being read out as searchall content by JAWS" src="https://github.com/alphagov/finder-frontend/assets/5007934/8c550768-c669-4ed4-a606-c6ed1fa3885e">

### After  (JAWS 2023)
<img width="300" alt="Search all content is now correctly read out by JAWS" src="https://github.com/alphagov/finder-frontend/assets/5007934/1445a94a-4c51-4a88-a075-99c40f737808">

### Before   (JAWS 2023)
<img width="300" alt="Screenshot 2023-06-15 at 11 22 59" src="https://github.com/alphagov/finder-frontend/assets/5007934/62a146aa-299f-48cd-b730-3cbd3beea26c">

### After  (JAWS 2023)
<img width="300" alt="Screenshot 2023-06-15 at 11 23 21" src="https://github.com/alphagov/finder-frontend/assets/5007934/dc882d7a-e1cf-418b-be1c-0997f703ec27">

### Testing results

#### Screen readers
✅ JAWS 2022 / Chrome
✅ JAWS 2023 / Chrome
✅ JAWS 2023 / IE 11
✅ JAWS 2023 / Edge
✅ NVDA / Firefox
✅ NVDA / Chrome
✅ NVDA / Edge
✅ Voiceover / Mac Safari 
❎  Voiceover / iOS Safari 
✅ Talkback / Chrome  Android

iOS VoiceOver announces the heading as two items with all the different fixes tested (including the current live version), apart from the `aria-label` solution which fixes the issue but cannot be used as it has other issues as documented below. This iOS issue has previously been reported [here](https://github.com/alphagov/govuk-frontend/issues/1643#issuecomment-696776658) - we might consider looking at this as a separate ticket or it might be something that's better worked on as part of the Design System. 

#### Browsers and devices
I was testing that there is no visual difference in the element with the pseudo element space characters.

✅ Edge 
✅ Firefox (Mac and Windows, and when user sets their own custom colours)
✅ Chrome (Mac and Windows)
✅ IE 11
✅ Safari Mac
 Safari iOS
✅ Samsung Internet (Android)
✅ Firefox (Android)
✅ Chrome (Android)
 Samsung Internet
✅  Firefox (Android)

#### Other modes tested
✅  Print styles
✅  Hidden and unhidden like `govuk-visually-hidden` when CSS fails to load

[Full testing spreadsheet](https://docs.google.com/spreadsheets/d/1m3-2dxB-uL3drew2jBK1u4HJ-SE2K07fGj_9wMGnSlY/edit#gid=1660522675)

## Other fixes that were explored
I also looked into using `opacity: 0` - this tested well in all screen readers and browsers, with the text visually hidden but accessible to assistive technologies. However, as it doesn't remove the element from the page flow, long visually hidden text would end up wrapping and pushing other elements down the page. 

Another alternative, also [explored on the original ticket](https://github.com/alphagov/govuk-frontend/issues/1643#issuecomment-582444654) would be to use a non-breaking space `&nbsp;`. This also tested well, but wouldn't fix the underlying problem but would be more of a manual fix which might also get removed by mistake by the next person working on the piece of code.

Another alternative would have been to use `aria-label` with "Search all content" but this doesn't get announced at all by JAWS and Mac VoiceOver (even though it fixes the iOS VoiceOver issue and [seems to be allowable content on headings](https://www.w3.org/TR/wai-aria/#aria-label)).

I also checked whether just moving the current whitespace from being outside the visually hidden text (it's currently set as "Search " and "all content") to inside the visually hidden text (so "Search" and " all content") would fix the current issue but there was no difference in screen reader announcements.

Fixes https://trello.com/c/T9erwGTG/1661-a-space-is-not-included-between-some-words-which-means-they-may-not-be-pronounced-correctly-by-some-screen-reader-software-675-m, [Jira issue NAV-8448](https://gov-uk.atlassian.net/browse/NAV-8448)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
