### PR TITLE
Add new large variation to option-select component

### DIFF
--- a/app/assets/stylesheets/components/_option-select.scss
+++ b/app/assets/stylesheets/components/_option-select.scss
@@ -94,6 +94,10 @@
   }
 }
 
+.app-c-option-select__container--large {
+  max-height: 600px;
+}
+
 .app-c-option-select__container-inner {
   padding: govuk-spacing(1) 13px;
 }
@@ -130,6 +134,10 @@
 
   .app-c-option-select__container {
     height: 200px;
+  }
+
+  .app-c-option-select__container--large {
+    height: 600px;
   }
 
   [data-closed-on-load="true"] .app-c-option-select__container {

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -31,6 +31,10 @@ class Facet
     facet["hide_facet_tag"] || false
   end
 
+  def large?
+    facet["large"] || false
+  end
+
   def filterable?
     facet["filterable"] || false
   end

--- a/app/views/components/_option-select.html.erb
+++ b/app/views/components/_option-select.html.erb
@@ -3,6 +3,10 @@
   checkboxes_id = "checkboxes-#{SecureRandom.hex(4)}"
   checkboxes_count_id = checkboxes_id + "-count"
   show_filter ||= false
+  large ||= false
+
+  classes = %w[app-c-option-select__container js-options-container]
+  classes << "app-c-option-select__container--large" if large
 %>
 
 <% if show_filter %>
@@ -38,7 +42,8 @@
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </h3>
-  <div role="group" aria-labelledby="<%= title_id %>" class="app-c-option-select__container js-options-container" id="<%= options_container_id %>" tabindex="-1">
+
+  <%= content_tag(:div, role: "group", aria: { labelledby: title_id }, class: classes, id: options_container_id, tabindex: "-1") do %>
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>"
@@ -58,5 +63,5 @@
         items: options
       } %>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/components/docs/option-select.yml
+++ b/app/views/components/docs/option-select.yml
@@ -249,3 +249,95 @@ examples:
       - value: trinidad
         label: Trinidad & Tobago
         id: trinidad
+  large:
+    description: When `large` is set to `true`, the option-select container has an increased max-height of 600px, allowing more checkbox items to be visible.
+    data:
+      key: large_demo
+      title: Countries
+      options_container_id: list_of_countries_to_filter_large
+      large: true
+      options:
+      - value: afghanistan
+        label: Afghanistan
+        id: afghanistanLargeExample
+      - value: albania
+        label: Albania
+        id: albaniaLargeExample
+      - value: algeria
+        label: Algeria
+        id: algeriaLargeExample
+      - value: american_samoa
+        label: American Samoa
+        id: american_samoaLargeExample
+      - value: andorra
+        label: Andorra
+        id: andorraLargeExample
+      - value: angola
+        label: Angola
+        id: angolaLargeExample
+      - value: anguilla
+        label: Anguilla
+        id: anguillaLargeExample
+      - value: antigua_and_barbuda
+        label: Antigua and Barbuda
+        id: antigua_and_barbudaLargeExample
+      - value: argentina
+        label: Argentina
+        id: argentinaLargeExample
+      - value: armenia
+        label: Armenia
+        id: armeniaLargeExample
+      - value: aruba
+        label: Aruba
+        id: arubaLargeExample
+      - value: australia
+        label: Australia
+        id: australiaLargeExample
+      - value: austria
+        label: Austria
+        id: austriaLargeExample
+      - value: azerbaijan
+        label: Azerbaijan
+        id: azerbaijanLargeExample
+      - value: bahamas
+        label: Bahamas
+        id: bahamasLargeExample
+      - value: bahrain
+        label: Bahrain
+        id: bahrainLargeExample
+      - value: bangladesh
+        label: Bangladesh
+        id: bangladeshLargeExample
+      - value: barbados
+        label: Barbados
+        id: barbadosLargeExample
+      - value: belarus
+        label: Belarus
+        id: belarusLargeExample
+      - value: belgium
+        label: Belgium
+        id: belgiumLargeExample
+      - value: belize
+        label: Belize
+        id: belizeLargeExample
+      - value: benin
+        label: Benin
+        id: beninLargeExample
+      - value: bermuda
+        label: Bermuda
+        id: bermudaLargeExample
+      - value: bhutan
+        label: Bhutan
+        id: bhutanLargeExample
+      - value: bolivia
+        label: Bolivia
+        id: boliviaLargeExample
+      - value: cote
+        label: Cote d'Ivoire
+        id: coteLargeExample
+      - value: sthelena
+        label: St Helena, Ascension and Tristan da Cunha
+        id: sthelenaLargeExample
+      - value: trinidad
+        label: Trinidad & Tobago
+        id: trinidadLargeExample

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -6,7 +6,8 @@
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
     :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
-    :show_filter => option_select_facet.show_option_select_filter
+    :show_filter => option_select_facet.show_option_select_filter,
+    :large => option_select_facet.large?
   }
   %>
 <% end %>

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -79,6 +79,14 @@ describe "components/_option-select.html.erb", type: :view do
     expect(rendered).to have_selector("\#list-of-sectors.app-c-option-select__container")
   end
 
+  it "renders the large version of the component" do
+    arguments = option_select_arguments
+    arguments[:large] = true
+    render_component(arguments)
+
+    expect(rendered).to have_selector(".app-c-option-select__container--large")
+  end
+
   it "can begin with the options box closed on load" do
     arguments = option_select_arguments
     arguments[:closed_on_load] = true


### PR DESCRIPTION
## What

Add new large variation to option-select component. When `large` is set to `true`, the max height is increased to 600px, allowing more items to be visible.

## Why

This will allow for better use of space, especially on larger screens when only a couple of facets are used on the page.

Trello: https://trello.com/c/Urpavm6J/1886-increase-the-height-of-the-industries-facet-filter-box

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
