### PR TITLE
Add support for `open_on_load` facet option

### DIFF
--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -58,6 +58,12 @@ class OptionSelectFacet < FilterableFacet
     { key => selected_values.map { |value| value["value"] } }
   end
 
+  def closed_on_load?(option_select_facet_counter)
+    return false if open_on_load?
+
+    closed_by_default?(option_select_facet_counter)
+  end
+
 private
 
   def value_fragments
@@ -78,5 +84,13 @@ private
         @value.include?(option["value"])
       end
     end
+  end
+
+  def open_on_load?
+    facet["open_on_load"] || false
+  end
+
+  def closed_by_default?(option_select_facet_counter)
+    option_select_facet_counter.positive? && unselected?
   end
 end

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -5,7 +5,7 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => option_select_facet_counter > 0 && option_select_facet.unselected?,
+    :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
     :show_filter => option_select_facet.show_option_select_filter
   }
   %>


### PR DESCRIPTION
## What

Adds a new `open_on_load` input to the option-slect component. When this is set to `true`, the option-select facet will always be in the open state on page load, overriding the default logic set in the component.

By default, the first option-select component on the page will be open, additional option select components will only be open if they have any items selected.

## Why

Allows for better control of over when an option select facet should be open on page load.

Trello: https://trello.com/c/WpDLBxS1/1885-expand-both-location-and-industry-filters-by-default

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
