### PR TITLE
Disable LTR for specialist finder path

### DIFF
--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -234,6 +234,10 @@ module Search
     end
 
     def ab_query
+      # We're using the ab test relevance:disable params here to turn off LTR for this
+      # finder. It would probably be best in the long run to create a specific way of
+      # doing this that uses a proper parameter, but we can't do that at the moment.
+      ab_params.merge!("relevance" => "disable") if licence_transaction_path?
       ab_params.any? ? { "ab_tests" => ab_params.map { |k, v| "#{k}:#{v}" }.join(",") } : {}
     end
 


### PR DESCRIPTION
Disables LTR ranking using the existing licence_transaction_path? method in the QueryBuilder.

Use hardcoded utility function introducted to catch boosts
and also turn off LTR ranking using ab_tests=disable:relevance
on that path, which improves search results on the licence
finder.

We're using the ab parameters relevance:disable to do this.
Since this isn't strictly an A/B thing it feels a bit wrong to
use this parameter, but it's all that's available to us at the
moment. We'll add a tech debt card to examine making this a
proper parameter.

https://trello.com/c/q3JBrj5U/1970-outcome-of-spike-switch-off-learn-to-rank

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
