### PR TITLE
Add boost fields query for licence finder 

### DIFF
--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -31,6 +31,7 @@ module Search
         debug_query,
         ab_query,
         suggest_query,
+        boost_fields_query,
       ].reduce(&:merge)
 
       return [base_query] if filter_queries.empty?
@@ -238,6 +239,16 @@ module Search
 
     def suggest_query
       { "suggest" => "spelling_with_highlighting" }
+    end
+
+    def boost_fields_query
+      return {} unless licence_transaction_path?
+
+      { "boost_fields" => "licence_transaction_industry" }
+    end
+
+    def licence_transaction_path?
+      finder_content_item.base_path == "/find-licences"
     end
 
     def stopwords

--- a/spec/lib/search/search_query_builder_spec.rb
+++ b/spec/lib/search/search_query_builder_spec.rb
@@ -238,6 +238,18 @@ describe Search::QueryBuilder do
       end
     end
 
+    context "with field boosts" do
+      let(:finder_content_item) do
+        ContentItem.new(
+          "base_path" => "/find-licences",
+        )
+      end
+
+      it "should include field boosts for eligible content items" do
+        expect(query).to include("boost_fields" => "licence_transaction_industry")
+      end
+    end
+
     context "without stopwords" do
       let(:params) do
         {


### PR DESCRIPTION
This adds a new query param that tells Search API to weight matches
against licence_transaction_industry field higher than indexable_content
(body etc).

More info in the PR implementing the change [1].

[1]: https://github.com/alphagov/search-api/pull/2552

Depends on:

- https://github.com/alphagov/finder-frontend/pull/3030

Trello:
https://trello.com/c/VhsBND5i/1888-boost-industry-field

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

