### PR TITLE
Add GA4 finder "change" tracker

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -1,0 +1,159 @@
+//= require govuk/vendor/polyfills/Element/prototype/closest.js
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.analyticsGa4 = GOVUK.analyticsGa4 || {}
+
+  GOVUK.analyticsGa4.Ga4FinderTracker = {
+
+    // Finds the parent div containing the filters. Loops through each child div that has data-ga4-section on it . Sets an index on each of these child divs.
+    setFilterIndexes: function () {
+      var filterContainer = document.querySelector('[data-ga4-filter-container]')
+
+      if (!filterContainer) {
+        return
+      }
+
+      var filterSections = filterContainer.querySelectorAll('[data-ga4-section]')
+
+      for (var i = 0; i < filterSections.length; i++) {
+        filterSections[i].setAttribute('data-ga4-index', JSON.stringify({ index_section: i + 1, index_section_count: filterSections.length }))
+      }
+    },
+
+    // Called when the search results updates. Takes the event target, and a string containing the type of change and element type. Creates the GTM schema and pushes it.
+    // changeEventMetadata is a string referring to the type of form change and the element type that triggered it. For example 'update-filter checkbox'.
+    trackChangeEvent: function (eventTarget, changeEventMetadata) {
+      changeEventMetadata = changeEventMetadata.split(' ')
+      var section = eventTarget.closest('[data-ga4-section]')
+      var changeType = changeEventMetadata[0]
+      var elementType = changeEventMetadata[1]
+
+      if ((!changeType || !elementType) && changeType !== 'clear-all-filters') {
+        console.warn('GA4 Finder tracker incorrectly configured for element: ' + eventTarget)
+        return
+      }
+
+      var schema = new GOVUK.analyticsGa4.Schemas().eventSchema()
+      schema.event = 'event_data'
+      schema.event_data.type = 'finder'
+      schema.event_data.event_name = 'select_content'
+
+      var elementInfo = this.getElementInfo(eventTarget, elementType, section)
+      var elementValue = elementInfo.elementValue
+      schema.event_data.text = elementValue
+
+      var wasFilterRemoved = elementInfo.wasFilterRemoved
+      schema = this.setSchemaBasedOnChangeType(schema, elementValue, elementType, wasFilterRemoved, changeType, section)
+
+      window.GOVUK.analyticsGa4.core.sendData(schema)
+    },
+
+    // Grabs the value from the eventTarget. Checks if the filter was removed if the eventTarget is unchecked, set back to default, or has its user input removed. Returns the results as an object.
+    getElementInfo: function (eventTarget, elementType, section) {
+      var elementValue = ''
+      var defaultValue
+      var wasFilterRemoved = false
+
+      switch (elementType) {
+        case 'checkbox':
+          var checkboxId = eventTarget.id
+
+          // The "value" we need for a checkbox is the label text that the user sees beside the checkbox.
+          elementValue = document.querySelector("label[for='" + checkboxId + "']").textContent
+
+          // If the checkbox is unchecked, the filter was removed.
+          wasFilterRemoved = !eventTarget.checked
+          break
+
+        case 'radio':
+          var radioId = eventTarget.id
+
+          // The "value" we need for a radio is the label text that the user sees beside the checkbox.
+          elementValue = document.querySelector("label[for='" + radioId + "']").textContent
+          defaultValue = section.querySelector('input[type=radio]:first-of-type')
+
+          if (eventTarget.id === defaultValue.id) {
+            // Radio elements being reverted to their first option (i.e. their default value) count as a "removed filter".
+            wasFilterRemoved = true
+          }
+          break
+
+        case 'select':
+          // The value of a <select> is the value attribute of the selected <option>, which is a hyphenated key. We need to grab the human readable label instead for tracking.
+          elementValue = eventTarget.querySelector("option[value='" + eventTarget.value + "']").textContent
+          defaultValue = eventTarget.querySelector('option:first-of-type').textContent
+
+          if (elementValue === defaultValue) {
+            // <select> elements being reverted to their first option (i.e. their default value) count as a "removed filter". (This will be used on the filter <select>s but not the sort by <select>, as you can't "remove" the sort by filter.)
+            wasFilterRemoved = true
+          }
+          break
+
+        case 'text':
+          elementValue = eventTarget.value
+          if (elementValue === '') {
+            // If our custom date filters are reset, they become an empty text box, so we count this as a "removed filter". This boolean won't be used for the keyword search box, as deleting the keyword isn't considered removing a filter.
+            wasFilterRemoved = true
+          }
+          break
+      }
+
+      return { elementValue: elementValue, wasFilterRemoved: wasFilterRemoved }
+    },
+
+    // Takes the GTM schema, the event target value, the event target HTML type, wether the filter was removed, the type of filter change it was, and the parent section heading. Populates the GTM object based on these values.
+    setSchemaBasedOnChangeType: function (schema, elementValue, elementType, wasFilterRemoved, changeType, section) {
+      var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
+
+      switch (changeType) {
+        case 'update-filter':
+          if (section) {
+            schema.event_data.section = section.getAttribute('data-ga4-section')
+          }
+
+          if (wasFilterRemoved) {
+            schema.event_data.action = 'remove'
+            schema.event_data.text = elementType === 'text' ? undefined : elementValue
+          } else {
+            schema.event_data.action = elementType === 'text' ? 'search' : 'select'
+            schema.event_data.index = this.getSectionIndex(section)
+          }
+          break
+
+        case 'update-keyword':
+          schema.event_data.event_name = 'search'
+          schema.event_data.url = window.location.pathname
+          schema.event_data.section = 'Search'
+          schema.event_data.action = 'search'
+          schema.event_data.text = PIIRemover.stripPIIWithOverride(schema.event_data.text, true, true)
+          break
+
+        case 'clear-all-filters':
+          schema.event_data.action = 'remove'
+          schema.event_data.text = 'Clear all filters'
+          break
+
+        case 'update-sort':
+          schema.event_data.action = 'sort'
+          schema.event_data.section = 'Sort by'
+          break
+      }
+      return schema
+    },
+
+    // Takes a filter section's div, and grabs the index value from it.
+    getSectionIndex: function (sectionElement) {
+      try {
+        var index = sectionElement.getAttribute('data-ga4-index')
+        index = JSON.parse(index)
+        return index
+      } catch (e) {
+        console.error('GA4 configuration error: ' + e.message, window.location)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -103,7 +103,7 @@
       return { elementValue: elementValue, wasFilterRemoved: wasFilterRemoved }
     },
 
-    // Takes the GTM schema, the event target value, the event target HTML type, wether the filter was removed, the type of filter change it was, and the parent section heading. Populates the GTM object based on these values.
+    // Takes the GTM schema, the event target value, the event target HTML type, whether the filter was removed, the type of filter change it was, and the parent section heading. Populates the GTM object based on these values.
     setSchemaBasedOnChangeType: function (schema, elementValue, elementType, wasFilterRemoved, changeType, section) {
       var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //
 //= require support
 //
+//= require_tree ./analytics-ga4
 //= require live_search
 //= require search-analytics
 //= require taxonomy-select

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -408,7 +408,7 @@
           var response = JSON.parse(e.target.response)
           liveSearch.updateUrl()
           liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
-          liveSearch.ga4TrackFormChange(formChangeEvent) // Must be above displayResults, as if the DOM changes formChangeEvent.target.closest breaks.
+          liveSearch.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
           liveSearch.displayResults(response, searchState)
           liveSearch.trackSearch()
         } else {
@@ -422,7 +422,7 @@
       xhr.send()
     } else {
       this.updateUrl()
-      this.ga4TrackFormChange(formChangeEvent) // Must be above displayResults, as if the DOM changes formChangeEvent.target.closest breaks.
+      this.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
       this.displayResults(cachedResultData, searchState)
       this.trackSearch()
     }
@@ -612,14 +612,10 @@
       var consentCookie = GOVUK.getConsentCookie()
 
       if (consentCookie && consentCookie.settings) {
-        if (GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes) {
-          GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
-        }
+        GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
       } else {
         window.addEventListener('cookie-consent', function () {
-          if (GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes) {
-            GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
-          }
+          GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
         })
       }
     }

--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,2 +1,3 @@
 // https://github.com/alphagov/finder-frontend/pull/864/commits/afd01dacfe142a5c441d50db591e5af0f7832cb0
 //= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/analytics-ga4

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -11,7 +11,7 @@
   css_classes << (shared_helper.get_margin_bottom) unless margin_bottom == 0
 %>
 <% if title %>
-  <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load } do %>
+  <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load, 'ga4-section': title } do %>
     <h3 class="app-c-expander__heading">
       <span class="app-c-expander__title js-toggle"><%= title %></span>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -33,7 +33,7 @@
 <% end %>
 
 <div
-  class="app-c-option-select" data-module="option-select"
+  class="app-c-option-select" data-module="option-select" data-ga4-change-category="update-filter checkbox" data-ga4-section="<%= title %>"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
   <% if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile %>data-closed-on-load-mobile="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -1,10 +1,12 @@
-<%=
-render "components/date_filter", {
-  name: date_facet.name,
-  key: date_facet.key,
-  from_value: date_facet.user_supplied_from_date,
-  to_value: date_facet.user_supplied_to_date,
-  aria_controls_id: "js-search-results-info",
-  date_errors_to: date_facet.error_message_to(@search_query),
-  date_errors_from: date_facet.error_message_from(@search_query)
-} %>
+<span data-ga4-change-category="update-filter text">
+  <%=
+  render "components/date_filter", {
+    name: date_facet.name,
+    key: date_facet.key,
+    from_value: date_facet.user_supplied_from_date,
+    to_value: date_facet.user_supplied_to_date,
+    aria_controls_id: "js-search-results-info",
+    date_errors_to: date_facet.error_message_to(@search_query),
+    date_errors_from: date_facet.error_message_from(@search_query)
+  } %>
+</span>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   <% end %>
   <% if !content_item.all_content_finder? %>
-    <div id="keywords" role="search" aria-label="<%= content_item.title %>">
+    <div id="keywords" role="search" aria-label="<%= content_item.title %>" data-ga4-change-category="update-keyword text">
       <% label_text = capture do %>
         Search <span class="govuk-visually-hidden"><%= content_item.title %></span>
       <% end %>
@@ -45,7 +45,7 @@
             } %>
           </div>
         </div>
-        <div class="facets__content">
+        <div class="facets__content" data-ga4-filter-container>
           <%= render facets.select(&:filterable?) %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,4 @@
-<div class="facet-container">
+<div class="facet-container" data-ga4-change-category="update-filter radio" data-ga4-section="">
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -22,7 +22,7 @@
         font_size: "xl",
         margin_bottom: 4
         } %>
-        <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide">
+        <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
           <%= render "govuk_publishing_components/components/search", {
             aria_controls: "js-search-results-info",
             id: "finder-keyword-search",

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -2,7 +2,7 @@
   <%= render "components/expander", {
     title: "Topic"
   } do %>
-    <div class="js-taxonomy-select">
+    <div class="js-taxonomy-select" data-ga4-change-category="update-filter select">
       <%= render "govuk_publishing_components/components/select", {
         id: 'level_one_taxon',
         label: "Topic",

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -15,7 +15,9 @@
   <% inverse = true %>
 <% end %>
 
-<form method="get" action="<%= content_item.base_path %>" class="js-live-search-form">
+<form method="get" action="<%= content_item.base_path %>" class="js-live-search-form"
+    data-ga4-change-category="clear-all-filters"
+>
   <input type="hidden" name="parent" value="<%= @parent %>">
 
   <% if topic_finder?(filter_params) && !content_item.all_content_finder? %>
@@ -85,7 +87,7 @@
 
         <div class="govuk-caption-l live-search-loading-message" id="js-loading-message"></div>
 
-        <div id="js-sort-options">
+        <div id="js-sort-options" data-ga4-change-category="update-sort select">
           <%= render "sort_options", @sort_presenter.to_hash %>
         </div>
 

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -5,7 +5,16 @@
 <% end %>
 
 <main id="content" class="search-wrapper search-wrapper--no-search-term">
-  <form action="/search" method="get" accept-charset="utf-8" class="search-header" role="search">
+  <form
+    action="/search"
+    method="get"
+    accept-charset="utf-8"
+    class="search-header"
+    role="search"
+    data-module="ga4-form-tracker"
+    data-ga4-form-include-text
+    data-ga4-form='{"event_name": "search", "type": "finder", "url": "/search/all", "section": "Search", "action": "search"}'
+  >
     <%= render 'search_field' %>
   </form>
 </main>

--- a/docs/analytics-ga4/ga4-finder-tracker.md
+++ b/docs/analytics-ga4/ga4-finder-tracker.md
@@ -1,0 +1,122 @@
+# Google Analytics 4 finder tracker
+
+This script is used to add GA4 tracking to the GOVUK finders in `finder-frontend` such as https://www.gov.uk/search/all. These finders use client side JavaScript to update their results in response to a change in the search term or filters. Therefore, this tracker hooks in to the JavaScript `change` event that fires whenever a user updates their search. A GA4 schema is then built depending on what change was made to their search. This differs from the `ga4-form-tracker`. Firstly, this is because our finders are all contained in one large form. The `ga4-form-tracker` only allows for one GTM object per `<form>` when we need multiple for each element that can change the search results. Secondly, the `ga4-form-tracker` relies on a JavaScript `submit` event. Our finder pages use a `change` event to update their results.
+
+## Basic use
+
+```html
+<form id="myForm">
+  <div data-ga4-filter-container>
+    <div data-ga4-section="Topics">
+        <select data-ga4-change-category="update-filter select">
+            <option value="1">Default option</option>
+            <option value="2">Option 1</option>
+            <option value="3">Option 2</option>
+        </select>
+    </div>
+  </div>
+  <input type="search" data-ga4-change-category="update-keyword text" />
+</form>
+```
+
+```JavaScript
+var myForm = document.querySelector('#myForm')
+
+window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
+
+myForm.addEventListener('change', function(event) {
+    var ga4ChangeCategory = event.target.closest('[data-ga4-change-category]').getAttribute('data-ga4-change-category')
+    window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event.target, ga4ChangeCategory)
+})
+```
+
+The tracker is not a regular module. Instead it is called manually where needed. This is to allow the tracker to be called at the appropriate time in our finder's code. In our case, we only call `Ga4FinderTracker.trackChangeEvent()` when our search successfully displays new results to the user. This stops erroring change events (i.e. the user inputting non-dates into the date filter) from being tracked as an "added filter" event. Therefore we only track updates to the finders if they result in a successful update to the search results.
+
+The flow of the tracker is:
+
+1. On the finder results page, tag your elements with the appropriate `data` attributes.
+
+    a. Tag the parent `<div>` or wrapper element for your filters with `data-ga4-filter-container`. This tells our code where to look for filter sections, so that we can set an `index_section` for each filter.
+
+    b. Tag each filter's wrapper element with a `data-ga4-section` attribute. This key can also be populated with a string value, which will be used to populate the `section` value of our GTM object. For example, on a "Topics" filter `<div>` you could add `data-ga4-section="Topics"` or just `data-ga4-section`.
+
+    c. Tag each element of the form that can trigger a `change` event with a `data-ga4-change-category`. This will contain some metadata about what the change is. The current categories are: `update-filter`, `update-sort`, `clear-all-filters` and `update-keyword`. As well as this, add the type of element that the filter is (further details on what types are tracked is documented below.) This assists with our tracker extracting the value of the filter. For example, a `<select>` element that updates a filter would have `data-ga4-change-category="update-filter select"`. A search box would have `data-ga4-change-category="update-keyword text"`.
+
+2. When the finder page loads, call `Ga4FinderTracker.setFilterIndexes()`. This will grab the `data-ga4-filter-container` element. It will then look for every instance of `data-ga4-section` inside this element, then loop through them and assign an `index` to the section based on its position in the NodeList.
+
+3. In the finder's JavaScript code, find where it updates your search results, and call `Ga4FinderTracker.trackChangeEvent()`. Pass through the `event.target` of the element that triggered the change. Also grab and pass through the `data-ga4-change-category` that was set on the event target or its parent.
+
+4. The `ga4-finder-tracker` will then grab the "value" of the event target, using the metadata passed through to help categorise what type of element the change came from. The value in this case is the name of the filter that was set, the keyword that was input. For filters, it will also determine whether the change was the filter being "added" or "removed".
+For example if the event target is a checkbox, `<input type="checkbox" data-ga4-change-category="update-filter checkbox">`, and it is `checked`, then we know the filter was added. If it isn't `checked`, we know the filter was removed.
+
+5. Using the `data-ga4-change-category`, the value of the event target, and whether it is a removed filter or not, we then build the GTM object and push it to the `dataLayer`.
+
+## Element types tracked
+
+### Checkbox (`<input type="checkbox" />`)
+
+Checkboxes have `data-ga4-change-category="update-filter checkbox"` on them. If a change event is fired on the element, and the checkbox is `checked`, the `update-filter` event will build an "Add filter" GTM Object. If the checkbox is not `checked`, it will build a "Remove filter" GTM Object. The value we grab for a checkbox is the user friendly label associated with the `<input>`.
+
+### Select (`<select>`)
+
+The value we grab from a `<select>` is the user friendly text of the selected option.
+
+Filter selects have  `data-ga4-change-category="update-filter select"` on them.
+
+If the filter `<select>` element changes and is set to their _first option_, we treat this as a "Filter removed" event. This is because the first `<option>` in a `<select>` is their default state in our use case. Therefore if the select has changed, and we're on the first option, we can safely assume we've moved from a "Added filter" option, back to the default option, so it's treated as a "Removed filter."
+
+"Sort by" selects have  `data-ga4-change-category="update-sort select"` on them. They send a separate "Sort event", so checking whether the filter was added or removed is irrelevant in this case.
+
+### Radio buttons (`<input type="radio">`)
+
+Radio buttons have `data-ga4-change-category="update-filter radio"` on them. If the changed radio button is not the _first radio button_ (i.e. the default selection), then, the `update-filter` event will build an "Filter added" GTM Object. If the changed radio button is the _first radio button_, it will build a "Filter removed" GTM Object. This is because the first radio button in a list is typically the default "All XYZ" filter state. The value we grab for a radio button is the user friendly label associated with the `<input>`.
+
+### Date filters (`<input type="text">`)
+
+Our date filters have `data-ga4-change-category="update-filter text"` on them. The value we grab is the text that is input into its text field. If the text is an empty string, we treat this as a "Filter removed" event, as this means the date was removed. If text is available in the text box, we treat this as a "Filter added" event.
+
+### Search keyword changes (`<input type="text">`)
+
+Search boxes have `data-ga4-change-category="update-keyword text"` on them. The value we grab on change is the text that was input into the text box.  Regardless if text is available in the text box, we always treat it as a "search" event. This is because an empty search box is still as search event but it just searches for everything in our database.
+
+We apply the maximum level of PII removal on the user input.
+
+
+### Clear all filters button
+
+On mobile, there is a "Clear all filters" button. This triggers a `change` event on the whole `<form>` element when clicked. Therefore, we have added `data-ga4-change-category="clear-all-filters"` on the parent `<form>` in our finders. The value pushed to GTM is hard coded in `Ga4FinderTracker` as "Clear all filters", so an element type is not passed through to `data-ga4-change-category` as we don't need to do any value extraction.
+
+## Example GTM Objects
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "select_content",
+        "type": "finder",
+        "text": "Environment",
+        "index": {
+            "index_section": 2,
+            "index_section_count": 5
+        },
+        "section": "Topic",
+        "action": "select"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```
+
+```JSON
+{
+    "event": "event_data",
+    "event_data": {
+        "event_name": "search",
+        "type": "finder",
+        "url": "/search/research-and-statistics",
+        "text": "hello world",
+        "section": "Search",
+        "action": "search"
+    },
+    "govuk_gem_version": "35.3.1",
+}
+```

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -1,0 +1,319 @@
+/* eslint-env jasmine */
+
+describe('GA4 finder change tracker', function () {
+  var GOVUK = window.GOVUK
+  var form
+  var inputParent
+  var input
+  var label
+  var label2
+  var option1
+  var option2
+  var expected
+
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  beforeAll(function () {
+    window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+    window.GOVUK.analyticsGa4.vars = window.GOVUK.analyticsGa4.vars || {}
+    window.GOVUK.analyticsGa4.vars.gem_version = 'aVersion'
+  })
+
+  beforeEach(function () {
+    window.dataLayer = []
+    form = document.createElement('form')
+    document.body.appendChild(form)
+
+    form.addEventListener('change', function (e) {
+      var ga4ChangeCategory = e.target.closest('[data-ga4-change-category]')
+      if (ga4ChangeCategory) {
+        ga4ChangeCategory = ga4ChangeCategory.getAttribute('data-ga4-change-category')
+        window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(e.target, ga4ChangeCategory)
+      }
+    })
+
+    expected = new GOVUK.analyticsGa4.Schemas().eventSchema()
+    expected.govuk_gem_version = 'aVersion'
+    expected.event = 'event_data'
+    expected.event_data.type = 'finder'
+
+    agreeToCookies()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(form)
+  })
+
+  afterAll(function () {
+    window.dataLayer = []
+  })
+
+  it('creates the correct GA4 object for a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = 'Hello world my postcode is SW1A 0AA. My birthday is 1970-01-01. My email is email@example.com'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'Hello world my postcode is [postcode]. My birthday is [date]. My email is [email]'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a checkbox filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter checkbox')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'checkbox')
+    input.id = 'checkbox'
+    input.checked = true
+    label = document.createElement('label')
+    label.setAttribute('for', 'checkbox')
+    label.innerText = 'All types of chocolate'
+
+    inputParent.appendChild(input)
+    inputParent.appendChild(label)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'All types of chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.checked = false
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a radio filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter radio')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 1, index_section_count: 1, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    option1 = document.createElement('input')
+    option1.setAttribute('type', 'radio')
+    option1.id = 'radio1'
+    option1.setAttribute('name', 'chocolates')
+    label = document.createElement('label')
+    label.setAttribute('for', 'radio1')
+    label.innerText = 'All types of chocolate (default)'
+
+    option2 = document.createElement('input')
+    option2.setAttribute('type', 'radio')
+    option2.setAttribute('name', 'chocolates')
+    option2.id = 'radio2'
+    label2 = document.createElement('label')
+    label2.setAttribute('for', 'radio2')
+    label2.innerText = 'Belgian chocolate'
+
+    inputParent.appendChild(option1)
+    inputParent.appendChild(label)
+    inputParent.appendChild(option2)
+    inputParent.appendChild(label2)
+    form.appendChild(inputParent)
+
+    option1.checked = false
+    option2.checked = true
+
+    window.GOVUK.triggerEvent(option2, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    option1.checked = true
+    option2.checked = false
+    window.GOVUK.triggerEvent(option1, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = 'All types of chocolate (default)'
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a <select> filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter select')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 5, index_section_count: 15, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'chocolates')
+    input.id = 'chocolates'
+
+    // This is the first/default option, so "adding a filter" means selecting any <option> other than this one.
+    option1 = document.createElement('option')
+    option1.value = 'all-types'
+    option1.innerText = 'All types of chocolate (default)'
+    input.appendChild(option1)
+
+    option2 = document.createElement('option')
+    option2.setAttribute('value', 'belgian-chocolate')
+    option2.innerText = 'Belgian chocolate'
+    input.appendChild(option2)
+
+    input.value = 'belgian-chocolate'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Belgian chocolate'
+    expected.event_data.action = 'select'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = 'all-types'
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = 'All types of chocolate (default)'
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for adding/removing a text filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter text')
+    inputParent.setAttribute('data-ga4-section', 'Your favourite chocolate')
+    var index = { index_section: 2, index_section_count: 2, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.value = 'Here is an email that should not get redacted email@example.com'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Your favourite chocolate'
+    expected.event_data.text = 'Here is an email that should not get redacted email@example.com'
+    expected.event_data.action = 'search'
+    expected.event_data.index = index
+
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    input.value = ''
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.action = 'remove'
+    expected.event_data.index = undefined
+    expected.event_data.text = undefined
+
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for clearing all filters', function () {
+    form.setAttribute('data-ga4-change-category', 'clear-all-filters')
+
+    window.GOVUK.triggerEvent(form, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.action = 'remove'
+    expected.event_data.text = 'Clear all filters'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('creates the correct GA4 object for changing the sort selection', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-sort select')
+    var index = { index_section: 1, index_section_count: 1, index_link: undefined }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    input = document.createElement('select')
+    input.setAttribute('name', 'sort')
+    input.id = 'sort'
+
+    option1 = document.createElement('option')
+    option1.value = 'most-viewed'
+    option1.innerText = 'Most viewed'
+    input.appendChild(option1)
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Sort by'
+    expected.event_data.text = 'Most viewed'
+    expected.event_data.action = 'sort'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('sets the correct indexes', function () {
+    form.setAttribute('data-ga4-filter-container', '')
+
+    for (var i = 0; i < 5; i++) {
+      var div = document.createElement('div')
+      div.setAttribute('data-ga4-section', '')
+      form.appendChild(div)
+    }
+
+    // Grabs each data-ga4-section element within a data-ga4-filter-container, and sets the appropriate indexes.
+    window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
+
+    var divs = form.querySelectorAll('[data-ga4-section]')
+
+    for (i = 0; i < divs.length; i++) {
+      var expectedIndexObject = { index_section: i + 1, index_section_count: divs.length, index_link: undefined }
+      expect(divs[i].getAttribute('data-ga4-index')).toEqual(JSON.stringify(expectedIndexObject))
+    }
+  })
+
+  it('does nothing if the elementType or changeType does not exist', function () {
+    inputParent = document.createElement('div')
+    input = document.createElement('input')
+    input.setAttribute('type', 'text')
+    input.id = 'textInput'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+  })
+})

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -73,6 +73,14 @@ describe('liveSearch', function () {
     '</select>'
   }
 
+  function agreeToCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+  }
+
+  function denyCookies () {
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+  }
+
   beforeEach(function () {
     jasmine.Ajax.install()
     var count = '<div aria-live="assertive" id="js-search-results-info"><h2 class="result-region-header__counter" id="f-result-count"></h2></div>'
@@ -777,12 +785,7 @@ describe('liveSearch', function () {
 
   describe('GA4 tracking', function () {
     beforeEach(function () {
-      window.GOVUK.getConsentCookie = function () {
-        return { settings: true }
-      }
-      window.GOVUK.analyticsGa4 = {}
-      window.GOVUK.analyticsGa4.Ga4FinderTracker = {}
-      window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent = function () {}
+      agreeToCookies()
 
       liveSearch = new GOVUK.LiveSearch({ $form: $form[0], $results: $results[0], $atomAutodiscoveryLink: $atomAutodiscoveryLink[0] })
       liveSearch.state = { search: 'state' }
@@ -836,9 +839,7 @@ describe('liveSearch', function () {
     })
 
     it('ignores GA4 finder tracker if cookies are rejected', function () {
-      window.GOVUK.getConsentCookie = function () {
-        return { settings: false }
-      }
+      denyCookies()
 
       var $input = $form.find('input[name="field"]')
       $input.attr('data-ga4-change-category', 'update-filter checkbox')


### PR DESCRIPTION
Hi @andysellick / @JamesCGDS - would you be able to review this when you get a chance? I've tried to explain it as best as I could, but let me know if something doesn't make sense. Thanks. 

Related to https://github.com/alphagov/govuk_publishing_components/pull/3362


## What
- Adds tracking to the `/search` page using `ga4-form-tracker`
- Adds a new `Ga4FinderTracker` which tracks whenever our GOVUK search or Finders are changed.
- Adds `data-` attributes that our `govuk_publishing_components` `Ga4FinderTracker` makes use of.


Related trello cards: https://trello.com/c/zCIwJ8pP/515-add-tracking-search-box-on-search-finder-pages https://trello.com/c/aEXGK5cE/527-add-tracking-select-filter-on-search-finders-selectcontent
https://trello.com/c/sH9vKqA4/528-add-tracking-remove-filter-on-search-finders-selectcontent
https://trello.com/c/ZQeyh2qb/530-add-tracking-sort-by-search-finders-selectcontent

## Why
- The new "finder tracker" is needed because the finders are updated with client side JavaScript. They fire a `change` event whenever a keyword/filter is changed. Therefore we need to hook into this to track it in GA4.
- As each finder is one big form, it fires one big change event if anything in the search changes. Therefore we need a way to know which element triggered the change, so that we can send the correct GA4 event. We use `event.target` as well as `data-` attributes on the input or input parent, which gives us a simple way to categorise the change and build our GA4 object.
- The code was originally in the other PR: https://github.com/alphagov/govuk_publishing_components/pull/3362 but now it is in this repo.

## Brief explanation of how it works

1. In finder-frontend, we define some data-attributes on the finder `<form>` elements. 
    a. Firstly, we put a `data-ga4-filter-container` on the element that wraps all the filters. This will be needed to set `index_section` on each filter.
    b. Next, we add a `data-ga4-section` on each filter with the `data-ga4-filter-container` element. This is needed to identify where we need to add `data-ga4-index` for our `index_section`s. This key is also used to identify the `section` value to add to the GTM object. E.g. for a Topics filter, the attribute would be `data-ga4-section="Topics"`
   c. Next, on each element that can cause a `change` event on the `<form>` we add an attribute called `data-ga4-change-category` which gives us 1. metadata on what that element changes about the search results and 2. the HTML type that the element is. For example, on a `<select>` element that changes the filters, we would add `data-ga4-change-category="update-filter select"`. On the search box we would add `data-ga4-change-category="update-keyword text".

2. On the loading of a `finder`, we call `window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()` in `finder-frontend`. This will grab the `data-ga4-filter-container`, look for any `data-ga4-section` elements inside it, and set an `index_section` on each section it finds.
3. In `finder-frontend`, when the search results are changed, we pass through the `event.target` and `data-ga4-change-category` to `Ga4FinderTracker.trackFormChange()`.
4. `trackFormChange()` will grab the "value" of the Filter that caused the change. For example the name of the checkbox, or the new keyword that was just searched for.
5. If it was a filter that caused the `change` event, then `trackFormChange()` will try and determine wether the filter that changed was a `Add filter` or `Remove filter` event.
6. It will then use a `switch` statement to build the GTM object based on which `data-ga4-change-category` was passed. 

I've also written a markdown documentation file. Hope how I've built this makes sense.

## How to test this
1. Run `finder-frontend` with this branch checked out
2. Go to http://127.0.0.1:3062/search/all and change something in the search (e.g. a keyword, add a filter, remove a filter, or click "Clear all filters" in mobile view.) Check the `dataLayer` for an `event_data` event (it's usually index 7 in the dataLayer). Also check the finders without any filters e.g. http://127.0.0.1:3062/government/people and ones with radio buttons e.g. http://127.0.0.1:3062/official-documents .

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

