### PR TITLE
Add transformative redirects to finder frontend

### DIFF
--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -26,9 +26,13 @@ class RedirectionController < ApplicationController
                             .permit(:level_one_taxon, :level_two_taxon, departments: [], world_locations: [], content_store_document_type: [])
                             .transform_keys { |k| k == "departments" ? "organisations" : k }
                             .compact
-
     redirect_params[:content_store_document_type] = %w[open_consultations closed_consultations]
+
     redirect_to(finder_path("search/policy-papers-and-consultations", params: { order: "updated-newest" }.merge(redirect_params)))
+  end
+
+  def redirect_statistics_announcements
+    redirect_to(finder_path("search/research-and-statistics", params: statistics_announcements_topic_and_other_params))
   end
 
   def advanced_search
@@ -79,5 +83,22 @@ private
       roles: filter_params["roles"],
       world_locations: filter_params["world_locations"],
     }.compact
+  end
+
+  def statistics_announcements_topic_and_other_params
+    {
+      content_store_document_type: "upcoming_statistics",
+      keywords: filter_params["keywords"],
+      level_one_taxon: filter_params["topics"],
+      organisations: filter_orgs_array(filter_params["organisations"]),
+      public_timestamp: {
+        from: filter_params["from_date"],
+        to: filter_params["to_date"],
+      },
+    }.compact
+  end
+
+  def filter_orgs_array(arr)
+    Array(arr).delete_if { |i| i == "all" }
   end
 end

--- a/app/controllers/redirection_controller.rb
+++ b/app/controllers/redirection_controller.rb
@@ -16,6 +16,21 @@ class RedirectionController < ApplicationController
     redirect_to(finder_path("search/all", params: { order: "updated-newest" }.merge(redirect_params)))
   end
 
+  def redirect_consultations
+    topics = {}
+    topics["level_one_taxon"] = params[:topics] if params[:topics]
+    topics["level_two_taxon"] = params[:subtaxons] if params[:subtaxons]
+
+    redirect_params = params.merge(topics)
+                            .slice(:departments, :level_one_taxon, :level_two_taxon, :world_locations, :content_store_document_type)
+                            .permit(:level_one_taxon, :level_two_taxon, departments: [], world_locations: [], content_store_document_type: [])
+                            .transform_keys { |k| k == "departments" ? "organisations" : k }
+                            .compact
+
+    redirect_params[:content_store_document_type] = %w[open_consultations closed_consultations]
+    redirect_to(finder_path("search/policy-papers-and-consultations", params: { order: "updated-newest" }.merge(redirect_params)))
+  end
+
   def advanced_search
     conversion_hash =
       {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
   get "/search/advanced" => "redirection#advanced_search"
   get "/search/latest" => "redirection#redirect_latest"
+  get "/search/consultations" => "redirection#redirect_consultations"
 
   get "/*slug" => "redirection#redirect_covid", constraints: lambda { |request|
     topical_events = request.params["topical_events"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   get "/search/advanced" => "redirection#advanced_search"
   get "/search/latest" => "redirection#redirect_latest"
   get "/search/consultations" => "redirection#redirect_consultations"
+  get "/search/statistics-announcements" => "redirection#redirect_statistics_announcements"
 
   get "/*slug" => "redirection#redirect_covid", constraints: lambda { |request|
     topical_events = request.params["topical_events"]

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -185,4 +185,25 @@ describe RedirectionController, type: :controller do
                                                             content_store_document_type: %w[open_consultations closed_consultations] })
     end
   end
+
+  describe "#redirect_statistics_announcements" do
+    it "redirects to /search/research-and-statistics" do
+      get :redirect_statistics_announcements, params: {
+        topics: "magic-competition",
+        keywords: %w[harry-potter],
+        organisations: %w[ministry-of-magic],
+        from_date: "01/01/2014",
+        to_date: "01/01/2014",
+      }
+      expect(response).to redirect_to finder_path("search/research-and-statistics",
+                                                  params: { content_store_document_type: "upcoming_statistics",
+                                                            keywords: %w[harry-potter],
+                                                            level_one_taxon: "magic-competition",
+                                                            organisations: %w[ministry-of-magic],
+                                                            public_timestamp: {
+                                                              from: "01/01/2014",
+                                                              to: "01/01/2014",
+                                                            } })
+    end
+  end
 end

--- a/spec/controllers/redirection_controller_spec.rb
+++ b/spec/controllers/redirection_controller_spec.rb
@@ -148,4 +148,41 @@ describe RedirectionController, type: :controller do
                                                   params: { order: "updated-newest" })
     end
   end
+
+  describe "#redirect_consultations" do
+    it "redirects to /search/policy-papers-and-consultations retaining level one and two taxons and setting content-store-document-type" do
+      get :redirect_consultations, params: {
+        topics: "magic-competition",
+        subtaxons: "potions",
+        content_store_document_type: %w[open_consultations],
+      }
+      expect(response).to redirect_to finder_path("search/policy-papers-and-consultations",
+                                                  params: { order: "updated-newest",
+                                                            level_one_taxon: "magic-competition",
+                                                            level_two_taxon: "potions",
+                                                            content_store_document_type: %w[open_consultations closed_consultations] })
+    end
+
+    it "redirects to /search/policy-papers-and-consultations retaining world locations and setting content-store-document-type" do
+      get :redirect_consultations, params: {
+        world_locations: %w[hogwarts],
+        content_store_document_type: %w[open_consultations],
+      }
+      expect(response).to redirect_to finder_path("search/policy-papers-and-consultations",
+                                                  params: { order: "updated-newest",
+                                                            world_locations: %w[hogwarts],
+                                                            content_store_document_type: %w[open_consultations closed_consultations] })
+    end
+
+    it "redirects to /search/policy-papers-and-consultations replacing departments with organisations and setting content-store-document-type" do
+      get :redirect_consultations, params: {
+        departments: %w[ministry_of_magic],
+        content_store_document_type: %w[open_consultations],
+      }
+      expect(response).to redirect_to finder_path("search/policy-papers-and-consultations",
+                                                  params: { order: "updated-newest",
+                                                            organisations: %w[ministry_of_magic],
+                                                            content_store_document_type: %w[open_consultations closed_consultations] })
+    end
+  end
 end


### PR DESCRIPTION
This PR adds both the consultations and statistics transformative redirects that were previously handled by whitehall into finder-frontend.

These need to be handled differently to other redirects being moved from Whitehall as there is some setting of query string parameters currently done by whitehall, as well as transformation from legacy params to newer ones. 

This is done as part of the mission to remove any frontend rendering form whitehall, as these redirects are handled by whitehall frontend instances, they needed to be moved. 

Trello: https://trello.com/c/SmdAt9SX/523-migrate-redirect-logic-from-whitehall-to-finder-frontend, [Jira issue PP-716](https://gov-uk.atlassian.net/browse/PP-716)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
