### PR TITLE
AA test for Search Results

### DIFF
--- a/app/controllers/ab_tests/elastic_search_aa_testable.rb
+++ b/app/controllers/ab_tests/elastic_search_aa_testable.rb
@@ -1,0 +1,19 @@
+module AbTests::ElasticSearchAaTestable
+  def elastic_search_aa_test
+    GovukAbTesting::AbTest.new(
+      "EsSixPointSeven",
+      dimension: 41,
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+  end
+
+  def page_under_test?
+    request.path.include?("/search/all")
+  end
+
+  def set_requested_variant
+    @requested_variant = elastic_search_aa_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   layout "finder_layout"
+  include AbTests::ElasticSearchAaTestable
 
   before_action do
     set_expiry(content_item)
@@ -7,6 +8,10 @@ class FindersController < ApplicationController
 
   def show
     slimmer_template "gem_layout_full_width" if i_am_a_topic_page_finder
+
+    if page_under_test?
+      set_requested_variant
+    end
 
     respond_to do |format|
       format.html do
@@ -58,7 +63,7 @@ private
 
   attr_reader :search_query
 
-  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets
+  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets, :page_under_test?
 
   def redirect_to_destination
     @redirect = content_item.redirect

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -66,6 +66,12 @@
       <% end %>
     </div>
 
+    <% if page_under_test? %>
+      <% content_for :meta_tags do %>
+        <%= @requested_variant.analytics_meta_tag.html_safe %>
+      <% end %>
+    <% end %>
+
     <% if content_item.summary %>
       <div class="govuk-grid-column-two-thirds">
         <div class="metadata-summary ">

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -24,6 +24,7 @@
       <meta name="robots" content="noindex">
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
+    <%= yield :meta_tags %>
   </head>
 
   <body class="<%= yield :body_classes %>">

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -40,6 +40,7 @@ describe FindersController, type: :controller do
   after { Rails.cache.clear }
 
   describe "GET show" do
+    render_views
     describe "a finder content item exists" do
       before do
         stub_content_store_has_item(
@@ -107,6 +108,52 @@ describe FindersController, type: :controller do
         request.headers["Accept"] = "text/plain"
         get :show, params: { slug: "lunch-finder" }
         expect(response.status).to eq(406)
+      end
+
+      context "with AA test" do
+        %w[A B Z].each do |variant|
+          it "renders the #{variant} variant for /search/all pages" do
+            stub_content_store_has_item(
+              "/search/all",
+              all_content_finder,
+            )
+
+            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+
+            get :show, params: { slug: "search/all" }
+
+            expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
+            expect(response.body).to include("EsSixPointSeven:#{variant}")
+          end
+
+          it "doesn't render the #{variant} for finders" do
+            stub_content_store_has_item(
+              "/lunch-finder",
+              lunch_finder,
+            )
+
+            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+
+            get :show, params: { slug: "lunch-finder" }
+
+            expect(response.status).to eq(200)
+            expect(response.header["Vary"]).not_to eq("GOVUK-ABTest-EsSixPointSeven")
+            expect(response.body).not_to include("EsSixPointSeven:#{variant}")
+          end
+        end
+
+        it "should render the page without an AB test variant for search" do
+          stub_content_store_has_item(
+            "/search/all",
+            all_content_finder,
+          )
+
+          get :show, params: { slug: "search/all" }
+
+          expect(response.status).to eq(200)
+          expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
+          expect(response.body).not_to include("<meta name=\"govuk:ab-test\">")
+        end
       end
     end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/AH3QERus/613-deploy-the-50-50-aa-test-for-the-search-team)

The purpose of the A/A test is to test the % of allocation of traffic/sample population based on the current version of elastic (6.7) against itself. A (ES 6.7) vs A (ES6.7). The A/A is solely to identify how the approach allocates traffic. This will provide benchmark data to aid analysis in future AA tests.

This test is only applied to `/search/all` results, not to finder search results.

### Manual testing using Postman on /search/all for the different variants

<img width="854" alt="Screenshot 2023-07-03 at 16 25 43" src="https://github.com/alphagov/finder-frontend/assets/5963488/ed726589-2681-4359-b519-bf884ca56eea">
<img width="864" alt="Screenshot 2023-07-03 at 16 25 19" src="https://github.com/alphagov/finder-frontend/assets/5963488/6156200b-bc52-4c9b-b6f0-2b7ad25dcc9f">
<img width="856" alt="Screenshot 2023-07-03 at 16 25 00" src="https://github.com/alphagov/finder-frontend/assets/5963488/b8ef5387-e0c5-4f4f-9142-f74797106801">

### A finder search results page, which the test is not applied to:

<img width="873" alt="Screenshot 2023-07-04 at 12 26 26" src="https://github.com/alphagov/finder-frontend/assets/5963488/66323b3f-f5df-4c4d-9206-90e985c7d562">





⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


