### PR TITLE
Close the Industry option-select on mobile

### DIFF
--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -58,7 +58,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     button.addEventListener('click', this.toggleOptionSelect.bind(this))
 
     var closedOnLoad = this.$optionSelect.getAttribute('data-closed-on-load')
-    if (closedOnLoad === 'true') {
+    var closedOnLoadMobile = this.$optionSelect.getAttribute('data-closed-on-load-mobile')
+
+    // By default the .filter-content container is hidden on mobile
+    // By checking if .filter-content is hidden, we are in mobile view given the current implementation
+    var isFacetsContentHidden = this.isFacetsContainerHidden()
+
+    // Check if the option select should be closed for mobile screen sizes
+    var closedForMobile = closedOnLoadMobile === 'true' && isFacetsContentHidden
+
+    // Always set the contain height to 200px for mobile screen sizes
+    if (closedForMobile) {
+      this.setContainerHeight(200)
+    }
+
+    if (closedOnLoad === 'true' || closedForMobile) {
       this.close()
     } else {
       this.setupHeight()

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -237,21 +237,33 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return visibleCheckboxes
   }
 
+  OptionSelect.prototype.isFacetsContainerHidden = function isFacetsContainerHidden () {
+    var facetsContent = this.$optionSelect.parentElement
+    var isFacetsContentHidden = false
+    // check whether this is hidden by progressive disclosure,
+    // because height calculations won't work
+    // would use offsetParent === null but for IE10+
+    if (facetsContent) {
+      isFacetsContentHidden = !(facetsContent.offsetWidth || facetsContent.offsetHeight || facetsContent.getClientRects().length)
+    }
+
+    return isFacetsContentHidden
+  }
+
   OptionSelect.prototype.setupHeight = function setupHeight () {
     var initialOptionContainerHeight = this.$optionsContainer.clientHeight
     var height = this.$optionList.offsetHeight
 
-    // check whether this is hidden by progressive disclosure,
-    // because height calculations won't work
-    // would use offsetParent === null but for IE10+
-    var parent = this.$optionSelect.parentElement
-    var parentIsHidden = !(parent.offsetWidth || parent.offsetHeight || parent.getClientRects().length)
-    if (parentIsHidden) {
+    var isFacetsContainerHidden = this.isFacetsContainerHidden()
+
+    if (isFacetsContainerHidden) {
       initialOptionContainerHeight = 200
       height = 200
     }
 
     // Resize if the list is only slightly bigger than its container
+    // If isFacetsContainerHidden is true, then 200 < 250
+    // And the container height is always set to 201px
     if (height < initialOptionContainerHeight + 50) {
       this.setContainerHeight(height + 1)
       return

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -64,6 +64,14 @@ class OptionSelectFacet < FilterableFacet
     closed_by_default?(option_select_facet_counter)
   end
 
+  # TODO: open_on_load is currently only used in the Industry facets
+  # and we want the industry facet to be closed on load for mobile devices
+  # This will likely need refactoring if we decide to keep this approach and
+  # use it in other option select facets
+  def closed_on_load_mobile?
+    open_on_load?
+  end
+
 private
 
   def value_fragments

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -35,6 +35,7 @@
 <div
   class="app-c-option-select" data-module="option-select"
   <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
+  <% if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile %>data-closed-on-load-mobile="true"<% end %>
   <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
   <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
 >

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -9,6 +9,7 @@
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
     :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
+    :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?
   }

--- a/spec/components/option_select_spec.rb
+++ b/spec/components/option_select_spec.rb
@@ -95,6 +95,14 @@ describe "components/_option_select.html.erb", type: :view do
     expect(rendered).to have_selector('.app-c-option-select[data-closed-on-load="true"]')
   end
 
+  it "can begin with the options box closed on load for mobile devices" do
+    arguments = option_select_arguments
+    arguments[:closed_on_load_mobile] = true
+    render_component(arguments)
+
+    expect(rendered).to have_selector('.app-c-option-select[data-closed-on-load-mobile="true"]')
+  end
+
   it "can show a filter control" do
     arguments = option_select_arguments
     arguments[:show_filter] = true


### PR DESCRIPTION
## What
Add `closed_on_load_mobile` option and use it to close the "Business or activity" option-select on mobile in the new licence finder.

**Note:** The `closed_on_load_mobile` option is currently only used in the "Business or activity" option select and will be used as part of user testing. If we receive positive feedback on this, and it is something we intend to keep, then we will refactor the code to make it easier to understand how both this feature and the option-select component used.

Trello: https://trello.com/b/NLbahOWX/doing-content-interactions-on-platform

## Why
To make it easier for the user to see the search button on mobile.

## Visual Changes - Mobile

| Before | After |
| --- | --- |
| <img width="416" alt="Screenshot 2023-05-12 at 10 11 31" src="https://github.com/alphagov/finder-frontend/assets/28779939/c014216c-0895-468c-abbc-aa352681e8bd"> | <img width="413" alt="Screenshot 2023-05-12 at 10 11 21" src="https://github.com/alphagov/finder-frontend/assets/28779939/14f121ff-c481-4693-bd8b-8bbd48737d9e"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
