### PR TITLE
Update column class for subscription_links container

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -74,7 +74,7 @@
               </div>
             </div>
 
-            <div class="govuk-grid-column-half govuk-!-text-align-right subscription-links subscription-links--desktop">
+            <div class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop">
               <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>
           </div>


### PR DESCRIPTION
## What

Update column class for subscription_links container

## Why

This will ensure that the component sits within the main container

## Visual Changes

### Before
<img width="684" alt="Screenshot 2023-05-18 at 12 40 45" src="https://github.com/alphagov/finder-frontend/assets/28779939/5649d618-2634-4a60-8b44-5104b20a657c">

### After
<img width="672" alt="Screenshot 2023-05-18 at 12 40 34" src="https://github.com/alphagov/finder-frontend/assets/28779939/e70facbc-0d00-4432-8ade-bebaac428ad5">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
