### PR TITLE
Alter option select facet cache key to be sensitive to ordering.

### DIFF
--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -51,7 +51,7 @@ class OptionSelectFacet < FilterableFacet
   end
 
   def cache_key
-    { selected: selected_values, allowed: allowed_values }
+    Digest::SHA256.hexdigest({ name:, selected: selected_values, allowed: allowed_values }.to_json)
   end
 
   def query_params

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -92,4 +92,49 @@ describe OptionSelectFacet do
       end
     end
   end
+
+  describe "#cache_key" do
+    context "where facet allowed values differ in order" do
+      let(:allowed_values_2) do
+        [
+          {
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2",
+          },
+          {
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1",
+          },
+          {
+            "label" => "Remittals",
+            "value" => "remittals",
+          },
+        ]
+      end
+
+      specify "cache keys should differ" do
+        f1 = OptionSelectFacet.new(facet_data, "1")
+        f2 = OptionSelectFacet.new(facet_data.merge({ "allowed_values" => allowed_values_2 }), "1")
+        expect(f1.cache_key).not_to eq(f2.cache_key)
+      end
+    end
+
+    context "where facet names differ" do
+      let(:facet_data_2) do
+        {
+          "type" => "multi-select",
+          "name" => "Test values 2",
+          "key" => "test_values",
+          "preposition" => "of value",
+          "allowed_values" => allowed_values,
+        }
+      end
+
+      specify "cache keys should differ" do
+        f1 = OptionSelectFacet.new(facet_data, "1")
+        f2 = OptionSelectFacet.new(facet_data_2, "1")
+        expect(f1.cache_key).not_to eq(f2.cache_key)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Making a digest of the map means that comparisons are sensitive to ordering of values in the hashes.

Currently reordering facets or the allowed values of facets currently won't bust the cache (which means that if we do a backend change of the order of facets we have to manually clear the cache to get the change visible). By altering the cache key to be dependent on ordering, we can make the cache key different, allowing it to refresh.

(Note that swapping the order of entire facets isn't cached, so already updates automatically)

https://trello.com/c/tQOVFnaT/2017-adjust-finder-frontend-caching-strategy-so-that-changing-order-or-name-of-facets-clears-cache

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
