### PR TITLE
Add GA4 tracking to Get emails and RSS subscribe links

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -74,7 +74,12 @@
               </div>
             </div>
 
-            <div class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop">
+            <div
+              class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop"
+              data-module="ga4-link-tracker"
+              data-ga4-track-links-only
+              data-ga4-set-indexes
+              data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Top" }'>
               <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>
           </div>
@@ -97,7 +102,13 @@
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
         </div>
 
-        <div class="subscription-links" id="subscription-links-footer">
+        <div
+          class="subscription-links"
+          id="subscription-links-footer"
+          data-module="ga4-link-tracker"
+          data-ga4-track-links-only
+          data-ga4-set-indexes
+          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Footer" }'>
           <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
         </div>
       </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add GA4 tracking to the `Get emails` and `Subscribe to feed` links at the top (right) and bottom of search results pages.

Examples: 
- both links: https://www.gov.uk/search/news-and-communications
- only the feed link: https://www.gov.uk/search/all?keywords=minister&order=relevance

![Screenshot 2023-06-14 at 13 28 36](https://github.com/alphagov/finder-frontend/assets/861310/450a7cb7-eba6-4a69-a6de-7b2476de8a0a)


## Why
Part of the GA4 implementation.

## Visual changes
None.

Trello card: https://trello.com/c/ywzg6mNC/569-subscribe-subscribe-to-feed-rss-link

Related PR: https://github.com/alphagov/govuk-developer-docs/pull/4045
