### PR TITLE
Move mobile filter below search

### DIFF
--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -1,5 +1,9 @@
 @import "govuk_publishing_components/individual_component_support";
 
+.app-c-mobile-filters {
+  position: relative;
+}
+
 .app-mobile-filters-link {
   display: none;
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -1,11 +1,4 @@
 <div class="filter-form">
-  <% if content_item.all_content_finder? %>
-    <%= render partial: 'filter_button'%>
-  <% elsif !content_item.all_content_finder? %>
-    <% if facets.select(&:filterable?).any? %>
-      <%= render partial: 'filter_button'%>
-    <% end %>
-  <% end %>
   <% if !content_item.all_content_finder? %>
     <div id="keywords" role="search" aria-label="<%= content_item.title %>" data-ga4-change-category="update-keyword text">
       <% label_text = capture do %>
@@ -21,6 +14,13 @@
         label_text: label_text
       } %>
     </div>
+  <% end %>
+  <% if content_item.all_content_finder? %>
+    <%= render partial: 'filter_button'%>
+  <% elsif !content_item.all_content_finder? %>
+    <% if facets.select(&:filterable?).any? %>
+      <%= render partial: 'filter_button'%>
+    <% end %>
   <% end %>
 
   <% if facets.select(&:filterable?).any? %>

--- a/app/views/finders/_filter_button.html.erb
+++ b/app/views/finders/_filter_button.html.erb
@@ -1,12 +1,14 @@
 <% add_app_component_stylesheet("mobile-filters") %>
-<button class="app-c-button-as-link app-mobile-filters-link js-toggle-mobile-filters"
-  data-toggle="mobile-filters-modal"
-  data-target="facet-wrapper"
-  data-track-category="filterClicked"
-  data-track-action="mobile-filter-button"
-  data-track-label="">
-    Filter <span class="govuk-visually-hidden"> results</span>
-    <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
-</button>
-<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"></path></svg>
-<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"></path></svg>
+<div class="app-c-mobile-filters">
+  <button class="app-c-button-as-link app-mobile-filters-link js-toggle-mobile-filters"
+    data-toggle="mobile-filters-modal"
+    data-target="facet-wrapper"
+    data-track-category="filterClicked"
+    data-track-action="mobile-filter-button"
+    data-track-label="">
+      Filter <span class="govuk-visually-hidden"> results</span>
+      <span class="js-selected-filter-count"><%= sanitize facet_tags.display_total_selected_filters %></span>
+  </button>
+  <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"></path></svg>
+  <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="mobile-filters-expander__icon mobile-filters-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"></path></svg>
+</div>


### PR DESCRIPTION
## What

- Move mobile filter below search
- Wrap the Filter link and icon in a div with a class of `app-c-mobile-filters`. The positioning of this element is set to relative to ensure the chevron icon renders correctly.

Trello: https://trello.com/c/IEb2RtOG/2009-ensure-any-filter-results-are-visible-when-zoomed-in-400x-2-days

## Why

If you click ‘filter’ on the facet when zoomed in x400, it looks like nothing is happening.

## Visual changes

| Before | After |
| --- | --- |
| <img width="1507" alt="Filter link before search input" src="https://github.com/alphagov/finder-frontend/assets/28779939/e1b7510f-0824-44d1-890e-327b6d4722ee"> | <img width="1531" alt="Filter link after search input" src="https://github.com/alphagov/finder-frontend/assets/28779939/c8d5c865-66e0-4af4-a03c-363b4ead7b61"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
