### PR TITLE
Capitalise AI on 'Ai assurance technique' results

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -39,6 +39,8 @@ class ResultSetPresenter
 
   def search_results_content
     component_data = document_list_component_data(documents_to_convert: documents)
+    component_data = capitalise_ai_values(component_data)
+
     {
       document_list_component_data: component_data,
       zero_results: total.zero?,
@@ -46,6 +48,19 @@ class ResultSetPresenter
       finder_name: content_item.title,
       debug_score:,
     }
+  end
+
+  def capitalise_ai_values(component_data)
+    component_data.each do |document|
+      next unless document[:metadata]
+
+      ai_assurance_value = document[:metadata]["Ai assurance technique"]
+
+      if ai_assurance_value
+        document[:metadata]["Ai assurance technique"] = ai_assurance_value.gsub("Ai assurance technique", "AI assurance technique")
+      end
+    end
+    component_data
   end
 
   def user_supplied_keywords

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -224,4 +224,52 @@ RSpec.describe ResultSetPresenter do
       end
     end
   end
+
+  describe "capitalise_ai_values function" do
+    it "replaces 'Ai assurance technique' values with 'AI assurance technique" do
+      component_data = [{
+        "hello": "i should remain unchanged",
+        "metadata": {
+          "Ai assurance technique": "This is the text displayed on the search, Ai assurance technique",
+        },
+      }]
+
+      # Clone the above search result, and then expect 'Ai' to be capitalised in the text displayed on search.
+      expected_result = {}.merge!(component_data[0])
+      expected_result[:metadata]["Ai assurance technique"] = "This is the text displayed on the search, AI assurance technique"
+
+      component_data = subject.capitalise_ai_values(component_data)
+
+      expect(component_data[0]).to eql expected_result
+    end
+
+    it "does nothing/doesn't crash if no 'Ai assurance technique' key exists" do
+      component_data = [{
+        "hello": "i should remain unchanged",
+        "metadata": {
+          "hello": "world",
+        },
+      }]
+
+      # Clone the above search result
+      expected_result = {}.merge!(component_data[0])
+
+      component_data = subject.capitalise_ai_values(component_data)
+
+      expect(component_data[0]).to eql expected_result
+    end
+
+    it "does nothing/doesn't crash if no metadata key exists" do
+      component_data = [{
+        "hello": "i should remain unchanged",
+      }]
+
+      # Clone the above search result
+      expected_result = {}.merge!(component_data[0])
+
+      component_data = subject.capitalise_ai_values(component_data)
+
+      expect(component_data[0]).to eql expected_result
+    end
+  end
 end


### PR DESCRIPTION
Hi @gclssvglx - would you be able to review this next week (and possibly merge if all is OK, as i'll be away next week?) Thanks :+1:

On this finder, https://www.gov.uk/ai-assurance-techniques, a `metadata` value comes through with the key `Ai assurance technique`. The value of this key is then displayed in the search results. The value is a string, which also contains the phrase `'Ai assurance technique'`.

We've received a request on 2nd Line to capitalise 'Ai' wherever it is displayed on this finder. Therefore I've looped through the search results, and done ` .gsub` to capitalise `AI` in `Ai assurance technique` if it exists.

I think the reason it isn't capitalised in the first place, is because `ai_assurance_technique` is the name of the key in elastic search in the Search API. So I think an auto formatter somewhere is turning `ai_assurance_technique` into `Ai assurance technique`, which works for the other keys, but not this one. 

## Visual changes

### Before

<img width="673" alt="image" src="https://github.com/alphagov/finder-frontend/assets/8880610/b7e977cf-1aab-4695-904b-300bd22776f5">

### After (Ai is now capitalised)

<img width="673" alt="image" src="https://github.com/alphagov/finder-frontend/assets/8880610/f4231714-bafd-4dc8-aa01-71247fda3b07">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
