### PR TITLE
Change search text field labels

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -104,6 +104,10 @@ class ContentItem
     content_item_hash["details"]["summary"]
   end
 
+  def label_text
+    content_item_hash["details"]["label_text"]
+  end
+
   def email_alert_signup
     content_item_hash.dig("links", "email_alert_signup", 0)
   end

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -11,7 +11,7 @@
         type: 'search',
         value: result_set_presenter.user_supplied_keywords,
         inline_label: false,
-        label_text: label_text
+        label_text: sanitize(content_item.label_text) || label_text
       } %>
     </div>
   <% end %>


### PR DESCRIPTION
## What

https://trello.com/c/UwVqYJjP/2065-change-frontend-text-for-search-boxes

- Add label text property to change the label **Search** to **Search keywords for example 'sell alcohol'**, for licence finder (specialist finder) only, which may help users with entering keywords and not treating it like a Google search box

## Why

There were examples in user research of users confusing the main search and the industry filter box, both on mobile and desktop, but particularly on mobile. A successful iteration will improve the usability of the tool.

## Visual changes

### Air Accidents Investigation Branch reports

<img src="https://github.com/alphagov/finder-frontend/assets/87758239/303de1ba-8e26-495b-8af3-920032c7f4f2">

### Air Accidents Investigation Branch reports

<img src="https://github.com/alphagov/finder-frontend/assets/87758239/eaf451c9-74a9-48f2-89f9-a475dbac0c61" width=300>

### Find a licence

<img src="https://github.com/alphagov/finder-frontend/assets/87758239/2cd6d2e5-fe0a-46e1-9da0-82f3660e7979">

### Find a licence

<img src="https://github.com/alphagov/finder-frontend/assets/87758239/95c46dcb-d53a-4a81-91c3-fa11104636fd" width=300>

## Anything else

- https://github.com/alphagov/publishing-api/pull/2415
- https://github.com/alphagov/specialist-publisher/pull/2315