### PR TITLE
Add intervention banner to find-licences

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,6 +13,14 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse, ga4_tracking: true %>
   <% end %>
 
+  <% if content_item.base_path == "/find-licences"%>
+    <div class="govuk-!-margin-top-5">
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: sanitize("This is a new tool. Your <a href='https://surveys.publishing.service.gov.uk/s/1AXTLB' class='govuk-link'>feedback</a> will help us to improve it."),
+      } %>
+    </div>
+  <% end %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>


### PR DESCRIPTION
## What

Adds the intervention banner to the new `find-licences` specialist finder. The intervention banner includes a link to a survey that will be used to gather user feedback following the launch of the new tool.

## Why

Find licences is a new specialist finder that we would like to get user feedback on when it launches.

Trello: https://trello.com/c/FzXAHU3g/2077-implement-feedback-banner-and-text-at-top-of-tool-to-manage-expectations

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
