### PR TITLE
Add optional parameter that allows forcing LTR on on the licences path.

### DIFF
--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -243,7 +243,7 @@ module Search
       # We're using the ab test relevance:disable params here to turn off LTR for this
       # finder. It would probably be best in the long run to create a specific way of
       # doing this that uses a proper parameter, but we can't do that at the moment.
-      ab_params.merge!("relevance" => "disable") if licence_transaction_path?
+      ab_params.merge!("relevance" => "disable") if licence_transaction_path? && !force_ltr?
       ab_params.any? ? { "ab_tests" => ab_params.map { |k, v| "#{k}:#{v}" }.join(",") } : {}
     end
 
@@ -259,6 +259,10 @@ module Search
 
     def licence_transaction_path?
       finder_content_item.base_path == "/find-licences"
+    end
+
+    def force_ltr?
+      params["force-ltr"] == "true"
     end
   end
 end


### PR DESCRIPTION
Allows &force-ltr=true as an optional parameter. Only affects the find licences path, and allows forcing LTR to be on (it is normally disabled for that path) so that post launch we can test whether LTR is okay in production.

https://trello.com/c/RnvhCxqe/2075-add-query-param-to-turn-on-learn-to-rank

### Test Examples

https://www.integration.publishing.service.gov.uk/find-licences?keywords=water
…would get us the search results (this is what typing water in the search box gets you)

https://www.integration.publishing.service.gov.uk/find-licences?keywords=water&force-ltr=true

…would get us the search results with ltr applied.

https://www.integration.publishing.service.gov.uk/find-licences?keywords=water&force-ltr=true&debug_score=true

…gets us ltr applied, with the debug scoring so we could compare ranking and LTR ranking in one go (but probably just comparing the first two versions in different tabs would tell us what we wanted to know)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

