### PR TITLE
Remove subscribe to feed link for licence finder

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,7 +36,7 @@ var $form = document.querySelector('.js-live-search-form')
 var $results = document.querySelector('.js-live-search-results-block')
 var $atomAutodiscoveryLink = document.querySelector("link[type='application/atom+xml']")
 
-if ($form && $results && $atomAutodiscoveryLink) {
+if ($form && $results) {
   // eslint-disable-next-line no-new
   new GOVUK.LiveSearch({
     $form: $form,

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -23,7 +23,9 @@
     this.$sortBlock = options.$results.querySelector('#js-sort-options')
     this.$paginationBlock = options.$results.querySelector('#js-pagination')
     this.action = this.$form.getAttribute('action') + '.json'
-    this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink
+    if (options.$atomAutodiscoveryLink) {
+      this.$atomAutodiscoveryLink = options.$atomAutodiscoveryLink
+    }
 
     this.baseTitle = document.querySelector("meta[name='govuk:base_title']")
     if (this.baseTitle) {
@@ -450,7 +452,9 @@
       for (var a = 0; a < this.$atomLinks.length; a++) {
         this.$atomLinks[a].setAttribute('href', encodeURI(this.atomHref.split('?')[0] + searchState))
       }
-      this.$atomAutodiscoveryLink.setAttribute('href', encodeURI(this.atomHref.split('?')[0] + searchState))
+      if (this.$atomAutodiscoveryLink) {
+        this.$atomAutodiscoveryLink.setAttribute('href', encodeURI(this.atomHref.split('?')[0] + searchState))
+      }
     }
   }
 
@@ -485,7 +489,9 @@
       this.updateSortOptions(results, action)
       this.updateResultsCountMeta(results.total)
       this.manipulateErrorMessages(results.errors)
-      this.$atomAutodiscoveryLink.setAttribute('href', results.atom_url)
+      if (this.$atomAutodiscoveryLink) {
+        this.$atomAutodiscoveryLink.setAttribute('href', results.atom_url)
+      }
       this.$loadingBlock.textContent = ''
       this.$loadingBlock.style.display = 'none'
     }

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -135,7 +135,7 @@ module Search
     end
 
     def stopwords_for_path
-      licence_transaction_path? ? LICENCE_STOPWORDS : []
+      finder_content_item.is_licence_transaction? ? LICENCE_STOPWORDS : []
     end
 
     def remove_stopwords
@@ -243,7 +243,7 @@ module Search
       # We're using the ab test relevance:disable params here to turn off LTR for this
       # finder. It would probably be best in the long run to create a specific way of
       # doing this that uses a proper parameter, but we can't do that at the moment.
-      ab_params.merge!("relevance" => "disable") if licence_transaction_path? && !force_ltr?
+      ab_params.merge!("relevance" => "disable") if finder_content_item.is_licence_transaction? && !force_ltr?
       ab_params.any? ? { "ab_tests" => ab_params.map { |k, v| "#{k}:#{v}" }.join(",") } : {}
     end
 
@@ -252,13 +252,9 @@ module Search
     end
 
     def boost_fields_query
-      return {} unless licence_transaction_path?
+      return {} unless finder_content_item.is_licence_transaction?
 
       { "boost_fields" => "licence_transaction_industry" }
-    end
-
-    def licence_transaction_path?
-      finder_content_item.base_path == "/find-licences"
     end
 
     def force_ltr?

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -152,6 +152,10 @@ class ContentItem
     base_path.split("/")[2]
   end
 
+  def is_licence_transaction?
+    base_path == "/find-licences"
+  end
+
 private
 
   attr_reader :content_item_hash

--- a/app/presenters/signup_links_presenter.rb
+++ b/app/presenters/signup_links_presenter.rb
@@ -22,11 +22,15 @@ private
     signup_link = content_item.signup_link
     return signup_link if signup_link.present?
 
-    "#{content_item.email_alert_signup['base_path']}#{query_string(alert_query_params)}" if content_item.email_alert_signup
+    if content_item.email_alert_signup
+      "#{content_item.email_alert_signup['base_path']}#{query_string(alert_query_params)}"
+    end
   end
 
   def feed_link
-    "#{content_item.base_path}.atom#{query_string(alert_query_params.merge(keywords:))}"
+    unless content_item.is_licence_transaction?
+      "#{content_item.base_path}.atom#{query_string(alert_query_params.merge(keywords:))}"
+    end
   end
 
   def alert_query_params

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -4,7 +4,9 @@
   <% content_for :title, content_item.title %>
 <% end %>
 <% content_for :head do %>
-  <%= auto_discovery_link_tag(:atom, signup_links[:feed_link]) %>
+  <% if signup_links[:feed_link] %>
+    <%= auto_discovery_link_tag(:atom, signup_links[:feed_link]) %>
+  <% end %>
   <%= render 'finder_meta', content_item: content_item %>
 <% end %>
 

--- a/spec/presenters/signup_link_presenter_spec.rb
+++ b/spec/presenters/signup_link_presenter_spec.rb
@@ -121,6 +121,20 @@ RSpec.describe SignupLinksPresenter do
           expect(subject.signup_links[:feed_link]).to eql("/mosw-reports.atom?keywords=micropig&topic%5B%5D=hidden_facet_content_id")
         end
       end
+
+      context "with a licence transaction" do
+        let(:facet_values) do
+          []
+        end
+
+        before do
+          allow(content_item).to receive(:is_licence_transaction?).and_return(true)
+        end
+
+        it "returns nil" do
+          expect(subject.signup_links[:feed_link]).to be nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Collaborated with @MartinJJones for this piece of work 🙌 

The plan is to remove the feed links from all finders, unless we gain
evidence that it is needed. Until this decision is made, we don't want to
introduce the feature for the new licence finder.

We've also had to update the JS to keep the live search feature working,
as removing the link removed this functionality. We've now added JS tests 
to ensure the feature works when the feed link isn't present.

Trello:
https://trello.com/c/9RFdV1KK/2094-remove-feed-link-from-only-the-new-licence-finder

## Visual Changes

| Visible | Removed (Licence Finder) |
| --- | --- |
| <img width="1113" alt="subscribe-to-feed-footer" src="https://github.com/alphagov/finder-frontend/assets/28779939/3c6865d0-d4d5-4986-9379-51b080b12d5e"> | <img width="1012" alt="subscribe-to-feed-removed-top" src="https://github.com/alphagov/finder-frontend/assets/28779939/93dded09-de19-4038-8049-1b2aaac555d6"> |
| <img width="1087" alt="subscribe-to-feed-head" src="https://github.com/alphagov/finder-frontend/assets/28779939/ca967f36-c444-4e20-abe5-463df4a89b96"> | <img width="1062" alt="subscribe-to-feed-footer-removed" src="https://github.com/alphagov/finder-frontend/assets/28779939/3dc099a8-48f8-40b8-bdbf-326492dc2d3f"> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
