### PR TITLE
Heed RAILS_LOG_LEVEL in production config.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", :info)
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
This was added to Rails's template for production.rb in https://github.com/rails/rails/blob/3b83758/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L73

We want to be able to control the log level this way so that:

- we don't have to rebuild an app just to change its log level
- we can enable debug logging if we need it to investigate a problem that's hard to reproduce
- we can tune the log levels so as not to waste resources logging things that we don't care about the rest of the time
- if a change to an app introduces a problem with logspew, we can just dial down the log level while someone tracks down the underlying issue

This is a bulk change; all 43 PRs are identical except for apps which had their loglevel set to `debug`, which we're resetting to `info` as the default.

To approve, use https://github.com/alphagov/bulk-merger:

```sh
./review 'Heed RAILS_LOG_LEVEL in production config.'
```
