### PR TITLE
GA4 Search Fixes

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -130,6 +130,8 @@
           schema.event_data.section = 'Search'
           schema.event_data.action = 'search'
           schema.event_data.text = PIIRemover.stripPIIWithOverride(schema.event_data.text, true, true)
+          schema.event_data.text = GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(schema.event_data.text)
+          schema.event_data.text = schema.event_data.text.toLowerCase()
           break
 
         case 'clear-all-filters':

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -214,14 +214,25 @@
 
   LiveSearch.prototype.serializeState = function (state) {
     var params = []
+    var keywords
     if (Array.isArray(state)) {
       for (var i = 0; i < state.length; i++) {
-        params.push(state[i].name + '=' + state[i].value)
+        if (state[i].name === 'keywords') {
+          keywords = state[i].value.replace(/\s+/g, '+')
+          params.push(state[i].name + '=' + keywords)
+        } else {
+          params.push(state[i].name + '=' + state[i].value)
+        }
       }
     } else {
       for (var key in state) {
         if (Object.prototype.hasOwnProperty.call(state, key)) {
-          params.push(encodeURIComponent(key) + '=' + encodeURIComponent(state[key]))
+          if (key === 'keywords') {
+            keywords = state[key].replace(/\s+/g, '+')
+            params.push(encodeURIComponent(key) + '=' + encodeURIComponent(keywords))
+          } else {
+            params.push(encodeURIComponent(key) + '=' + encodeURIComponent(state[key]))
+          }
         }
       }
     }

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -65,7 +65,29 @@ describe('GA4 finder change tracker', function () {
 
     expected.event_data.event_name = 'search'
     expected.event_data.url = window.location.pathname
-    expected.event_data.text = 'Hello world my postcode is [postcode]. My birthday is [date]. My email is [email]'
+    expected.event_data.text = 'hello world my postcode is [postcode]. my birthday is [date]. my email is [email]'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('trims extra spaces and converts downcases characters on a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = ' I    have a lot of   SPACES   in a lot of PLACES         '
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'i have a lot of spaces in a lot of places'
     expected.event_data.section = 'Search'
     expected.event_data.action = 'search'
 


### PR DESCRIPTION
This PR contains two fixes for the GA4 search tracking.

1. When tracking searches, it will now make sure the search term doesn't contain any extra spaces, and that the search term is lowercase.

2. When you initially load a search result, the page URL looks like `?keywords=hello+world`. However when you update a filter, the URL becomes `?keywords=hello%20world` because JavaScript is updating the URL using `encodeURI` which turns spaces into `%20`. This causes an issue for analysts as the URLs in the dashboard become inconsistent having a mixture of `%20` and `+`.  Therefore, in this PR I am manually changing any spaces to `+` before `encodeURI` runs, to get rid of any `%20` references in the `keywords` part of the URL.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
