### PR TITLE
Update world location code for breaking changes in `gds-api-adapters` version 89.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     ffi (1.15.5)
-    gds-api-adapters (88.2.0)
+    gds-api-adapters (89.0.0)
       addressable
       link_header
       null_logger
@@ -445,7 +445,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.3.0)
       nio4r (~> 2.0)
     racc (1.7.1)

--- a/app/lib/registries/world_locations_registry.rb
+++ b/app/lib/registries/world_locations_registry.rb
@@ -43,7 +43,7 @@ module Registries
     end
 
     def fetch_locations_from_worldwide_api
-      Services.worldwide_api.world_locations.with_subsequent_pages.to_a
+      Services.worldwide_api.world_locations.to_a
     end
   end
 end

--- a/spec/lib/registries/world_locations_registry_spec.rb
+++ b/spec/lib/registries/world_locations_registry_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Registries::WorldLocationsRegistry do
 
   def world_locations_api_is_unavailable
     base_url = GdsApi::TestHelpers::Worldwide::WORLDWIDE_API_ENDPOINT
-    stub_request(:get, "#{base_url}/api/world-locations").to_return(status: 500)
+    stub_request(:get, "#{base_url}/api/content/world").to_return(status: 500)
   end
 
   def clear_cache


### PR DESCRIPTION
, [Jira issue PP-761](https://gov-uk.atlassian.net/browse/PP-761)This version of `gds-api-adapters` removes pagination of the world locations, so we need to update this application accordingly.

[Trello card](https://trello.com/c/4r5uSD2R)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
