### PR TITLE
Add scroll tracking to finders

### DIFF
--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -24,6 +24,7 @@
       <meta name="robots" content="noindex">
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
     <%= yield :meta_tags %>
   </head>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds scroll tracking to finders, e.g. `/search/all`. Should work for all finders, check the page at `/` for a full list to test.

- adds scroll tracking module to the base template for all finders
- uses the default scroll track mode of tracking percentage scrolled, every 20%

**NOTE** this PR depends upon the scroll tracking code in `static`, it's currently only on integration.

## Why
Part of the GA4 migration

## Visual changes
None.

Trello card: https://trello.com/c/r75BqxiW/608-scroll-tracking-percent-type-finders
