### PR TITLE
Add data-ga4-index-group-number attributes

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -82,7 +82,7 @@
               class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop"
               data-module="ga4-link-tracker"
               data-ga4-track-links-only
-              data-ga4-set-indexes
+              data-ga4-index-group-number="1"
               data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Top" }'>
               <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>
@@ -111,7 +111,7 @@
           id="subscription-links-footer"
           data-module="ga4-link-tracker"
           data-ga4-track-links-only
-          data-ga4-set-indexes
+          data-ga4-index-group-number="1"
           data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Footer" }'>
           <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
         </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR removes `data-ga4-set-indexes` and adds a `data-ga4-index-group-number` attribute to subscription links so that we can combine their GA4 indexes when they appear in different places on the page. The code in this PR is reliant on https://github.com/alphagov/govuk_publishing_components/pull/3528

## Why
GA4 migration bug fix - [trello card](https://trello.com/c/kBakyMMc/613-fix-index-on-subscribe-to-feed-interaction)

## Visual Changes
N/A
