### PR TITLE
Add scrolltracker reset event

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -506,6 +506,8 @@
       this.$loadingBlock.textContent = ''
       this.$loadingBlock.style.display = 'none'
     }
+    // send this event to notify the scroll tracker to reset, if listening
+    window.GOVUK.triggerEvent(this.$form, 'dynamic-page-update')
   }
 
   LiveSearch.prototype.restoreBooleans = function restoreBooleans () {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Adds a dynamic page update event (custom event) into the bit of the search code where the page is dynamically updated.

If listening, the scroll tracker will detect this event and reset scroll tracking.

See related PR: https://github.com/alphagov/govuk_publishing_components/pull/3544

## Visual changes
None.

Trello card: https://trello.com/c/fhnLqnKw/669-scroll-tracker-to-refresh-on-dynamic-pages