### PR TITLE
Add GA4 tracking for email subscriptions

### DIFF
--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -9,22 +9,53 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <%= form_tag email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params), class: 'signup-choices' do %>
+  <%
+    ga4_data = {
+      event_name: "form_response",
+      type: "email subscription",
+      section: t("email_alert_subscriptions.new.question", locale: :en),
+      action: "continue",
+      tool_name: "Get emails from GOV.UK",
+    }.to_json
+  %>
+  <%= form_tag(
+    email_alert_subscriptions_path(subscriber_list_params: subscriber_list_params),
+    class: 'signup-choices',
+    data: {
+      module: "ga4-form-tracker",
+      ga4_form: ga4_data,
+    }) do %>
     <% if @signup_presenter.can_modify_choices? %>
       <%= render partial: 'govuk_publishing_components/components/title', locals: {
         title: @signup_presenter.name,
       } %>
 
       <% if @error_message.present? %>
-        <%= render "govuk_publishing_components/components/error_summary", {
-          title: "There is a problem",
-          items: [
-            {
-              text: @error_message,
-              href: "#signup-choices-options",
-            }
-          ]
-        } %>
+        <%
+          ga4_data = {
+            event_name: "form_error",
+            type: "email subscription",
+            text: @error_message,
+            section: t("email_alert_subscriptions.new.question", locale: :en),
+            action: "error",
+            tool_name: "Get emails from GOV.UK"
+          }.to_json
+        %>
+        <%= content_tag(:div,
+          data: {
+            module: "ga4-auto-tracker",
+            ga4_auto: ga4_data
+          }) do %>
+            <%= render "govuk_publishing_components/components/error_summary", {
+              title: "There is a problem",
+              items: [
+                {
+                  text: @error_message,
+                  href: "#signup-choices-options",
+                }
+              ]
+            } %>
+        <% end %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/checkboxes", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- adds tracking to the form and error message for the first step of the email subscriptions for search results journey
- journey starts from clicking 'get emails' on search results, tracking is being added on the confirmation page that follows, at e.g. https://www.gov.uk/search/research-and-statistics/email-signup?content_store_document_type=all_research_and_statistics

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms
