### PR TITLE
Reinstate AA test ElasticSearch 6.7

### DIFF
--- a/app/controllers/ab_tests/elastic_search_aa_testable.rb
+++ b/app/controllers/ab_tests/elastic_search_aa_testable.rb
@@ -1,0 +1,19 @@
+module AbTests::ElasticSearchAaTestable
+  def elastic_search_aa_test
+    GovukAbTesting::AbTest.new(
+      "EsSixPointSeven",
+      dimension: 41,
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+  end
+
+  def page_under_test?
+    request.path.include?("/search/all")
+  end
+
+  def set_requested_variant
+    @requested_variant = elastic_search_aa_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,5 +1,6 @@
 class FindersController < ApplicationController
   layout "finder_layout"
+  include AbTests::ElasticSearchAaTestable
 
   before_action do
     set_expiry(content_item)
@@ -7,6 +8,10 @@ class FindersController < ApplicationController
 
   def show
     slimmer_template "gem_layout_full_width" if i_am_a_topic_page_finder
+
+    if page_under_test?
+      set_requested_variant
+    end
 
     respond_to do |format|
       format.html do
@@ -58,7 +63,7 @@ private
 
   attr_reader :search_query
 
-  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets
+  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets, :page_under_test?
 
   def redirect_to_destination
     @redirect = content_item.redirect

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -66,6 +66,12 @@
       <% end %>
     </div>
 
+    <% if page_under_test? %>
+      <% content_for :meta_tags do %>
+        <%= @requested_variant.analytics_meta_tag.html_safe %>
+      <% end %>
+    <% end %>
+
     <% if content_item.summary %>
       <div class="govuk-grid-column-two-thirds">
         <div class="metadata-summary ">

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -25,6 +25,7 @@
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
     <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
+    <%= yield :meta_tags %>
   </head>
 
   <body class="<%= yield :body_classes %>">

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -109,6 +109,52 @@ describe FindersController, type: :controller do
         get :show, params: { slug: "lunch-finder" }
         expect(response.status).to eq(406)
       end
+
+      context "with AA test" do
+        %w[A B Z].each do |variant|
+          it "renders the #{variant} variant for /search/all pages" do
+            stub_content_store_has_item(
+              "/search/all",
+              all_content_finder,
+            )
+
+            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+
+            get :show, params: { slug: "search/all" }
+
+            expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
+            expect(response.body).to include("EsSixPointSeven:#{variant}")
+          end
+
+          it "doesn't render the #{variant} for finders" do
+            stub_content_store_has_item(
+              "/lunch-finder",
+              lunch_finder,
+            )
+
+            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+
+            get :show, params: { slug: "lunch-finder" }
+
+            expect(response.status).to eq(200)
+            expect(response.header["Vary"]).not_to eq("GOVUK-ABTest-EsSixPointSeven")
+            expect(response.body).not_to include("EsSixPointSeven:#{variant}")
+          end
+        end
+
+        it "should render the page without an AB test variant for search" do
+          stub_content_store_has_item(
+            "/search/all",
+            all_content_finder,
+          )
+
+          get :show, params: { slug: "search/all" }
+
+          expect(response.status).to eq(200)
+          expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
+          expect(response.body).not_to include("<meta name=\"govuk:ab-test\">")
+        end
+      end
     end
 
     describe "a finder content item with a default order exists" do


### PR DESCRIPTION
[Trello](https://trello.com/c/VfqiGVjQ/318-reinstate-elasticsearch-67-aa-test-for-the-search-team)

[We recently ran an AA test for the Search team](https://github.com/alphagov/finder-frontend/pull/3053).

We are going to run it again, hence reinstating it in this PR!

The purpose of the A/A test is to test the % of allocation of traffic/sample population based on the current version of elastic (6.7) against itself. A (ES 6.7) vs A (ES6.7). The A/A is solely to identify how the approach allocates traffic. This will provide benchmark data to aid analysis in future AA tests.

This time around, the code will stay the same. We will use the same custom dimension and the variant split will still be 50/50. The only difference is that the custom dimension has been scoped as ‘user' as opposed to ‘session’ like it was last time. Scoping the custom dimension has already been done by a performance analyst.

We plan to deploy this on Thursday 17 August for 1 week.

[Corresponding CDN config PR](https://github.com/alphagov/govuk-cdn-config/pull/467)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
