### PR TITLE
Add signup links index to data_attributes

### DIFF
--- a/app/presenters/signup_links_presenter.rb
+++ b/app/presenters/signup_links_presenter.rb
@@ -6,17 +6,62 @@ class SignupLinksPresenter
   end
 
   def signup_links
-    {
-      feed_link:,
-      hide_heading: true,
-      small_form: true,
-      email_signup_link: email_signup_link.presence,
-    }.compact
+    # if there are 4 links, we start from 2
+    # if there are 2 links, we start from 1
+    [
+      get_signup_link(0),
+      get_signup_link(count_signup_links / 2),
+    ]
   end
 
 private
 
   attr_reader :content_item, :facets, :keywords
+
+  def get_signup_link(pos)
+    total_links = count_signup_links
+
+    data_attributes = {
+      hide_heading: true,
+      small_form: true,
+      feed_link:,
+      email_signup_link: email_signup_link.presence,
+    }.compact
+
+    if email_signup_link && feed_link
+      email_index_link = pos + 1
+      feed_index_link = pos + 2
+    elsif email_signup_link
+      email_index_link = pos + 1
+    elsif feed_link
+      feed_index_link = pos + 1
+    end
+
+    if email_signup_link
+      data_attributes[:email_signup_link_data_attributes] = {}
+      data_attributes[:email_signup_link_data_attributes][:ga4_index] = {
+        index_link: email_index_link,
+        index_total: total_links,
+      }
+    end
+
+    if feed_link
+      data_attributes[:feed_link_data_attributes] = {}
+      data_attributes[:feed_link_data_attributes][:ga4_index] = {
+        index_link: feed_index_link,
+        index_total: total_links,
+      }
+    end
+
+    data_attributes
+  end
+
+  def count_signup_links
+    total = 0
+    total += 1 if feed_link
+    total += 1 if email_signup_link
+    total * 2
+  end
 
   def email_signup_link
     signup_link = content_item.signup_link

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -4,8 +4,8 @@
   <% content_for :title, content_item.title %>
 <% end %>
 <% content_for :head do %>
-  <% if signup_links[:feed_link] %>
-    <%= auto_discovery_link_tag(:atom, signup_links[:feed_link]) %>
+  <% if signup_links[0][:feed_link] %>
+    <%= auto_discovery_link_tag(:atom, signup_links[0][:feed_link]) %>
   <% end %>
   <%= render 'finder_meta', content_item: content_item %>
 <% end %>
@@ -82,9 +82,8 @@
               class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop"
               data-module="ga4-link-tracker"
               data-ga4-track-links-only
-              data-ga4-set-indexes
               data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Top" }'>
-              <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
+              <%= render "govuk_publishing_components/components/subscription_links", signup_links[0] %>
             </div>
           </div>
           <div id="js-facet-tag-wrapper" class="facet-tags__container" aria-live="assertive">
@@ -111,9 +110,8 @@
           id="subscription-links-footer"
           data-module="ga4-link-tracker"
           data-ga4-track-links-only
-          data-ga4-set-indexes
           data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Footer" }'>
-          <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
+          <%= render "govuk_publishing_components/components/subscription_links", signup_links[1] %>
         </div>
       </div>
     </div>

--- a/spec/presenters/signup_link_presenter_spec.rb
+++ b/spec/presenters/signup_link_presenter_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SignupLinksPresenter do
         let(:facet_values) { [] }
 
         it "returns the finder URL appended with /email-signup" do
-          expect(subject.signup_links[:email_signup_link]).to eql("/email_signup")
+          expect(subject.signup_links[0][:email_signup_link]).to eql("/email_signup")
         end
       end
 
@@ -93,7 +93,15 @@ RSpec.describe SignupLinksPresenter do
         end
 
         it "returns the finder URL appended with permitted query params" do
-          expect(subject.signup_links[:email_signup_link]).to eql("/mosw-reports/email-signup?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[0][:email_signup_link]).to eql("/mosw-reports/email-signup?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[0][:email_signup_link_data_attributes][:ga4_index]).to eql({ index_link: 1, index_total: 4 })
+          expect(subject.signup_links[0][:feed_link]).to eql("/mosw-reports.atom?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[0][:feed_link_data_attributes][:ga4_index]).to eql({ index_link: 2, index_total: 4 })
+
+          expect(subject.signup_links[1][:email_signup_link]).to eql("/mosw-reports/email-signup?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[1][:email_signup_link_data_attributes][:ga4_index]).to eql({ index_link: 3, index_total: 4 })
+          expect(subject.signup_links[1][:feed_link]).to eql("/mosw-reports.atom?topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[1][:feed_link_data_attributes][:ga4_index]).to eql({ index_link: 4, index_total: 4 })
         end
       end
     end
@@ -104,7 +112,7 @@ RSpec.describe SignupLinksPresenter do
           []
         end
         it "returns the finder URL appended with .atom" do
-          expect(subject.signup_links[:feed_link]).to eql("/mosw-reports.atom")
+          expect(subject.signup_links[0][:feed_link]).to eql("/mosw-reports.atom")
         end
       end
 
@@ -118,7 +126,7 @@ RSpec.describe SignupLinksPresenter do
         end
 
         it "returns the finder URL appended with permitted query params" do
-          expect(subject.signup_links[:feed_link]).to eql("/mosw-reports.atom?keywords=micropig&topic%5B%5D=hidden_facet_content_id")
+          expect(subject.signup_links[0][:feed_link]).to eql("/mosw-reports.atom?keywords=micropig&topic%5B%5D=hidden_facet_content_id")
         end
       end
 
@@ -132,9 +140,105 @@ RSpec.describe SignupLinksPresenter do
         end
 
         it "returns nil" do
-          expect(subject.signup_links[:feed_link]).to be nil
+          expect(subject.signup_links[0][:feed_link]).to be nil
         end
       end
+    end
+  end
+
+  describe "only a feed link" do
+    let(:content_item) do
+      content_item_hash = {
+        content_id: "content_id",
+        base_path: "/mosw-reports",
+        title: "A finder",
+        name: "A finder",
+        links: {},
+        signup_link: false,
+        email_alert_signup: false,
+        details: {
+          show_summaries: true,
+          document_noun: "case",
+          sort: [
+            {
+              "name" => "Most viewed",
+              "key" => "-popularity",
+            },
+            {
+              "name" => "Relevance",
+              "key" => "-relevance",
+            },
+            {
+              "name" => "Updated (newest)",
+              "key" => "-public_timestamp",
+              "default" => true,
+            },
+          ],
+        },
+      }
+      ContentItem.new(content_item_hash.deep_stringify_keys)
+    end
+
+    let(:email_signup_hash) do
+      {}
+    end
+
+    it "returns data for the feed link only" do
+      expect(subject.signup_links[0][:feed_link]).to eql("/mosw-reports.atom")
+      expect(subject.signup_links[0][:feed_link_data_attributes][:ga4_index]).to eql({ index_link: 1, index_total: 2 })
+      expect(subject.signup_links[0][:email_signup_link]).to eql(nil)
+      expect(subject.signup_links[0][:email_signup_link_data_attributes]).to eql(nil)
+
+      expect(subject.signup_links[1][:feed_link]).to eql("/mosw-reports.atom")
+      expect(subject.signup_links[1][:feed_link_data_attributes][:ga4_index]).to eql({ index_link: 2, index_total: 2 })
+      expect(subject.signup_links[1][:email_signup_link]).to eql(nil)
+      expect(subject.signup_links[1][:email_signup_link_data_attributes]).to eql(nil)
+    end
+  end
+
+  describe "only an email link" do
+    let(:content_item) do
+      content_item_hash = {
+        content_id: "content_id",
+        base_path: "/find-licences",
+        title: "A finder",
+        name: "A finder",
+        links: {
+          email_alert_signup: Array.wrap(email_signup_hash),
+        },
+        details: {
+          show_summaries: true,
+          document_noun: "case",
+          sort: [
+            {
+              "name" => "Most viewed",
+              "key" => "-popularity",
+            },
+            {
+              "name" => "Relevance",
+              "key" => "-relevance",
+            },
+            {
+              "name" => "Updated (newest)",
+              "key" => "-public_timestamp",
+              "default" => true,
+            },
+          ],
+        },
+      }
+      ContentItem.new(content_item_hash.deep_stringify_keys)
+    end
+
+    it "returns data for the email signup link only" do
+      expect(subject.signup_links[0][:feed_link]).to eql(nil)
+      expect(subject.signup_links[0][:feed_link_data_attributes]).to eql(nil)
+      expect(subject.signup_links[0][:email_signup_link]).to eql("/email_signup")
+      expect(subject.signup_links[0][:email_signup_link_data_attributes][:ga4_index]).to eql({ index_link: 1, index_total: 2 })
+
+      expect(subject.signup_links[1][:feed_link]).to eql(nil)
+      expect(subject.signup_links[1][:feed_link_data_attributes]).to eql(nil)
+      expect(subject.signup_links[1][:email_signup_link]).to eql("/email_signup")
+      expect(subject.signup_links[1][:email_signup_link_data_attributes][:ga4_index]).to eql({ index_link: 2, index_total: 2 })
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
On finder pages, signup links can appear at the top and bottom of the page and they are rendered as separate modules. For GA4 analytics purposes, however, we want to treat these separate modules as if they were in the same module and combine their index values.

For example, if there are 2 signup links at the top of the page, their current index properties are `index_link: 1/2`, `index_total: 2`. Similarly, if there are a further 2 signup links at the bottom of the page, their current index properties are also `index_link: 1/2`, `index_total: 2`. We want to combine these index properties so that they become `index_link: 1/2/3/4` and `index_total: 4`.

This PR calculates the index values in `app/presenters/signup_links_presenter.rb` and adds them to the `data_attributes` hash, which ultimately sets the `data-ga4-index` attribute in the `govuk_publishing_components/components/subscription_links` component.

Credit for the code used in this PR belongs to @andysellick ⭐ 

Examples:

- [finder with two links](https://www.gov.uk/administrative-appeals-tribunal-decisions) (both `Get emails` and `Subscribe to feed`)
- [finder with one link](https://www.gov.uk/aaib-reports) (`Subscribe to feed`)

## Why
[Trello card](https://trello.com/c/kBakyMMc/613-paused-fix-index-on-subscribe-to-feed-interaction)

## Visual changes
N/A
