### PR TITLE
Update AA test config for ElasticSearch 6.7

### DIFF
--- a/app/controllers/ab_tests/elastic_search_aa_testable.rb
+++ b/app/controllers/ab_tests/elastic_search_aa_testable.rb
@@ -3,7 +3,7 @@ module AbTests::ElasticSearchAaTestable
     GovukAbTesting::AbTest.new(
       "EsSixPointSeven",
       dimension: 41,
-      allowed_variants: %w[A B Z],
+      allowed_variants: %w[A B C Z],
       control_variant: "Z",
     )
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -111,7 +111,7 @@ describe FindersController, type: :controller do
       end
 
       context "with AA test" do
-        %w[A B Z].each do |variant|
+        %w[A B C Z].each do |variant|
           it "renders the #{variant} variant for /search/all pages" do
             stub_content_store_has_item(
               "/search/all",


### PR DESCRIPTION
There is currently an AA test running with a 50/50 split [1]. 

We now want to run a throttled version with a 0.5% split. The C variant has therefore been added to the [corresponding govuk-cdn-config PR](https://github.com/alphagov/govuk-cdn-config/pull/470) to soak up the traffic that is not in A or B. This PR allows the C variant. Z will remain as the control variant. 

[1]https://github.com/alphagov/finder-frontend/pull/3135

### Manual testing:

#### GOVUK-ABTest-EsSixPointSeven header not set

<img width="860" alt="no-header" src="https://github.com/alphagov/finder-frontend/assets/5963488/ff0cad98-d13f-4c30-a1ac-313097c1c9aa">

#### Header value set to A

<img width="872" alt="a-header" src="https://github.com/alphagov/finder-frontend/assets/5963488/8c69e665-bf8d-463a-9e2b-9e4ebc02f915">

#### Header value set to B

<img width="875" alt="b-header" src="https://github.com/alphagov/finder-frontend/assets/5963488/a649745b-765f-4359-8c7a-98b8823285d5">

#### Header value set to C

<img width="872" alt="c-header" src="https://github.com/alphagov/finder-frontend/assets/5963488/b8bbdbff-4d97-4701-9ffc-ac09fda61e2c">

#### Header value set to a value that isn't ABC


<img width="888" alt="non-abc-header" src="https://github.com/alphagov/finder-frontend/assets/5963488/c0a1613a-a651-4618-84cf-414220021768">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
