### PR TITLE
Remove `whenever` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "sassc-rails"
 gem "slimmer"
 gem "sprockets-rails"
 gem "uglifier"
-gem "whenever"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,8 +619,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -660,7 +658,6 @@ DEPENDENCIES
   timecop
   uglifier
   webmock
-  whenever
 
 BUNDLED WITH
    2.4.3

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,1 +1,0 @@
-# File required to ensure cronjobs are removed


### PR DESCRIPTION
Scheduled tasks now run as Kubernetes cronjobs and this gem is no longer used. It also breaks the Rails console due to an incompatibility with Ruby 3.2, so this is a good opportunity to get rid of it!