### PR TITLE
Allow manually calling `search-api-v2`

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -87,7 +87,11 @@ module Search
         override_sort_for_feed:,
       ).call
 
-      if queries.one?
+      if use_v2_api?
+        GovukStatsd.time("search_api_v2.finder_search") do
+          Services.search_api_v2.search(queries.first).to_hash
+        end
+      elsif queries.one?
         GovukStatsd.time("rummager.finder_search") do
           Services.rummager.search(queries.first).to_hash
         end
@@ -98,6 +102,10 @@ module Search
           )
         end
       end
+    end
+
+    def use_v2_api?
+      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
     end
   end
 end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -25,6 +25,10 @@ module Services
     GdsApi::Search.new(Plek.find("search-api"))
   end
 
+  def self.search_api_v2
+    GdsApi::SearchApiV2.new(Plek.find("search-api-v2"))
+  end
+
   def self.email_alert_api
     Services::EmailAlertApi.new
   end


### PR DESCRIPTION
As a first step to building the integration with `search-api-v2`, allow `finder-frontend` to call it if and only if an explicit `use_v2` query parameter is supplied.

- Bump `gds-api-adapters` to get new adapter for `search-api-v2`
- Add `Services#search_api_v2`
- Update `Search::Query` to call `search-api-v2` if `use_v2` parameter is present and truthy (accoring to `ActiveModel::Type::Boolean`)