### PR TITLE
Spike: Refactor option-select component to isolate it from GA4 functionality specific to finder-frontend

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -147,7 +147,6 @@
     },
 
     addFilterButtonTracking: function (button, section) {
-      button.setAttribute('data-ga4-expandable', '')
       var ga4JSON = { event_name: 'select_content', type: 'finder', section: section }
 
       try {

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -7,9 +7,7 @@
 
   GOVUK.analyticsGa4.Ga4FinderTracker = {
 
-    setFilterIndexes: function () {
-      window.GOVUK.triggerEvent(window, 'ga4-filter-indexes-added')
-    },
+    setFilterIndexes: function () {},
 
     // Called when the search results updates. Takes the event target, and a string containing the type of change and element type. Creates the GTM schema and pushes it.
     // changeEventMetadata is a string referring to the type of form change and the element type that triggered it. For example 'update-filter checkbox'.
@@ -146,25 +144,7 @@
       }
     },
 
-    addFilterButtonTracking: function (button, section) {
-      var ga4JSON = { event_name: 'select_content', type: 'finder', section: section }
-
-      try {
-        var index = button.closest('[data-ga4-index]') || undefined
-        if (index) {
-          ga4JSON.index = JSON.parse(index.getAttribute('data-ga4-index'))
-        } else {
-          console.warn('No data-ga4-index found on the following element or its parents:')
-          console.warn(button)
-        }
-      } catch (e) {
-        // if there's a problem with the index object, don't add the attribute
-        console.error('GA4 configuration error: ' + e.message, window.location)
-        return
-      }
-
-      button.setAttribute('data-ga4-event', JSON.stringify(ga4JSON))
-    }
+    addFilterButtonTracking: function (button, section) {}
   }
 
   global.GOVUK = GOVUK

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -7,20 +7,7 @@
 
   GOVUK.analyticsGa4.Ga4FinderTracker = {
 
-    // Finds the parent div containing the filters. Loops through each child div that has data-ga4-section on it . Sets an index on each of these child divs.
     setFilterIndexes: function () {
-      var filterContainer = document.querySelector('[data-ga4-filter-container]')
-
-      if (!filterContainer) {
-        return
-      }
-
-      var filterSections = filterContainer.querySelectorAll('[data-ga4-section]')
-
-      for (var i = 0; i < filterSections.length; i++) {
-        filterSections[i].setAttribute('data-ga4-index', JSON.stringify({ index_section: i + 1, index_section_count: filterSections.length }))
-      }
-
       window.GOVUK.triggerEvent(window, 'ga4-filter-indexes-added')
     },
 

--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -68,6 +68,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
     $button.setAttribute('type', 'button')
     $button.setAttribute('aria-expanded', expanded)
     $button.setAttribute('aria-controls', this.$content.getAttribute('id'))
+    $button.setAttribute('data-ga4-expandable', '')
 
     // GA4 Accordion tracking. Relies on the ga4-finder-tracker setting the index first, so we wrap this in a custom event.
     window.addEventListener('ga4-filter-indexes-added', function () {

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -166,18 +166,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     button.setAttribute('aria-expanded', true)
     button.setAttribute('id', containerHead.getAttribute('id'))
     button.setAttribute('aria-controls', this.$optionsContainer.getAttribute('id'))
-    button.setAttribute('data-ga4-expandable', '')
     button.innerHTML = jsContainerHeadHTML
-    containerHead.parentNode.replaceChild(button, containerHead)
 
-    // GA4 Accordion tracking. Relies on the ga4-finder-tracker setting the index first, so we wrap this in a custom event.
-    window.addEventListener('ga4-filter-indexes-added', function () {
-      if (window.GOVUK.analyticsGa4) {
-        if (window.GOVUK.analyticsGa4.Ga4FinderTracker) {
-          window.GOVUK.analyticsGa4.Ga4FinderTracker.addFilterButtonTracking(button, button.innerHTML)
-        }
-      }
-    })
+    dataAttributes = JSON.parse(this.$optionSelect.getAttribute("data-button-data-attributes"))
+    for (const key in dataAttributes) {
+      var rawValue = dataAttributes[key]
+      var value = typeof rawValue == "object" ? JSON.stringify(rawValue) : rawValue
+      button.setAttribute('data-' + key, value)
+    }
+
+    containerHead.parentNode.replaceChild(button, containerHead)
   }
 
   OptionSelect.prototype.attachCheckedCounter = function attachCheckedCounter (checkedString) {

--- a/app/assets/javascripts/components/option-select.js
+++ b/app/assets/javascripts/components/option-select.js
@@ -166,6 +166,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     button.setAttribute('aria-expanded', true)
     button.setAttribute('id', containerHead.getAttribute('id'))
     button.setAttribute('aria-controls', this.$optionsContainer.getAttribute('id'))
+    button.setAttribute('data-ga4-expandable', '')
     button.innerHTML = jsContainerHeadHTML
     containerHead.parentNode.replaceChild(button, containerHead)
 

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -92,7 +92,7 @@ private
   def result_set_presenter
     @result_set_presenter ||= ResultSetPresenter.new(
       content_item,
-      facets,
+      all_facets,
       results,
       filter_params,
       sort_presenter,
@@ -106,12 +106,16 @@ private
     @results ||= ResultSetParser.parse(search_results)
   end
 
-  def facets
+  def all_facets
     @facets ||= FacetsBuilder.new(content_item:, search_results:, value_hash: filter_params).facets
   end
 
+  def facets
+    all_facets.select(&:filterable?)
+  end
+
   def signup_links
-    @signup_links ||= SignupLinksPresenter.new(content_item, facets, keywords).signup_links
+    @signup_links ||= SignupLinksPresenter.new(content_item, all_facets, keywords).signup_links
   end
 
   def initialize_search_query(is_for_feed: false)
@@ -174,7 +178,7 @@ private
 
   def facet_tags
     @facet_tags ||= FacetTagsPresenter.new(
-      facets.select(&:filterable?),
+      facets,
       sort_presenter,
       i_am_a_topic_page_finder:,
     )

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -111,7 +111,7 @@ private
   end
 
   def facets
-    all_facets.select(&:filterable?)
+    FacetsIterator.new(all_facets.select(&:filterable?))
   end
 
   def signup_links

--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -1,0 +1,14 @@
+class FacetsIterator
+  delegate :select, :any?, to: :@facets
+
+  def initialize(facets)
+    @facets = facets
+    @facets_with_ga4_section = @facets.select(&:has_ga4_section?)
+  end
+
+  def each_with_index_and_count
+    @facets.each do |facet|
+      yield facet, @facets_with_ga4_section.index(facet), @facets_with_ga4_section.count
+    end
+  end
+end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -45,6 +45,10 @@ class DateFacet < FilterableFacet
     { key => date_values }
   end
 
+  def ga4_section
+    name
+  end
+
 private
 
   def value_fragments

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -55,6 +55,10 @@ class Facet
     {}
   end
 
+  def ga4_section
+    nil
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -59,6 +59,10 @@ class Facet
     nil
   end
 
+  def has_ga4_section?
+    !ga4_section.nil?
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -72,6 +72,10 @@ class OptionSelectFacet < FilterableFacet
     open_on_load?
   end
 
+  def ga4_section
+    name
+  end
+
 private
 
   def value_fragments

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -30,6 +30,10 @@ class RadioFacet < FilterableFacet
     { key => selected_value["value"] }
   end
 
+  def ga4_section
+    ""
+  end
+
 private
 
   def selected_value

--- a/app/models/radio_facet_for_multiple_filters.rb
+++ b/app/models/radio_facet_for_multiple_filters.rb
@@ -37,6 +37,10 @@ class RadioFacetForMultipleFilters < FilterableFacet
     @filter_hashes
   end
 
+  def ga4_section
+    ""
+  end
+
 private
 
   attr_reader :filter_hashes

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -43,6 +43,10 @@ class TaxonFacet < FilterableFacet
     }
   end
 
+  def ga4_section
+    "Topic"
+  end
+
 private
 
   def value_fragments

--- a/app/models/topical_facet.rb
+++ b/app/models/topical_facet.rb
@@ -6,4 +6,8 @@ class TopicalFacet < OptionSelectFacet
   def to_partial_path
     "option_select_facet"
   end
+
+  def ga4_section
+    name
+  end
 end

--- a/app/views/components/_date_filter.html.erb
+++ b/app/views/components/_date_filter.html.erb
@@ -6,9 +6,10 @@
   aria_controls_id ||= false
   date_errors_from ||= nil
   date_errors_to ||= nil
+  data_attributes ||= {}
 %>
 <% if key && name %>
-  <%= render "components/expander", { title: name, data_attributes: { "ga4-section": name } } do %>
+  <%= render "components/expander", { title: name, data_attributes: } do %>
     <div class="govuk-!-margin-bottom-0" id="<%= key %>">
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/components/_date_filter.html.erb
+++ b/app/views/components/_date_filter.html.erb
@@ -8,7 +8,7 @@
   date_errors_to ||= nil
 %>
 <% if key && name %>
-  <%= render "components/expander", { title: name } do %>
+  <%= render "components/expander", { title: name, data_attributes: { "ga4-section": name } } do %>
     <div class="govuk-!-margin-bottom-0" id="<%= key %>">
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -7,11 +7,17 @@
   content_id = "expander-content-#{SecureRandom.hex(4)}"
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
+  helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  helper.add_data_attribute({ module: "expander" })
+
+  helper.add_data_attribute({ "open-on-load": open_on_load })
+  helper.add_data_attribute({ "ga4-section": title })
+
   css_classes = %w( app-c-expander )
   css_classes << (shared_helper.get_margin_bottom) unless margin_bottom == 0
 %>
 <% if title %>
-  <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load, 'ga4-section': title } do %>
+  <%= tag.div(**helper.all_attributes.merge(class: css_classes)) do %>
     <h3 class="app-c-expander__heading">
       <span class="app-c-expander__title js-toggle"><%= title %></span>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -11,7 +11,6 @@
   helper.add_data_attribute({ module: "expander" })
 
   helper.add_data_attribute({ "open-on-load": open_on_load })
-  helper.add_data_attribute({ "ga4-section": title })
 
   css_classes = %w( app-c-expander )
   css_classes << (shared_helper.get_margin_bottom) unless margin_bottom == 0

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -6,8 +6,8 @@
   show_filter ||= false
   large ||= false
 
-  classes = %w[app-c-option-select__container js-options-container]
-  classes << "app-c-option-select__container--large" if large
+  options_container_classes = %w[app-c-option-select__container js-options-container]
+  options_container_classes << "app-c-option-select__container--large" if large
 %>
 
 <% if show_filter %>
@@ -45,7 +45,7 @@
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
   </h3>
 
-  <%= content_tag(:div, role: "group", aria: { labelledby: title_id }, class: classes, id: options_container_id, tabindex: "-1") do %>
+  <%= content_tag(:div, role: "group", aria: { labelledby: title_id }, class: options_container_classes, id: options_container_id, tabindex: "-1") do %>
     <div class="app-c-option-select__container-inner js-auto-height-inner">
       <% if show_filter %>
         <span id="<%= checkboxes_count_id %>"

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -32,13 +32,19 @@
   <% filter_element = CGI::escapeHTML(filter) %>
 <% end %>
 
-<div
-  class="app-c-option-select" data-module="option-select" data-ga4-change-category="update-filter checkbox" data-ga4-section="<%= title %>"
-  <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>
-  <% if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile %>data-closed-on-load-mobile="true"<% end %>
-  <% if local_assigns.include?(:aria_controls_id) %>data-input-aria-controls="<%= aria_controls_id %>"<% end %>
-  <% if show_filter %>data-filter-element="<%= filter_element %>"<% end %>
->
+<%
+  helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+
+  helper.add_data_attribute({ module: "option-select" })
+  helper.add_data_attribute({ "ga4-change-category": "update-filter checkbox", "ga4-section": title })
+
+  helper.add_data_attribute({ "closed-on-load": true }) if local_assigns.include?(:closed_on_load) && closed_on_load
+  helper.add_data_attribute({ "closed-on-load-mobile": "true" }) if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile
+  helper.add_data_attribute({ "input-aria-controls": aria_controls_id }) if local_assigns.include?(:aria_controls_id)
+  helper.add_data_attribute({ "filter-element": filter_element }) if show_filter
+%>
+
+<%= tag.div(**helper.all_attributes.merge(class: "app-c-option-select")) do %>
   <h3 class="app-c-option-select__heading js-container-heading">
     <span class="app-c-option-select__title js-container-button" id="<%= title_id %>"><%= title %></span>
     <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-option-select__icon app-c-option-select__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
@@ -66,4 +72,4 @@
       } %>
     </div>
   <% end %>
-</div>
+<% end %>

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -36,7 +36,6 @@
   helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
 
   helper.add_data_attribute({ module: "option-select" })
-  helper.add_data_attribute({ "ga4-change-category": "update-filter checkbox", "ga4-section": title })
 
   helper.add_data_attribute({ "closed-on-load": true }) if local_assigns.include?(:closed_on_load) && closed_on_load
   helper.add_data_attribute({ "closed-on-load-mobile": "true" }) if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile

--- a/app/views/components/_option_select.html.erb
+++ b/app/views/components/_option_select.html.erb
@@ -40,6 +40,7 @@
   helper.add_data_attribute({ "closed-on-load": true }) if local_assigns.include?(:closed_on_load) && closed_on_load
   helper.add_data_attribute({ "closed-on-load-mobile": "true" }) if local_assigns.include?(:closed_on_load_mobile) && closed_on_load_mobile
   helper.add_data_attribute({ "input-aria-controls": aria_controls_id }) if local_assigns.include?(:aria_controls_id)
+  helper.add_data_attribute({ "button-data-attributes": button_data_attributes }) if local_assigns.include?(:button_data_attributes)
   helper.add_data_attribute({ "filter-element": filter_element }) if show_filter
 %>
 

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -8,6 +8,6 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-section": date_facet.name }
+    data_attributes:  { "ga4-section": date_facet.ga4_section }
   } %>
 </span>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -8,6 +8,6 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-section": date_facet.ga4_section }
+    data_attributes:  { "ga4-section": date_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
   } %>
 </span>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -7,6 +7,7 @@
     to_value: date_facet.user_supplied_to_date,
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
-    date_errors_from: date_facet.error_message_from(@search_query)
+    date_errors_from: date_facet.error_message_from(@search_query),
+    data_attributes:  { "ga4-section": date_facet.name }
   } %>
 </span>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -46,8 +46,8 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.each.with_index do |facet, index| %>
-            <%= render partial: facet, object: facet, locals: { index: } %>
+          <% facets.each_with_index_and_count do |facet, index, count| %>
+            <%= render partial: facet, object: facet, locals: { index:, count: } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -46,7 +46,9 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <%= render facets.select(&:filterable?) %>
+          <% facets.select(&:filterable?).each.with_index do |facet, index| %>
+            <%= render partial: facet, object: facet, locals: { index: } %>
+          <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>
           </div>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -18,12 +18,12 @@
   <% if content_item.all_content_finder? %>
     <%= render partial: 'filter_button'%>
   <% elsif !content_item.all_content_finder? %>
-    <% if facets.select(&:filterable?).any? %>
+    <% if facets.any? %>
       <%= render partial: 'filter_button'%>
     <% end %>
   <% end %>
 
-  <% if facets.select(&:filterable?).any? %>
+  <% if facets.any? %>
     <div data-module="gem-track-click" data-track-category="filterClicked"
         data-track-action="skip-Link" data-track-label="">
       <%= render "govuk_publishing_components/components/skip_link", {
@@ -46,7 +46,7 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.select(&:filterable?).each.with_index do |facet, index| %>
+          <% facets.each.with_index do |facet, index| %>
             <%= render partial: facet, object: facet, locals: { index: } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -12,7 +12,16 @@
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    :button_data_attributes => {
+      "ga4-expandable": "",
+      "ga4-event": {
+        event_name: 'select_content',
+        type: 'finder',
+        section: option_select_facet.name,
+        index: { index_section: index + 1, index_section_count: count }
+      }
+    }
   }
   %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -12,7 +12,7 @@
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.name }
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.ga4_section }
   }
   %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -11,7 +11,8 @@
     :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
-    :large => option_select_facet.large?
+    :large => option_select_facet.large?,
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.name }
   }
   %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -8,7 +8,7 @@
     :aria_controls_id => "js-search-results-info",
     :options_container_id => option_select_facet.key,
     :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
+    :closed_on_load => option_select_facet.closed_on_load?(index),
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -12,7 +12,7 @@
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.ga4_section }
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
   }
   %>
 <% end %>

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "" }) do %>
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": radio_facet.ga4_section }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": radio_facet.ga4_section }) do %>
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": radio_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,7 +1,7 @@
-<div class="facet-container" data-ga4-change-category="update-filter radio" data-ga4-section="">
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "" }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,
     items: radio_facet.options
   } %>
-</div>
+<% end %>

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,6 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
-    title: "Topic"
+    title: "Topic",
+    data_attributes: { "ga4-section": "Topic" }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select">
       <%= render "govuk_publishing_components/components/select", {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,7 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-section": "Topic" }
+    data_attributes: { "ga4-section": taxon_facet.ga4_section }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select">
       <%= render "govuk_publishing_components/components/select", {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,7 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-section": taxon_facet.ga4_section }
+    data_attributes: { "ga4-section": taxon_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select">
       <%= render "govuk_publishing_components/components/select", {


### PR DESCRIPTION
Trello: https://trello.com/c/qs60lCxl

This is a spike into moving the GA4-related code out of the `option-select` component prior to extracting it into the `govuk_publishing_components` gem. My motivation was that I felt the GA4-related code was quite specific to finder-frontend.

Broadly the approach I've tried to take is to move the setting of all GA4-related data attributes out into the Rails facet templates rather than relying on setting them in a combination of in the component templates, in the component JavaScript, and in some more "global" GA4 JavaScript. This branch is very much a spike so I've made no attempt at fixing any linting or tests and while I've tried hard to make the commit notes as detailed and useful as possible, the last few are marked as "WIP" because either I'm not very happy with them or there is still some work to do in them.

I think my conclusion is that, while this specific approach might not be the best, it might be worth going for some kind of middle ground where it's possible to enable GA4-related functionality within the components, but supply non-generic values as data attributes from the facet templates. I've tried to explain this in a bit more detail in the final commit note.

I'm very happy to chat about any of this if it would be useful! Otherwise I'll probably close the PR fairly soon.

/cc @andysellick 