### PR TITLE
Fix expander component when no CSS

### DIFF
--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -14,8 +14,8 @@
   <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load, 'ga4-filter-parent': '' } do %>
     <h3 class="app-c-expander__heading">
       <span class="app-c-expander__title js-toggle"><%= title %></span>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
     </h3>
     <div class="app-c-expander__content js-content <%= 'app-c-expander__content--visible' if open_on_load %>" id="<%= content_id %>">
       <%= yield %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- the expander component contains SVGs for the up/down arrow
- if CSS is disabled or fails to load for the component, these SVGs appear unstyled, and expand to fill the available space, making the component look very broken
- solution is to apply width and height zero attributes inline to the SVG, which renders it invisible when styles are not present, and is overridden by styles when they load

Applies to both the expander and date filter component, as the date filter uses the expander.

## Why
The site should be broadly usable even if styles have failed to load. See also:

- https://github.com/alphagov/govuk_publishing_components/pull/3642
- https://github.com/alphagov/govuk_publishing_components/pull/3639

## Visual changes

Before | After
------ | -------
![Screenshot 2023-09-28 at 13 25 56](https://github.com/alphagov/finder-frontend/assets/861310/1387568f-d35c-4a46-aee2-4dba00bf90f4) | ![Screenshot 2023-09-28 at 13 30 32](https://github.com/alphagov/finder-frontend/assets/861310/6fb49d25-5308-4b9d-b9a9-b17509ed3ebd)

