### PR TITLE
Separate UA ecommerce tracking enabler from GA4 ecommerce tracking enabler

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -27,7 +27,7 @@ class SearchResultPresenter
         text: title,
         path: link,
         description: sanitize(summary_text),
-        data_attributes: ecommerce_data(link, title),
+        data_attributes: ga4_ecommerce_data(link).merge(ecommerce_data(link, title)),
       },
       metadata: structure_metadata,
       metadata_raw: metadata,
@@ -80,23 +80,29 @@ private
         GovukError.notify(MalformedPartError.new, extra: { part:, link: })
         next
       end
+      path = "#{link}/#{part[:slug]}"
       {
         link: {
           text: part[:title],
-          path: "#{link}/#{part[:slug]}",
+          path:,
           description: part[:body],
-          data_attributes: ecommerce_data("#{link}/#{part[:slug]}", part[:title], part_index: index),
+          data_attributes: ga4_ecommerce_data(path).merge(ecommerce_data(path, part[:title], part_index: index)),
         },
       }
     end
     structured_parts.compact
   end
 
+  def ga4_ecommerce_data(path)
+    {
+      ga4_ecommerce_path: path,
+    }
+  end
+
   def ecommerce_data(link, title, part_index: nil)
     return {} unless @include_ecommerce
 
     {
-      ga4_ecommerce_path: link,
       ecommerce_path: link,
       ecommerce_row: 1,
       ecommerce_index: document.index,

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe ResultSetPresenter do
       end
     end
 
-    context "with ecommerce disabled" do
+    context "with universal analytics ecommerce disabled" do
       let(:enable_ecommerce) { false }
       let(:results) do
         [FactoryBot.build(
@@ -195,13 +195,15 @@ RSpec.describe ResultSetPresenter do
         )]
       end
 
-      it "doesn't include ecommerce attributes" do
+      it "doesn't include UA ecommerce attributes" do
         expected_hash = {
           link: {
             text: "document_title",
             path: "/path/to/doc",
             description: "document_description",
-            data_attributes: {},
+            data_attributes: {
+              ga4_ecommerce_path: "/path/to/doc",
+            },
           },
           metadata: {
             "Organisations" => "Organisations: Department for Work and Pensions",


### PR DESCRIPTION
## What
- Our GA4 ecommerce tracking was missing on these three finders: [1](https://www.gov.uk/world/organisations) [2](https://www.gov.uk/government/organisations/hm-revenue-customs/contact) [3](https://www.gov.uk/government/groups)
- This is because there is a boolean called `@include_ecommerce` in this repo, which determined wether UA ecommerce tracking was enabled or not.
- UA ecommerce tracking was specifically disabled on those three finders. This is because the payload they sent to UA was too large, resulting in a JavaScript error. See https://github.com/alphagov/finder-frontend/pull/2286. 
- The GA4 ecommerce tracking was also using this `@include_ecommerce` boolean to determine wether it was enabled or not.
- As we want to enable GA4 ecommerce tracking everywhere, but keep those three pages disabled for UA tracking, I have created a new boolean called `@include_ga4_ecommerce_tracking` and set it to `true`. When `true`, `data-ga4-ecommerce-path` is appended to the search result links, which allows the JS to use the links for the `ecommerce` array and the `select_item` events.
- This way, we can enable GA4 ecommerce tracking on these pages, while not interfering with the disabled UA ecommerce tracking.

## Why
- https://trello.com/c/TIFQm2EL/677-fix-hmrc-contacts-finder-ecommerce-tracking
- https://trello.com/c/wLz7uULw/679-fix-world-organisations-finder-ecommerce-tracking
- https://trello.com/c/jHYCtOA8/678-fix-groups-finder-ecommerce-tracking

## How to test
- Go to http://127.0.0.1:3062/government/groups or http://127.0.0.1:3062/world/organisations or http://127.0.0.1:3062/government/organisations/hm-revenue-customs/contact 
- You will see `data-ga4-ecommerce-path` on the links (and `data-ecommerce-index` - i've noted this [here](https://trello.com/c/gFiJmH3D/553-audit-and-ensure-that-every-data-attribute-relies-on-has-ga4-somewhere-in-its-name)) and no UA ecommerce attributes (e.g. `ecommerce_row`).
- You will see the `ecommerce` array populated in the ecommerce dataLayer object.
- If you click a search result and then stop the page loading, you'll see the `select_item` event in the dataLayer object.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
