### PR TITLE
Remove intervention banner from find-licences

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -22,14 +22,6 @@
     } %>
   <% end %>
 
-  <% if content_item.base_path == "/find-licences"%>
-    <div class="govuk-!-margin-top-5">
-      <%= render "govuk_publishing_components/components/intervention", {
-        suggestion_text: sanitize("This is a new tool. Your <a href='https://surveys.publishing.service.gov.uk/s/1AXTLB' class='govuk-link'>feedback</a> will help us to improve it."),
-      } %>
-    </div>
-  <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>


### PR DESCRIPTION
We want to close the survey, so need to remove the banner linking to it.

https://trello.com/c/FuWQQWnH/32-hardcoded-intervention-banner-component-finder-frontend

https://trello.com/c/imwhGMZr/2232-remove-survey-from-find-a-licence-tool

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
