### PR TITLE
GA4 track spelling suggestions

### DIFF
--- a/app/views/finders/_spelling_suggestion.html.erb
+++ b/app/views/finders/_spelling_suggestion.html.erb
@@ -1,11 +1,22 @@
-<% # we want an empty string if there are no suggestions on page load %> 
+<% # we want an empty string if there are no suggestions on page load %>
 <% _spelling_suggestion = '' %>
 <% if @spelling_suggestion_presenter.suggestions.any? %>
 <p class="govuk-body">Did you mean
   <% @spelling_suggestion_presenter.suggestions.each do |suggestion| %>
+    <%
+      ga4_data = {
+        module: "ga4-link-tracker",
+        ga4_link: {
+          event_name: "navigation",
+          type: "spelling suggestion",
+          section: "search",
+          text: suggestion[:keywords],
+        }
+      }
+    %>
     <%= link_to sanitize(suggestion[:highlighted]), suggestion[:link],
       class: "govuk-link",
-      :data => suggestion[:data_attributes]
+      :data => ga4_data.merge(suggestion[:data_attributes])
     %>
     <% _spelling_suggestion = suggestion[:keywords] %>
   <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add GA4 link tracking to spelling suggestions on pages like https://www.gov.uk/search/all?keywords=self+assessesment&order=relevance

![Screenshot 2023-10-03 at 10 04 11](https://github.com/alphagov/finder-frontend/assets/861310/3484ef85-0108-4170-849f-a9ad156c13e9)

This should not disturb the existing UA tracking on this link.

In testing this I've discovered a small problem - the link tracker gets the `text` data based on the target of the link click, not the overall text of the link. When a spelling suggestion is shown, the specific word suggestion is wrapped in a `mark` element inside the link. This means that for spelling suggestions like the one above, if the user clicks on the highlighted word, only that word is captured in the GA4 data. Will need to raise a separate PR in the gem to address this.

UPDATE: or I can just set the value of `text` directly in the attributes, which I've done. Thanks @AshGDS 

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/ts2o6lKc/687-search-enhancement-search-events-on-search-spelling-suggestion