### PR TITLE
Turn GA4 tracking on for next/prev links

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -11,7 +11,7 @@ class PaginationPresenter
   def next_and_prev_links
     return unless can_paginate?
 
-    { previous_page:, next_page: }.compact
+    { ga4_tracking: true, previous_page:, next_page: }.compact
   end
 
 private

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -39,6 +39,7 @@ describe PaginationPresenter do
 
       it "returns a next page link" do
         expect(subject).to eq(
+          ga4_tracking: true,
           next_page: {
             label: "2 of 5",
             title: "Next page",
@@ -55,6 +56,7 @@ describe PaginationPresenter do
 
       it "returns a previous page link" do
         expect(subject).to eq(
+          ga4_tracking: true,
           previous_page: {
             label: "4 of 5",
             title: "Previous page",
@@ -71,6 +73,7 @@ describe PaginationPresenter do
 
       it "returns next and previous page links" do
         expect(subject).to eq(
+          ga4_tracking: true,
           next_page: {
             label: "3 of 5",
             title: "Next page",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Turns on GA4 tracking for next/previous links at the bottom of search results.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/PY3swyBq/685-placeholder-add-previous-next-navigation-on-finders
