### PR TITLE
Flatten GA4 data attributes

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -167,7 +167,11 @@
       try {
         var index = button.closest('[data-ga4-index]') || undefined
         if (index) {
-          ga4JSON.index = JSON.parse(index.getAttribute('data-ga4-index'))
+          var indexData = JSON.parse(index.getAttribute('data-ga4-index'))
+          // flatten the attributes in index into the main data
+          for (var prop in indexData) {
+            ga4JSON[prop] = indexData[prop]
+          }
         } else {
           console.warn('No data-ga4-index found on the following element or its parents:')
           console.warn(button)

--- a/app/assets/javascripts/modules/mobile-filters-modal.js
+++ b/app/assets/javascripts/modules/mobile-filters-modal.js
@@ -97,10 +97,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       type: 'finder',
       text: 'Filter',
       section: 'Filter',
-      index: {
-        index_section: 0,
-        index_section_count: indexSectionCount
-      }
+      index_section: 0,
+      index_section_count: indexSectionCount
     }))
   }
 

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -145,10 +145,8 @@ describe('An expander module', function () {
         event_name: 'select_content',
         type: 'finder',
         section: 'Organisation',
-        index: {
-          index_section: 1,
-          index_section_count: 3
-        }
+        index_section: 1,
+        index_section_count: 3
       })
 
       expect($button.attr('data-ga4-event')).toEqual(expected)

--- a/spec/javascripts/modules/mobile-filters-modal.spec.js
+++ b/spec/javascripts/modules/mobile-filters-modal.spec.js
@@ -142,10 +142,8 @@ describe('Mobile filters', function () {
           type: 'finder',
           text: 'Filter',
           section: 'Filter',
-          index: {
-            index_section: 0,
-            index_section_count: 5
-          }
+          index_section: 0,
+          index_section_count: 5
         }
         expect(button.getAttribute('data-ga4-event')).toEqual(JSON.stringify(expected))
       })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Flatten any JSON data attached to an element that will be read by a GA4 tracker - particularly the nested `index` attributes.

## Why
This nesting is no longer necessary due to a change in the way that our central processing of GA4 data works.

See [this PR](https://github.com/alphagov/govuk_publishing_components/pull/3649) for related information.

## Visual changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes