### PR TITLE
Add data-ga4-ecommerce-content-id to search results

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -96,6 +96,7 @@ private
   def ga4_ecommerce_data(path)
     {
       ga4_ecommerce_path: path,
+      ga4_ecommerce_content_id: @document.content_id,
     }
   end
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe ResultSetPresenter do
             data_attributes: {
               ecommerce_path: "/path/to/doc",
               ga4_ecommerce_path: "/path/to/doc",
+              ga4_ecommerce_content_id: "content_id",
               ecommerce_row: 1,
               ecommerce_index: 1,
               track_category: "navFinderLinkClicked",
@@ -203,6 +204,7 @@ RSpec.describe ResultSetPresenter do
             description: "document_description",
             data_attributes: {
               ga4_ecommerce_path: "/path/to/doc",
+              ga4_ecommerce_content_id: "content_id",
             },
           },
           metadata: {

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe SearchResultPresenter do
           description: "I am a document. I am full of words and that.",
           data_attributes: {
             ga4_ecommerce_path: link,
+            ga4_ecommerce_content_id: "content_id",
             ecommerce_path: link,
             ecommerce_row: 1,
             ecommerce_index: 1,
@@ -108,6 +109,7 @@ RSpec.describe SearchResultPresenter do
               description: "Part description",
               data_attributes: {
                 ga4_ecommerce_path: "#{link}/part-path",
+                ga4_ecommerce_content_id: "content_id",
                 ecommerce_path: "#{link}/part-path",
                 ecommerce_row: 1,
                 ecommerce_index: 1,


### PR DESCRIPTION
## What

We want to track the content id of results, as the URLs get cut off by GA4s 100 character limit. Therefore we add a new data attribute, which `govuk_publishing_components` will grab and push to the `dataLayer`.

## Why

- High priority bug fix https://trello.com/c/7Snj5Lx1/710-search-enhancement-add-content-id-to-searchresults-ecommerce-items-because-link-paths-are-truncated-to-100-characters
- Related to https://github.com/alphagov/govuk_publishing_components/pull/3676  - but either PR can be merged in any order, as nothing should crash if one is merged and the other isn't

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
