### PR TITLE
Component auditing fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/radio

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -265,12 +265,6 @@ mark {
     margin-bottom: 0;
   }
 
-  .gem-c-subscription-links {
-    @include govuk-media-query($until: tablet) {
-      margin-bottom: govuk-spacing(2);
-    }
-  }
-
   // NOTE: used to override govspeak component when it's used on an inverse header
   .gem-c-inverse-header {
     .gem-c-govspeak {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -265,10 +265,6 @@ mark {
     margin-bottom: 0;
   }
 
-  .gem-c-intervention {
-    margin-bottom: 0;
-  }
-
   .gem-c-subscription-links {
     @include govuk-media-query($until: tablet) {
       margin-bottom: govuk-spacing(2);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -264,13 +264,6 @@ mark {
   .govuk-checkboxes__label {
     margin-bottom: 0;
   }
-
-  // NOTE: used to override govspeak component when it's used on an inverse header
-  .gem-c-inverse-header {
-    .gem-c-govspeak {
-      color: govuk-colour("white");
-    }
-  }
 }
 
 .govspeak-wrapper {

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -16,11 +16,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: sanitize("Search <span class='govuk-visually-hidden'>all content</span>"),
-        heading_level: 1,
-        font_size: "xl",
-        margin_bottom: 4
+        <%= render "govuk_publishing_components/components/heading", {
+          text: sanitize("Search <span class='govuk-visually-hidden'>all content</span>"),
+          heading_level: 1,
+          font_size: "xl",
+          margin_bottom: 4,
+          inverse: inverse,
         } %>
         <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
           <%= render "govuk_publishing_components/components/search", {
@@ -29,6 +30,7 @@
             name: "keywords",
             type: 'search',
             value: result_set_presenter.user_supplied_keywords,
+            on_govuk_blue: inverse,
           } %>
         </div>
         <div id="js-spelling-suggestions" class="spelling-suggestions"
@@ -44,16 +46,18 @@
         <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'govuk-link topic-finder__taxon-link' %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: content_item.title,
-          inverse: true,
+          inverse: inverse,
         } %>
       <% else %>
         <%= render partial: 'govuk_publishing_components/components/title', locals: {
           title: content_item.title,
           context: title_context,
+          inverse: inverse,
         } %>
       <% end %>
 
       <% if page_metadata.any? %>
+        <% page_metadata.merge!({ inverse: inverse, margin_bottom: 2 }) %>
         <%= render 'govuk_publishing_components/components/metadata', page_metadata %>
       <% end %>
     </div>
@@ -67,7 +71,7 @@
     <% if content_item.summary %>
       <div class="govuk-grid-column-two-thirds">
         <div class="metadata-summary ">
-          <%= render 'govuk_publishing_components/components/govspeak', {} do %>
+          <%= render 'govuk_publishing_components/components/govspeak', { inverse: inverse } do %>
             <%= sanitize(content_item.summary) %>
           <% end %>
         </div>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -57,7 +57,7 @@
       <% end %>
 
       <% if page_metadata.any? %>
-        <% page_metadata.merge!({ inverse: inverse, margin_bottom: 2 }) %>
+        <% page_metadata.merge!({ inverse: inverse, inverse_compress: true, margin_bottom: 2 }) %>
         <%= render 'govuk_publishing_components/components/metadata', page_metadata %>
       <% end %>
     </div>

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -3,23 +3,20 @@
     title: "Topic"
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
-
       <%= render "govuk_publishing_components/components/select", {
         id: 'level_one_taxon',
         label: "Topic",
         full_width: true,
         options: taxon_facet.topics
-      }
-      %>
+      } %>
 
-      <div class="js-required govuk-form-group gem-c-select" data-ga4-section="Sub-topic">
+      <div class="js-required govuk-form-group" data-ga4-section="Sub-topic">
         <%= render "govuk_publishing_components/components/select", {
           id: 'level_two_taxon',
           label: "Sub-topic",
           full_width: true,
           options: taxon_facet.sub_topics
-        }
-        %>
+        } %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes some issues relating to component use in this application. See individual commits for details.

## Why
Issues flagged by our component auditing tools.

## Visual changes
First change shown below is the removal of the `margin: 0` on the intervention component.

Second is the appearance of an inverted header finder before and after. I'm not sure this option is in use anywhere (couldn't see a finder using it) but might as well make it work properly. 

There's a small issue introduced by this change, which is that the metadata component has extra spacing around it when inverted. This appears to be a quirk of the component design and something we could fix in the component, but for now I'm happy to replace a serious accessibility issue with a minor spacing issue. **EDIT** this has now been fixed in the component and applied in the final commit.

Before | After
------ | ------
![Screenshot 2023-10-23 at 08 45 09](https://github.com/alphagov/finder-frontend/assets/861310/1da3c251-fae7-405b-a86d-a1c9494ca6b8) | ![Screenshot 2023-10-23 at 08 45 18](https://github.com/alphagov/finder-frontend/assets/861310/90cf5ee7-f51f-49ad-b105-511026ce7f39)
![Screenshot 2023-10-23 at 09 02 19](https://github.com/alphagov/finder-frontend/assets/861310/2ed050be-4c66-48e5-9261-ca0d3db8446f) | ![Screenshot 2023-10-23 at 09 15 14](https://github.com/alphagov/finder-frontend/assets/861310/2d276bdd-7f6d-424e-b480-9ef72b8b3c89)

