### PR TITLE
Duplicate ecommerce attributes, appending ga4 to the names

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -146,6 +146,14 @@
       var consentCookie = GOVUK.getConsentCookie()
 
       if (consentCookie && consentCookie.settings) {
+        if (this.$resultsWrapper) {
+          this.$resultsWrapper.setAttribute('data-ga4-search-query', this.currentKeywords())
+          var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
+          if (sortedBy) {
+            this.$resultsWrapper.setAttribute('data-ga4-ecommerce-variant', sortedBy.options[sortedBy.selectedIndex].text)
+          }
+        }
+
         GOVUK.analyticsGa4.Ga4EcommerceTracker.init(referrer)
       } else {
         window.addEventListener('cookie-consent', function () {

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -97,6 +97,8 @@ private
     {
       ga4_ecommerce_path: path,
       ga4_ecommerce_content_id: @document.content_id,
+      ga4_ecommerce_row: 1,
+      ga4_ecommerce_index: document.index,
     }
   end
 

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -50,10 +50,14 @@
         data-analytics-ecommerce
         data-ga4-ecommerce
         data-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
+        data-ga4-ecommerce-start-index="<%= result_set_presenter.start_offset %>"
         data-list-title="<%= content_item.title %>"
+        data-ga4-list-title="<%= content_item.title %>"
         data-search-query="<%= result_set_presenter.user_supplied_keywords %>"
+        data-ga4-search-query="<%= result_set_presenter.user_supplied_keywords %>"
         <% unless result_set_presenter.sort_option.nil? %>
           data-ecommerce-variant="<%= result_set_presenter.sort_option[:data_track_label] %>"
+          data-ga4-ecommerce-variant="<%= result_set_presenter.sort_option[:data_track_label] %>"
         <% end %>
         data-module="gem-track-click"
         >

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -36,6 +36,24 @@ Then(/^the ecommerce tracking tags are present$/) do
   expect(first_link["data-ecommerce-path"]).to eq("/restrictions-on-usage-of-spells-within-school-grounds")
 end
 
+Then(/^the GA4 ecommerce tracking tags are present$/) do
+  visit finder_path("search/all", q: "breakfast")
+
+  expect(page).to have_selector(".js-live-search-results-block[data-ga4-ecommerce]")
+
+  form = page.find(".js-live-search-results-block[data-ga4-ecommerce]")
+  expect(form["data-ga4-ecommerce-start-index"]).to eq("1")
+  expect(form["data-ga4-list-title"]).to eq("Search")
+  expect(form["data-ga4-search-query"]).to eq("breakfast")
+
+  results = page.all("a[data-ga4-ecommerce-row]")
+  expect(results.count).to be_positive
+
+  first_link = results.first
+
+  expect(first_link["data-ga4-ecommerce-path"]).to eq("/restrictions-on-usage-of-spells-within-school-grounds")
+end
+
 And "I search for lunch" do
   stub_search_api_request_with_query_param_no_results("lunch")
 

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe ResultSetPresenter do
               ecommerce_path: "/path/to/doc",
               ga4_ecommerce_path: "/path/to/doc",
               ga4_ecommerce_content_id: "content_id",
+              ga4_ecommerce_row: 1,
+              ga4_ecommerce_index: 1,
               ecommerce_row: 1,
               ecommerce_index: 1,
               track_category: "navFinderLinkClicked",
@@ -205,6 +207,8 @@ RSpec.describe ResultSetPresenter do
             data_attributes: {
               ga4_ecommerce_path: "/path/to/doc",
               ga4_ecommerce_content_id: "content_id",
+              ga4_ecommerce_row: 1,
+              ga4_ecommerce_index: 1,
             },
           },
           metadata: {

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe SearchResultPresenter do
           data_attributes: {
             ga4_ecommerce_path: link,
             ga4_ecommerce_content_id: "content_id",
+            ga4_ecommerce_row: 1,
+            ga4_ecommerce_index: 1,
             ecommerce_path: link,
             ecommerce_row: 1,
             ecommerce_index: 1,
@@ -110,6 +112,8 @@ RSpec.describe SearchResultPresenter do
               data_attributes: {
                 ga4_ecommerce_path: "#{link}/part-path",
                 ga4_ecommerce_content_id: "content_id",
+                ga4_ecommerce_row: 1,
+                ga4_ecommerce_index: 1,
                 ecommerce_path: "#{link}/part-path",
                 ecommerce_row: 1,
                 ecommerce_index: 1,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
- Duplicate ecommerce attributes, appending ga4 to the names.
- The trackers in `govuk_publishing_components` will then use these instead of the UA attributes: https://github.com/alphagov/govuk_publishing_components/pull/3688

## Why
- This is to decouple our GA4 analytics code from universal analytics
- https://trello.com/c/gFiJmH3D/553-audit-and-ensure-that-every-data-attribute-relies-on-has-ga4-somewhere-in-its-name
