### PR TITLE
Remove research banner

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -17,8 +17,6 @@ class FindersController < ApplicationController
       format.html do
         raise UnsupportedContentItem unless content_item.is_finder?
 
-        @show_banner = content_item.base_path == "/government/organisations/hm-revenue-customs/contact"
-
         if legacy_params_present?
           transform_legacy_announcement_params_and_redirect if content_item.base_path == "/search/news-and-communications"
           transform_legacy_publication_params_and_redirect if content_item.base_path == "/search/all"

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,15 +13,6 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse, ga4_tracking: true %>
   <% end %>
 
-  <% if @show_banner %>
-    <%= render "govuk_publishing_components/components/intervention", {
-      suggestion_text: "Help improve a new GOV.UK tool",
-      suggestion_link_text: "Sign up to take part in user research",
-      suggestion_link_url: "https://surveys.publishing.service.gov.uk/s/SNFVW1/",
-      new_tab: true,
-    } %>
-  <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>


### PR DESCRIPTION
## What

Remove research banner from HMRC contact page.

Reverts https://github.com/alphagov/finder-frontend/pull/3169

## Why

Target survey responses reached.

## Visual Differences

### Before

<img width="998" alt="Screenshot 2023-09-26 at 10 02 49" src="https://github.com/alphagov/finder-frontend/assets/96050928/21d701d4-ad67-48f9-bcd6-71e4222b3d2e">

### After

<img width="994" alt="Screenshot 2023-09-26 at 10 03 01" src="https://github.com/alphagov/finder-frontend/assets/96050928/a90d00a3-0ae0-4520-b032-a052987642a6">
