### PR TITLE
Remove scroll tracking

### DIFF
--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -24,7 +24,6 @@
       <meta name="robots" content="noindex">
     <% end %>
     <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
-    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
     <%= yield :meta_tags %>
   </head>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes scroll tracking for GA4 from all finders.

## Why
Scroll tracking is no longer required.

## Visual changes
None.

Trello card: https://trello.com/c/R6z5Hd3d/714-remove-scroll-tracking
