### PR TITLE
Add document content_id to atom feeds

### DIFF
--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -1,6 +1,7 @@
 class EntryPresenter
   delegate :title,
            :path,
+           :content_id,
            to: :entry
 
   WEBSITE_ROOT = Plek.new.website_root.gsub(/https?:\/\//, "")

--- a/app/views/finders/show.atom.builder
+++ b/app/views/finders/show.atom.builder
@@ -11,6 +11,7 @@ atom_feed do |feed|
     feed.entry(result, id: result.tag(feed), url: absolute_url_for(result.path), updated: result.updated_at) do |entry|
       entry.title(result.title)
       entry.summary(result.summary, type: "html")
+      entry.content_id(result.content_id)
     end
   end
 end

--- a/spec/presenters/entry_presenter_spec.rb
+++ b/spec/presenters/entry_presenter_spec.rb
@@ -35,4 +35,16 @@ RSpec.describe EntryPresenter do
       expect(EntryPresenter.feed_ended_id(atom_feed_builder, "/path/to/content")).to eq("tag:www.test.gov.uk,2019:/path/to/content/feed-ended")
     end
   end
+
+  # Note - this is a simple delegation and we wouldn't normally test, but
+  # it's important for email-alert-api's monitoring of medical alerts, so
+  # worth checking that it hasn't been accidentally removed.
+  describe "#content_id" do
+    let(:document) do
+      FactoryBot.build(:document, content_id: "AAAA-BBBB")
+    end
+    it "displays the content_id" do
+      expect(EntryPresenter.new(document, true).content_id).to eq("AAAA-BBBB")
+    end
+  end
 end


### PR DESCRIPTION
To allow email alert matching in email-alert-api (replacing the current brittle subject line matching) we need to show the content id of the alert document in the atom feed (this is findable by a person anyway so no security risk).

https://trello.com/c/ncj8UGmZ/2245-add-content-id-information-to-medical-alerts-rss-feed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

