### PR TITLE
Add DublinCore namespace to atom feed to make it validate

### DIFF
--- a/app/views/finders/show.atom.builder
+++ b/app/views/finders/show.atom.builder
@@ -1,4 +1,4 @@
-atom_feed do |feed|
+atom_feed({ "xmlns:dc" => "http://purl.org/dc/elements/1.1/" }) do |feed|
   feed.title(@feed.title)
 
   feed.updated(@feed.updated_at) if @feed.entries.present?
@@ -11,7 +11,7 @@ atom_feed do |feed|
     feed.entry(result, id: result.tag(feed), url: absolute_url_for(result.path), updated: result.updated_at) do |entry|
       entry.title(result.title)
       entry.summary(result.summary, type: "html")
-      entry.content_id(result.content_id)
+      entry.tag!("dc:identifier", result.content_id)
     end
   end
 end


### PR DESCRIPTION
The atom builder in Rails will let you put in arbitrary keys, but atom readers in strict mode (such as that used in email-alert-api) will reject the xml as invalid. Rather than write and maintain our own namespace extension, replace the content_id tag with the Dublin Core Elements Identifier tag (dc:identifier) which is semantically appropriate, so that we're serving valid Atom.

https://trello.com/c/ncj8UGmZ/2246-add-content-id-information-to-medical-alerts-rss-feed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
