### PR TITLE
Capitalise GA4 section value

### DIFF
--- a/app/views/finders/_spelling_suggestion.html.erb
+++ b/app/views/finders/_spelling_suggestion.html.erb
@@ -9,7 +9,7 @@
         ga4_link: {
           event_name: "navigation",
           type: "spelling suggestion",
-          section: "search",
+          section: "Search",
           text: suggestion[:keywords],
         }
       }


### PR DESCRIPTION
## What
Capitalise GA4 section value from `search` to `Search`

## Why
https://trello.com/c/VxP8FsIa/731-capitalise-first-letter-of-section-parameter-on-search-spelling-event