### PR TITLE
Revert "Add document content_id to atom feeds"

### DIFF
--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -1,7 +1,6 @@
 class EntryPresenter
   delegate :title,
            :path,
-           :content_id,
            to: :entry
 
   WEBSITE_ROOT = Plek.new.website_root.gsub(/https?:\/\//, "")

--- a/app/views/finders/show.atom.builder
+++ b/app/views/finders/show.atom.builder
@@ -11,7 +11,6 @@ atom_feed do |feed|
     feed.entry(result, id: result.tag(feed), url: absolute_url_for(result.path), updated: result.updated_at) do |entry|
       entry.title(result.title)
       entry.summary(result.summary, type: "html")
-      entry.content_id(result.content_id)
     end
   end
 end

--- a/spec/presenters/entry_presenter_spec.rb
+++ b/spec/presenters/entry_presenter_spec.rb
@@ -35,16 +35,4 @@ RSpec.describe EntryPresenter do
       expect(EntryPresenter.feed_ended_id(atom_feed_builder, "/path/to/content")).to eq("tag:www.test.gov.uk,2019:/path/to/content/feed-ended")
     end
   end
-
-  # Note - this is a simple delegation and we wouldn't normally test, but
-  # it's important for email-alert-api's monitoring of medical alerts, so
-  # worth checking that it hasn't been accidentally removed.
-  describe "#content_id" do
-    let(:document) do
-      FactoryBot.build(:document, content_id: "AAAA-BBBB")
-    end
-    it "displays the content_id" do
-      expect(EntryPresenter.new(document, true).content_id).to eq("AAAA-BBBB")
-    end
-  end
 end


### PR DESCRIPTION
Reverts alphagov/finder-frontend#3202

https://trello.com/c/ncj8UGmZ/2246-add-content-id-information-to-medical-alerts-rss-feed

Since this feed is powered by search results anyway, it's been deemed simpler to use the search results directly (since we can then use a unified approach for this and travel advice).