### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -11,7 +11,7 @@ class PaginationPresenter
   def next_and_prev_links
     return unless can_paginate?
 
-    { ga4_tracking: true, previous_page:, next_page: }.compact
+    { previous_page:, next_page: }.compact
   end
 
 private

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if @signup_presenter.beta? %>
-  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta", ga4_tracking: true %>
+  <%= render 'govuk_publishing_components/components/phase_banner', phase: "beta" %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-width-container">
   <% if content_item.show_phase_banner? %>
-    <%= render 'govuk_publishing_components/components/phase_banner', phase: content_item.phase, message: sanitize(content_item.phase_message), inverse: inverse, ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/phase_banner', phase: content_item.phase, message: sanitize(content_item.phase_message), inverse: inverse %>
   <% end %>
 
   <% if @breadcrumbs.breadcrumbs %>
@@ -10,7 +10,7 @@
       collapse_on_mobile: true
     } %>
   <% else %>
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse, ga4_tracking: true %>
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
 
   <div class="govuk-grid-row">

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -39,7 +39,6 @@ describe PaginationPresenter do
 
       it "returns a next page link" do
         expect(subject).to eq(
-          ga4_tracking: true,
           next_page: {
             label: "2 of 5",
             title: "Next page",
@@ -56,7 +55,6 @@ describe PaginationPresenter do
 
       it "returns a previous page link" do
         expect(subject).to eq(
-          ga4_tracking: true,
           previous_page: {
             label: "4 of 5",
             title: "Previous page",
@@ -73,7 +71,6 @@ describe PaginationPresenter do
 
       it "returns next and previous page links" do
         expect(subject).to eq(
-          ga4_tracking: true,
           next_page: {
             label: "3 of 5",
             title: "Next page",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
