### PR TITLE
Refactor GA4 code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (36.1.0)
+    govuk_publishing_components (37.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -189,6 +189,7 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+      sprockets-rails
     govuk_schemas (4.7.0)
       json-schema (>= 2.8, < 4.2)
     govuk_test (4.0.1)
@@ -241,7 +242,7 @@ GEM
     msgpack (1.7.2)
     multi_test (1.1.0)
     mutex_m (0.2.0)
-    net-imap (0.4.7)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -7,20 +7,7 @@
 
   GOVUK.analyticsGa4.Ga4FinderTracker = {
 
-    // Finds the parent div containing the filters. Loops through each child div that has data-ga4-filter-parent on it . Sets an index on each of these child divs.
     setFilterIndexes: function () {
-      var filterContainer = document.querySelector('[data-ga4-filter-container]')
-
-      if (!filterContainer) {
-        return
-      }
-
-      var filterParents = filterContainer.querySelectorAll('[data-ga4-filter-parent]')
-
-      for (var i = 0; i < filterParents.length; i++) {
-        filterParents[i].setAttribute('data-ga4-index', JSON.stringify({ index_section: i + 1, index_section_count: filterParents.length }))
-      }
-
       window.GOVUK.triggerEvent(window, 'ga4-filter-indexes-added')
     },
 

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -6,11 +6,6 @@
   GOVUK.analyticsGa4 = GOVUK.analyticsGa4 || {}
 
   GOVUK.analyticsGa4.Ga4FinderTracker = {
-
-    setFilterIndexes: function () {
-      window.GOVUK.triggerEvent(window, 'ga4-filter-indexes-added')
-    },
-
     // Called when the search results updates. Takes the event target, and a string containing the type of change and element type. Creates the GTM schema and pushes it.
     // changeEventMetadata is a string referring to the type of form change and the element type that triggered it. For example 'update-filter checkbox'.
     trackChangeEvent: function (eventTarget, changeEventMetadata) {
@@ -144,31 +139,6 @@
       } catch (e) {
         console.error('GA4 configuration error: ' + e.message, window.location)
       }
-    },
-
-    addFilterButtonTracking: function (button, section) {
-      button.setAttribute('data-ga4-expandable', '')
-      var ga4JSON = { event_name: 'select_content', type: 'finder', section: section }
-
-      try {
-        var index = button.closest('[data-ga4-index]') || undefined
-        if (index) {
-          var indexData = JSON.parse(index.getAttribute('data-ga4-index'))
-          // flatten the attributes in index into the main data
-          for (var prop in indexData) {
-            ga4JSON[prop] = indexData[prop]
-          }
-        } else {
-          console.warn('No data-ga4-index found on the following element or its parents:')
-          console.warn(button)
-        }
-      } catch (e) {
-        // if there's a problem with the index object, don't add the attribute
-        console.error('GA4 configuration error: ' + e.message, window.location)
-        return
-      }
-
-      button.setAttribute('data-ga4-event', JSON.stringify(ga4JSON))
     }
   }
 

--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -74,7 +74,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
       try {
         buttonAttributes = JSON.parse(buttonAttributes)
         for (var rawKey in buttonAttributes) {
-          var key = rawKey.replace(/_/i, '-').toLowerCase()
+          var key = rawKey.replace(/_/g, '-').toLowerCase()
           var rawValue = buttonAttributes[rawKey]
           var value = typeof rawValue === 'object' ? JSON.stringify(rawValue) : rawValue
           $button.setAttribute('data-' + key, value)

--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -69,17 +69,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
     $button.setAttribute('aria-expanded', expanded)
     $button.setAttribute('aria-controls', this.$content.getAttribute('id'))
 
-    // GA4 Accordion tracking. Relies on the ga4-finder-tracker setting the index first, so we wrap this in a custom event.
-    window.addEventListener('ga4-filter-indexes-added', function () {
-      if (window.GOVUK.analyticsGa4) {
-        if (window.GOVUK.analyticsGa4.Ga4FinderTracker) {
-          window.GOVUK.analyticsGa4.Ga4FinderTracker.addFilterButtonTracking($button, this.$toggle.innerHTML)
+    var buttonAttributes = this.$module.getAttribute('data-button-data-attributes')
+    if (buttonAttributes) {
+      try {
+        buttonAttributes = JSON.parse(buttonAttributes)
+        for (var rawKey in buttonAttributes) {
+          var key = rawKey.replace(/_/i, '-').toLowerCase()
+          var rawValue = buttonAttributes[rawKey]
+          var value = typeof rawValue === 'object' ? JSON.stringify(rawValue) : rawValue
+          $button.setAttribute('data-' + key, value)
         }
+      } catch (e) {
+        console.error('Error with expander button data attributes, invalid JSON passed' + e.message, window.location)
       }
-    }.bind(this))
-
+    }
     $button.innerHTML = toggleHtml
-
     this.$toggle.parentNode.replaceChild($button, this.$toggle)
   }
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -56,11 +56,9 @@
 
     if (document.readyState === 'complete') {
       this.Ga4EcommerceTracking()
-      this.ga4SetFilterIndexes()
     } else {
       window.addEventListener('DOMContentLoaded', function () {
         this.Ga4EcommerceTracking()
-        this.ga4SetFilterIndexes()
       }.bind(this))
     }
 
@@ -630,20 +628,6 @@
             GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event.target, ga4ChangeCategory)
           }
         }
-      }
-    }
-  }
-
-  LiveSearch.prototype.ga4SetFilterIndexes = function () {
-    if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4FinderTracker) {
-      var consentCookie = GOVUK.getConsentCookie()
-
-      if (consentCookie && consentCookie.settings) {
-        GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
-      } else {
-        window.addEventListener('cookie-consent', function () {
-          GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
-        })
       }
     }
   }

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -113,7 +113,7 @@ private
   end
 
   def facets
-    all_facets.select(&:filterable?)
+    FacetsIterator.new(all_facets.select(&:filterable?))
   end
 
   def signup_links

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -92,7 +92,7 @@ private
   def result_set_presenter
     @result_set_presenter ||= ResultSetPresenter.new(
       content_item,
-      facets,
+      all_facets,
       results,
       filter_params,
       sort_presenter,
@@ -106,12 +106,18 @@ private
     @results ||= ResultSetParser.parse(search_results)
   end
 
+  def all_facets
+    return @facets if defined?(@facets)
+
+    FacetsBuilder.new(content_item:, search_results:, value_hash: filter_params).facets
+  end
+
   def facets
-    @facets ||= FacetsBuilder.new(content_item:, search_results:, value_hash: filter_params).facets
+    all_facets.select(&:filterable?)
   end
 
   def signup_links
-    @signup_links ||= SignupLinksPresenter.new(content_item, facets, keywords).signup_links
+    @signup_links ||= SignupLinksPresenter.new(content_item, all_facets, keywords).signup_links
   end
 
   def initialize_search_query(is_for_feed: false)
@@ -174,7 +180,7 @@ private
 
   def facet_tags
     @facet_tags ||= FacetTagsPresenter.new(
-      facets.select(&:filterable?),
+      facets,
       sort_presenter,
       i_am_a_topic_page_finder:,
     )

--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -1,0 +1,14 @@
+class FacetsIterator
+  delegate :select, :any?, to: :@facets
+
+  def initialize(facets)
+    @facets = facets
+    @facets_with_ga4_section = @facets.select(&:has_ga4_section?)
+  end
+
+  def each_with_index_and_count
+    @facets.each do |facet|
+      yield facet, @facets_with_ga4_section.index(facet), @facets_with_ga4_section.count
+    end
+  end
+end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -45,6 +45,10 @@ class DateFacet < FilterableFacet
     { key => date_values }
   end
 
+  def ga4_section
+    name
+  end
+
 private
 
   def value_fragments

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -55,6 +55,10 @@ class Facet
     {}
   end
 
+  def ga4_section
+    nil
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -59,6 +59,10 @@ class Facet
     nil
   end
 
+  def has_ga4_section?
+    !ga4_section.nil?
+  end
+
 private
 
   def and_word_connectors

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -72,6 +72,10 @@ class OptionSelectFacet < FilterableFacet
     open_on_load?
   end
 
+  def ga4_section
+    name
+  end
+
 private
 
   def value_fragments

--- a/app/models/radio_facet.rb
+++ b/app/models/radio_facet.rb
@@ -30,6 +30,10 @@ class RadioFacet < FilterableFacet
     { key => selected_value["value"] }
   end
 
+  def ga4_section
+    ""
+  end
+
 private
 
   def selected_value

--- a/app/models/radio_facet_for_multiple_filters.rb
+++ b/app/models/radio_facet_for_multiple_filters.rb
@@ -37,6 +37,10 @@ class RadioFacetForMultipleFilters < FilterableFacet
     @filter_hashes
   end
 
+  def ga4_section
+    ""
+  end
+
 private
 
   attr_reader :filter_hashes

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -43,6 +43,10 @@ class TaxonFacet < FilterableFacet
     }
   end
 
+  def ga4_section
+    "Topic"
+  end
+
 private
 
   def value_fragments

--- a/app/models/topical_facet.rb
+++ b/app/models/topical_facet.rb
@@ -6,4 +6,8 @@ class TopicalFacet < OptionSelectFacet
   def to_partial_path
     "option_select_facet"
   end
+
+  def ga4_section
+    name
+  end
 end

--- a/app/views/components/_date_filter.html.erb
+++ b/app/views/components/_date_filter.html.erb
@@ -8,7 +8,7 @@
   date_errors_to ||= nil
 %>
 <% if key && name %>
-  <%= render "components/expander", { title: name } do %>
+  <%= render "components/expander", { title: name, data_attributes: { "ga4-filter-parent": name } } do %>
     <div class="govuk-!-margin-bottom-0" id="<%= key %>">
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/components/_date_filter.html.erb
+++ b/app/views/components/_date_filter.html.erb
@@ -7,9 +7,10 @@
   date_errors_from ||= nil
   date_errors_to ||= nil
   data_attributes ||= nil
+  button_data_attributes ||= nil
 %>
 <% if key && name %>
-  <%= render "components/expander", { title: name, data_attributes: } do %>
+  <%= render "components/expander", { title: name, data_attributes:, button_data_attributes: } do %>
     <div class="govuk-!-margin-bottom-0" id="<%= key %>">
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/components/_date_filter.html.erb
+++ b/app/views/components/_date_filter.html.erb
@@ -6,9 +6,10 @@
   aria_controls_id ||= false
   date_errors_from ||= nil
   date_errors_to ||= nil
+  data_attributes ||= nil
 %>
 <% if key && name %>
-  <%= render "components/expander", { title: name, data_attributes: { "ga4-filter-parent": name } } do %>
+  <%= render "components/expander", { title: name, data_attributes: } do %>
     <div class="govuk-!-margin-bottom-0" id="<%= key %>">
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -7,11 +7,15 @@
   content_id = "expander-content-#{SecureRandom.hex(4)}"
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
-  css_classes = %w( app-c-expander )
-  css_classes << (shared_helper.get_margin_bottom) unless margin_bottom == 0
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_data_attribute({ module: "expander" })
+  component_helper.add_data_attribute({ "open-on-load": open_on_load })
+  component_helper.add_data_attribute({ "ga4-filter-parent": title })
+  component_helper.add_class("app-c-expander")
+  component_helper.add_class(shared_helper.get_margin_bottom) unless margin_bottom == 0
 %>
 <% if title %>
-  <%= tag.div class: css_classes, data: { module: "expander", 'open-on-load': open_on_load, 'ga4-filter-parent': '' } do %>
+  <%= tag.div(**component_helper.all_attributes) do %>
     <h3 class="app-c-expander__heading">
       <span class="app-c-expander__title js-toggle"><%= title %></span>
       <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -10,7 +10,6 @@
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_data_attribute({ module: "expander" })
   component_helper.add_data_attribute({ "open-on-load": open_on_load })
-  component_helper.add_data_attribute({ "ga4-filter-parent": title })
   component_helper.add_class("app-c-expander")
   component_helper.add_class(shared_helper.get_margin_bottom) unless margin_bottom == 0
 %>

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -12,6 +12,7 @@
   component_helper.add_data_attribute({ "open-on-load": open_on_load })
   component_helper.add_class("app-c-expander")
   component_helper.add_class(shared_helper.get_margin_bottom) unless margin_bottom == 0
+  component_helper.add_data_attribute({ "button-data-attributes": button_data_attributes }) if local_assigns.include?(:button_data_attributes)
 %>
 <% if title %>
   <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/components/docs/expander.yml
+++ b/app/views/components/docs/expander.yml
@@ -28,3 +28,43 @@ examples:
       margin_bottom: 9
       block: |
         This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.
+  with_counter:
+    description: If there are form elements within the expander it can display a count of the number of form elements with a selected or input value. This is to make it appear the same as the option select component when appearing with it in search pages. Note that if any form elements are selected on page load, the component will expand by default.
+    data:
+      title: Things
+      block: |
+        <div class="govuk-form-group gem-c-select">
+          <label class="govuk-label" for="level_one_taxon">Topic</label>
+          <select name="level_one_taxon" id="level_one_taxon" class="govuk-select gem-c-select__select--full-width">
+            <option value="">All topics</option>
+            <option value="1" selected>Business and industry</option>
+            <option value="2">COVID-19</option>
+            <option value="3">Corporate information</option>
+          </select>
+        </div>
+        <div class="govuk-form-group" data-ga4-section="Sub-topic">
+          <div class="govuk-form-group gem-c-select">
+            <label class="govuk-label" for="level_two_taxon">Sub-topic</label>
+            <select name="level_two_taxon" id="level_two_taxon" class="govuk-select gem-c-select__select--full-width">
+              <option value="">All sub-topics</option>
+              <option value="2">Business and the environment</option>
+              <option value="3">Business regulation</option>
+              <option value="4">Charities and social enterprises</option>
+            </select>
+          </div>
+        </div>
+        <div class="govuk-form-group">
+          <label for="public_timestamp[from]" class="gem-c-label govuk-label">Updated after</label>
+          <input aria-describedby="hint-fe643477" class="gem-c-input govuk-input" id="public_timestamp[from]" name="public_timestamp[from]" spellcheck="false" type="text" value="2023">
+        </div>
+  with_button_data_attributes:
+    description: Allows data attributes to be passed to the component to be added to the expand/collapse button. The attributes are written to the parent element then read by the JavaScript and applied to the button. This is used for tracking purposes.
+    data:
+      title: Organisation
+      button_data_attributes:
+        ga4_expandable: ""
+        ga4_event:
+          event_name: "select_content"
+          type: "finder"
+      block: |
+        Sssh I'm hiding

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -7,6 +7,15 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
+    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    button_data_attributes: {
+      ga4_expandable: "",
+      ga4_event: {
+        event_name: 'select_content',
+        type: 'finder',
+        section: date_facet.name,
+        index: { index_section: index + 1, index_section_count: count }
+      }
+    }
   } %>
 </span>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -7,6 +7,6 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-filter-parent": date_facet.name }
+    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section }
   } %>
 </span>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -7,6 +7,6 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section }
+    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
   } %>
 </span>

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -1,12 +1,12 @@
 <span data-ga4-change-category="update-filter text">
-  <%=
-  render "components/date_filter", {
+  <%= render "components/date_filter", {
     name: date_facet.name,
     key: date_facet.key,
     from_value: date_facet.user_supplied_from_date,
     to_value: date_facet.user_supplied_to_date,
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
-    date_errors_from: date_facet.error_message_from(@search_query)
+    date_errors_from: date_facet.error_message_from(@search_query),
+    data_attributes:  { "ga4-filter-parent": date_facet.name }
   } %>
 </span>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -46,8 +46,8 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.each.with_index do |facet, index| %>
-            <%= render partial: facet, object: facet, locals: { index: } %>
+          <% facets.each_with_index_and_count do |facet, index, count| %>
+            <%= render partial: facet, object: facet, locals: { index:, count: } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -46,7 +46,9 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <%= render facets.select(&:filterable?) %>
+          <% facets.select(&:filterable?).each.with_index do |facet, index| %>
+            <%= render partial: facet, object: facet, locals: { index: } %>
+          <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>
           </div>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -18,12 +18,12 @@
   <% if content_item.all_content_finder? %>
     <%= render partial: 'filter_button'%>
   <% elsif !content_item.all_content_finder? %>
-    <% if facets.select(&:filterable?).any? %>
+    <% if facets.any? %>
       <%= render partial: 'filter_button'%>
     <% end %>
   <% end %>
 
-  <% if facets.select(&:filterable?).any? %>
+  <% if facets.any? %>
     <div data-module="gem-track-click" data-track-category="filterClicked"
         data-track-action="skip-Link" data-track-label="">
       <%= render "govuk_publishing_components/components/skip_link", {
@@ -46,7 +46,7 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.select(&:filterable?).each.with_index do |facet, index| %>
+          <% facets.each.with_index do |facet, index| %>
             <%= render partial: facet, object: facet, locals: { index: } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -17,6 +17,15 @@
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    :button_data_attributes => {
+      "ga4-expandable": "",
+      "ga4-event": {
+        event_name: 'select_content',
+        type: 'finder',
+        section: option_select_facet.name,
+        index: { index_section: index + 1, index_section_count: count }
+      }
+    }
   } %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -1,4 +1,4 @@
-<%# 
+<%#
   Always ensure the option-select and checkbox stylesheets are requested,
   otherwise the helper methods to include the stylesheets are not called when
   caching is used
@@ -7,7 +7,7 @@
 <% add_gem_component_stylesheet("checkboxes") %>
 
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
-  <div data-ga4-change-category="update-filter checkbox" data-ga4-filter-parent data-ga4-section="<%= option_select_facet.name %>">
+  <%= tag.div(data: { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.name }) do %>
     <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
       :key => option_select_facet.key,
       :title => option_select_facet.name,
@@ -19,5 +19,5 @@
       :show_filter => option_select_facet.show_option_select_filter,
       :large => option_select_facet.large?
     } %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -7,17 +7,16 @@
 <% add_gem_component_stylesheet("checkboxes") %>
 
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
-  <%= tag.div(data: { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section }) do %>
-    <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
-      :key => option_select_facet.key,
-      :title => option_select_facet.name,
-      :aria_controls_id => "js-search-results-info",
-      :options_container_id => option_select_facet.key,
-      :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-      :closed_on_load => option_select_facet.closed_on_load?(index),
-      :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
-      :show_filter => option_select_facet.show_option_select_filter,
-      :large => option_select_facet.large?
-    } %>
-  <% end %>
+  <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
+    :key => option_select_facet.key,
+    :title => option_select_facet.name,
+    :aria_controls_id => "js-search-results-info",
+    :options_container_id => option_select_facet.key,
+    :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
+    :closed_on_load => option_select_facet.closed_on_load?(index),
+    :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
+    :show_filter => option_select_facet.show_option_select_filter,
+    :large => option_select_facet.large?,
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
+  } %>
 <% end %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -14,7 +14,7 @@
       :aria_controls_id => "js-search-results-info",
       :options_container_id => option_select_facet.key,
       :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-      :closed_on_load => option_select_facet.closed_on_load?(option_select_facet_counter),
+      :closed_on_load => option_select_facet.closed_on_load?(index),
       :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
       :show_filter => option_select_facet.show_option_select_filter,
       :large => option_select_facet.large?

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -7,7 +7,7 @@
 <% add_gem_component_stylesheet("checkboxes") %>
 
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
-  <%= tag.div(data: { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.name }) do %>
+  <%= tag.div(data: { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section }) do %>
     <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
       :key => option_select_facet.key,
       :title => option_select_facet.name,

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "", "ga4-filter-parent": radio_facet.ga4_section }) do %>
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-filter-parent": radio_facet.ga4_section, "ga4-section": "", "ga4-index": { index_section: index + 1, index_section_count: count } }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "", "ga4-filter-parent": "" }) do %>
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "", "ga4-filter-parent": radio_facet.ga4_section }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,7 +1,7 @@
-<div class="facet-container" data-ga4-change-category="update-filter radio" data-ga4-section="" data-ga4-filter-parent>
+<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-section": "", "ga4-filter-parent": "" }) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,
     items: radio_facet.options
   } %>
-</div>
+<% end %>

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,7 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-filter-parent": "Topic" }
+    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
       <%= render "govuk_publishing_components/components/select", {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,7 +1,19 @@
 <% unless i_am_a_topic_page_finder %>
+  <%
+    button_data_attributes = {
+      ga4_expandable: "",
+      ga4_event: {
+        event_name: 'select_content',
+        type: 'finder',
+        section: "Topic",
+        index: { index_section: index + 1, index_section_count: count }
+      }
+    }
+  %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
+    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    button_data_attributes:
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
       <%= render "govuk_publishing_components/components/select", {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,7 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section }
+    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
       <%= render "govuk_publishing_components/components/select", {

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -1,6 +1,7 @@
 <% unless i_am_a_topic_page_finder %>
   <%= render "components/expander", {
-    title: "Topic"
+    title: "Topic",
+    data_attributes: { "ga4-filter-parent": "Topic" }
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
       <%= render "govuk_publishing_components/components/select", {

--- a/spec/components/expander_spec.rb
+++ b/spec/components/expander_spec.rb
@@ -42,4 +42,20 @@ describe "expander", type: :view do
 
     assert_select '.app-c-expander.govuk-\!-margin-bottom-9'
   end
+
+  it "accepts button data attributes" do
+    button_attrs = {
+      ga4_expandable: "true",
+      ga4_event: {
+        event_name: "select_content",
+        type: "finder",
+      },
+    }
+
+    render_component(title: "Some title", button_data_attributes: button_attrs) do
+      "This is more info"
+    end
+
+    assert_select ".app-c-expander[data-button-data-attributes='#{button_attrs.to_json}']"
+  end
 end

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -349,26 +349,6 @@ describe('GA4 finder change tracker', function () {
     expect(window.dataLayer[0]).toEqual(expected)
   })
 
-  it('sets the correct indexes', function () {
-    form.setAttribute('data-ga4-filter-container', '')
-
-    for (var i = 0; i < 5; i++) {
-      var div = document.createElement('div')
-      div.setAttribute('data-ga4-filter-parent', '')
-      form.appendChild(div)
-    }
-
-    // Grabs each data-ga4-filter-parent element within a data-ga4-filter-container, and sets the appropriate indexes.
-    window.GOVUK.analyticsGa4.Ga4FinderTracker.setFilterIndexes()
-
-    var divs = form.querySelectorAll('[data-ga4-filter-parent]')
-
-    for (i = 0; i < divs.length; i++) {
-      var expectedIndexObject = { index_section: i + 1, index_section_count: divs.length, index_link: undefined }
-      expect(divs[i].getAttribute('data-ga4-index')).toEqual(JSON.stringify(expectedIndexObject))
-    }
-  })
-
   it('does nothing if the elementType or changeType does not exist', function () {
     inputParent = document.createElement('div')
     input = document.createElement('input')

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -131,7 +131,8 @@ describe('An expander module', function () {
       ga4_expandable: '',
       ga4_event: {
         event_name: 'select_content',
-        type: 'finder'
+        type: 'finder',
+        test_attribute_with_many_underscores: 'oh yes'
       }
     }
 

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -126,30 +126,38 @@ describe('An expander module', function () {
     })
   })
 
-  describe('GA4 tracking', function () {
+  describe('adds data attributes to the button', function () {
+    var buttonAttrs = {
+      ga4_expandable: '',
+      ga4_event: {
+        event_name: 'select_content',
+        type: 'finder'
+      }
+    }
+
     beforeEach(function () {
       $element = document.createElement('div')
       $element.innerHTML = html
-
-      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
+      $element.querySelector('.app-c-expander').setAttribute('data-button-data-attributes', JSON.stringify(buttonAttrs))
     })
 
     afterEach(function () {
       $(document).off()
     })
 
-    it('adds the ga4 event tracker values to the button', function () {
+    it('adds button data attributes passed to the component onto the button', function () {
+      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
       var $button = $($element).find('.app-c-expander__button')
-      window.GOVUK.triggerEvent(window, 'ga4-filter-indexes-added')
-      var expected = JSON.stringify({
-        event_name: 'select_content',
-        type: 'finder',
-        section: 'Organisation',
-        index_section: 1,
-        index_section_count: 3
-      })
-
+      var expected = JSON.stringify(buttonAttrs.ga4_event)
+      expect($button.attr('data-ga4-expandable')).toEqual('')
       expect($button.attr('data-ga4-event')).toEqual(expected)
+    })
+
+    it('does not error with invalid button data attributes', function () {
+      $element.querySelector('.app-c-expander').setAttribute('data-button-data-attributes', 'invalidjson')
+      new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
+      var $button = $($element).find('.app-c-expander__button')
+      expect($button.attr('data-ga4-expandable')).toEqual(undefined)
     })
   })
 })

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -128,11 +128,10 @@ describe('An expander module', function () {
 
   describe('adds data attributes to the button', function () {
     var buttonAttrs = {
-      ga4_expandable: '',
+      test_attribute_with_many_underscores: 'oh yes',
       ga4_event: {
         event_name: 'select_content',
-        type: 'finder',
-        test_attribute_with_many_underscores: 'oh yes'
+        type: 'finder'
       }
     }
 
@@ -150,7 +149,7 @@ describe('An expander module', function () {
       new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
       var $button = $($element).find('.app-c-expander__button')
       var expected = JSON.stringify(buttonAttrs.ga4_event)
-      expect($button.attr('data-ga4-expandable')).toEqual('')
+      expect($button.attr('data-test-attribute-with-many-underscores')).toEqual('oh yes')
       expect($button.attr('data-ga4-event')).toEqual(expected)
     })
 
@@ -158,7 +157,7 @@ describe('An expander module', function () {
       $element.querySelector('.app-c-expander').setAttribute('data-button-data-attributes', 'invalidjson')
       new GOVUK.Modules.Expander($element.querySelector('.app-c-expander')).init()
       var $button = $($element).find('.app-c-expander__button')
-      expect($button.attr('data-ga4-expandable')).toEqual(undefined)
+      expect($button.attr('data-test-attribute-with-many-underscores')).toEqual(undefined)
     })
   })
 })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Refactor some of the GA4 code in `finder-frontend`, based on @floehopper's previous work in https://github.com/alphagov/finder-frontend/pull/3166. This moves the logic for generating indexes for GA4 tracking on search elements (the option select and expander components) from the JS into Ruby.

Now depends upon this change in the components gem: https://github.com/alphagov/govuk_publishing_components/pull/3750

## Why
We want our code to be clean and readable.

## Visual changes
None.

Trello card: https://trello.com/c/OdYXlYqQ/673-finder-frontend-code-optimisations