### PR TITLE
Run search term standardise function on GA4 search event

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -109,8 +109,6 @@
 
     // Takes the GTM schema, the event target value, the event target HTML type, whether the filter was removed, the type of filter change it was, and the parent section heading. Populates the GTM object based on these values.
     setSchemaBasedOnChangeType: function (schema, elementValue, elementType, wasFilterRemoved, changeType, section, filterParent) {
-      var PIIRemover = new window.GOVUK.analyticsGa4.PIIRemover()
-
       switch (changeType) {
         case 'update-filter':
           if (section) {
@@ -134,9 +132,7 @@
           schema.url = window.location.pathname
           schema.section = 'Search'
           schema.action = 'search'
-          schema.text = PIIRemover.stripPIIWithOverride(schema.text, true, true)
-          schema.text = GOVUK.analyticsGa4.core.trackFunctions.removeLinesAndExtraSpaces(schema.text)
-          schema.text = schema.text.toLowerCase()
+          schema.text = GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(schema.text)
           break
 
         case 'clear-all-filters':

--- a/docs/analytics-ga4/ga4-finder-tracker.md
+++ b/docs/analytics-ga4/ga4-finder-tracker.md
@@ -79,7 +79,7 @@ Our date filters have `data-ga4-change-category="update-filter text"` on them. T
 
 Search boxes have `data-ga4-change-category="update-keyword text"` on them. The value we grab on change is the text that was input into the text box.  Regardless if text is available in the text box, we always treat it as a "search" event. This is because an empty search box is still as search event but it just searches for everything in our database.
 
-We apply the maximum level of PII removal on the user input.
+The search value is sanitised with PII removal, + characters converted to spaces, spaces and new lines trimmed, and downcasing.
 
 
 ### Clear all filters button

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -78,7 +78,7 @@ describe('GA4 finder change tracker', function () {
 
     input = document.createElement('input')
     input.setAttribute('type', 'search')
-    input.value = ' I    have a lot of   SPACES   in a lot of PLACES         '
+    input.value = ' I    have a lot of   SPACES   in a lot of PLACES         \n \r'
 
     inputParent.appendChild(input)
     form.appendChild(inputParent)
@@ -88,6 +88,28 @@ describe('GA4 finder change tracker', function () {
     expected.event_data.event_name = 'search'
     expected.event_data.url = window.location.pathname
     expected.event_data.text = 'i have a lot of spaces in a lot of places'
+    expected.event_data.section = 'Search'
+    expected.event_data.action = 'search'
+
+    expect(window.dataLayer[0]).toEqual(expected)
+  })
+
+  it('replaces + characters with spaces on a search box keyword update', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('data-ga4-change-category', 'update-keyword text')
+
+    input = document.createElement('input')
+    input.setAttribute('type', 'search')
+    input.value = 'i+have%2Bspaces+in+places'
+
+    inputParent.appendChild(input)
+    form.appendChild(inputParent)
+
+    window.GOVUK.triggerEvent(input, 'change')
+
+    expected.event_data.event_name = 'search'
+    expected.event_data.url = window.location.pathname
+    expected.event_data.text = 'i have spaces in places'
     expected.event_data.section = 'Search'
     expected.event_data.action = 'search'
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Run `standardiseSearchTerm` on the GA4 search event, so that it looks the same as all the other search terms that come through e.g. in the ecommerce and pageview events.

## Why

https://trello.com/c/J5XcLlvh/743-collect-undefined-instead-of-when-removing-search-terms-on-finders