### PR TITLE
Set up Vertex search A/B test

### DIFF
--- a/app/controllers/ab_tests/vertex_search_ab_testable.rb
+++ b/app/controllers/ab_tests/vertex_search_ab_testable.rb
@@ -17,4 +17,7 @@ module AbTests::VertexSearchAbTestable
     @requested_variant.configure_response(response)
   end
 
+  def ab_params
+    { vertex: @requested_variant.variant_name }
+  end
 end

--- a/app/controllers/ab_tests/vertex_search_ab_testable.rb
+++ b/app/controllers/ab_tests/vertex_search_ab_testable.rb
@@ -1,7 +1,7 @@
-module AbTests::ElasticSearchAaTestable
-  def elastic_search_aa_test
+module AbTests::VertexSearchAbTestable
+  def vertex_search_ab_test
     GovukAbTesting::AbTest.new(
-      "EsSixPointSeven",
+      "VertexSearch",
       dimension: 41,
       allowed_variants: %w[A B Z],
       control_variant: "Z",
@@ -13,7 +13,8 @@ module AbTests::ElasticSearchAaTestable
   end
 
   def set_requested_variant
-    @requested_variant = elastic_search_aa_test.requested_variant(request.headers)
+    @requested_variant = vertex_search_ab_test.requested_variant(request.headers)
     @requested_variant.configure_response(response)
   end
+
 end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,6 +1,6 @@
 class FindersController < ApplicationController
   layout "finder_layout"
-  include AbTests::ElasticSearchAaTestable
+  include AbTests::VertexSearchAbTestable
 
   before_action do
     set_expiry(content_item)

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -119,7 +119,7 @@ private
       content_item,
       filter_params,
       override_sort_for_feed: is_for_feed,
-      ab_params: {},
+      ab_params: page_under_test? ? ab_params : {},
     )
   end
 

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -83,7 +83,6 @@ module Search
       queries = QueryBuilder.new(
         finder_content_item: content_item,
         params: filter_params,
-        ab_params:,
         override_sort_for_feed:,
       ).call
 

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -104,7 +104,7 @@ module Search
     end
 
     def use_v2_api?
-      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
+      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"]) || ab_params[:vertex] == "B"
     end
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -140,6 +140,19 @@ describe FindersController, type: :controller do
             expect(response.header["Vary"]).not_to eq("GOVUK-ABTest-VertexSearch")
             expect(response.body).not_to include("VertexSearch:#{variant}")
           end
+
+          it "sends ab_params to search query if page is being tested" do
+            stub_content_store_has_item(
+              "/search/all",
+              all_content_finder,
+            )
+
+            @request.headers["GOVUK-ABTest-VertexSearch"] = variant
+
+            expect(Search::Query).to receive(:new).with(anything, anything, hash_including(ab_params: { vertex: variant })).and_call_original
+
+            get :show, params: { slug: "search/all" }
+          end
         end
 
         it "should render the page without an AB test variant for search" do

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -49,20 +49,7 @@ describe FindersController, type: :controller do
           { max_age: 900, public: true },
         )
 
-        url = "#{Plek.find('search-api')}/search.json"
-
-        stub_request(:get, url)
-          .with(
-            query: {
-              count: 10,
-              fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
-              filter_document_type: "mosw_report",
-              order: "-public_timestamp",
-              start: 0,
-              suggest: "spelling_with_highlighting",
-            },
-          )
-          .to_return(status: 200, body: rummager_response, headers: {})
+        search_api_request
       end
 
       it "correctly renders a finder page" do
@@ -111,6 +98,10 @@ describe FindersController, type: :controller do
       end
 
       context "with AB test" do
+        before do
+          search_api_request(search_api_app: "search-api-v2")
+        end
+
         %w[A B Z].each do |variant|
           it "renders the #{variant} variant for /search/all pages" do
             stub_content_store_has_item(
@@ -537,8 +528,8 @@ describe FindersController, type: :controller do
     end
   end
 
-  def search_api_request(query: {})
-    stub_request(:get, "#{Plek.find('search-api')}/search.json")
+  def search_api_request(query: {}, search_api_app: "search-api")
+    stub_request(:get, "#{Plek.find(search_api_app)}/search.json")
       .with(
         query: {
           count: 10,

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -110,7 +110,7 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(406)
       end
 
-      context "with AA test" do
+      context "with AB test" do
         %w[A B Z].each do |variant|
           it "renders the #{variant} variant for /search/all pages" do
             stub_content_store_has_item(
@@ -118,12 +118,12 @@ describe FindersController, type: :controller do
               all_content_finder,
             )
 
-            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+            @request.headers["GOVUK-ABTest-VertexSearch"] = variant
 
             get :show, params: { slug: "search/all" }
 
-            expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
-            expect(response.body).to include("EsSixPointSeven:#{variant}")
+            expect(response.header["Vary"]).to eq("GOVUK-ABTest-VertexSearch")
+            expect(response.body).to include("VertexSearch:#{variant}")
           end
 
           it "doesn't render the #{variant} for finders" do
@@ -132,13 +132,13 @@ describe FindersController, type: :controller do
               lunch_finder,
             )
 
-            @request.headers["GOVUK-ABTest-EsSixPointSeven"] = variant
+            @request.headers["GOVUK-ABTest-VertexSearch"] = variant
 
             get :show, params: { slug: "lunch-finder" }
 
             expect(response.status).to eq(200)
-            expect(response.header["Vary"]).not_to eq("GOVUK-ABTest-EsSixPointSeven")
-            expect(response.body).not_to include("EsSixPointSeven:#{variant}")
+            expect(response.header["Vary"]).not_to eq("GOVUK-ABTest-VertexSearch")
+            expect(response.body).not_to include("VertexSearch:#{variant}")
           end
         end
 
@@ -151,7 +151,7 @@ describe FindersController, type: :controller do
           get :show, params: { slug: "search/all" }
 
           expect(response.status).to eq(200)
-          expect(response.header["Vary"]).to eq("GOVUK-ABTest-EsSixPointSeven")
+          expect(response.header["Vary"]).to eq("GOVUK-ABTest-VertexSearch")
           expect(response.body).not_to include("<meta name=\"govuk:ab-test\">")
         end
       end

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -67,6 +67,24 @@ describe Search::Query do
     end
   end
 
+  context "when in AB test variant B" do
+    subject { described_class.new(content_item, {}, ab_params: { vertex: "B" }).search_results }
+
+    before do
+      stub_search_v2.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v2-api", "I am the v2 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v2 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v2-api"))
+    end
+  end
+
   context "when searching using a single query" do
     subject { described_class.new(content_item, filter_params).search_results }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello: https://trello.com/c/HlEuqcgE/213-implement-switching-based-on-ab-test-in-finder-frontend
Related PR: https://github.com/alphagov/govuk-fastly/pull/33

# What's changed?

Renames and expands the old "EsSixPointSeven" A/A test to A/B test the new Vertex AI site search.
The renamed test will use the same Dimension (41) as the old A/A control test.

Users have two paths to try out the Vertex search. The first is by using the existing "use_v2" query parameter. The second is by being assigned to the "B" variant of the "VertexSearch" A/B test.

# Why?

The new Vertex AI site search will be A/B tested in the New Year. Initially with 5% of traffic (where cookies have been accepted) being directed to the new search before being ramped up to 50%.