### PR TITLE
Only show parts for top three results

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -87,6 +87,7 @@ private
       SearchResultPresenter.new(
         document:,
         rank: index + 1,
+        result_number: start_offset + index,
         metadata_presenter_class:,
         doc_count: documents.count,
         facets:,

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -1,4 +1,7 @@
 class SearchResultPresenter
+  # Defines how many of the top results to show parts for (if present)
+  SHOW_PARTS_FOR_TOP_N_RESULTS = 3
+
   include ActionView::Helpers::SanitizeHelper
 
   delegate :title,
@@ -11,12 +14,13 @@ class SearchResultPresenter
            :original_rank,
            to: :document
 
-  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, include_ecommerce: true)
+  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, result_number:, include_ecommerce: true)
     @document = document
     @rank = rank
     @metadata = metadata_presenter_class.new(document.metadata(facets)).present
     @count = doc_count
     @debug_score = debug_score
+    @result_number = result_number
     @content_item = content_item
     @include_ecommerce = include_ecommerce
   end
@@ -32,7 +36,7 @@ class SearchResultPresenter
       metadata: structure_metadata,
       metadata_raw: metadata,
       subtext:,
-      parts: structure_parts,
+      parts: include_parts? ? structure_parts : nil,
     }
   end
 
@@ -71,6 +75,10 @@ private
       value = meta[:is_date] ? "<time datetime='#{meta[:machine_date]}'>#{meta[:human_date]}</time>" : meta[:value]
       component_metadata[meta[:label]] = sanitize("#{meta[:label]}: #{value}", tags: %w[time span])
     end
+  end
+
+  def include_parts?
+    result_number <= SHOW_PARTS_FOR_TOP_N_RESULTS
   end
 
   def structure_parts
@@ -120,5 +128,5 @@ private
     }
   end
 
-  attr_reader :document, :metadata, :content_item
+  attr_reader :document, :metadata, :content_item, :result_number
 end


### PR DESCRIPTION
There is a requirement for only the top three search results to show parts, which is currently handled by `search-api` only returning parts for the top three results. However, this should really be a frontend concern, and shouldn't be handled by the backend returning different result data depending on what the position of a result is across all results.

- Determine the `result_number` for each result in `ResultSetPresenter` and pass on to `SearchResultPresenter` (ideally this would use "rank" for better semantics but that's currently used by a debug parameter)
- Determine in `SearchResultPresenter` whether or not to include parts in the presentation depending on the result number