### PR TITLE
Add Prometheus metrics for search requests/duration

### DIFF
--- a/app/lib/metrics.rb
+++ b/app/lib/metrics.rb
@@ -1,0 +1,45 @@
+module Metrics
+  CLIENT = PrometheusExporter::Client.default
+  COUNTERS = {
+    searches: CLIENT.register(
+      :counter,
+      "finder_frontend_searches",
+      "Total number of requests performed to a backend search API",
+    ),
+  }.freeze
+  HISTOGRAMS = {
+    search_request_duration: CLIENT.register(
+      :histogram,
+      "finder_frontend_search_request_duration",
+      "Time taken to perform a request to a backend search API",
+    ),
+  }.freeze
+
+  def self.increment_counter(counter, labels = {})
+    Rails.logger.warn("Unknown counter: #{counter}") and return unless COUNTERS.key?(counter)
+
+    COUNTERS[counter].observe(1, labels)
+  rescue StandardError
+    # Metrics are best effort only, don't raise if they fail
+  end
+
+  def self.observe_duration(histogram, labels = {}, &block)
+    unless HISTOGRAMS.key?(histogram)
+      Rails.logger.warn("Unknown histogram: #{histogram}")
+      return block.call
+    end
+
+    result = nil
+    duration = Benchmark.realtime do
+      result = block.call
+    end
+
+    begin
+      HISTOGRAMS[histogram].observe(duration, labels)
+    rescue StandardError
+      # Metrics are best effort only, don't raise if they fail
+    end
+
+    result
+  end
+end

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -87,15 +87,21 @@ module Search
       ).call
 
       if use_v2_api?
-        GovukStatsd.time("search_api_v2.finder_search") do
+        Metrics.increment_counter(:searches, api: "v2")
+
+        Metrics.observe_duration(:search_request_duration, api: "v2") do
           Services.search_api_v2.search(queries.first).to_hash
         end
       elsif queries.one?
-        GovukStatsd.time("rummager.finder_search") do
+        Metrics.increment_counter(:searches, api: "v1")
+
+        Metrics.observe_duration(:search_request_duration, api: "v1") do
           Services.rummager.search(queries.first).to_hash
         end
       else
-        GovukStatsd.time("rummager.finder_batch_search") do
+        Metrics.increment_counter(:searches, api: "v1_bulk")
+
+        Metrics.observe_duration(:search_request_duration, api: "v1_bulk") do
           merge_and_deduplicate(
             Services.rummager.batch_search(queries).to_hash,
           )

--- a/spec/lib/metrics_spec.rb
+++ b/spec/lib/metrics_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe Metrics do
+  describe ".increment_counter" do
+    let(:counter) { double(observe: nil) }
+
+    before do
+      stub_const("Metrics::COUNTERS", { foo: counter })
+    end
+
+    it "observes an increment of 1 for the given counter with the given labels" do
+      described_class.increment_counter(:foo, bar: "baz")
+
+      expect(counter).to have_received(:observe).with(1, bar: "baz")
+    end
+
+    it "fails gracefully if the counter does not exist" do
+      expect { described_class.increment_counter(:bar) }.not_to raise_error
+    end
+
+    it "fails gracefully if the operation raises an error" do
+      allow(counter).to receive(:observe).and_raise("boom")
+
+      expect { described_class.increment_counter(:foo) }.not_to raise_error
+    end
+  end
+
+  describe ".observe_duration" do
+    let(:histogram) { double(observe: nil) }
+
+    before do
+      stub_const("Metrics::HISTOGRAMS", { foo: histogram })
+    end
+
+    it "observes the duration of the given block for the given histogram with the given labels" do
+      described_class.observe_duration(:foo, bar: "baz") { "result" }
+
+      expect(histogram).to have_received(:observe).with(kind_of(Float), bar: "baz")
+    end
+
+    it "returns the result of the given block" do
+      expect(described_class.observe_duration(:foo) { "result" }).to eq("result")
+    end
+
+    it "fails gracefully if the histogram does not exist" do
+      expect(described_class.observe_duration(:bar) { "result" }).to eq("result")
+    end
+
+    it "fails gracefully if the operation raises an error" do
+      allow(histogram).to receive(:observe).and_raise("boom")
+
+      expect(described_class.observe_duration(:bar) { "result" }).to eq("result")
+    end
+  end
+end


### PR DESCRIPTION
- Add a `Metrics` convenience module for exporting Prometheus metrics
- Add a counter metric for number of search requests performed against a backend API, labelled by API version
- Add a histogram metric for duration of search requests performed against a backend API, labelled by API version
- Remove collection of legacy StatsD metrics for search request timing (these aren't really used for any useful purpose at the moment anyway, and we're moving away from StatsD across the GOV.UK estate)

---

Manually validated that the metrics are successfully exported:
<img width="734" alt="image" src="https://github.com/alphagov/finder-frontend/assets/72141/820e9548-1af6-4976-8337-3d5692abe52f">
