### PR TITLE
[EMERGENCY ONLY] Disable v2 search AB test

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -110,7 +110,7 @@ module Search
     end
 
     def use_v2_api?
-      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"]) || ab_params[:vertex] == "B"
+      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
     end
   end
 end

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -71,17 +71,25 @@ describe Search::Query do
     subject { described_class.new(content_item, {}, ab_params: { vertex: "B" }).search_results }
 
     before do
-      stub_search_v2.to_return(body: {
+      # TODO: This is part of a "break glass" revert commit and should be fixed properly
+      stub_search.to_return(body: {
         "results" => [
-          result_item("/i-am-the-v2-api", "I am the v2 API", score: nil, updated: "14-12-19", popularity: 1),
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
         ],
       }.to_json)
+      # stub_search_v2.to_return(body: {
+      #   "results" => [
+      #     result_item("/i-am-the-v2-api", "I am the v2 API", score: nil, updated: "14-12-19", popularity: 1),
+      #   ],
+      # }.to_json)
     end
 
-    it "calls the v2 API" do
+    # TODO: This is part of a "break glass" revert commit and should be fixed properly
+    it "calls the v1 API" do
       results = subject.fetch("results")
       expect(results.length).to eq(1)
-      expect(results.first).to match(hash_including("_id" => "/i-am-the-v2-api"))
+      # expect(results.first).to match(hash_including("_id" => "/i-am-the-v2-api"))
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
     end
   end
 


### PR DESCRIPTION
# ⚠️ Only merge this in case of emergency

**This commit removes usage of `search-api-v2` for the B variant of the "new search" AB test, which means all searches will go back to using v1.**

Merge this commit in case of an emergency where fixing the root issue isn't feasible.
