### PR TITLE
Accessibility fixes

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -376,7 +376,7 @@
   }
 
   LiveSearch.prototype.removeSelectElement = function removeSelectElement (sortOptionsMarkup) {
-    var SELECT_TAG_REGEX = /<\s*\/?\s*select\b[^>]*>/g
+    var SELECT_TAG_REGEX = /<\/?select\b[^>]*>/g
     return sortOptionsMarkup.replace(SELECT_TAG_REGEX, '')
   }
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -359,7 +359,15 @@
 
   LiveSearch.prototype.updateSortOptions = function updateSortOptions (results, action) {
     if (action !== this.serializeState(this.state)) { return }
-    this.updateElement(this.$sortBlock, results.sort_options_markup)
+    var currentSortOptions = this.$sortBlock.querySelector('select')
+    var newSortOptions
+
+    if (results.sort_options_markup) {
+      var EXTRACT_OPTION_TAGS = /(?<=<select .+>)(.*)(?=<\/select>)/
+      newSortOptions = results.sort_options_markup.replace(newSortOptions, EXTRACT_OPTION_TAGS)
+    }
+
+    this.updateElement(currentSortOptions, newSortOptions)
     this.bindSortElements()
   }
 

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -365,12 +365,19 @@
     var newSortOptions
 
     if (results.sort_options_markup) {
-      var EXTRACT_OPTION_TAGS = /(?<=<select .+>)(.*)(?=<\/select>)/
-      newSortOptions = results.sort_options_markup.replace(newSortOptions, EXTRACT_OPTION_TAGS)
+      // The select element is removed from results.sort_options_markup in order to retain the original select element. Only the option
+      // elements are updated with new markup. This is to prevent focus from being lost on the select element after the user sorts their
+      // results.
+      newSortOptions = this.removeSelectElement(results.sort_options_markup)
     }
 
     this.updateElement(currentSortOptions, newSortOptions)
     this.bindSortElements()
+  }
+
+  LiveSearch.prototype.removeSelectElement = function removeSelectElement (sortOptionsMarkup) {
+    var SELECT_TAG_REGEX = /<\s*\/?\s*select\b[^>]*>/g
+    return sortOptionsMarkup.replace(SELECT_TAG_REGEX, '')
   }
 
   LiveSearch.prototype.bindSortElements = function bindSortElements () {

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -121,7 +121,8 @@
     if (this.$resultsWrapper) {
       this.$resultsWrapper.setAttribute('data-search-query', this.currentKeywords())
       var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
-      if (sortedBy) {
+      // Check that the sortedBy element exists and contains option elements
+      if (sortedBy && sortedBy.options.length > 0) {
         this.$resultsWrapper.setAttribute('data-ecommerce-variant', sortedBy.options[sortedBy.selectedIndex].text)
       }
     }
@@ -147,7 +148,8 @@
         if (this.$resultsWrapper) {
           this.$resultsWrapper.setAttribute('data-ga4-search-query', this.currentKeywords())
           var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
-          if (sortedBy) {
+          // Check that the sortedBy element exists and contains option elements
+          if (sortedBy && sortedBy.options.length > 0) {
             this.$resultsWrapper.setAttribute('data-ga4-ecommerce-variant', sortedBy.options[sortedBy.selectedIndex].text)
           }
         }

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -635,7 +635,7 @@ describe('liveSearch', function () {
       liveSearch.state = { search: 'state' }
 
       expect($('#order option').length).toBe(2)
-      $('#order').remove()
+      $('option').remove()
       expect($('#order option').length).toBe(0)
       // We receive new data, which adds the sort options to the DOM.
       liveSearch.updateSortOptions(responseWithSortOptions, $.param(liveSearch.state))

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -645,6 +645,41 @@ describe('liveSearch', function () {
     })
   })
 
+  describe('removeSelectElement', function () {
+    it('removes the select element', function () {
+      var expectedResult = '<option ' +
+        'value="option-val" ' +
+        'data_track_category="option-data_track_category"' +
+        'data_track_action="option-data_track_action"' +
+        'data_track_label="option-data_track_label"' +
+        'selected' +
+      '/>' +
+      '<option ' +
+        'value="option-val-2" ' +
+        'data_track_category="option-data_track_category-2"' +
+        'data_track_action="option-data_track_action-2"' +
+        'data_track_label="option-data_track_label-2"' +
+        'disabled' +
+      '/>'
+
+      expect(liveSearch.removeSelectElement(responseWithSortOptions.sort_options_markup)).toEqual(expectedResult)
+    })
+
+    it('only targets select elements', function () {
+      var sortOptionsWithTypo = '<slect id="order">' +
+        '<option ' +
+          'value="option-val" ' +
+          'data_track_category="option-data_track_category"' +
+          'data_track_action="option-data_track_action"' +
+          'data_track_label="option-data_track_label"' +
+          'selected' +
+          '/>' +
+      '</slect>'
+
+      expect(liveSearch.removeSelectElement(sortOptionsWithTypo)).toEqual(sortOptionsWithTypo)
+    })
+  })
+
   describe('spelling suggestions', function () {
     var $suggestionBlock = $('<div class="spelling-suggestions" id="js-spelling-suggestions"></div>')
     var responseWithSpellingSuggestions = {


### PR DESCRIPTION
## What
This PR fixes a bug where focus is lost on the "Sort by" `select` element after using it to sort search results. This is because the DOM is updated with new elements when a user uses the "Sort by" filter. This includes inserting an entirely new "Sort by" `select` element and removing the previous `select` element which had received focus. I have applied a fix which retains the original `select` element and only updates the `option` elements within, therefore retaining the focus on the `select` element after it's been used.

This is achieved by using a regex on the new stringified HTML (`results.sort_options_markup`) that is received when `updateSortOptions()` is run following the application of filters to extract the `option` elements. The new `option` elements then replace the existing `option` elements in the "Sort by" `select` element. 

## Why
Identified as an issue as part of the WCAG audit of GOV.UK - [trello card](https://trello.com/c/fQ7cavwh/26-focus-gets-lost-when-sorting-search-results)

## Visual changes
None.