### PR TITLE
Fix search filter GA4 indexes

### DIFF
--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -14,7 +14,8 @@
         event_name: 'select_content',
         type: 'finder',
         section: date_facet.name,
-        index: { index_section: index + 1, index_section_count: count }
+        index_section: index + 1,
+        index_section_count: count,
       }
     }
   } %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -24,7 +24,8 @@
         event_name: 'select_content',
         type: 'finder',
         section: option_select_facet.name,
-        index: { index_section: index + 1, index_section_count: count }
+        index_section: index + 1,
+        index_section_count: count
       }
     }
   } %>

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -6,7 +6,8 @@
         event_name: 'select_content',
         type: 'finder',
         section: "Topic",
-        index: { index_section: index + 1, index_section_count: count }
+        index_section: index + 1,
+        index_section_count: count,
       }
     }
   %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the index values on bits down the side of search that expand and collapse when you click on them. Previously was being returned as `[Object object]` (a JS problem) being caused by incorrectly nested data attributes in the markup.

Examples of things that expand and collapse when you click on them (be sure to check them all, because some of them look the same but are different components):

- http://localhost:3062/search/all
- http://localhost:3062/find-licences

## Why
Incorrect data was being sent to GA4.

## Visual changes
None.

Trello card: https://trello.com/c/tRUT7Bim/789-fix-broken-indexsection-and-indexsectioncount-on-finder-filter-open-close-interactions