### PR TITLE
Disable document list component tracking in search

### DIFF
--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -4,6 +4,7 @@
 
 <div class="finder-results js-finder-results">
   <%= render "govuk_publishing_components/components/document_list", {
+    disable_ga4: true,
     items: local_assigns[:document_list_component_data],
     remove_underline: true,
     remove_top_border_from_first_child: result_set_presenter.has_sort_options


### PR DESCRIPTION
## What
- GA4 tracking was added to the document list component (gem version isn't released yet)
- Disable it from being enabled in finder frontend

## Why
- Finder frontend uses this component for the search results
- However the search results have their own eCommerce tracking, so we should disable the document list component tracking


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
