### PR TITLE
Fix GA4 indexes on search filters

### DIFF
--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -1,11 +1,12 @@
-<%#
-  Always ensure the option-select and checkbox stylesheets are requested,
-  otherwise the helper methods to include the stylesheets are not called when
-  caching is used
+<%
+  # Always ensure the option-select and checkbox stylesheets are requested,
+  # otherwise the helper methods to include the stylesheets are not called when
+  # caching is used
+  add_gem_component_stylesheet("option-select")
+  add_gem_component_stylesheet("checkboxes")
+  index_section = index + 1
+  index_section_count = count
 %>
-<% add_gem_component_stylesheet("option-select") %>
-<% add_gem_component_stylesheet("checkboxes") %>
-
 <% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
   <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
     :key => option_select_facet.key,
@@ -17,15 +18,15 @@
     :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
     :show_filter => option_select_facet.show_option_select_filter,
     :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index_section, index_section_count: index_section_count } },
     :button_data_attributes => {
       "ga4-expandable": "",
       "ga4-event": {
         event_name: 'select_content',
         type: 'finder',
         section: option_select_facet.name,
-        index_section: index + 1,
-        index_section_count: count
+        index_section: index_section,
+        index_section_count: index_section_count
       }
     }
   } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
Fix GA4 indexes on search facets when expanded or collapsed on pages like: https://www.gov.uk/search/guidance-and-regulation

- the indexes were coming out wrong for the option select facets, increased by 1, but okay for any preceding or following facets
- looks to be a problem where the values for `index_section` and `index_section_count` are cached inside the facet and are therefore sometimes wrong
- defining them outside of the cache block seems to solve the problem

Also I reformatted the option select facet file a little because the way the comment at the top was written previously stopped syntax highlighting from working for the rest of the file in my editor.

Credit to @AshGDS for figuring out it was being caused by the cache 👏 

## Why
The indexes were being generated as e.g.

1. (topic facet) `index_section: 1`, `index_section_count: 4`
1. (option select facet) `index_section: 3`, `index_section_count: 5` (wrong)
1. (option select facet) `index_section: 4`, `index_section_count: 5` (wrong)
1. (date facet) `index_section: 4`, `index_section_count: 4`

## Visual changes
None.

Trello card: https://trello.com/c/l5YsyfsN/794-fix-incorrect-index-values-on-guidance-and-regulation-finder-filters