### PR TITLE
Fix GA4 indexes on option select search facets

### DIFF
--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -50,8 +50,8 @@ class OptionSelectFacet < FilterableFacet
     unselected? || selected_values.one?
   end
 
-  def cache_key
-    Digest::SHA256.hexdigest({ name:, selected: selected_values, allowed: allowed_values }.to_json)
+  def cache_key(index_section = nil, index_section_count = nil)
+    Digest::SHA256.hexdigest({ name:, ga4_section:, index_section:, index_section_count:, selected: selected_values, allowed: allowed_values }.to_json)
   end
 
   def query_params

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -7,7 +7,7 @@
   index_section = index + 1
   index_section_count = count
 %>
-<% cache_if option_select_facet.cacheable?, option_select_facet.cache_key do %>
+<% cache_if option_select_facet.cacheable?, option_select_facet.cache_key(index_section, index_section_count) do %>
   <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
     :key => option_select_facet.key,
     :title => option_select_facet.name,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix GA4 indexes on search facets when expanded or collapsed on pages like: https://www.gov.uk/search/guidance-and-regulation

- the indexes were coming out wrong for the option select facets, increased by 1, but okay for any preceding or following facets
- looks to be a problem where the values for `index_section` and `index_section_count` are cached inside the facet and are therefore sometimes wrong
- need to pass them to the `cache_key` to let it invalidate the cache if the numbers change

Thanks to @sihugh for invaluable cache advice 👍 

## Why
The indexes were being generated as e.g.

1. (topic facet) `index_section: 1`, `index_section_count: 4`
1. (option select facet) `index_section: 3`, `index_section_count: 5` (wrong)
1. (option select facet) `index_section: 4`, `index_section_count: 5` (wrong)
1. (date facet) `index_section: 4`, `index_section_count: 4`

## Visual changes
None.

Trello card: https://trello.com/c/l5YsyfsN/794-fix-incorrect-index-values-on-guidance-and-regulation-finder-filters