### PR TITLE
Use v2 for all site search queries

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -2,6 +2,8 @@
 # search results from rummager.
 module Search
   class Query
+    SITE_SEARCH_FINDER_BASE_PATH = "/search/all".freeze
+
     include ActiveModel::Validations
 
     attr_reader :filter_params
@@ -110,7 +112,10 @@ module Search
     end
 
     def use_v2_api?
-      ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"]) || ab_params[:vertex] == "B"
+      return false if ActiveModel::Type::Boolean.new.cast(filter_params["use_v1"])
+      return true if ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
+
+      content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
     end
   end
 end

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -187,6 +187,17 @@ When(/^I view the all content finder with a manual filter$/) do
       order: "-public_timestamp",
     )).to_return(body: all_content_manuals_results_json)
 
+  stub_request(:get, DocumentHelper::SEARCH_V2_ENDPOINT)
+    .with(query: hash_including(q: "Replacing bristles", order: "-public_timestamp"))
+    .to_return(body: all_content_results_json)
+
+  stub_request(:get, DocumentHelper::SEARCH_V2_ENDPOINT)
+    .with(query: hash_including(
+      filter_manual: "/guidance/care-and-use-of-a-nimbus-2000",
+      q: "Replacing bristles",
+      order: "-public_timestamp",
+    )).to_return(body: all_content_manuals_results_json)
+
   visit finder_path("search/all", manual: "/guidance/care-and-use-of-a-nimbus-2000", q: "Replacing bristles")
 end
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -16,6 +16,7 @@ module DocumentHelper
   include GdsApi::TestHelpers::Worldwide
 
   SEARCH_ENDPOINT = "#{Plek.find('search-api')}/search.json".freeze
+  SEARCH_V2_ENDPOINT = "#{Plek.find('search-api-v2')}/search.json".freeze
 
   def stub_taxonomy_api_request
     stub_content_store_has_item("/", "links" => { "level_one_taxons" => [] })
@@ -47,6 +48,12 @@ module DocumentHelper
 
   def stub_search_api_request_with_query_param_no_results(query)
     stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including("q" => query))
+      .to_return(
+        body: no_results_json,
+      )
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
       .with(query: hash_including("q" => query))
       .to_return(
         body: no_results_json,
@@ -91,10 +98,18 @@ module DocumentHelper
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including(all_content_params.merge(order: "-public_timestamp")))
       .to_return(body: all_content_results_json)
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
+      .with(query: hash_including(all_content_params.merge(order: "-public_timestamp")))
+      .to_return(body: all_content_results_json)
   end
 
   def stub_search_api_request_with_organisation_filter_all_content_results
     stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including("q" => "search-term", "filter_organisations" => %w[ministry-of-magic]))
+      .to_return(body: filtered_by_organisation_all_content_results_json)
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
       .with(query: hash_including("q" => "search-term", "filter_organisations" => %w[ministry-of-magic]))
       .to_return(body: filtered_by_organisation_all_content_results_json)
   end
@@ -103,10 +118,18 @@ module DocumentHelper
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => "drving"))
       .to_return(body: spelling_suggestions_json)
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
+      .with(query: hash_including("q" => "drving"))
+      .to_return(body: spelling_suggestions_json)
   end
 
   def stub_search_api_request_with_manual_filter_all_content_results
     stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including("q" => "search-term", "filter_manual" => %w[how-to-be-a-wizard]))
+      .to_return(body: filtered_by_manual_all_content_results_json)
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
       .with(query: hash_including("q" => "search-term", "filter_manual" => %w[how-to-be-a-wizard]))
       .to_return(body: filtered_by_manual_all_content_results_json)
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -425,7 +425,7 @@ describe FindersController, type: :controller do
 
   describe "with legacy query parameters for publications" do
     before do
-      search_api_request
+      search_api_request(search_api_app: "search-api-v2")
       stub_content_store_has_item("/search/all", all_content_finder)
 
       @default_params = { slug: "search/all" }

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -18,6 +18,7 @@ describe Search::Query do
       "details" => {
         "facets" => facets,
       },
+      "base_path" => "/some/finder",
     )
   end
 
@@ -49,6 +50,33 @@ describe Search::Query do
     }
   end
 
+  context "when manually overriding parameters to use the v1 API" do
+    subject { described_class.new(content_item, { "use_v1" => "true" }).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
+
+    before do
+      stub_search.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v1 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
+    end
+  end
+
   context "when manually overriding parameters to use the v2 API" do
     subject { described_class.new(content_item, { "use_v2" => "true" }).search_results }
 
@@ -67,8 +95,17 @@ describe Search::Query do
     end
   end
 
-  context "when in AB test variant B" do
-    subject { described_class.new(content_item, {}, ab_params: { vertex: "B" }).search_results }
+  context "when on the site search finder" do
+    subject { described_class.new(content_item, {}).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
 
     before do
       stub_search_v2.to_return(body: {


### PR DESCRIPTION
This switches the `/search/all` ("site search") finder over to use `search-api-v2` exclusively now that our AB test has concluded with a positive outcome.

- Instead of checking for AB test variant, check for site search finder base path to establish whether to use v2
- Add `use_v1` query parameter along the lines of the existing `use_v2` to force use of `search-api` in circumstances where `search-api-v2` would normally be used
- Fix stubbing of API endpoints in tests