### PR TITLE
BREAK GLASS: Revert to always using Search API v1

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -115,7 +115,11 @@ module Search
       return false if ActiveModel::Type::Boolean.new.cast(filter_params["use_v1"])
       return true if ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
 
-      content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
+      # TODO: The following has been removed and hardcoded to false as part of a "break glass"
+      # commit:
+      #
+      # content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
+      false
     end
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -425,6 +425,7 @@ describe FindersController, type: :controller do
 
   describe "with legacy query parameters for publications" do
     before do
+      search_api_request(search_api_app: "search-api")
       search_api_request(search_api_app: "search-api-v2")
       stub_content_store_has_item("/search/all", all_content_finder)
 

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -108,17 +108,19 @@ describe Search::Query do
     end
 
     before do
-      stub_search_v2.to_return(body: {
+      stub_search.to_return(body: {
         "results" => [
-          result_item("/i-am-the-v2-api", "I am the v2 API", score: nil, updated: "14-12-19", popularity: 1),
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
         ],
       }.to_json)
     end
 
-    it "calls the v2 API" do
+    # TODO: This is part of the "break glass" and should be changed back to the intended behaviour
+    # after investigation
+    it "calls the v1 API" do
       results = subject.fetch("results")
       expect(results.length).to eq(1)
-      expect(results.first).to match(hash_including("_id" => "/i-am-the-v2-api"))
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
     end
   end
 


### PR DESCRIPTION
This is an emergency-only commit that can be merged in order to revert
all searches (in particular site search) back to exclusively using the
v1 `search-api`, for example if a major incident occurs in the short
term after launching.