### PR TITLE
Use V1 search when filtering by world location

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -114,6 +114,7 @@ module Search
     def use_v2_api?
       return false if ActiveModel::Type::Boolean.new.cast(filter_params["use_v1"])
       return true if ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
+      return false if filter_params["world_locations"].present?
 
       content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
     end

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -122,6 +122,33 @@ describe Search::Query do
     end
   end
 
+  context "when filtering by world location on the site search finder" do
+    subject { described_class.new(content_item, { "world_locations" => "austria" }).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
+
+    before do
+      stub_search.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v1 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
+    end
+  end
+
   context "when searching using a single query" do
     subject { described_class.new(content_item, filter_params).search_results }
 


### PR DESCRIPTION
Strange behaviour has been seen when filtering by some world locations. If the title doesn't fully match the slug, then zero results are fetched by the new site search.

This is due to some odd behaviour originating in Whitehall. Finder Frontend and the entire search stack (v1/v2) uses Whitehall slugs for world locations as identifiers (instead of content IDs).

Whitehall considers slugs an implementation detail and doesn't expose them on the publishing-api MQ, but does push them directly into search-api v1 through the legacy API. But v2 and parts of v1 only listen to the publishing-api MQ, and therefore needs to guess what the slug might be based on the title.

If the guess is wrong no results will be returned. e.g.

https://www.gov.uk/search/all?order=updated-newest&world_locations%5B%5D=uk-delegation-to-council-of-europe&use_v1=true (16 results)

https://www.gov.uk/search/all?order=updated-newest&world_locations%5B%5D=uk-delegation-to-council-of-europe&use_v2=true (No results)

This is complicated by the fact that Whitehal has both world_location and world_location_news models, and the content id it assigns to either depends on whether the world location is an international delegation. [see the content id assignment]

There three options to fix this:

- add a search_id field (aka slug) to both schemas (world_location and world_location_news)
- add a search_id field (aka slug) just to the world_location_news schema, and leave world_location doing whatever it's doing now (note that world_locations don't have base paths, so it's likely they'll never appear on the website, but should probably still be known about by search)
- switch to using v1 search for just these world locations links

Option 3 was picked as a stop gap to fix the problem in the short term for users of the world location pages whilst a proper fix is investigated for the title / slug not matching problem.

Rendered results 👉 https://finder-frontend-pr-3314.herokuapp.com/search/all?order=updated-newest&world_locations%5B%5D=uk-delegation-to-council-of-europe

[see the content id assignment]: https://github.com/alphagov/whitehall/blob/main/app/presenters/publishing_api/world_location_news_presenter.rb#L13

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
