### PR TITLE
Display Google discovery engine attribution token in debug information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.9.0)
+    govuk_publishing_components (37.10.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -257,7 +257,7 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.7.0)
+    nio4r (2.7.1)
     nokogiri (1.16.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -359,7 +359,7 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.20.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-faraday (0.24.0)
+    opentelemetry-instrumentation-faraday (0.24.1)
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.20.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
@@ -457,7 +457,7 @@ GEM
       opentelemetry-helpers-sql-obfuscation
       opentelemetry-instrumentation-base (~> 0.22.1)
       opentelemetry-semantic_conventions (>= 1.8.0)
-    opentelemetry-registry (0.3.0)
+    opentelemetry-registry (0.3.1)
       opentelemetry-api (~> 1.1)
     opentelemetry-sdk (1.4.0)
       opentelemetry-api (~> 1.1)
@@ -485,7 +485,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (3.0.9.1)
+    rack (3.0.10)
     rack-proxy (0.7.7)
       rack
     rack-session (2.0.0)
@@ -533,10 +533,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.6.2)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
-    reline (0.4.3)
+    reline (0.5.0)
       io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -35,6 +35,7 @@
     }
 
     this.$resultsCountMetaTag = document.querySelector("meta[name='govuk:search-result-count']")
+    this.$resultsTokenMetaTag = document.querySelector("meta[name='govuk:discovery-engine-attribution-token']")
     this.$emailLinks = document.querySelectorAll('[href*="email-signup"]')
     this.previousSearchTerm = ''
 
@@ -352,10 +353,10 @@
     }
   }
 
-  LiveSearch.prototype.updateResultsCountMeta = function updateResultsCountMeta (totalCount) {
+  LiveSearch.prototype.updateMeta = function updateMeta (tag, value) {
     // update search tracking meta data tag with new value
-    if (this.$resultsCountMetaTag) {
-      this.$resultsCountMetaTag.setAttribute('content', totalCount)
+    if (tag) {
+      tag.setAttribute('content', value)
     }
   }
 
@@ -521,7 +522,8 @@
       this.updateElement(this.$suggestionsBlock, results.suggestions)
       this.trackSpellingSuggestionsImpressions(results.suggestions)
       this.updateSortOptions(results, action)
-      this.updateResultsCountMeta(results.total)
+      this.updateMeta(this.$resultsCountMetaTag, results.total)
+      this.updateMeta(this.$resultsTokenMetaTag, results.discovery_engine_attribution_token)
       this.manipulateErrorMessages(results.errors)
       if (this.$atomAutodiscoveryLink) {
         this.$atomAutodiscoveryLink.setAttribute('href', results.atom_url)

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -82,6 +82,7 @@ private
       next_and_prev_links: render_component("govuk_publishing_components/components/previous_and_next_navigation", pagination_presenter.next_and_prev_links),
       suggestions: render_component("finders/spelling_suggestion", suggestions: spelling_suggestion_presenter.suggestions),
       errors: search_query.errors_hash,
+      discovery_engine_attribution_token: result_set_presenter.discovery_engine_attribution_token,
     }
   end
 

--- a/app/models/result_set.rb
+++ b/app/models/result_set.rb
@@ -1,9 +1,10 @@
 class ResultSet
-  attr_reader :documents, :start, :total
+  attr_reader :documents, :start, :total, :discovery_engine_attribution_token
 
-  def initialize(documents, start, total)
+  def initialize(documents, start, total, discovery_engine_attribution_token = nil)
     @documents = documents
     @start = start
     @total = total
+    @discovery_engine_attribution_token = discovery_engine_attribution_token
   end
 end

--- a/app/parsers/result_set_parser.rb
+++ b/app/parsers/result_set_parser.rb
@@ -3,12 +3,14 @@ module ResultSetParser
     results = search_results.fetch("results")
     start = search_results.fetch("start", 0)
     total = search_results.fetch("total")
+    discovery_engine_attribution_token = search_results.fetch("discovery_engine_attribution_token", nil)
     documents = results.each_with_index.map { |document, index| Document.new(document, index + 1) }
 
     ResultSet.new(
       documents,
       start,
       total,
+      discovery_engine_attribution_token,
     )
   end
 end

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -2,7 +2,7 @@ class ResultSetPresenter
   include ERB::Util
   include ActionView::Helpers::NumberHelper
 
-  attr_reader :pluralised_document_noun, :debug_score, :start_offset, :include_ecommerce
+  attr_reader :pluralised_document_noun, :debug_score, :start_offset, :include_ecommerce, :discovery_engine_attribution_token
 
   delegate :atom_url, to: :content_item
 
@@ -18,6 +18,7 @@ class ResultSetPresenter
     @metadata_presenter_class = metadata_presenter_class
     @debug_score = debug_score
     @include_ecommerce = include_ecommerce
+    @discovery_engine_attribution_token = results.discovery_engine_attribution_token.presence
   end
 
   def displayed_total
@@ -46,6 +47,7 @@ class ResultSetPresenter
       page_count: component_data.count,
       finder_name: content_item.title,
       debug_score:,
+      discovery_engine_attribution_token:,
     }
   end
 

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -1,5 +1,8 @@
 <% content_for :head do %>
   <meta name="govuk:search-result-count" content="<%= result_set_presenter.total_count %>">
+  <% if local_assigns[:discovery_engine_attribution_token].present? %>
+    <meta name="govuk:discovery-engine-attribution-token" content="<%= local_assigns[:discovery_engine_attribution_token] %>">
+  <% end %>
 <% end %>
 
 <% if local_assigns[:debug_score] && local_assigns[:discovery_engine_attribution_token].present? %>

--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -2,6 +2,12 @@
   <meta name="govuk:search-result-count" content="<%= result_set_presenter.total_count %>">
 <% end %>
 
+<% if local_assigns[:debug_score] && local_assigns[:discovery_engine_attribution_token].present? %>
+  <div class="debug-results debug-results--meta">
+    Discovery Engine Attribution token: <%= local_assigns[:discovery_engine_attribution_token] %>
+  </div>
+<% end %>
+
 <div class="finder-results js-finder-results">
   <%= render "govuk_publishing_components/components/document_list", {
     disable_ga4: true,

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -1,5 +1,5 @@
 describe('liveSearch', function () {
-  var $form, $results, _supportHistory, liveSearch, $atomAutodiscoveryLink, $count
+  var $form, $results, _supportHistory, liveSearch, $atomAutodiscoveryLink, $count, countMeta, tokenMeta
   var dummyResponse = {
     display_total: 1,
     pluralised_document_noun: 'reports',
@@ -107,6 +107,10 @@ describe('liveSearch', function () {
     $count = $form.find('#js-search-results-info')
     $('body').append($form)
     $('head').append('<meta name="govuk:base_title" content="All Content - GOV.UK">').append($atomAutodiscoveryLink)
+    countMeta = $('<meta name="govuk:search-result-count" content="">')
+    $('head').append(countMeta)
+    tokenMeta = $('<meta name="govuk:discovery-engine-attribution-token" content="">')
+    $('head').append(tokenMeta)
     _supportHistory = GOVUK.support.history
     GOVUK.support.history = function () { return true }
     window.ga = function () {}
@@ -119,6 +123,8 @@ describe('liveSearch', function () {
     $form.remove()
     $results.remove()
     $atomAutodiscoveryLink.remove()
+    countMeta.remove()
+    tokenMeta.remove()
     var url = encodeURI(window.location.pathname)
     window.history.pushState('', '', url)
     GOVUK.support.history = _supportHistory
@@ -1009,6 +1015,27 @@ describe('liveSearch', function () {
       })
 
       expect(window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('meta tag updating', function () {
+    beforeEach(function () {
+      countMeta.attr('content', '0')
+      tokenMeta.attr('content', '0')
+    })
+
+    it('works for the result count and attribution tokens meta tags', function () {
+      var $input = $form.find('input[name="field"]')
+      liveSearch.state = []
+
+      liveSearch.formChange({ target: $input[0] })
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        response: '{"discovery_engine_attribution_token":"whatisthisthingwowitisreallysurprisinglylong","total":500,"display_total":"81 reports","facet_tags":"","search_results":"","display_selected_facets_count":"","sort_options_markup":"","next_and_prev_links":"","suggestions":"","errors":{}}'
+      })
+
+      expect(countMeta.attr('content')).toEqual('500')
+      expect(tokenMeta.attr('content')).toEqual('whatisthisthingwowitisreallysurprisinglylong')
     })
   })
 })

--- a/spec/parsers/result_set_parser_spec.rb
+++ b/spec/parsers/result_set_parser_spec.rb
@@ -17,4 +17,27 @@ describe ResultSetParser do
     specify { expect(subject.start).to eql(start) }
     specify { expect(subject.total).to eql(total) }
   end
+
+  context "when an attribution token is returned" do
+    let(:results) { %i[a_document_hash] }
+    let(:total) { 1 }
+    let(:start) { 1 }
+    let(:discovery_engine_attribution_token) { "123ABC" }
+
+    subject do
+      ResultSetParser.parse(
+        "results" => results,
+        "start" => start,
+        "total" => total,
+        "discovery_engine_attribution_token" => discovery_engine_attribution_token,
+      )
+    end
+
+    before do
+      allow(Document).to receive(:new).with(:a_document_hash, 1).and_return(:a_document_instance)
+    end
+
+    specify { expect(subject.documents).to eql(%i[a_document_instance]) }
+    specify { expect(subject.discovery_engine_attribution_token).to eql(discovery_engine_attribution_token) }
+  end
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -184,6 +184,30 @@ RSpec.describe ResultSetPresenter do
         search_result_objects = subject.search_results_content[:document_list_component_data]
         expect(search_result_objects.first[:subtext]).to eql(expected_document_content_with_debug)
       end
+
+      it "shows the attribution token for the search results" do
+        discovery_engine_attribution_token = "123ABC"
+
+        search_results = ResultSetParser.parse(
+          "results" => results.map(&:deep_stringify_keys),
+          "start" => 1,
+          "total" => total_number_of_results,
+          "discovery_engine_attribution_token" => discovery_engine_attribution_token,
+        )
+
+        subject = ResultSetPresenter.new(
+          content_item,
+          facets,
+          search_results,
+          filter_params,
+          sort_presenter,
+          metadata_presenter_class,
+          debug_score:,
+          include_ecommerce: enable_ecommerce,
+        )
+
+        expect(subject.search_results_content[:discovery_engine_attribution_token]).to eq(discovery_engine_attribution_token)
+      end
     end
 
     context "with universal analytics ecommerce disabled" do


### PR DESCRIPTION
, [Jira issue SCH-941](https://gov-uk.atlassian.net/browse/SCH-941)⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello: https://trello.com/c/nHpXC1FH

# What's changed?

Display the Google discovery engine attribution token in the search results when `debug_score` is set to true.

# Why?

The discovery engine attribution token is the unique id for every query set to Google Vertex Search, the new search provider for site search.

Every time a ticket is logged with Google support about search results the first thing they ask for is the attribution token for the request.

This attribution token is being returned in the response from search-api-v2, but as the api is not exposed on the internet it is
difficult to get the token without logging into Google Cloud Platform.

If the attribution token was more easily accessible it would be possible for non-developers to log tickets with Google support.

# Expected changes

## User Interface

/search/all?debug_score=true

| V1 results - no change | V2 results |
|:-----------------------|:-----------|
|![Screenshot 2024-03-22 at 16 12 33](https://github.com/alphagov/finder-frontend/assets/5793815/415f6d5e-0d94-4a32-bc07-4c50d1b6290b)|![Screenshot 2024-03-22 at 16 53 09](https://github.com/alphagov/finder-frontend/assets/5793815/229891a7-b4db-4ba8-80aa-9e10e7bb3ae2)|

## Analytics

<img width="1173" alt="Screenshot 2024-03-25 at 14 44 44" src="https://github.com/alphagov/finder-frontend/assets/5793815/7cf39ea1-1d24-43a2-8912-1bb038eb34e9">
