### PR TITLE
Force start Prometheus Exporter

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,3 +70,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end
+
+# TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.
+ENV["GOVUK_PROMETHEUS_EXPORTER"] = "force"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,3 +55,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end
+
+# TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.
+ENV["GOVUK_PROMETHEUS_EXPORTER"] = "force"


### PR DESCRIPTION
# What?
Suppresses Prometheus Exporter errors in development and test environments

## Before

<img width="1527" alt="Screenshot 2024-03-26 at 13 21 50" src="https://github.com/alphagov/finder-frontend/assets/5793815/d6dd7e05-b430-4203-9cdd-69b9ecaed093">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
