### PR TITLE
Stop displaying discovery engine attribution token on the search results page

### DIFF
--- a/app/views/finders/_search_results.html.erb
+++ b/app/views/finders/_search_results.html.erb
@@ -5,12 +5,6 @@
   <% end %>
 <% end %>
 
-<% if local_assigns[:debug_score] && local_assigns[:discovery_engine_attribution_token].present? %>
-  <div class="debug-results debug-results--meta">
-    Discovery Engine Attribution token: <%= local_assigns[:discovery_engine_attribution_token] %>
-  </div>
-<% end %>
-
 <div class="finder-results js-finder-results">
   <%= render "govuk_publishing_components/components/document_list", {
     disable_ga4: true,


### PR DESCRIPTION
# What's changed and why?

Stop displaying discovery engine attribution token on the search results page.

The attribution token takes up a lot of space on the screen, and can still be accessed from the `head` element by viewing the page source:

e.g.
`<meta name="govuk:discovery-engine-attribution-token" content="jwHwjgoMCO2uv7AGEIu6v_sBEiQ2NjE2MGM1Ni0wMDAwLTI4ZWQtYjBhYy0zYzI4NmQ1MDBkZDIiB0dFTkVSSUMqUKvEii367Igtg7KaIq7Eii2N96ci24-aIt7tiC3Fy_MX5-2ILaOAlyK2t4wtwvCeFYCymiKOvp0V3o-aIpD3pyL37Igt2-2ILdSynRXk7Ygt">`

# Expected changes

| Before |After|
|:------  |:-----------|
|![Screenshot 2024-04-05 at 11 56 27](https://github.com/alphagov/finder-frontend/assets/5793815/925d4786-5146-4e29-9093-cb82853241ed)|![Screenshot 2024-04-05 at 11 56 03](https://github.com/alphagov/finder-frontend/assets/5793815/3096a71f-997c-46a7-948a-e9ce89912c4b)|



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
