### PR TITLE
Use `search-api` v1 for non-keyword searches

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -116,6 +116,10 @@ module Search
       return true if ActiveModel::Type::Boolean.new.cast(filter_params["use_v2"])
       return false if filter_params["world_locations"].present?
 
+      # Non-keyword search is (for now) better served by v1, both in terms of cost and in terms of results (as v2 will
+      # not always return *all* documents for non-keyword searches, particularly when sorting is applied).
+      return false if filter_params["keywords"].blank?
+
       content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
     end
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -242,7 +242,7 @@ describe FindersController, type: :controller do
 
     describe "the finder response is from search api v2" do
       before do
-        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC")
+        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil })
         stub_content_store_has_item(
           "/search/all",
           all_content_finder,
@@ -250,20 +250,20 @@ describe FindersController, type: :controller do
       end
 
       it "correctly renders the finder page" do
-        get :show, params: { slug: "search/all" }
+        get :show, params: { slug: "search/all", keywords: "hello" }
         expect(response.status).to eq(200)
         expect(response).to render_template("finders/show")
       end
 
       it "responds with JSON" do
-        get :show, params: { slug: "search/all", format: "json" }
+        get :show, params: { slug: "search/all", keywords: "hello", format: "json" }
 
         expect(response.status).to eq(200)
         expect(response.media_type).to eq("application/json")
       end
 
       it "responds with the discovery engine attribution token" do
-        get :show, params: { slug: "search/all", format: "json" }
+        get :show, params: { slug: "search/all", keywords: "hello", format: "json" }
 
         response_body = JSON.parse(response.body)
         expect(response_body["discovery_engine_attribution_token"]).to eq("123ABC")
@@ -392,7 +392,7 @@ describe FindersController, type: :controller do
 
   describe "with legacy query parameters for publications" do
     before do
-      search_api_request(search_api_app: "search-api-v2")
+      search_api_request
       stub_content_store_has_item("/search/all", all_content_finder)
 
       @default_params = { slug: "search/all" }
@@ -505,7 +505,7 @@ describe FindersController, type: :controller do
           order: "-public_timestamp",
           start: 0,
           suggest: "spelling_with_highlighting",
-        }.merge(query),
+        }.merge(query).compact,
       )
       .to_return(
         status: 200,

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -96,7 +96,7 @@ describe Search::Query do
   end
 
   context "when on the site search finder" do
-    subject { described_class.new(content_item, {}).search_results }
+    subject { described_class.new(content_item, { "keywords" => "hello" }).search_results }
 
     let(:content_item) do
       ContentItem.new({
@@ -119,6 +119,33 @@ describe Search::Query do
       results = subject.fetch("results")
       expect(results.length).to eq(1)
       expect(results.first).to match(hash_including("_id" => "/i-am-the-v2-api"))
+    end
+  end
+
+  context "when on the site search finder without any keywords given" do
+    subject { described_class.new(content_item, { "keywords" => "" }).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
+
+    before do
+      stub_search.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v1 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
     end
   end
 


### PR DESCRIPTION
We're moving away from our initial intent to use Search API v2 exclusively for all queries to "site search" (aka `/search/all`) for the short to medium term.

This is for two reasons:
- Our underlying search engine technology isn't designed (yet) to handle non-relevance based queries well (resulting in e.g. attempting to view _all_ documents matching certain filter criteria sorted by updated missing many documents)
- We get a lot of queries without keywords from automated processes, which costs money in a usage-based charging model

In the longer term, this should be resolved by a more flexible content API that allows retrieving doucments by certain criteria. Until then, we can continue to use v1 as it is still around and we know it's able to serve non-relevance based search scenarios well.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
