### PR TITLE
Improve the spacing and alignment of search filters on mobile

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -46,7 +46,7 @@
 .app-c-expander__icon {
   display: none;
   position: absolute;
-  top: 0;
+  top: 3px;
   left: 9px;
   width: 30px;
   height: 40px;

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -74,7 +74,8 @@
     .facets__box {
       border-left: 5px solid #b1b4b6;
       padding-left: govuk-spacing(2);
-      margin-bottom: govuk-spacing(3);
+      padding-bottom: 2px;
+      margin-bottom: govuk-spacing(4);
     }
 
     .facets__header {
@@ -84,12 +85,16 @@
         display: grid;
         grid-auto-flow: column;
       }
+
+      .gem-c-heading {
+        @include govuk-font(19);
+      }
     }
 
     .facets__footer {
       display: block;
       margin-top: govuk_spacing(3);
-      margin-bottom: govuk_spacing(3);
+      margin-bottom: 0;
     }
 
     .facets__return-link {
@@ -109,6 +114,28 @@
     .facets__tags-block {
       display: block;
     }
+
+    // Temporary spacing fix because first item is shorter than the others
+    .facets__content > .app-c-expander:first-child {
+      padding-top: govuk-spacing(2);
+    }
+
+    // Temporary override for consistent heading sizes. Needs manual
+    // intervention in the future to determine correct approach after
+    // the design system font size changes have been rolled out.
+    .result-info__header .gem-c-heading {
+      @include govuk-font($size: 19, $weight: 700);
+    }
+
+  }
+}
+
+// The vertical position of other expander icons was fixed in _expander.scss
+// as it's app specifc. However, we also have gem expanders mixed in here
+// so these need the same override, for all breakpoints:
+.js-enabled {
+  .facets__content .gem-c-option-select__icon {
+    top: 3px;
   }
 }
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -289,8 +289,11 @@ mark {
 }
 
 .result-info {
-  margin: 0 0 govuk-spacing(4) 0;
+  @include govuk-media-query($until: tablet) {
+    padding-bottom: govuk-spacing(2);
+  }
   border-bottom: solid 1px govuk-colour("black");
+  margin: 0 0 govuk-spacing(4) 0;
 }
 
 // NOTE: Reset from element level styles inherited from the deprecated `govuk-template`.
@@ -327,7 +330,7 @@ mark {
 
   // we need consistent font-size across breakpoints
   // so we cannot use govuk-font mixin
-  font-size: 16px;
+  @include govuk-font($size: 19);
   @include govuk-link-common;
   @include govuk-link-style-default;
 


### PR DESCRIPTION
## What

Improve the spacing and alignment of elements within the search filters component in the mobile view:

## Why

This component is a bit messy with several elements not lining up and the submit button falls outside the container. With the forthcoming changes to the font sizes, the spacing looks even worse and must be fixed. The improvements will help make this a more visually consistent.

## How

* All 16px sizes increased to 19px in line with forthcoming DS changes
* Extra top padding for first filter item, previously too short
* Expander icons adjusted for better vertical alignment with text
* Consistent spacing around second bold results text
* Facets form now accounts for 2px shadow on the button

## BEFORE

## AFTER

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
