### PR TITLE
Improve the spacing and alignment of search filters on mobile

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -22,7 +22,10 @@
 .govuk-frontend-supported {
   .app-c-expander__heading {
     position: relative;
-    padding: 10px 8px 5px 43px;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: start;
+    align-items: center;
     margin: 0;
   }
 
@@ -45,11 +48,9 @@
 
 .app-c-expander__icon {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 9px;
   width: 30px;
   height: 40px;
+  margin-inline: 9px 4px;
   fill: govuk-colour("black");
 }
 

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -74,7 +74,8 @@
     .facets__box {
       border-left: 5px solid #b1b4b6;
       padding-left: govuk-spacing(2);
-      margin-bottom: govuk-spacing(3);
+      padding-bottom: 2px;
+      margin-bottom: govuk-spacing(4);
     }
 
     .facets__header {
@@ -86,10 +87,14 @@
       }
     }
 
+    .facets__content {
+      padding-top: govuk-spacing(2);
+    }
+
     .facets__footer {
       display: block;
       margin-top: govuk_spacing(3);
-      margin-bottom: govuk_spacing(3);
+      margin-bottom: 0;
     }
 
     .facets__return-link {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -290,8 +290,11 @@ mark {
 }
 
 .result-info {
-  margin: 0 0 govuk-spacing(4) 0;
+  @include govuk-media-query($until: tablet) {
+    padding-bottom: govuk-spacing(2);
+  }
   border-bottom: solid 1px govuk-colour("black");
+  margin: 0 0 govuk-spacing(4) 0;
 }
 
 // NOTE: Reset from element level styles inherited from the deprecated `govuk-template`.
@@ -325,10 +328,7 @@ mark {
   cursor: pointer;
   -webkit-appearance: none;
   text-decoration: underline;
-
-  // we need consistent font-size across breakpoints
-  // so we cannot use govuk-font mixin
-  font-size: 16px;
+  @include govuk-font($size: 19);
   @include govuk-link-common;
   @include govuk-link-style-default;
 


### PR DESCRIPTION
## What

Improve the spacing and alignment of elements within the search filters component in the mobile view.
[Trello](https://trello.com/c/65zYsdtH/275-type-scale-finder-frontend-improve-spacing-and-alignment-in-search-filters-on-mobile), [Jira issue PNP-8551](https://gov-uk.atlassian.net/browse/PNP-8551)

## Why

This component is a bit messy with several elements not lining up and the submit button falls outside the container. With the forthcoming changes to the font sizes, the spacing looks even worse and must be fixed. The improvements will help make this more visually consistent.

## How

* Extra top padding added inside `facets__content` to ensure that all filter items have the same apparent vertical height
* Expander headings now use flexbox to align the icon and button text. This is more robust and ensures that the vertical  centring of the icon and text are respected for different browser zoom settings (for example when using the 'Zoom Text Only' option in Firefox).
* Consistent spacing around second bold results text
* Facets form now accounts for 2px shadow on the button

Note that the same tweak to the expander icons will be applied in the Options Select component in the gem, see this PR: https://github.com/alphagov/govuk_publishing_components/pull/4256

## BEFORE / AFTER

![image](https://github.com/alphagov/finder-frontend/assets/2166204/63df6f66-e92b-43ce-ba19-cf6f994bebb5)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
