### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "govuk_publishing_components"
 gem "rest-client"
 gem "slimmer"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     ffi (1.16.3)
@@ -640,13 +640,13 @@ GEM
     stringio (3.1.0)
     sys-uname (1.2.3)
       ffi (~> 1.1)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timecop (0.9.8)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.23.0)
       addressable (>= 2.8.0)
@@ -693,8 +693,8 @@ DEPENDENCIES
   simplecov
   slimmer
   sprockets-rails
+  terser
   timecop
-  uglifier
   webmock
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Compress JS using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## What
Use Terser instead of Uglifier to compile JavaScript.

## Why
This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l), [Jira issue NAV-12307](https://gov-uk.atlassian.net/browse/NAV-12307)

## Further info

### JS Size

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  finder-frontend/application.js | 111KB | 22.6KB |
| terser |  finder-frontend/application.js | 111KB | 22.6KB |

### Browser testing

I've tested the changes on Integration using the browsers below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11