### PR TITLE
Take out specialist code to turn off LTR for licence finder

### DIFF
--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -240,10 +240,6 @@ module Search
     end
 
     def ab_query
-      # We're using the ab test relevance:disable params here to turn off LTR for this
-      # finder. It would probably be best in the long run to create a specific way of
-      # doing this that uses a proper parameter, but we can't do that at the moment.
-      ab_params.merge!("relevance" => "disable") if finder_content_item.is_licence_transaction? && !force_ltr?
       ab_params.any? ? { "ab_tests" => ab_params.map { |k, v| "#{k}:#{v}" }.join(",") } : {}
     end
 


### PR DESCRIPTION
- LTR ranking is now disabled globally for finders, so no need to handle it specifically.

https://trello.com/c/HFqHpKBp/11-finder-frontend-uses-a-b-parameters-to-disable-ltr-despite-it-not-being-an-a-b-issue

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
