### PR TITLE
Revert "Default to V1 search unless V2 explicitly asked for"

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -120,11 +120,7 @@ module Search
       # not always return *all* documents for non-keyword searches, particularly when sorting is applied).
       return false if filter_params["keywords"].blank?
 
-      return false # Force V1 during incident
-
-      # rubocop:disable Lint/UnreachableCode
       content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
-      # rubocop:enable Lint/UnreachableCode
     end
   end
 end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -242,7 +242,7 @@ describe FindersController, type: :controller do
 
     describe "the finder response is from search api v2" do
       before do
-        search_api_request(search_api_app: "search-api", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil })
+        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil })
         stub_content_store_has_item(
           "/search/all",
           all_content_finder,

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -108,7 +108,7 @@ describe Search::Query do
     end
 
     before do
-      stub_search.to_return(body: {
+      stub_search_v2.to_return(body: {
         "results" => [
           result_item("/i-am-the-v2-api", "I am the v2 API", score: nil, updated: "14-12-19", popularity: 1),
         ],


### PR DESCRIPTION

Reverts alphagov/finder-frontend#3357 - DO NOT MERGE UNTIL V2 SEARCH RESULTS ARE AVAILABLE.