### PR TITLE
Add v1 fallback feature flag and documentation

### DIFF
--- a/docs/search-apis.md
+++ b/docs/search-apis.md
@@ -1,0 +1,22 @@
+# Search APIs
+Finder Frontend can use either "v1" [`search-api`][search-api] or [`search-api-v2`][search-api-v2]
+depending on the finder in use and the parameters of a user's search.
+
+Note that v2 is not (yet) able to handle all the use cases of v1, and the extent to which v1 use
+cases will be migrated is still under discussion.
+
+## Forcing the use of a specific API
+The `use_v1` and `use_v2` query parameters are available on the `finders#show` action and take
+precedence over any other logic. These are useful for comparing results and debugging.
+
+## Using v1 as a backup in case of v2 issues
+In the event of a major issue with `search-api-v2` or its underlying SaaS search product (Google
+Vertex AI Search), a feature flag `FORCE_USE_V1_SEARCH_API` is available and will force all search
+traffic to use the v1 API.
+
+The v1 API provides pure keyword search and lacks the "smart" semantic search of v2, leading to
+significantly poorer result quality for more complex searches. Consider whether the issue with v2 is
+uncontained, escalating, or has significant user impact before enabling the fallback.
+
+[search-api]: https://github.com/alphagov/search-api
+[search-api-v2]: https://github.com/alphagov/search-api-v2

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -122,6 +122,35 @@ describe Search::Query do
     end
   end
 
+  context "when the fallback feature flag is enabled" do
+    subject { described_class.new(content_item, { "keywords" => "hello" }).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
+
+    before do
+      stub_const("ENV", ENV.to_hash.merge("FORCE_USE_V1_SEARCH_API" => "true"))
+
+      stub_search.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v1 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
+    end
+  end
+
   context "when on the site search finder without any keywords given" do
     subject { described_class.new(content_item, { "keywords" => "" }).search_results }
 


### PR DESCRIPTION
- Add a `FORCE_USE_V1_SEARCH_API` feature flag to force all searches to use v1 `search-api` as a backup in case of v2 incidents
- Improve the grouping and comments around the decision logic for when which API is used in `Search::Query`
- Add some basic documentation around when v1/v2 is used and how to enable the fallback (and when to consider not doing so)