### PR TITLE
Reintroduce GA4 pageview tracking code

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -116,11 +116,16 @@
     }
   }
 
+  LiveSearch.prototype.trackingInit = function trackingInit () {
+    GOVUK.modules.start(this.$resultsWrapper)
+    this.startEnhancedEcommerceTracking()
+  }
+
   LiveSearch.prototype.Ga4EcommerceTracking = function (referrer) {
     if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4EcommerceTracker) {
       var consentCookie = GOVUK.getConsentCookie()
 
-      if (consentCookie && consentCookie.settings) {
+      if (consentCookie && consentCookie.usage) {
         if (this.$resultsWrapper) {
           this.$resultsWrapper.setAttribute('data-ga4-search-query', this.currentKeywords())
           var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
@@ -129,7 +134,6 @@
             this.$resultsWrapper.setAttribute('data-ga4-ecommerce-variant', sortedBy.options[sortedBy.selectedIndex].text)
           }
         }
-
         GOVUK.analyticsGa4.Ga4EcommerceTracker.init(referrer)
       } else {
         window.addEventListener('cookie-consent', function () {
@@ -355,6 +359,7 @@
           liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
           liveSearch.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
           liveSearch.displayResults(response, searchState)
+          liveSearch.trackingInit()
         } else {
           liveSearch.showErrorIndicator()
         }
@@ -368,6 +373,7 @@
       this.updateUrl()
       this.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
       this.displayResults(cachedResultData, searchState)
+      this.trackingInit()
     }
   }
 
@@ -541,7 +547,7 @@
         if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4FinderTracker) {
           var consentCookie = GOVUK.getConsentCookie()
 
-          if (consentCookie && consentCookie.settings) {
+          if (consentCookie && consentCookie.usage) {
             GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event.target, ga4ChangeCategory)
           }
         }

--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -106,7 +106,7 @@
     }
   }
 
-  LiveSearch.prototype.startEnhancedEcommerceTracking = function startEnhancedEcommerceTracking () {
+  LiveSearch.prototype.restartGa4EcommerceTracking = function restartGa4EcommerceTracking () {
     if (document.readyState === 'complete') {
       this.Ga4EcommerceTracking(this.previousSearchUrl)
     } else {
@@ -116,9 +116,9 @@
     }
   }
 
-  LiveSearch.prototype.trackingInit = function trackingInit () {
+  LiveSearch.prototype.reinitialiseGa4Tracking = function reinitialiseGa4Tracking () {
     GOVUK.modules.start(this.$resultsWrapper)
-    this.startEnhancedEcommerceTracking()
+    this.restartGa4EcommerceTracking()
   }
 
   LiveSearch.prototype.Ga4EcommerceTracking = function (referrer) {
@@ -359,7 +359,7 @@
           liveSearch.cache(liveSearch.serializeState(liveSearch.state), response)
           liveSearch.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
           liveSearch.displayResults(response, searchState)
-          liveSearch.trackingInit()
+          liveSearch.reinitialiseGa4Tracking()
         } else {
           liveSearch.showErrorIndicator()
         }
@@ -373,7 +373,7 @@
       this.updateUrl()
       this.ga4TrackFormChange(formChangeEvent) // must be before displayResults changes the DOM, otherwise will break formChangeEvent.target.closest
       this.displayResults(cachedResultData, searchState)
-      this.trackingInit()
+      this.reinitialiseGa4Tracking()
     }
   }
 

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -793,6 +793,25 @@ describe('liveSearch', function () {
 
       expect(window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent).not.toHaveBeenCalled()
     })
+
+    it('reinitialises tracking when search is updated', function () {
+      spyOn(liveSearch, 'reinitialiseGa4Tracking')
+
+      expect(liveSearch.reinitialiseGa4Tracking).not.toHaveBeenCalled()
+
+      var $input = $form.find('input[name="field"]')
+      $input.attr('data-ga4-change-category', 'update-sort select')
+
+      liveSearch.state = []
+
+      liveSearch.formChange({ target: $input[0] })
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        response: '{"total":81,"display_total":"81 reports","facet_tags":"","search_results":"","display_selected_facets_count":"","sort_options_markup":"","next_and_prev_links":"","suggestions":"","errors":{}}'
+      })
+
+      expect(liveSearch.reinitialiseGa4Tracking).toHaveBeenCalled()
+    })
   })
 
   describe('meta tag updating', function () {


### PR DESCRIPTION
## What / Why
- Reintroduce some code that was accidentally removed during UA removal
- This caused updating sort options to not trigger a new pageview event
- This is because I removed `trackSearch`, which calls `trackingInit` (which I also removed), and `trackingInit` called`this.startEnhancedEcommerceTracking()` which was needed to reinitialise the GA4 Pageview tracker when the sort options update.  To see the code that was accidentally removed, see [here](https://github.com/alphagov/finder-frontend/pull/3396/files#diff-fe1355439297aa459f871621b4f95627ea330655c7c6eb08ef10bda7ab66c0feL262) and [here](https://github.com/alphagov/finder-frontend/pull/3396/files#diff-fe1355439297aa459f871621b4f95627ea330655c7c6eb08ef10bda7ab66c0feL450)
- Therefore I've added the necessary code back - I'm now just calling one function, `reinitialiseGa4Tracking`(as we don't need the equivalent of `trackSearch` anymore.)
- I've also namespaced those functions with Ga4 just so they aren't removed by accident in the future
- Also updates a couple cookie checks to `usage` instead of `settings`

