### PR TITLE
Disable corrections across search fields

### DIFF
--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -11,7 +11,8 @@
         type: 'search',
         value: result_set_presenter.user_supplied_keywords,
         inline_label: false,
-        label_text: sanitize(content_item.label_text) || label_text
+        label_text: sanitize(content_item.label_text) || label_text,
+        disable_corrections: true,
       } %>
     </div>
   <% end %>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -31,6 +31,7 @@
             type: 'search',
             value: result_set_presenter.user_supplied_keywords,
             on_govuk_blue: inverse,
+            disable_corrections: true,
           } %>
         </div>
         <div id="js-spelling-suggestions" class="spelling-suggestions">

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -10,7 +10,8 @@
   inline_label: false,
   label_text: label_text,
   size: "large",
-  id: "search-main"
+  id: "search-main",
+  disable_corrections: true,
 } %>
 
 <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual] %>


### PR DESCRIPTION
As part of our work on site search, we've discovered a pain point where mobile browsers' autocorrection features mess up user queries, especially when it comes to domain specific terminology. For example, searches for "HMRC" are frequently autocorrected to "Hercules", or searches for "SORN" to "sworn".

- Set `disable_corrections` parameter for all uses of `search` component

See: https://github.com/alphagov/govuk_publishing_components/pull/4112