### PR TITLE
Remove unused 'sign-in' route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get "/sign-in", to: proc { [200, {}, %w[OK]] }
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: proc { [200, {}, [JSON.generate({ status: :ok })]] }
 


### PR DESCRIPTION
This page is rendered in frontend on the www domain.

Looks like it's left over from the days of the account team.