### PR TITLE
Move breadcrumbs out of the <main> landmark to fix a WCAG fail

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -365,3 +365,10 @@ mark {
   padding-left: 13px;
   padding-right: 13px;
 }
+
+.app-before-content--inverse {
+  background-color: govuk-colour("blue");
+  // Stretch background colour over inner margins
+  overflow: hidden;
+  padding-top: govuk-spacing(3);
+}

--- a/app/helpers/topic_finder_helper.rb
+++ b/app/helpers/topic_finder_helper.rb
@@ -6,4 +6,8 @@ module TopicFinderHelper
   def topic_finder_parent(filter_params)
     Services.registries.all["full_topic_taxonomy"][filter_params["topic"]]
   end
+
+  def is_inverse?
+    topic_finder?(filter_params) && !content_item.all_content_finder?
+  end
 end

--- a/app/views/finders/_before_content.html.erb
+++ b/app/views/finders/_before_content.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_content do %>
+    <div class="app-before-content">
+        <div class="govuk-width-container">
+            <% if content_item.show_phase_banner? %>
+                <%= render 'govuk_publishing_components/components/phase_banner', {
+                    phase: content_item.phase, 
+                    message: sanitize(content_item.phase_message), 
+                    inverse: inverse
+                } %>
+            <% end %>
+
+            <% if @breadcrumbs.breadcrumbs %>
+                <%= render 'govuk_publishing_components/components/breadcrumbs', {
+                    breadcrumbs: @breadcrumbs.breadcrumbs,
+                    inverse: inverse,
+                    collapse_on_mobile: true
+                } %>
+            <% else %>
+                <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {     
+                    content_item: content_item.as_hash,
+                    inverse: inverse
+                } %>
+            <% end %>
+        </div>
+    </div>
+<% end %>

--- a/app/views/finders/_before_content.html.erb
+++ b/app/views/finders/_before_content.html.erb
@@ -1,24 +1,24 @@
 <% content_for :before_content do %>
-    <div class="app-before-content">
+    <div class="app-before-content<%= " app-before-content--inverse" if is_inverse? %>">
         <div class="govuk-width-container">
             <% if content_item.show_phase_banner? %>
                 <%= render 'govuk_publishing_components/components/phase_banner', {
                     phase: content_item.phase, 
                     message: sanitize(content_item.phase_message), 
-                    inverse: inverse
+                    inverse: is_inverse?
                 } %>
             <% end %>
 
             <% if @breadcrumbs.breadcrumbs %>
                 <%= render 'govuk_publishing_components/components/breadcrumbs', {
                     breadcrumbs: @breadcrumbs.breadcrumbs,
-                    inverse: inverse,
+                    inverse: is_inverse?,
                     collapse_on_mobile: true
                 } %>
             <% else %>
                 <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {     
                     content_item: content_item.as_hash,
-                    inverse: inverse
+                    inverse: is_inverse?
                 } %>
             <% end %>
         </div>

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,18 +1,4 @@
 <div class="govuk-width-container">
-  <% if content_item.show_phase_banner? %>
-    <%= render 'govuk_publishing_components/components/phase_banner', phase: content_item.phase, message: sanitize(content_item.phase_message), inverse: inverse %>
-  <% end %>
-
-  <% if @breadcrumbs.breadcrumbs %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', {
-      breadcrumbs: @breadcrumbs.breadcrumbs,
-      inverse: inverse,
-      collapse_on_mobile: true
-    } %>
-  <% else %>
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
-  <% end %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -12,6 +12,8 @@
 
 <% content_for :meta_title, content_item.title %>
 
+<%= render partial: 'before_content' %>
+
 <% if topic_finder?(filter_params) && !content_item.all_content_finder? %>
   <% content_for :body_classes, "full-width" %>
   <% inverse = true %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -14,9 +14,8 @@
 
 <%= render partial: 'before_content' %>
 
-<% if topic_finder?(filter_params) && !content_item.all_content_finder? %>
+<% if is_inverse? %>
   <% content_for :body_classes, "full-width" %>
-  <% inverse = true %>
 <% end %>
 
 <form method="get" action="<%= content_item.base_path %>" class="js-live-search-form"
@@ -24,18 +23,19 @@
 >
   <input type="hidden" name="parent" value="<%= @parent %>">
 
-  <% if topic_finder?(filter_params) && !content_item.all_content_finder? %>
+  <% if is_inverse? %>
     <%= render "govuk_publishing_components/components/inverse_header", {
-      full_width: true
+      full_width: true,
+      padding_top: false
     } do %>
       <%= render partial: 'show_header', locals: {
-        inverse: inverse,
+        inverse: is_inverse?,
         page_metadata: page_metadata(content_item, filter_params)
       } %>
     <% end %>
   <% else %>
     <%= render partial: 'show_header', locals: {
-      inverse: inverse,
+      inverse: is_inverse?,
       page_metadata: page_metadata(content_item, filter_params)
     } %>
   <% end %>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -1,4 +1,7 @@
 <% content_for :body do %>
+
+  <%= yield :before_content %>
+
   <main id="content" class="finder-frontend-content">
     <div class="finder-frontend">
       <%= yield %>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -1,5 +1,4 @@
 <% content_for :body do %>
-  <%= yield :breadcrumbs %>
   <main id="content" class="finder-frontend-content">
     <div class="finder-frontend">
       <%= yield %>

--- a/features/finders.feature
+++ b/features/finders.feature
@@ -74,6 +74,7 @@ Feature: Filtering documents
   Scenario: Visit a finder with metadata with a topic param set
     When I view the aaib reports finder with a topic param set
     Then I can see that the finder metadata is present and inverted
+    And the breadcrumbs are outside the main container
 
   Scenario: Visit a finder with description
     Given a finder with description exists

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -449,6 +449,11 @@ When(/^I can see that the finder metadata is present and inverted$/) do
   expect(page).to have_css(".gem-c-metadata.gem-c-metadata--inverse")
 end
 
+And(/^the breadcrumbs are outside the main container$/) do
+  expect(page).to have_selector(".app-before-content .gem-c-breadcrumbs")
+  expect(page).not_to have_selector("#main .gem-c-breadcrumbs")
+end
+
 When(/^I can see that the description in the metadata is present$/) do
   visit "/cma-cases"
 


### PR DESCRIPTION
## What
Move breadcrumbs and phase banner out of the `<main>` landmark, retaining the existing visual design. This change fixes a WCAG fail and skips the breadcrumbs and phase banner when the 'skip to main content' link is activated (which it should do as breadcrumbs are navigational content). 

This PR:
- Moves the phase banner and breadcrumbs out of `<main>`into a new partial that the finders layout now yields before rendering `<main>`. [The GOV.UK Design System documentation](https://design-system.service.gov.uk/styles/page-template/#options) calls this area of the page before the main container `before_content` so the name of the partial is aligned with that naming convention. (We yield the template in finder_layout rather than just render it, because the email alert subscriptions also use finder_layout and those pages don't include the phase banner or breadcrumbs.)
- Calls the `/before_content` partial inside `/show` (instead of `/show_header` which previously housed the breadcrumbs and phase banner) because the breadcrumbs and phase banner are now outside the main content and no longer inside the header content.
-  Supports an inverse design with a full-width blue banner on topic pages and simplifies the logic of enabling the design
- Removes redundant breadcrumbs call which was tech debt from the Brexit checkers

## Why
The breadcrumbs were within the `<main>` landmark which is also the target of the ‘skip to main content' link. There was no mechanism to allow users to bypass the breadcrumb links. Typically users should be able to use the ‘skip to main content’ link to bypass repeated blocks of content, like navigation links and breadcrumbs, that are repeated on multiple pages, and navigate directly to the main content of the page.

The breadcrumbs should not be in the main landmark and the 'skip to content' link should skip over them. This would also comply with [Design System guidance](https://design-system.service.gov.uk/components/breadcrumbs/#how-it-works).

WCAG reference: 2.4.1 Bypass Blocks (Level A)

## How the change was tested

The change was confirmed to allow the 'skip to main content' link to skip over the breadcrumbs. There were no visual changes to the page.

### Before


<img width="500" alt="Screenshot 2024-09-10 at 10 12 04" src="https://github.com/user-attachments/assets/53cf7b61-33a2-4ac2-bfa8-e94f4dadcc07" >

### After

<img width="500" alt="Screenshot 2024-09-10 at 10 12 04" src="https://github.com/user-attachments/assets/f5ee7bef-5f25-4b83-8c25-0c66718c8a95">

### Before

<img width="500" alt="Screenshot 2024-09-10 at 10 12 13" src="https://github.com/user-attachments/assets/9b52f164-c090-407f-a8ea-5a73fcc1d831">


### After

<img width="500" alt="Screenshot 2024-09-10 at 10 12 23" src="https://github.com/user-attachments/assets/56021f29-76ec-49fc-b9e8-d2aded660a05">

### Before

<img width="500" alt="Screenshot 2024-09-10 at 10 25 49" src="https://github.com/user-attachments/assets/c5ef0454-d769-4820-8f2c-d49d92785926">


### After


<img width="500" alt="Screenshot 2024-09-10 at 10 25 58" src="https://github.com/user-attachments/assets/c51c8cbb-ee84-431a-91f2-90d491b9e5e5">


## Pages checked


- /search/guidance-and-regulation
- /search/guidance-and-regulation?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- /aaib-reports
- /drug-device-alerts
- /government/case-studies
- /government/people

## Devices, browsers and assistive technology the change has been tested with

#### Windows 11	
✅ Edge  (latest versions)
✅ Google Chrome  (latest versions)
✅ IE11 (Windows 8)

#### macOS 14.5	
✅  Safari 17
✅  Google Chrome (latest version)

#### iOS	
✅  Safari on iPhone 14

#### Android	
✅  Chrome on Samsung Galaxy S23

### Screen readers
✅  JAWS 2023 with Chrome 
✅  NVDA 2024 with Firefox

Fixes https://trello.com/c/OVhV3mnw/2772-fix-breadcrumbs-wcag-fails-in-finder-frontend-m-l, [Jira issue NAV-15179](https://gov-uk.atlassian.net/browse/NAV-15179)#comment-66c488bd6d425a3f347b49bf

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
