### PR TITLE
Add spelling suggestion to new all content finder UI

### DIFF
--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -40,6 +40,10 @@
           } %>
         </div>
 
+        <div class="spelling-suggestions">
+          <%= render 'spelling_suggestion' %>
+        </div>
+
         <% if result_set_presenter.total_count.positive? %>
           <%= render "govuk_publishing_components/components/document_list", {
             disable_ga4: true,

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -10,3 +10,7 @@ Feature: All content finder ("site search")
   Scenario: Making a search
     When I search all content for "how to walk silly"
     Then I can see results for my search
+
+  Scenario: Spelling suggestion
+    When I search all content for "drving"
+    Then I see a "driving" spelling suggestion

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -55,5 +55,5 @@ When(/^I search for "([^"]*)"$/) do |search_term|
 end
 
 Then(/^I see a "(.*)" spelling suggestion$/) do |suggestion|
-  expect(page).to have_link suggestion.to_s, href: "/search/all?keywords=#{suggestion}&order=relevance"
+  expect(page).to have_link suggestion.to_s, href: %r{/search/all\?keywords=#{suggestion}}
 end


### PR DESCRIPTION
- Add the existing spelling suggestion partial (as we don't need to do anything special compared to before)
- Update Cucumber step to check for suggestion link as regex (because the other feature using it additionally has a specific sort order set)

<img width="685" alt="image" src="https://github.com/user-attachments/assets/a8e196b8-5291-45dc-a6d0-f340899da963">
