### PR TITLE
Filter section component

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -2,7 +2,7 @@
 
 .app-c-filter-panel__content {
   background-color:  govuk-colour("light-grey");
-  padding: govuk-spacing(3);
+  padding: 0 govuk-spacing(3);
   margin-top: govuk-spacing(2);
 }
 

--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -1,0 +1,75 @@
+@import "govuk_publishing_components/individual_component_support";
+@import "govuk_publishing_components/components/mixins/prefixed-transform";
+
+.app-c-filter-section {
+  border-bottom: 1px solid $govuk-border-colour;
+
+  &:last-child {
+    border-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  &:first-child {
+    margin-top: 0;
+  }
+
+  &[open] .app-c-filter-section__summary {
+    &::before {
+      @include prefixed-transform($translateY: 30%, $rotate: -45deg);
+    }
+  }
+}
+
+.app-c-filter-section__summary {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  cursor: pointer;
+  color: $govuk-text-colour;
+
+  &:hover .app-c-filter-section__summary-heading {
+    @include govuk-link-decoration;
+    @include govuk-link-hover-decoration;
+  }
+
+  &:focus .app-c-filter-section__summary-heading {
+    background-color: $govuk-focus-colour;
+    @include govuk-focused-text;
+  }
+
+  &::before {
+    border-style: solid;
+    border-width: 2px 2px 0 0;
+    content: '';
+    display: inline-block;
+    height: govuk-spacing(2);
+    left: govuk-spacing(1);
+    position: relative;
+    vertical-align: middle;
+    width: govuk-spacing(2);
+    border-color: $govuk-text-colour;
+    clip-path: unset;
+    @include prefixed-transform($translateY: -25%, $rotate: 135deg);
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.app-c-filter-section__summary-heading {
+  margin-left: govuk-spacing(3);
+  @include govuk-font(19, $weight: bold);
+}
+
+.app-c-filter-section__summary-status {
+  padding-right: govuk-spacing(1);
+  flex-grow: 1;
+  text-align: right;
+  @include govuk-font(16, $weight: regular);
+}
+
+.app-c-filter-section__content {
+  padding: govuk-spacing(2) 0;
+}

--- a/app/views/components/_filter_section.html.erb
+++ b/app/views/components/_filter_section.html.erb
@@ -1,0 +1,32 @@
+<% add_app_component_stylesheet("filter-section") %>
+<%
+  raise ArgumentError, "heading_text is required" unless local_assigns[:heading_text]
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  open ||= nil
+  status_text ||= ""
+  heading_text ||= ""
+  heading_level ||= 2
+  summary_aria_attributes ||= {}
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class("app-c-filter-section")
+  component_helper.set_open(open)
+%>
+
+<%= tag.details(**component_helper.all_attributes) do %>
+  <%= tag.summary class: "app-c-filter-section__summary", aria: summary_aria_attributes do %>
+      <%= content_tag("h#{heading_level}", class: "app-c-filter-section__summary-heading") do %>
+        <span class="govuk-visually-hidden">Filter by</span>
+        <%= heading_text %>
+      <% end %>
+
+      <% if status_text.present? %>
+        <span class="app-c-filter-section__summary-status">
+          <%= status_text %>
+        </span>
+      <% end %>
+  <% end %>
+  <div class="app-c-filter-section__content">
+    <%= yield %>
+  </div>
+<% end %>

--- a/app/views/components/docs/filter_panel.yml
+++ b/app/views/components/docs/filter_panel.yml
@@ -31,6 +31,19 @@ examples:
         <p class="govuk-body">
           I am open by default!
         </p>
+  with_filter_section:
+    description: |
+      Pass filter section component as a block
+    data:
+      result_count: 1
+      button_text: View filter section
+      block: |
+        <%= render "components/filter_section", {
+          status_text: "1 Selected",
+          heading_text: "Filter 1"
+        } do %>
+          <span>filter section content</span>
+        <% end %>
   with_margin_bottom:
     description: |
       Allows the spacing at the bottom of the component to be adjusted.

--- a/app/views/components/docs/filter_section.yml
+++ b/app/views/components/docs/filter_section.yml
@@ -1,0 +1,39 @@
+name: Filter section
+description: Displays a section with status text that be expanded/collapsed
+uses_component_wrapper_helper: true
+accessibility_criteria: |
+  The component must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when it has focus
+  - toggle the visibility of the section when interacted with
+  - indicate the expanded state when section is visible
+  - indicate the collapsed state when section is hidden
+examples:
+  default:
+    data:
+      heading_text: Filter by something
+      block: |
+        <span>Filter form controls</span>
+  open:
+    data:
+      heading_text: Filter by something
+      open: true
+      block: |
+        <span>Filter form controls open by default</span>
+  status_text:
+    data:
+      heading_text: Filter by something
+      status_text: 1 Selected
+      block: |
+        <span>Filter form controls with status text</span>
+  heading_level:
+    description: The heading level that the heading text will be rendered as.
+    data:
+      heading_text: Section heading is h3
+      heading_level: 3
+      block: |
+        <span>Filter form controls</span>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -49,7 +49,32 @@
           result_count: result_set_presenter.total_count,
           margin_bottom: 3,
         } do %>
-          TODO: Add filter panel content here
+          <%= render "components/filter_section", {
+            open: true,
+            heading_text: "Filter 1"
+          } do %>
+            <span>filter section content</span>
+          <% end %>
+
+          <%= render "components/filter_section", {
+            status_text: "1 Selected",
+            heading_text: "Filter 2"
+          } do %>
+            <span>filter section content</span>
+          <% end %>
+
+          <%= render "components/filter_section", {
+            heading_text: "Filter 3"
+          } do %>
+            <span>filter section content</span>
+          <% end %>
+
+          <%= render "components/filter_section", {
+            status_text: "1 Selected",
+            heading_text: "Filter 4"
+          } do %>
+            <span>filter section content</span>
+          <% end %>
         <% end %>
 
         <% if result_set_presenter.total_count.positive? %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -2,6 +2,7 @@ APP_STYLESHEETS = {
   "application.scss" => "application.css",
   "components/_expander.scss" => "components/_expander.css",
   "components/_filter-panel.scss" => "components/_filter-panel.css",
+  "components/_filter-section.scss" => "components/_filter-section.css",
   "components/_mobile-filters.scss" => "components/_mobile-filters.css",
   "views/_search.scss" => "views/_search.css",
 }.freeze

--- a/spec/components/filter_section_spec.rb
+++ b/spec/components/filter_section_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe "Filter section component", type: :view do
+  def component_name
+    "filter_section"
+  end
+
+  def render_component(locals)
+    render "components/#{component_name}", locals
+  end
+
+  it "raises an error if heading_text option is omitted" do
+    expect { render_component({}) }.to raise_error(/heading_text/)
+  end
+
+  it "renders a filter section that is closed" do
+    render_component({ heading_text: "heading" })
+
+    assert_select ".app-c-filter-section", count: 1
+    assert_select ".app-c-filter-section[open=open]", false
+  end
+
+  it "renders a filter section that is open when open option is true" do
+    render_component({ heading_text: "heading", open: true })
+
+    assert_select ".app-c-filter-section[open=open]"
+  end
+
+  it "set section heading text with hidden context for accessibility" do
+    render_component({ heading_text: "section heading" })
+
+    assert_select ".app-c-filter-section__summary-heading", include: "section heading"
+    assert_select ".app-c-filter-section__summary-heading .govuk-visually-hidden", text: "Filter by"
+  end
+
+  it "set section heading text to different value to default renders correct heading level" do
+    render_component({ heading_text: "section heading", heading_level: 3 })
+
+    assert_select "h3.app-c-filter-section__summary-heading", count: 1
+  end
+
+  it "set section status text" do
+    render_component({ heading_text: "heading", status_text: "1 selected" })
+
+    assert_select ".app-c-filter-section__summary-status", text: "1 selected"
+  end
+
+  it "does not render status text when none supplied" do
+    render_component({ heading_text: "heading" })
+
+    assert_select ".app-c-filter-section__summary-status", false
+  end
+end


### PR DESCRIPTION
This adds a new app-specific component that displays a details component to open/close a section of filters. The summary displays a section title (required) and optional status text if the filters within the section have been applied. This will be used for the new site search ("all content" finder) UI instead of the existing filters sidebar.

- Create `filter_section` component
- Add (empty for now) `filter_section` components to the (work in progress and hidden behind feature flag) `show_all_content_finder` view template

## Review app
- [Component guide preview](https://finder-frontend-pr-3449.herokuapp.com/component-guide/filter_section)
- [In context on new search page](https://finder-frontend-pr-3449.herokuapp.com/search/all)

## Visual changes
### Closed
<img width="859" alt="Screenshot 2024-09-18 at 15 22 21" src="https://github.com/user-attachments/assets/da121796-037c-4c4c-a58a-926445fb17d0">


### Hover
<img width="869" alt="Screenshot 2024-09-18 at 15 22 57" src="https://github.com/user-attachments/assets/44819037-9d2a-44c2-822d-5db24fd13175">

### Focus
<img width="868" alt="Screenshot 2024-09-18 at 15 22 31" src="https://github.com/user-attachments/assets/6af45a51-0cce-4070-bf35-fe3288fd1565">

### In context on new UI
<img width="546" alt="Screenshot 2024-09-18 at 15 27 37" src="https://github.com/user-attachments/assets/8288ccef-16b7-4eb4-8bcc-8c051a512a8d">


## Designs
https://www.figma.com/design/H99sZyzK3aT9Tet0r6AtOC/Search-Designs?node-id=1154-41574&node-type=canvas&t=aJqXa88NDTPd7HYg-0