### PR TITLE
New all content finder UI tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
+@import "govuk_publishing_components/components/mixins/prefixed-transform";
 
 .app-c-filter-panel__content {
   background-color:  govuk-colour("light-grey");
@@ -36,9 +37,9 @@
       color: $govuk-link-hover-colour;
     }
   }
-  
+
   .app-c-filter-panel__button[aria-expanded="true"] .app-c-filter-panel__button-icon {
-    transform: translateY(0) rotate(-135deg);
+    @include prefixed-transform($translateY: 0, $rotate: -135deg);
   }
 
   .app-c-filter-panel__button-icon {
@@ -46,10 +47,11 @@
     border-width: 0 2px 2px 0;
     height: 0.5rem;
     pointer-events: none;
-    transform: translateY(-50%) rotate(45deg);
     width: 0.5rem;
     display: inline-block;
     vertical-align: baseline;
     margin-right: govuk-spacing(1);
+
+    @include prefixed-transform($translateY: -50%, $rotate: 45deg);
   }
 }

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -1,11 +1,11 @@
 <% add_app_component_stylesheet("filter-panel") %>
 <%
   raise ArgumentError, "button_text is required" unless local_assigns[:button_text]
-  raise ArgumentError, "result_count is required" unless local_assigns[:result_count]
 
   id_suffix = SecureRandom.hex(4)
   panel_content_id = "filter-panel-#{id_suffix}"
   button_id = "filter-button-#{id_suffix}"
+  result_text ||= ""
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
@@ -25,11 +25,13 @@
       <%= button_text %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: pluralize(number_with_delimiter(result_count), "result"),
-      heading_level: 2,
-      font_size: "s",
-    } %>
+    <% if result_text.present? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: result_text,
+        heading_level: 2,
+        font_size: "s",
+      } %>
+    <% end %>
   </div>
 
   <%= tag.div(

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -46,7 +46,7 @@
 
         <%= render "components/filter_panel", {
           button_text: "Filter and sort",
-          result_count: result_set_presenter.total_count,
+          result_text: result_set_presenter.displayed_total,
           margin_bottom: 3,
         } do %>
           TODO: Add filter panel content here

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -10,6 +10,7 @@ Feature: All content finder ("site search")
   Scenario: Making a search
     When I search all content for "how to walk silly"
     Then I can see results for my search
+    And I can see how many results there are
 
   Scenario: Spelling suggestion
     When I search all content for "drving"

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -6,3 +6,7 @@ Then("I can see results for my search") do
   expect(page).to have_link("West London wobbley walk")
   expect(page).to have_link("The Gerry Anderson")
 end
+
+Then("I can see how many results there are") do
+  expect(page).to have_selector("h2", text: "2 results")
+end

--- a/spec/components/filter_panel_spec.rb
+++ b/spec/components/filter_panel_spec.rb
@@ -14,39 +14,29 @@ describe "Filter panel component", type: :view do
   end
 
   it "raises an error if button_text option is omitted" do
-    expect { render_component(result_count: 42) }.to raise_error(/button_text/)
-  end
-
-  it "raises an error if result_count option is omitted" do
-    expect { render_component(button_text: "Oops") }.to raise_error(/result_count/)
+    expect { render_component({}) }.to raise_error(/button_text/)
   end
 
   it "renders the button with the correct text" do
-    render_component(button_text: "Filtern und sortieren", result_count: 42)
+    render_component(button_text: "Filtern und sortieren")
 
     assert_select ".app-c-filter-panel button", text: "Filtern und sortieren"
   end
 
-  it "renders the correct result count heading for a single result" do
-    render_component(button_text: "Filter", result_count: 1)
+  it "renders the result text as an h2 if given" do
+    render_component(button_text: "Filter", result_text: "Lorem ipsum")
 
-    assert_select ".app-c-filter-panel h2", text: "1 result"
+    assert_select ".app-c-filter-panel h2", text: "Lorem ipsum"
   end
 
-  it "renders the correct result count heading for a small number" do
-    render_component(button_text: "Filter", result_count: 84)
+  it "does not render an h2 if no result text is given" do
+    render_component(button_text: "Filter")
 
-    assert_select ".app-c-filter-panel h2", text: "84 results"
-  end
-
-  it "renders the correct result count heading for a large number" do
-    render_component(button_text: "Filter", result_count: 12_345_678)
-
-    assert_select ".app-c-filter-panel h2", text: "12,345,678 results"
+    assert_select ".app-c-filter-panel h2", false
   end
 
   it "renders the passed block into the content area" do
-    render_component(button_text: "Filter", result_count: 42) do
+    render_component(button_text: "Filter") do
       tag.p("Hello, world!")
     end
 
@@ -54,13 +44,13 @@ describe "Filter panel component", type: :view do
   end
 
   it "does not render the content hidden to begin with" do
-    render_component(button_text: "Filter", result_count: 42)
+    render_component(button_text: "Filter")
 
     assert_select ".app-c-filter-panel[hidden]", false
   end
 
   it "respects the standard 'open' option" do
-    render_component(button_text: "Filter", result_count: 42, open: true)
+    render_component(button_text: "Filter", open: true)
 
     assert_select ".app-c-filter-panel[open=open]"
   end


### PR DESCRIPTION
A couple of assorted UI tweaks to the new all content finder UI:
- Use `prefixed-transform` mixin instead of raw transform to improve support for legacy browsers
- Allow filter panel to accept verbatim result count text instead of generating result count text in the component based on a number, and only render heading if text is passed in
- Pass in result presenter's preformatted result text in all content finder view
- Add basic Cucumber step to validate result count is present