### PR TITLE
alignment of filter section/panel styles

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -1,5 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
-@import "govuk_publishing_components/components/mixins/prefixed-transform";
+@import "mixins/chevron";
 
 .app-c-filter-panel__content {
   background-color:  govuk-colour("light-grey");
@@ -13,45 +13,41 @@
   place-content: space-between;
   align-items: center;
   gap: govuk-spacing(2);
+}
 
-  .gem-c-heading {
-    font-weight: normal;
+.app-c-filter-panel__count {
+  margin: 0;
+  @include govuk-font(19, $weight: regular);
+}
+
+.app-c-filter-panel__button {
+  background-color: transparent;
+  color: $govuk-link-colour;
+  text-decoration: none;
+  border-style: none;
+  padding-left: 0;
+  cursor: pointer;
+  @include chevron;
+  @include govuk-font(19);
+
+  &[aria-expanded="true"] {
+    @include chevron(true);
   }
 
-  .app-c-filter-panel__button {
-    background-color: transparent;
-    color: $govuk-link-colour;
+  &:hover {
+    @include govuk-link-decoration;
+    @include govuk-link-hover-decoration;
+  }
+
+  &:focus,
+  &:focus-visible {
     text-decoration: none;
-    border-style: none;
-    @include govuk-font(19);
-
-    &:focus,
-    &:focus-visible {
-      background-color: $govuk-focus-colour;
-      @include govuk-link-hover-decoration;
-      @include govuk-focused-text;
-    }
-
-    &:hover {
-      cursor: pointer;
-      color: $govuk-link-hover-colour;
-    }
+    background-color: $govuk-focus-colour;
+    @include govuk-link-hover-decoration;
+    @include govuk-focused-text;
   }
 
-  .app-c-filter-panel__button[aria-expanded="true"] .app-c-filter-panel__button-icon {
-    @include prefixed-transform($translateY: 0, $rotate: -135deg);
-  }
-
-  .app-c-filter-panel__button-icon {
-    border: solid currentcolor;
-    border-width: 0 2px 2px 0;
-    height: 0.5rem;
-    pointer-events: none;
-    width: 0.5rem;
-    display: inline-block;
-    vertical-align: baseline;
-    margin-right: govuk-spacing(1);
-
-    @include prefixed-transform($translateY: -50%, $rotate: 45deg);
+  &::before {
+    margin: 0 govuk-spacing(2) govuk-spacing(1) 0;
   }
 }

--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -1,5 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
-@import "govuk_publishing_components/components/mixins/prefixed-transform";
+@import "mixins/chevron";
 
 .app-c-filter-section {
   border-bottom: 1px solid $govuk-border-colour;
@@ -15,9 +15,7 @@
   }
 
   &[open] .app-c-filter-section__summary {
-    &::before {
-      @include prefixed-transform($translateY: 30%, $rotate: -45deg);
-    }
+    @include chevron(true);
   }
 }
 
@@ -27,6 +25,7 @@
   width: 100%;
   cursor: pointer;
   color: $govuk-text-colour;
+  @include chevron;
 
   &:hover .app-c-filter-section__summary-heading {
     @include govuk-link-decoration;
@@ -36,21 +35,6 @@
   &:focus .app-c-filter-section__summary-heading {
     background-color: $govuk-focus-colour;
     @include govuk-focused-text;
-  }
-
-  &::before {
-    border-style: solid;
-    border-width: 2px 2px 0 0;
-    content: '';
-    display: inline-block;
-    height: govuk-spacing(2);
-    left: govuk-spacing(1);
-    position: relative;
-    vertical-align: middle;
-    width: govuk-spacing(2);
-    border-color: $govuk-text-colour;
-    clip-path: unset;
-    @include prefixed-transform($translateY: -25%, $rotate: 135deg);
   }
 
   &:focus-visible {

--- a/app/assets/stylesheets/components/mixins/_chevron.scss
+++ b/app/assets/stylesheets/components/mixins/_chevron.scss
@@ -1,0 +1,22 @@
+@import "govuk_publishing_components/components/mixins/prefixed-transform";
+
+@mixin chevron($open: false) {
+  &::before {
+    border-style: solid;
+    border-width: 2px 2px 0 0;
+    content: '';
+    display: inline-block;
+    height: govuk-spacing(2);
+    left: govuk-spacing(1);
+    position: relative;
+    vertical-align: middle;
+    width: govuk-spacing(2);
+    border-color: initial;
+    clip-path: unset;
+    @include prefixed-transform($translateY: -25%, $rotate: 135deg);
+
+    @if $open {
+      @include prefixed-transform($translateY: 30%, $rotate: -45deg);
+    }
+  }
+}

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -21,16 +21,13 @@
       class: "app-c-filter-panel__button govuk-link",
       aria: { expanded: "false", controls: panel_content_id }
     ) do %>
-      <span class="app-c-filter-panel__button-icon"></span>
       <%= button_text %>
     <% end %>
 
     <% if result_text.present? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: result_text,
-        heading_level: 2,
-        font_size: "s",
-      } %>
+      <%= content_tag("h2", class: "app-c-filter-panel__count") do %>
+        <%= result_text %>
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -47,7 +47,7 @@
         <%= render "components/filter_panel", {
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
-          margin_bottom: 3,
+          margin_bottom: 2,
         } do %>
           <%= render "components/filter_section", {
             open: true,


### PR DESCRIPTION
This addresses some design inconsitencies between the filter panel and sections:

- chevrons on panel and sections for filters were inconsistent sizes. Creates a shared mixin to address inconsistency
- chevron is consistently applied to before pseudo class on element where is is required
- correct margin between panel header and content as per designs
- align css class names as per GDS model
- align the panel toggle button hover/focus styling with the panel section summary elements
- remove uneccessary nesting to be inline with GDS conventions



## before

<img width="573" alt="Screenshot 2024-09-19 at 10 53 11" src="https://github.com/user-attachments/assets/db809437-e281-439b-9c97-1922610d6ea5">

## after
<img width="575" alt="Screenshot 2024-09-19 at 10 52 15" src="https://github.com/user-attachments/assets/30fb8ec2-96c3-4754-81d0-993cf6ea4aa0">
