### PR TITLE
Fix sort order behaviour bug when JS disabled

### DIFF
--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -62,8 +62,12 @@ private
 
   def user_selected_option
     selected = sort_options.find { |option| option_value(option) == user_selected_order }
-    if selected == popularity_option && !relevance_option.nil? && keywords.present?
+    return selected if relevance_option.nil? || popularity_option.nil?
+
+    if selected == popularity_option && keywords.present?
       relevance_option
+    elsif selected == relevance_option && keywords.blank?
+      popularity_option
     else
       selected
     end

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe SortPresenter do
           expect(popularity_option[:disabled]).to be false
           expect(popularity_option[:selected]).to be true
         end
+
+        context "even when the relevance option is explicitly requested" do
+          let(:values) { super().merge("order" => "relevance") }
+
+          it "should still disable the relevance option" do
+            expect(relevance_option[:disabled]).to be true
+            expect(relevance_option[:selected]).to be false
+          end
+
+          it "should enable the popularity option" do
+            expect(popularity_option[:disabled]).to be false
+            expect(popularity_option[:selected]).to be true
+          end
+        end
       end
 
       context "when keywords are not blank" do
@@ -128,6 +142,20 @@ RSpec.describe SortPresenter do
         it "should disable the popularity option" do
           expect(popularity_option[:disabled]).to be true
           expect(popularity_option[:selected]).to be false
+        end
+
+        context "even when the popularity option is explicitly requested" do
+          let(:values) { super().merge("order" => "most-viewed") }
+
+          it "should still disable the popularity option" do
+            expect(popularity_option[:disabled]).to be true
+            expect(popularity_option[:selected]).to be false
+          end
+
+          it "should enable the relevance option" do
+            expect(relevance_option[:disabled]).to be false
+            expect(relevance_option[:selected]).to be true
+          end
         end
       end
     end

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -99,47 +99,36 @@ RSpec.describe SortPresenter do
         )
     end
 
-    it "should disable the relevance option if keywords are not present" do
-      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-        o[:value] == "relevance"
-      }[:disabled]).to be true
+    describe "disabling options based on keyword presence" do
+      let(:relevance_option) { presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o| o[:value] == "relevance" } }
+      let(:popularity_option) { presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o| o[:value] == "most-viewed" } }
 
-      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-        o[:value] == "relevance"
-      }[:selected]).to be false
-    end
+      context "when keywords are blank" do
+        let(:values) { { "keywords" => "" } }
 
-    it "should enable the popularity option if keywords are not present" do
-      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-        o[:value] == "most-viewed"
-      }[:disabled]).to be false
+        it "should disable the relevance option" do
+          expect(relevance_option[:disabled]).to be true
+          expect(relevance_option[:selected]).to be false
+        end
 
-      expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-        o[:value] == "most-viewed"
-      }[:selected]).to be true
-    end
-
-    context "keywords are not blank" do
-      let(:values) { { "keywords" => "something not blank" } }
-
-      it "should not disable relevance" do
-        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-          o[:value] == "relevance"
-        }[:disabled]).to be false
-
-        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-          o[:value] == "relevance"
-        }[:selected]).to be true
+        it "should enable the popularity option" do
+          expect(popularity_option[:disabled]).to be false
+          expect(popularity_option[:selected]).to be true
+        end
       end
 
-      it "should disable popularity" do
-        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-          o[:value] == "most-viewed"
-        }[:disabled]).to be true
+      context "when keywords are not blank" do
+        let(:values) { { "keywords" => "something not blank" } }
 
-        expect(presenter_with_popularity_default_and_relevance.to_hash[:options].find { |o|
-          o[:value] == "most-viewed"
-        }[:selected]).to be false
+        it "should not disable the relevance option" do
+          expect(relevance_option[:disabled]).to be false
+          expect(relevance_option[:selected]).to be true
+        end
+
+        it "should disable the popularity option" do
+          expect(popularity_option[:disabled]).to be true
+          expect(popularity_option[:selected]).to be false
+        end
       end
     end
 


### PR DESCRIPTION
When a finder has both relevance and popularity options, `SortPresenter` will check for the presence of keywords and force the relevance option even if popularity was explicitly requested. It doesn't do the converse though: force the popularity option when relevance was explicitly requested but no keyword(s) given.

This is papered over with Javascript for those users who have it enabled, but since our upcoming search UI does not have dynamic behaviour, it has surfaced this bug.

- Add tests for overriding explicitly provided sort order
- Fix missing override of relevance sort order when no keyword(s) given
- Tidy up `SortPresenter#user_selected_option` a little bit

## How to reproduce
- Disable Javascript
- Go to "all content" finder
- Note that "Most viewed" is the selected default sort option (correctly so)
- Enter a keyword and submit
- Note that the sort order is overridden to "Relevance" (correctly so)
- Remove the keyword and submit again
- **"Relevance" incorrectly remains selected, despite being correctly disabled**:

<img width="272" alt="Screenshot 2024-09-19 at 11 29 08" src="https://github.com/user-attachments/assets/7fc115a8-fd20-4bd1-ba39-ae18021ee49b">
