### PR TITLE
Fix filter panel docs using wrong attribute

### DIFF
--- a/app/views/components/docs/filter_panel.yml
+++ b/app/views/components/docs/filter_panel.yml
@@ -16,7 +16,7 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      result_count: 123456
+      result_text: 123,456 results
       button_text: Filter and sort
       block: |
         <p class="govuk-body">
@@ -24,7 +24,7 @@ examples:
         </p>
   open:
     data:
-      result_count: 1989
+      result_text: 1,989 seeds
       button_text: Open sesame
       open: true
       block: |
@@ -35,7 +35,7 @@ examples:
     description: |
       Pass filter section component as a block
     data:
-      result_count: 1
+      result_text: 42 universes
       button_text: View filter section
       block: |
         <%= render "components/filter_section", {
@@ -50,6 +50,6 @@ examples:
 
       This accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom.
     data:
-      result_count: 1
+      result_text: 1 partridge in a pear tree
       button_text: Loooooads of space
       margin_bottom: 9


### PR DESCRIPTION
We changed from having a `result_count` to a freeform `result_text`, but forgot to update the documentation for the component guide.

<img width="933" alt="image" src="https://github.com/user-attachments/assets/5d7291fb-3119-429b-a500-cc8c3a8d82f1">
