### PR TITLE
New all content finder: Add ability to sort

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,10 +187,11 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (43.4.1)
+    govuk_publishing_components (43.5.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
+      ostruct
       plek
       rails (>= 6)
       rouge
@@ -465,6 +466,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    ostruct (0.6.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -648,7 +650,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)

--- a/app/presenters/sort_option_presenter.rb
+++ b/app/presenters/sort_option_presenter.rb
@@ -24,6 +24,16 @@ class SortOptionPresenter
     }
   end
 
+  def to_radio_option
+    return nil if disabled
+
+    {
+      value:,
+      text: label,
+      checked: selected,
+    }
+  end
+
 private
 
   attr_reader :default, :selected, :disabled

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -5,6 +5,12 @@ class SortPresenter
     @content_item_sort_options = content_item.sort_options
   end
 
+  def to_radio_options
+    return nil unless has_options?
+
+    presented_sort_options.map(&:to_radio_option).compact
+  end
+
   def to_hash
     return nil unless has_options?
 

--- a/app/presenters/sort_presenter.rb
+++ b/app/presenters/sort_presenter.rb
@@ -5,6 +5,13 @@ class SortPresenter
     @content_item_sort_options = content_item.sort_options
   end
 
+  def status_text
+    return nil unless has_options?
+    return nil if option_value(selected_option) == default_value
+
+    selected_option["name"]
+  end
+
   def to_radio_options
     return nil unless has_options?
 

--- a/app/views/finders/all_content_finder_facets/_sort_options.html.erb
+++ b/app/views/finders/all_content_finder_facets/_sort_options.html.erb
@@ -1,0 +1,15 @@
+<%= render "components/filter_section", {
+  heading_text: "Sort by",
+  status_text: @sort_presenter.status_text,
+} do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: "Sort order",
+    heading_level: 0,
+    # Legend is visually hidden as non-screenreader users already have the section heading above
+    visually_hidden_heading: true,
+    margin_bottom: 2,
+    name: "order",
+    small: true,
+    items: @sort_presenter.to_radio_options,
+  } %>
+<% end %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -48,6 +48,8 @@
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
         } do %>
+          <%= render "finders/all_content_finder_facets/sort_options" %>
+
           <% facets.each_with_index_and_count do |facet, index, count| %>
             <%=
               render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -17,6 +17,14 @@ Feature: All content finder ("site search")
     And I open the filter panel
     Then I can see a filter section for every visible facet on the all content finder
 
+  Scenario: Changing the sort order of a search
+    When I search all content for "dark gray all alone"
+    And I open the filter panel
+    And I open the "Sort by" filter section
+    And I select the "Updated (oldest)" option
+    And I apply the filters
+    Then I can see sorted results
+
   Scenario: Spelling suggestion
     When I search all content for "drving"
     Then I see a "driving" spelling suggestion

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -34,6 +34,7 @@ Given(/^the all content finder exists$/) do
   stub_search_api_request_with_manual_filter_all_content_results
   stub_search_api_request_with_misspelt_query
   stub_search_api_request_with_query
+  stub_search_api_request_with_sorted_query
 end
 
 Given(/^the new all content finder UI is (\w+)$/) do |state|

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -26,3 +26,21 @@ Then("I can see a filter section for every visible facet on the all content find
   expect(page).not_to have_selector("h2", text: "Filter by World location")
   expect(page).not_to have_selector("h2", text: "Filter by Topical event")
 end
+
+When(/^I open the "([^"]*)" filter section$/) do |title|
+  # Capybara #click can't deal with <details> elements, so need to manually find summary first
+  section = find("details summary", text: title)
+  section.click
+end
+
+When(/^I select the "([^"]*)" option$/) do |option|
+  choose option
+end
+
+When("I apply the filters") do
+  click_on "Apply filters"
+end
+
+Then("I can see sorted results") do
+  expect(page).to have_link("Loving him was red")
+end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -124,6 +124,24 @@ module DocumentHelper
       .to_return(body: all_documents_json)
   end
 
+  def stub_search_api_request_with_sorted_query
+    stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including("q" => "dark gray all alone", "order" => "-public_timestamp"))
+      .to_return(body: %({ "results": [], "total": 0, "start": 0}))
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
+      .with(query: hash_including("q" => "dark gray all alone", "order" => "-public_timestamp"))
+      .to_return(body: %({ "results": [], "total": 0, "start": 0}))
+
+    stub_request(:get, SEARCH_ENDPOINT)
+      .with(query: hash_including("q" => "dark gray all alone", "order" => "public_timestamp"))
+      .to_return(body: sorted_documents_json)
+
+    stub_request(:get, SEARCH_V2_ENDPOINT)
+      .with(query: hash_including("q" => "dark gray all alone", "order" => "public_timestamp"))
+      .to_return(body: sorted_documents_json)
+  end
+
   def stub_search_api_request_with_misspelt_query
     stub_request(:get, SEARCH_ENDPOINT)
       .with(query: hash_including("q" => "drving"))
@@ -664,6 +682,25 @@ module DocumentHelper
         }
       ],
       "total": 2,
+      "start": 0,
+      "facets": {},
+      "suggested_queries": []
+    })
+  end
+
+  def sorted_documents_json
+    %({
+      "results": [
+        {
+          "title": "Loving him was red",
+          "public_timestamp": "2012-10-22",
+          "summary": "Losing him was blue like I'd never known",
+          "document_type": "song",
+          "link": "/red",
+          "_id": "/red"
+        }
+      ],
+      "total": 1,
       "start": 0,
       "facets": {},
       "suggested_queries": []

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -126,11 +126,11 @@ module DocumentHelper
 
   def stub_search_api_request_with_sorted_query
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: hash_including("q" => "dark gray all alone", "order" => "-public_timestamp"))
+      .with(query: hash_including("q" => "dark gray all alone"))
       .to_return(body: %({ "results": [], "total": 0, "start": 0}))
 
     stub_request(:get, SEARCH_V2_ENDPOINT)
-      .with(query: hash_including("q" => "dark gray all alone", "order" => "-public_timestamp"))
+      .with(query: hash_including("q" => "dark gray all alone"))
       .to_return(body: %({ "results": [], "total": 0, "start": 0}))
 
     stub_request(:get, SEARCH_ENDPOINT)

--- a/spec/presenters/sort_option_presenter_spec.rb
+++ b/spec/presenters/sort_option_presenter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SortOptionPresenter do
   subject(:sort_option_with_value) { described_class.new(label: "Updated (newest)", value: "frogs-frogs-frogs", key: "-public_timestamp") }
   subject(:default_sort_option) { described_class.new(label: "Most viewed", key: "most-viewed", default: true) }
   subject(:relevance_sort_option) { described_class.new(label: "Show least relevant", key: "-relevance") }
+  subject(:disabled_sort_option) { described_class.new(label: "Show in order of redness", key: "redness", disabled: true) }
 
   describe "#value" do
     context "a value is provided" do
@@ -38,6 +39,20 @@ RSpec.describe SortOptionPresenter do
         selected: false,
         value: "updated-newest",
       )
+    end
+  end
+
+  describe "#to_radio_option" do
+    it "returns a hash appropriate for the radio component" do
+      expect(sort_option.to_radio_option).to eq(
+        value: "updated-newest",
+        text: "Updated (newest)",
+        checked: false,
+      )
+    end
+
+    it "returns nil for a disabled option" do
+      expect(disabled_sort_option.to_radio_option).to eq(nil)
     end
   end
 end

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -57,6 +57,24 @@ RSpec.describe SortPresenter do
     ]
   end
 
+  describe "#status_text" do
+    context "when the default sort order is selected" do
+      let(:values) { { "order" => "-public_timestamp" } }
+
+      it "returns nil" do
+        expect(presenter_with_default.status_text).to be_nil
+      end
+    end
+
+    context "when another sort order is selected" do
+      let(:values) { { "order" => "most-viewed" } }
+
+      it "returns a status message" do
+        expect(presenter_with_default.status_text).to eq("Most viewed")
+      end
+    end
+  end
+
   describe "#to_radio_options" do
     let(:values) { { "keywords" => "red", "order" => "relevance" } }
 

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SortPresenter do
       "order" => "relevance",
     )
   end
+  subject(:presenter_including_a_disabled_value) { described_class.new(content_item(sort_options: sort_options_including_a_disabled_value), values) }
 
   let(:values) { {} }
 
@@ -54,6 +55,19 @@ RSpec.describe SortPresenter do
       { "name" => "Most viewed", "key" => "-popularity" },
       { "name" => "Updated (newest)", "key" => "-public_timestamp", "default" => true },
     ]
+  end
+
+  describe "#to_radio_options" do
+    let(:values) { { "keywords" => "red", "order" => "relevance" } }
+
+    it "returns only enabled sort options as radio options" do
+      expect(presenter_with_relevance.to_radio_options).to eq(
+        [
+          { value: "updated-newest", text: "Updated (newest)", checked: false },
+          { value: "relevance", text: "Relevance", checked: true },
+        ],
+      )
+    end
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
This adds the ability to sort results to the new "all content" finder.

- Update `SortPresenter` and `SortOptionPresenter` to be able to present sort options as radio options (in addition to the existing select box style)
- Add in a sort section to the filter panel with the sort options from the presenter

➡️ [**Search page in review app**](https://finder-frontend-pr-3462.herokuapp.com/search/all)

---

<img width="723" alt="image" src="https://github.com/user-attachments/assets/f86785f5-12b2-4e45-b47a-7d63324b48c5">