### PR TITLE
add filter summary component

### DIFF
--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,0 +1,51 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.app-c-filter-summary__heading {
+  display: block;
+  margin-bottom: govuk-spacing(2);
+  @include govuk-font(16);
+}
+
+.app-c-filter-summary__remove-filters {
+  list-style-type: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(1);
+}
+
+.app-c-filter-summary__remove-filter {
+  border: 1px solid $govuk-border-colour;
+  border-radius: govuk-em(5, 16px);
+  padding: govuk-spacing(2);
+  text-decoration: none;
+  display: flex;
+  color: $govuk-text-colour;
+  background-color: govuk-colour("light-grey");
+  @include govuk-font(16);
+
+  &:focus {
+    background-color: $govuk-focus-colour;
+    outline: 2px $govuk-text-colour solid;
+    outline-offset: 0;
+    border-color: $govuk-text-colour;
+  }
+
+  &:hover {
+    outline: 1px $govuk-text-colour solid;
+    outline-offset: 0;
+    border-color: $govuk-text-colour;
+  }
+
+  &::before {
+    content: "\00d7";
+    padding-right: govuk-spacing(1);
+    vertical-align: top;
+    line-height: 1;
+    font-size: 22px;
+  }
+}
+
+.app-c-filter-summary__remove-filter-text {
+  vertical-align: middle;
+}

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -1,0 +1,44 @@
+<% add_app_component_stylesheet("filter-summary") %>
+
+<%
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
+  filters ||= []
+
+  clear_all_href ||= nil
+  clear_all_text ||= nil
+  heading_level ||= 3
+  heading_text ||= nil
+
+  component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
+  component_helper.add_class(shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
+  component_helper.add_class("app-c-filter-summary")
+%>
+
+<% if filters && filters.length > 0  %>
+  <%= tag.div(**component_helper.all_attributes) do %>
+    <% if heading_text.present? %>
+      <%= content_tag("h#{heading_level}", class: "app-c-filter-summary__heading") do %>
+        <% heading_text %>
+      <% end %>
+    <% end %>
+    <ul class="app-c-filter-summary__remove-filters">
+    <% filters.each do |filter| %>
+      <li>
+        <%= content_tag("a", class: "app-c-filter-summary__remove-filter", href: "#{filter[:remove_href]}") do %>
+          <span class="app-c-filter-summary__remove-filter-text">
+            <span class="govuk-visually-hidden"><%= filter[:visually_hidden_prefix] %></span>
+            <%= filter[:label] %>: <%= filter[:value] %>
+          </span>
+        <% end %>
+      </li>
+    <% end %>
+    </ul>
+    <% if clear_all_text.present? && clear_all_href.present? %>
+      <%= tag.div do %>
+        <%= content_tag("a", class: "app-c-filter-summary__clear-filters govuk-link", href: "#{clear_all_href}") do %>
+          <%= clear_all_text %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/filter_summary.yml
+++ b/app/views/components/docs/filter_summary.yml
@@ -1,0 +1,38 @@
+name: Filter summary
+description: Displays a summary of applied filters as links that can remove a specific filter. Also a link for clearing all filters.
+uses_component_wrapper_helper: true
+accessibility_criteria: |
+  The component items must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - be usable with touch
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      clear_all_href: "#"
+      clear_all_text: "Clear all filters"
+      heading_level: 3
+      heading_text: "Selected filters"
+      filters: [
+        {
+          label: "Filter 1",
+          value: "Value 1",
+          remove_href: "#",
+          visually_hidden_prefix: "Remove filter",
+        },
+        {
+          label: "Filter 2",
+          value: "Value 2",
+          remove_href: "#",
+          visually_hidden_prefix: "Remove filter",
+        },
+        {
+          label: "Filter 3",
+          value: "Value that is so long that the styling needs to handle it correctly",
+          remove_href: "#",
+          visually_hidden_prefix: "Remove filter",
+        }
+      ]

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -77,6 +77,34 @@
           <% end %>
         <% end %>
 
+        <%= render "components/filter_summary", {
+          clear_all_href: "#",
+          clear_all_text: "Clear all filters",
+          heading_level: 3,
+          heading_text: "Selected filters",
+          margin_bottom: 2,
+          filters: [
+            {
+              label: "Filter 1",
+              value: "Value 1",
+              remove_href: "#",
+              visually_hidden_prefix: "Remove filter"
+            },
+            {
+              label: "Filter 2",
+              value: "Value 2",
+              remove_href: "#",
+              visually_hidden_prefix: "Remove filter"
+            },
+            {
+              label: "Filter 3",
+              value: "Value 3",
+              remove_href: "#",
+              visually_hidden_prefix: "Remove filter"
+            }
+          ]
+        } %>
+
         <% if result_set_presenter.total_count.positive? %>
           <%= render "govuk_publishing_components/components/document_list", {
             disable_ga4: true,

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -3,6 +3,7 @@ APP_STYLESHEETS = {
   "components/_expander.scss" => "components/_expander.css",
   "components/_filter-panel.scss" => "components/_filter-panel.css",
   "components/_filter-section.scss" => "components/_filter-section.css",
+  "components/_filter-summary.scss" => "components/_filter-summary.css",
   "components/_mobile-filters.scss" => "components/_mobile-filters.css",
   "views/_search.scss" => "views/_search.css",
 }.freeze

--- a/spec/components/filter_summary_spec.rb
+++ b/spec/components/filter_summary_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+describe "Filter summary component", type: :view do
+  def component_name
+    "filter_summary"
+  end
+
+  let(:filters) do
+    [
+      {
+        label: "Filter 1",
+        value: "Value 1",
+        remove_href: "/remove_url",
+        visually_hidden_prefix: "Remove filter",
+      },
+      {
+        label: "Filter 2",
+        value: "Value 2",
+        remove_href: "/remove_url",
+        visually_hidden_prefix: "Remove filter",
+      },
+      {
+        label: "Filter 3",
+        value: "Value that is so long that the styling needs to handle it correctly",
+        remove_href: "/remove_url",
+        visually_hidden_prefix: "Remove filter",
+      },
+    ]
+  end
+
+  def render_component(locals)
+    render "components/#{component_name}", locals
+  end
+
+  it "does not render a filter summary when no filters array passed" do
+    render_component({ heading_text: "Selected filters" })
+
+    assert_select ".app-c-filter-summary", false
+  end
+
+  it "does not render a filter summary when empty filters array passed" do
+    render_component({ heading_text: "Selected filters", filters: [] })
+
+    assert_select ".app-c-filter-summary", false
+  end
+
+  it "renders correct number of filters with hidden accesibilty text" do
+    render_component({ filters: })
+
+    assert_select ".app-c-filter-summary__remove-filter-text", count: 3
+    assert_select ".app-c-filter-summary__remove-filter-text .govuk-visually-hidden", text: "Remove filter"
+  end
+
+  it "renders a heading if supplied" do
+    render_component({ heading_text: "Selected filters", filters: })
+
+    assert_select ".app-c-filter-summary__heading", text: "Selected filters"
+  end
+
+  it "renders a clear all link if supplied" do
+    render_component({ filters:, clear_all_href: "/url", clear_all_text: "Clear all" })
+
+    assert_select ".app-c-filter-summary__clear-filters", count: 1
+    assert_select ".app-c-filter-summary__clear-filters", href: "/url"
+  end
+
+  it "renders a clear all link if text and href supplied" do
+    render_component({ filters:, clear_all_href: "/url", clear_all_text: "Clear all" })
+
+    assert_select ".app-c-filter-summary__clear-filters", count: 1
+    assert_select ".app-c-filter-summary__clear-filters", href: "/url"
+  end
+
+  it "does not render a clear all link if one of text and href are omitted" do
+    render_component({ filters:, clear_all_text: "Clear all" })
+
+    assert_select ".app-c-filter-summary__clear-filters", false
+  end
+
+  it "set summary heading text to different value to default renders correct heading level" do
+    render_component({ heading_text: "Selected filters", filters:, clear_all_href: "/url", heading_level: 4 })
+
+    assert_select "h4.app-c-filter-summary__heading", count: 1
+  end
+end


### PR DESCRIPTION
This adds a new app-specific component that displays a summary component to indicate applied filters and the ability to remove them individually or a link to clear all filters. This will be used for the new site search ("all content" finder) UI instead of the existing filters sidebar.

Create filter_summary component
Add filter_summary components to the (work in progress and hidden behind feature flag) show_all_content_finder view template

### Default
<img width="927" alt="Screenshot 2024-09-20 at 12 02 05" src="https://github.com/user-attachments/assets/a14d7c3f-4941-48dd-b209-841dafc3e9ba">

### Hover
<img width="900" alt="Screenshot 2024-09-20 at 12 02 27" src="https://github.com/user-attachments/assets/5d7d6ae8-0f94-4d2d-bac3-f7e52e36c00f">

### Focus
<img width="894" alt="Screenshot 2024-09-20 at 12 02 17" src="https://github.com/user-attachments/assets/1f5aab25-2133-42c3-be30-cf44f6b09c7d">

### Mobile
<img width="392" alt="Screenshot 2024-09-23 at 10 51 04" src="https://github.com/user-attachments/assets/ce7b3bde-d6b7-4ea3-b729-74a2f7b98788">


## Designs
https://www.figma.com/design/H99sZyzK3aT9Tet0r6AtOC/Search-Designs?node-id=1154-41574&node-type=canvas&t=aJqXa88NDTPd7HYg-0

