### PR TITLE
Update all content finder fixture

### DIFF
--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -2,33 +2,71 @@
   "analytics_identifier": null,
   "base_path": "/search/all",
   "content_id": "dd395436-9b40-41f3-8157-740a453ac972",
-  "content_purpose_document_supertype": "navigation",
   "description": "Find content from government",
   "details": {
-    "default_documents_per_page": 20,
+    "default_documents_per_page": 10,
     "document_noun": "result",
     "facets": [
       {
         "display_as_result_metadata": false,
         "filter_key": "all_part_of_taxonomy_tree",
         "filterable": true,
+        "key": "_unused",
         "keys": [
           "level_one_taxon",
           "level_two_taxon"
         ],
-        "name": "topic",
+        "name": "Topic",
         "preposition": "about",
         "short_name": "topic",
         "type": "taxon"
       },
       {
+        "allowed_values": [],
         "display_as_result_metadata": false,
         "filterable": true,
         "key": "manual",
         "name": "Manual",
         "preposition": "in manual",
         "short_name": "in",
+        "show_option_select_filter": false,
         "type": "hidden_clearable"
+      },
+      {
+        "allowed_values": [
+          {
+            "label": "Services",
+            "value": "services"
+          },
+          {
+            "label": "Guidance and regulation",
+            "value": "guidance_and_regulation"
+          },
+          {
+            "label": "News and communications",
+            "value": "news_and_communications"
+          },
+          {
+            "label": "Research and statistics",
+            "value": "research_and_statistics"
+          },
+          {
+            "label": "Policy papers and consultations",
+            "value": "policy_and_engagement"
+          },
+          {
+            "label": "Transparency and freedom of information releases",
+            "value": "transparency"
+          }
+        ],
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "content_purpose_supergroup",
+        "name": "Type",
+        "preposition": "in",
+        "short_name": "In",
+        "show_option_select_filter": false,
+        "type": "text"
       },
       {
         "display_as_result_metadata": true,
@@ -37,40 +75,49 @@
         "name": "Organisation",
         "preposition": "from",
         "short_name": "From",
-        "type": "text",
-        "show_option_select_filter": true
+        "show_option_select_filter": true,
+        "type": "hidden_clearable"
       },
       {
         "display_as_result_metadata": false,
         "filterable": true,
-        "key": "people",
-        "name": "Person",
-        "preposition": "from",
-        "type": "text",
-        "show_option_select_filter": true
-      },
-      {
-        "display_as_result_metadata": true,
-        "filterable": true,
         "key": "world_locations",
         "name": "World location",
         "preposition": "in",
-        "type": "text",
-        "show_option_select_filter": true
+        "show_option_select_filter": false,
+        "type": "hidden_clearable"
       },
       {
         "display_as_result_metadata": true,
         "filterable": true,
-        "preposition": "Updated",
         "key": "public_timestamp",
         "name": "Updated",
+        "preposition": "Updated",
         "short_name": "Updated",
         "type": "date"
+      },
+      {
+        "allowed_values": [],
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "topical_events",
+        "name": "Topical event",
+        "preposition": "about",
+        "short_name": "about",
+        "show_option_select_filter": false,
+        "type": "hidden_clearable"
       }
     ],
+    "format_name": "Documents",
+    "reject": {
+      "link": [
+        "/search/all"
+      ]
+    },
     "show_summaries": true,
     "sort": [
       {
+        "default": true,
         "key": "-popularity",
         "name": "Most viewed"
       },
@@ -79,7 +126,6 @@
         "name": "Relevance"
       },
       {
-        "default": true,
         "key": "-public_timestamp",
         "name": "Updated (newest)"
       },
@@ -90,19 +136,35 @@
     ]
   },
   "document_type": "finder",
-  "email_document_supertype": "other",
-  "first_published_at": "2019-01-17T13:00:00.000+00:00",
-  "government_document_supertype": "other",
-  "links": {},
+  "first_published_at": "2019-02-14T14:57:43+00:00",
+  "links": {
+    "available_translations": [
+      {
+        "api_path": "/api/content/search/all",
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/search/all",
+        "base_path": "/search/all",
+        "content_id": "dd395436-9b40-41f3-8157-740a453ac972",
+        "document_type": "finder",
+        "links": {},
+        "locale": "en",
+        "public_updated_at": "2024-09-20T09:17:24Z",
+        "schema_name": "finder",
+        "title": "Search",
+        "web_url": "https://www.integration.publishing.service.gov.uk/search/all",
+        "withdrawn": false
+      }
+    ]
+  },
   "locale": "en",
-  "navigation_document_supertype": "other",
-  "phase": "alpha",
-  "public_updated_at": "2019-01-17T13:00:00.000+00:00",
-  "publishing_app": "finder-frontend",
+  "phase": "live",
+  "public_updated_at": "2024-09-20T10:17:24+01:00",
+  "publishing_app": "search-api",
+  "publishing_request_id": "21-1726823845.044-10.1.34.217-616",
+  "publishing_scheduled_at": null,
   "rendering_app": "finder-frontend",
+  "scheduled_publishing_delay_seconds": null,
   "schema_name": "finder",
-  "search_user_need_document_supertype": "government",
   "title": "Search",
-  "updated_at": "2019-01-17T13:00:00.000+00:00",
-  "user_journey_document_supertype": "finding"
+  "updated_at": "2024-09-20T10:17:25+01:00",
+  "withdrawn_notice": {}
 }

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -173,29 +173,28 @@ When(/^I view the all content finder with a manual filter$/) do
   content_store_has_all_content_finder
   stub_organisations_registry_request
   stub_world_locations_api_request
+  stub_topical_events_api_request
   stub_people_registry_request
   stub_manuals_registry_request
 
   stub_request(:get, DocumentHelper::SEARCH_ENDPOINT)
-    .with(query: hash_including(q: "Replacing bristles", order: "-public_timestamp"))
+    .with(query: hash_including(q: "Replacing bristles"))
     .to_return(body: all_content_results_json)
 
   stub_request(:get, DocumentHelper::SEARCH_ENDPOINT)
     .with(query: hash_including(
       filter_manual: "/guidance/care-and-use-of-a-nimbus-2000",
       q: "Replacing bristles",
-      order: "-public_timestamp",
     )).to_return(body: all_content_manuals_results_json)
 
   stub_request(:get, DocumentHelper::SEARCH_V2_ENDPOINT)
-    .with(query: hash_including(q: "Replacing bristles", order: "-public_timestamp"))
+    .with(query: hash_including(q: "Replacing bristles"))
     .to_return(body: all_content_results_json)
 
   stub_request(:get, DocumentHelper::SEARCH_V2_ENDPOINT)
     .with(query: hash_including(
       filter_manual: "/guidance/care-and-use-of-a-nimbus-2000",
       q: "Replacing bristles",
-      order: "-public_timestamp",
     )).to_return(body: all_content_manuals_results_json)
 
   visit finder_path("search/all", manual: "/guidance/care-and-use-of-a-nimbus-2000", q: "Replacing bristles")

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -25,8 +25,8 @@ end
 Given(/^the all content finder exists$/) do
   topic_taxonomy_has_taxons
   content_store_has_all_content_finder
+  stub_topical_events_api_request
   stub_world_locations_api_request
-  stub_people_registry_request
   stub_organisations_registry_request
   stub_manuals_registry_request
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -241,6 +241,15 @@ module DocumentHelper
       )
   end
 
+  def stub_topical_events_api_request
+    stub_request(:get, SEARCH_ENDPOINT)
+      .with(
+        query: hash_including({ filter_format: "topical_event", count: "1500" }),
+      ).to_return(
+        body: { results: [], total: 0, start: 0 }.to_json,
+      )
+  end
+
   def stub_world_locations_api_request
     stub_worldwide_api_has_locations(%w[azkaban tracy-island])
   end


### PR DESCRIPTION
This doesn't accurately represent the facets of the all content finder anymore, limiting our ability to write reasonable and representative Cucumber tests for the new UI.

- Update `all_content.json` with the current state of the all content finder
- Add basic `DocumentHelper#stub_topical_events_api_request` to stub requests from the topical events registry triggered by the newly added hidden topical event facet, and use it where needed
- Remove stubbing of no longer used people registry from all content finder step
- Remove now incorrect default sort order from request stubs