### PR TITLE
Filter panel UI tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -1,6 +1,12 @@
 @import "govuk_publishing_components/individual_component_support";
 @import "mixins/chevron";
 
+.app-c-filter-panel {
+  padding-bottom: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
 .app-c-filter-panel__content {
   background-color:  govuk-colour("light-grey");
   padding: 0 govuk-spacing(3);

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -57,7 +57,7 @@
   }
 
   &::before {
-    margin: 0 govuk-spacing(2) govuk-spacing(1) 0;
+    margin: 0 govuk-spacing(3) govuk-spacing(1) 0;
   }
 }
 

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -5,6 +5,15 @@
   background-color:  govuk-colour("light-grey");
   padding: 0 govuk-spacing(3);
   margin-top: govuk-spacing(2);
+
+  // GOV.UK Frontend radio and checkboxes are rendered with a transparent background, which makes
+  // them look wrong on this component's grey background. This is intentional in GOV.UK Frontend and
+  // unlikely to change (see https://github.com/alphagov/govuk-frontend/issues/1625).
+  .govuk-checkboxes__label, .govuk-radios__label {
+    &::before {
+        background-color: govuk-colour('white');
+    }
+  }
 }
 
 .app-c-filter-panel__header {

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -24,9 +24,7 @@
       id: button_id,
       class: "app-c-filter-panel__button govuk-link",
       aria: { expanded: "false", controls: panel_content_id }
-    ) do %>
-      <%= button_text %>
-    <% end %>
+    ) { button_text } %>
 
     <% if result_text.present? %>
       <%= content_tag("h2", class: "app-c-filter-panel__count") do %>

--- a/app/views/components/docs/filter_panel.yml
+++ b/app/views/components/docs/filter_panel.yml
@@ -60,6 +60,44 @@ examples:
         } do %>
           <span>filter section content</span>
         <% end %>
+  with_radios_and_checkboxes:
+    description: |
+      Overrides default styles of GOV.UK Frontend radios and checkboxes to ensure they have a white
+      background despite being inside a grey panel.
+    data:
+      button_text: Filter with radios and checkboxes
+      open: true
+      block: |
+        <div class="govuk-!-padding-4">
+          <%= render "govuk_publishing_components/components/radio", {
+            heading: "Radios",
+            name: "radio",
+            small: true,
+            items: [
+              { value: "1", text: "Radio 1" },
+              { value: "2", text: "Radio 2", checked: true }
+            ]
+          } %>
+          <%= render "govuk_publishing_components/components/checkboxes", {
+            name: "checkbox",
+            heading: "Checkboxes",
+            small: true,
+            items: [
+              {
+                label: "Red",
+                value: "red"
+              },
+              {
+                label: "Green",
+                value: "green"
+              },
+              {
+                label: "Blue",
+                value: "blue"
+              }
+            ]
+          } %>
+        </div>
   with_margin_bottom:
     description: |
       Allows the spacing at the bottom of the component to be adjusted.

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -47,7 +47,6 @@
         <%= render "components/filter_panel", {
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
-          margin_bottom: 2,
         } do %>
           <%= render "components/filter_section", {
             open: true,
@@ -79,11 +78,12 @@
 
         <% if result_set_presenter.total_count.positive? %>
           <%= render "govuk_publishing_components/components/document_list", {
+            remove_top_border_from_first_child: true,
             disable_ga4: true,
             items: result_set_presenter.search_results_content[:document_list_component_data],
           } %>
         <% else %>
-          <div class='no-results govuk-!-font-size-19'>
+          <div class='no-results govuk-!-font-size-19 govuk-!-margin-top-4'>
             <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
             <p class='govuk-body'>Improve your search results by:</p>
             <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
- **Force checkbox/radio background**
  - GOV.UK Frontend radio and checkboxes are rendered with a transparent
background, which makes them look wrong on this component's grey background. This is intentional in GOV.UK Frontend and unlikely to
change (see https://github.com/alphagov/govuk-frontend/issues/1625).
- **Fix hover underline**
  - There was a stray space at the beginning of the button element which was causing the underline to cover more than just the text. This removes it and increases the chevron margin instead.
- **Give panel its own bottom border**
  - The filter panel is always supposed to have a bottom border, but currently relies on the top border of the document list following it for its border. This gives the panel its own border so it's present even if there is no document list following it, and accordingly removes it from the top of the first document list item on the new all content finder view.

## Before

<img width="407" alt="image" src="https://github.com/user-attachments/assets/0698b31b-75b0-4cec-8e0e-0299574bd813">

---

<img width="292" alt="image" src="https://github.com/user-attachments/assets/7df5661d-1e77-4a0a-9897-8d9b197378dd">

---

<img width="712" alt="image" src="https://github.com/user-attachments/assets/14d8c369-23e5-4a56-9f2d-e091b17c3353">

---

## After

<img width="409" alt="image" src="https://github.com/user-attachments/assets/fff699f7-0576-4b3b-a6b7-67e2995115d1">

---

<img width="158" alt="image" src="https://github.com/user-attachments/assets/c0115177-74fd-4f79-b4f6-ba4208392672">

---

<img width="678" alt="image" src="https://github.com/user-attachments/assets/ef1691be-cede-4789-bb39-8d8a48edeaeb">
