### PR TITLE
All content finder: Show filters based on actual facets

### DIFF
--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -1,0 +1,7 @@
+<%= render "components/filter_section", {
+  heading_text: date_facet.name,
+  visually_hidden_heading_prefix: "Filter by",
+  id: "facet_date_#{date_facet.key}"
+} do %>
+  TODO: Date facet
+<% end %>

--- a/app/views/finders/all_content_finder_facets/_hidden_clearable_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_hidden_clearable_facet.html.erb
@@ -1,0 +1,1 @@
+<%# TODO: Hidden clearable facet %>

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -1,0 +1,7 @@
+<%= render "components/filter_section", {
+  heading_text: option_select_facet.name,
+  visually_hidden_heading_prefix: "Filter by",
+  id: "facet_option_select_#{option_select_facet.key}"
+} do %>
+  TODO: Option select facet
+<% end %>

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -1,0 +1,7 @@
+<%= render "components/filter_section", {
+  heading_text: taxon_facet.name,
+  visually_hidden_heading_prefix: "Filter by",
+  id: "facet_taxon_#{taxon_facet.key}"
+} do %>
+  TODO: Taxon facet
+<% end %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -48,31 +48,12 @@
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
         } do %>
-          <%= render "components/filter_section", {
-            open: true,
-            heading_text: "Filter 1"
-          } do %>
-            <span>filter section content</span>
-          <% end %>
-
-          <%= render "components/filter_section", {
-            status_text: "1 Selected",
-            heading_text: "Filter 2"
-          } do %>
-            <span>filter section content</span>
-          <% end %>
-
-          <%= render "components/filter_section", {
-            heading_text: "Filter 3"
-          } do %>
-            <span>filter section content</span>
-          <% end %>
-
-          <%= render "components/filter_section", {
-            status_text: "1 Selected",
-            heading_text: "Filter 4"
-          } do %>
-            <span>filter section content</span>
+          <% facets.each_with_index_and_count do |facet, index, count| %>
+            <%=
+              render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
+                object: facet,
+                locals: { index:, count: }
+            %>
           <% end %>
         <% end %>
 

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -12,6 +12,11 @@ Feature: All content finder ("site search")
     Then I can see results for my search
     And I can see how many results there are
 
+  Scenario: Filtering results
+    When I search all content for "how to walk silly"
+    And I open the filter panel
+    Then I can see a filter section for every visible facet on the all content finder
+
   Scenario: Spelling suggestion
     When I search all content for "drving"
     Then I see a "driving" spelling suggestion

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -10,3 +10,19 @@ end
 Then("I can see how many results there are") do
   expect(page).to have_selector("h2", text: "2 results")
 end
+
+When("I open the filter panel") do
+  click_on "Filter and sort"
+end
+
+Then("I can see a filter section for every visible facet on the all content finder") do
+  # These are visible filter types and should have a section
+  expect(page).to have_selector("h2", text: "Filter by Topic")
+  expect(page).to have_selector("h2", text: "Filter by Type")
+  expect(page).to have_selector("h2", text: "Filter by Updated")
+
+  # These are hidden clearable filters and should not have a section
+  expect(page).not_to have_selector("h2", text: "Filter by Organisation")
+  expect(page).not_to have_selector("h2", text: "Filter by World location")
+  expect(page).not_to have_selector("h2", text: "Filter by Topical event")
+end


### PR DESCRIPTION
> [!NOTE]
> The view being updated by this PR is behind a feature flag and not yet visible to users.

This uses the finder's facets to display sections in the filter panel, rather than the current hardcoded ones.