### PR TITLE
Update `govuk_publishing_components` to 43.4.1; fix GA4 spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (43.1.1)
+    govuk_publishing_components (43.4.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -545,7 +545,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.3.7)
-    rouge (4.3.0)
+    rouge (4.4.0)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.2)

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -58,7 +58,7 @@ describe('GA4 finder change tracker', function () {
 
     input = document.createElement('input')
     input.setAttribute('type', 'search')
-    input.value = 'Hello world my postcode is SW1A 0AA. My birthday is 1970-01-01. My email is email@example.com'
+    input.value = 'Hello world my postcode is SW1A 0AA. My email is email@example.com'
 
     inputParent.appendChild(input)
     form.appendChild(inputParent)
@@ -67,7 +67,7 @@ describe('GA4 finder change tracker', function () {
 
     expected.event_data.event_name = 'search'
     expected.event_data.url = window.location.pathname
-    expected.event_data.text = 'hello world my postcode is [postcode]. my birthday is [date]. my email is [email]'
+    expected.event_data.text = 'hello world my postcode is [postcode]. my email is [email]'
     expected.event_data.section = 'Search'
     expected.event_data.action = 'search'
 


### PR DESCRIPTION
A recent change in `govuk_publishing_components` removed date redaction from search term updates: https://github.com/alphagov/govuk_publishing_components/pull/4223

The GA4 finder tracking spec additionally tests this behaviour, so was failing when the gem was bumped.
