### PR TITLE
Filter summary: Add bottom border

### DIFF
--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,5 +1,10 @@
 @import "govuk_publishing_components/individual_component_support";
 
+.app-c-filter-summary {
+  padding-bottom: govuk-spacing(4);
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
 .app-c-filter-summary__heading {
   display: block;
   margin-bottom: govuk-spacing(2);

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -62,7 +62,6 @@
           clear_all_text: "Clear all filters",
           heading_level: 3,
           heading_text: "Selected filters",
-          margin_bottom: 2,
           filters: [
             {
               label: "Filter 1",


### PR DESCRIPTION
This adds a bottom border to the filter summary now that the document list no longer comes with a top border.

### Before

<img width="729" alt="image" src="https://github.com/user-attachments/assets/809090eb-d3a3-4028-901a-cc6ba54b1f30">

### After

<img width="697" alt="image" src="https://github.com/user-attachments/assets/12687682-a997-4b04-9592-dd92480a7aa0">
