### PR TITLE
Assorted new search UI tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -53,7 +53,3 @@
   text-align: right;
   @include govuk-font(16, $weight: regular);
 }
-
-.app-c-filter-section__content {
-  padding: govuk-spacing(2) 0;
-}

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -22,9 +22,10 @@
 .app-c-filter-summary__remove-filter {
   border: 1px solid $govuk-border-colour;
   border-radius: govuk-em(5, 16px);
-  padding: govuk-spacing(2);
+  padding: govuk-spacing(1) govuk-spacing(2);
   text-decoration: none;
   display: flex;
+  align-items: center;
   color: $govuk-text-colour;
   background-color: govuk-colour("light-grey");
   @include govuk-font(16);
@@ -43,14 +44,9 @@
   }
 
   &::before {
+    margin-top: 1px;
     content: "\00d7";
     padding-right: govuk-spacing(1);
-    vertical-align: top;
-    line-height: 1;
     font-size: 22px;
   }
-}
-
-.app-c-filter-summary__remove-filter-text {
-  vertical-align: middle;
 }

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -21,24 +21,24 @@
         <% heading_text %>
       <% end %>
     <% end %>
+
     <ul class="app-c-filter-summary__remove-filters">
-    <% filters.each do |filter| %>
-      <li>
-        <%= content_tag("a", class: "app-c-filter-summary__remove-filter", href: "#{filter[:remove_href]}") do %>
-          <span class="app-c-filter-summary__remove-filter-text">
-            <span class="govuk-visually-hidden"><%= filter[:visually_hidden_prefix] %></span>
-            <%= filter[:label] %>: <%= filter[:value] %>
-          </span>
-        <% end %>
-      </li>
-    <% end %>
-    </ul>
-    <% if clear_all_text.present? && clear_all_href.present? %>
-      <%= tag.div do %>
-        <%= content_tag("a", class: "app-c-filter-summary__clear-filters govuk-link", href: "#{clear_all_href}") do %>
-          <%= clear_all_text %>
-        <% end %>
+      <% filters.each do |filter| %>
+        <li>
+          <%= link_to filter[:remove_href], class: "app-c-filter-summary__remove-filter" do %>
+            <span class="app-c-filter-summary__remove-filter-text">
+              <span class="govuk-visually-hidden"><%= filter[:visually_hidden_prefix] %></span>
+              <%= filter[:label] %>: <%= filter[:value] %>
+            </span>
+          <% end %>
+        </li>
       <% end %>
+    </ul>
+
+    <% if clear_all_text.present? && clear_all_href.present? %>
+      <div>
+        <%= link_to clear_all_text, clear_all_href, class: "app-c-filter-summary__clear-filters govuk-link" %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -37,7 +37,7 @@
 
     <% if clear_all_text.present? && clear_all_href.present? %>
       <div>
-        <%= link_to clear_all_text, clear_all_href, class: "app-c-filter-summary__clear-filters govuk-link" %>
+        <%= link_to clear_all_text, clear_all_href, class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
- Remove spacing on filter section content
- Tidy up filter summary component ERB
- Filter summary clear all link should not have visited state
- Tweak filter summary tag styling

## Remove spacing on filter section content
### Before
<img width="668" alt="image" src="https://github.com/user-attachments/assets/d1d27d84-466a-42ef-b9ee-a120e29c4e03">

### After
<img width="674" alt="image" src="https://github.com/user-attachments/assets/3d3e613a-f19e-4869-9c69-c368b0369eb3">

## Filter tag styling tweaks
### Before
<img width="614" alt="image" src="https://github.com/user-attachments/assets/6762168d-1491-4189-924b-8f039f82e5ee">

### After
<img width="605" alt="image" src="https://github.com/user-attachments/assets/d8c5f62b-c732-4741-9397-a19ee7b9749e">
