### PR TITLE
Fix tech debt in facet model specs

### DIFF
--- a/spec/models/checkbox_facet_spec.rb
+++ b/spec/models/checkbox_facet_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe CheckboxFacet do
+  subject { described_class.new(facet_data, value) }
+
   let(:facet_data) do
     {
       "type" => "checkbox",
@@ -15,7 +17,7 @@ describe CheckboxFacet do
 
   describe "#sentence_fragment" do
     context "single value" do
-      subject { described_class.new(facet_data, "yes") }
+      let(:value) { "yes" }
 
       specify do
         expect(subject.sentence_fragment["preposition"]).to eql("of value")
@@ -26,7 +28,7 @@ describe CheckboxFacet do
 
     context "when multiple values are provided" do
       context "when a value is provided" do
-        subject { described_class.new(facet_data, true) }
+        let(:value) { true }
 
         specify do
           expect(subject.sentence_fragment["preposition"]).to eql("of value")
@@ -36,7 +38,7 @@ describe CheckboxFacet do
       end
 
       context "when no value is provided" do
-        subject { described_class.new(facet_data, nil) }
+        let(:value) { nil }
 
         specify { expect(subject.sentence_fragment).to be_nil }
       end
@@ -45,25 +47,21 @@ describe CheckboxFacet do
 
   describe "#checked?" do
     context "checkbox is selected" do
-      subject { described_class.new(facet_data, "yes") }
+      let(:value) { "yes" }
 
-      specify do
-        expect(subject.is_checked?).to be(true)
-      end
+      it { is_expected.to be_is_checked }
     end
 
     context "checkbox is not selected" do
-      subject { described_class.new(facet_data, nil) }
+      let(:value) { nil }
 
-      specify do
-        expect(subject.is_checked?).to be(false)
-      end
+      it { is_expected.not_to be_is_checked }
     end
   end
 
   describe "#query_params" do
     context "checkbox is selected" do
-      subject { described_class.new(facet_data, "yes") }
+      let(:value) { "yes" }
 
       specify do
         expect(subject.query_params).to eql("show_extra_information" => "selectedvalue")
@@ -71,7 +69,7 @@ describe CheckboxFacet do
     end
 
     context "checkbox is not selected" do
-      subject { described_class.new(facet_data, nil) }
+      let(:value) { nil }
 
       specify do
         expect(subject.query_params).to eql({})

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe DateFacet do
+  subject { described_class.new(facet_data, value) }
+
   let(:facet_data) do
     {
       "type" => "date",
@@ -12,8 +14,6 @@ describe DateFacet do
 
   describe "#sentence_fragment" do
     context "single date value" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) { { from: "22/09/1988" } }
 
       specify do
@@ -24,8 +24,6 @@ describe DateFacet do
     end
 
     context "6 digit date value" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) { { to: "22/09/14" } }
 
       specify do
@@ -36,8 +34,6 @@ describe DateFacet do
     end
 
     context "multiple date values" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) do
         {
           "from" => "22/09/1988",
@@ -56,8 +52,6 @@ describe DateFacet do
 
   describe "#query_params" do
     context "multiple date values" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) do
         {
           "from" => "22/09/1988",

--- a/spec/models/hidden_clearable_facet_spec.rb
+++ b/spec/models/hidden_clearable_facet_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe HiddenClearableFacet do
+  subject { described_class.new(facet_data, value) }
+
   let(:allowed_values) do
     [
       {
@@ -27,11 +29,9 @@ describe HiddenClearableFacet do
     }
   end
 
-  let(:facet_class) { described_class }
-
   describe "#sentence_fragment" do
     context "single value" do
-      subject { facet_class.new(facet_data, %w[allowed-value-1]) }
+      let(:value) { %w[allowed-value-1] }
 
       specify do
         expect(subject.sentence_fragment["preposition"]).to eql("of value")
@@ -41,7 +41,7 @@ describe HiddenClearableFacet do
     end
 
     context "multiple values" do
-      subject { facet_class.new(facet_data, %w[allowed-value-1 allowed-value-2]) }
+      let(:value) { %w[allowed-value-1 allowed-value-2] }
 
       specify do
         expect(subject.sentence_fragment["preposition"]).to eql("of value")
@@ -54,7 +54,7 @@ describe HiddenClearableFacet do
     end
 
     context "disallowed values" do
-      subject { facet_class.new(facet_data, ["disallowed-value-1, disallowed-value-2"]) }
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
 
       specify { expect(subject.sentence_fragment).to be_nil }
     end
@@ -62,25 +62,21 @@ describe HiddenClearableFacet do
 
   describe "#has_filters?" do
     context "no value" do
-      subject { facet_class.new(facet_data, nil) }
+      let(:value) { nil }
 
-      specify do
-        expect(subject.has_filters?).to be(false)
-      end
+      it { is_expected.not_to have_filters }
     end
 
     context "has a value" do
-      subject { facet_class.new(facet_data, %w[allowed-value-1]) }
+      let(:value) { %w[allowed-value-1] }
 
-      specify do
-        expect(subject.has_filters?).to be(true)
-      end
+      it { is_expected.to have_filters }
     end
   end
 
   describe "#query_params" do
     context "value selected" do
-      subject { described_class.new(facet_data, "allowed-value-1") }
+      let(:value) { "allowed-value-1" }
 
       specify do
         expect(subject.query_params).to eql("test_facet" => %w[allowed-value-1])

--- a/spec/models/hidden_facet_spec.rb
+++ b/spec/models/hidden_facet_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe HiddenFacet do
-  subject { facet_class.new(facet_data, nil) }
+  subject { described_class.new(facet_data, value) }
+
+  let(:value) { nil }
 
   let(:facet_data) do
     {
@@ -12,8 +14,6 @@ describe HiddenFacet do
     }
   end
 
-  let(:facet_class) { described_class }
-
   describe "#to_partial_path" do
     context "with a Facet" do
       specify { expect(subject.to_partial_path).to eql("hidden_facet") }
@@ -22,16 +22,18 @@ describe HiddenFacet do
 
   describe "#query_params" do
     context "value selected" do
+      let(:value) { "hidden_value" }
+
       it "returns the value" do
-        facet = described_class.new(facet_data, "hidden_value")
-        expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
+        expect(subject.query_params).to eql("test_facet" => %w[hidden_value])
       end
     end
 
     context "invalid value selected" do
+      let(:value) { "not_allowed_value" }
+
       it "removes the invalid values" do
-        facet = described_class.new(facet_data, "not_allowed_value")
-        expect(facet.query_params).to eql("test_facet" => [])
+        expect(subject.query_params).to eql("test_facet" => [])
       end
     end
 
@@ -44,10 +46,10 @@ describe HiddenFacet do
           "allowed_values" => [],
         }
       end
+      let(:value) { "hidden_value" }
 
       it "returns the values without validation" do
-        facet = described_class.new(facet_data, "hidden_value")
-        expect(facet.query_params).to eql("test_facet" => %w[hidden_value])
+        expect(subject.query_params).to eql("test_facet" => %w[hidden_value])
       end
     end
   end

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
 describe KeywordFacet do
-  let(:query) { "Happy Christmas" }
-  let(:query_with_quotes) { "\"Merry Christmas\"" }
-  let(:query_with_multiple_quotes) { "\"Merry Christmas\"\" Happy Birthday\" i'm 100 today" }
+  subject { described_class.new(query) }
+
+  let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
 
   describe "#sentence_fragment" do
     context "keywords without quotes" do
-      subject { described_class.new(query) }
+      let(:query) { "Happy Christmas" }
 
       let(:first_word) { subject.sentence_fragment["values"].first }
       let(:second_word) { subject.sentence_fragment["values"].second }
@@ -23,9 +23,7 @@ describe KeywordFacet do
     end
 
     context "keywords with quotes" do
-      subject { described_class.new(query_with_quotes) }
-
-      let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
+      let(:query) { "\"Merry Christmas\"" }
 
       specify do
         expect(subject.sentence_fragment["preposition"]).to eql("containing")
@@ -34,9 +32,7 @@ describe KeywordFacet do
     end
 
     context "keywords with multiple quotes" do
-      subject { described_class.new(query_with_multiple_quotes) }
-
-      let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
+      let(:query) { "\"Merry Christmas\"\" Happy Birthday\" i'm 100 today" }
 
       specify do
         expect(subject.sentence_fragment["preposition"]).to eql("containing")
@@ -45,7 +41,7 @@ describe KeywordFacet do
     end
 
     context "without any keywords" do
-      subject { described_class.new }
+      let(:query) { nil }
 
       specify do
         expect(subject.sentence_fragment).to be_nil
@@ -55,7 +51,7 @@ describe KeywordFacet do
 
   describe "#query_params" do
     context "value selected" do
-      subject { described_class.new("keyword") }
+      let(:query) { "keyword" }
 
       specify do
         expect(subject.query_params).to eql("keywords" => %w[keyword])

--- a/spec/models/radio_facet_for_multiple_filters_spec.rb
+++ b/spec/models/radio_facet_for_multiple_filters_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe RadioFacetForMultipleFilters do
+  subject { described_class.new(facet_data, value, filter_hashes) }
+
   let(:facet_data) do
     {
       "type" => "radio_facet",
@@ -40,7 +42,7 @@ describe RadioFacetForMultipleFilters do
 
   describe "#options" do
     context "valid value" do
-      subject { described_class.new(facet_data, "value_1", filter_hashes) }
+      let(:value) { "value_1" }
 
       it "sets the options, selecting the correct value" do
         expect(subject.options).to eq([
@@ -64,7 +66,7 @@ describe RadioFacetForMultipleFilters do
     end
 
     context "invalid value" do
-      subject { described_class.new(facet_data, "something", filter_hashes) }
+      let(:value) { "something" }
 
       it "sets the options, selecting the default value" do
         expect(subject.options).to include(
@@ -78,7 +80,7 @@ describe RadioFacetForMultipleFilters do
 
   describe "#query_params" do
     context "value selected" do
-      subject { described_class.new(facet_data, "value_1", filter_hashes) }
+      let(:value) { "value_1" }
 
       specify do
         expect(subject.query_params).to eq("type" => "value_1")

--- a/spec/models/radio_facet_spec.rb
+++ b/spec/models/radio_facet_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe RadioFacet do
+  subject { described_class.new(facet_data, "selected_value") }
+
   let(:facet_data) do
     {
       "type" => "radio_facet",
@@ -12,12 +14,8 @@ describe RadioFacet do
   end
 
   describe "#query_params" do
-    context "value selected" do
-      subject { described_class.new(facet_data, "selected_value") }
-
-      specify do
-        expect(subject.query_params).to eql("type" => "selected_value")
-      end
+    specify do
+      expect(subject.query_params).to eql("type" => "selected_value")
     end
   end
 end

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -3,6 +3,8 @@ require "spec_helper"
 describe TaxonFacet do
   include TaxonomySpecHelper
 
+  subject { described_class.new(facet_data, allowed_values) }
+
   before do
     Rails.cache.clear
     topic_taxonomy_has_taxons([
@@ -89,9 +91,7 @@ describe TaxonFacet do
     end
 
     context "disallowed value selected" do
-      subject { described_class.new(facet_data, disallowed_values) }
-
-      let(:disallowed_values) do
+      let(:allowed_values) do
         {
           "level_one_taxon" => "disallowed-value-1",
           "level_two_taxon" => "disallowed-value-2",

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe TopicalFacet do
+  subject { described_class.new(facet_data, value) }
+
   let(:facet_data) do
     {
       "type" => "topical",
@@ -20,8 +22,6 @@ describe TopicalFacet do
 
   describe "#sentence_fragment" do
     context "single value" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) { %w[open] }
 
       specify do
@@ -32,8 +32,6 @@ describe TopicalFacet do
     end
 
     context "multiple values" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) { %w[open closed] }
 
       specify do
@@ -47,8 +45,6 @@ describe TopicalFacet do
     end
 
     context "disallowed values" do
-      subject { described_class.new(facet_data, value) }
-
       let(:value) { %w[disallowed-value-1 disallowed-value-2] }
 
       specify { expect(subject.sentence_fragment).to be_nil }


### PR DESCRIPTION
- Ensure consistent and correct use of `subject` and `described_class`
- Remove excessive redefining of `subject` where only a single property of subject changes
- Ensure consistent use of `let` instead of manual local variable assigment
- Change predicate method tests to be idiomatic `expect(...).to be/have_...`
