### PR TITLE
Change facet visibility terminology

### DIFF
--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -6,7 +6,7 @@ class FacetsIterator
     @user_visible_facets = @facets.select(&:user_visible?)
   end
 
-  def each_with_index_and_count
+  def each_with_visible_index_and_count
     @facets.each do |facet|
       yield facet, @user_visible_facets.index(facet), @user_visible_facets.count
     end

--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -3,12 +3,12 @@ class FacetsIterator
 
   def initialize(facets)
     @facets = facets
-    @facets_with_ga4_section = @facets.select(&:has_ga4_section?)
+    @user_visible_facets = @facets.select(&:user_visible?)
   end
 
   def each_with_index_and_count
     @facets.each do |facet|
-      yield facet, @facets_with_ga4_section.index(facet), @facets_with_ga4_section.count
+      yield facet, @user_visible_facets.index(facet), @user_visible_facets.count
     end
   end
 end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -64,10 +64,6 @@ class Facet
     nil
   end
 
-  def has_ga4_section?
-    !ga4_section.nil?
-  end
-
 private
 
   def and_word_connectors

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -3,6 +3,11 @@ class Facet
     @facet = facet
   end
 
+  # Whether or not a facet is visible to the user (true by default except for hidden facets)
+  def user_visible?
+    true
+  end
+
   def key
     facet["key"]
   end

--- a/app/models/hidden_clearable_facet.rb
+++ b/app/models/hidden_clearable_facet.rb
@@ -4,6 +4,10 @@ class HiddenClearableFacet < FilterableFacet
     super(facet)
   end
 
+  def user_visible?
+    false
+  end
+
   def sentence_fragment
     return nil unless selected_values.any?
 

--- a/app/models/hidden_facet.rb
+++ b/app/models/hidden_facet.rb
@@ -4,6 +4,10 @@ class HiddenFacet < FilterableFacet
     super(facet)
   end
 
+  def user_visible?
+    false
+  end
+
   def sentence_fragment
     return nil unless has_filters?
 

--- a/app/models/keyword_facet.rb
+++ b/app/models/keyword_facet.rb
@@ -3,6 +3,10 @@ class KeywordFacet
     @keywords = keywords
   end
 
+  def user_visible?
+    false
+  end
+
   def sentence_fragment
     return nil unless has_filters?
 

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.each_with_index_and_count do |facet, index, count| %>
+          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
             <%= render partial: facet, object: facet, locals: { index:, count: } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -48,7 +48,7 @@
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
         } do %>
-          <% facets.each_with_index_and_count do |facet, index, count| %>
+          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
             <%=
               render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
                 object: facet,

--- a/spec/lib/facets_iterator_spec.rb
+++ b/spec/lib/facets_iterator_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 RSpec.describe FacetsIterator do
   subject(:facets_iterator) { described_class.new(facets) }
 
-  let(:visible_facet) { instance_double(Facet, has_ga4_section?: true) }
-  let(:another_visible_facet) { instance_double(Facet, has_ga4_section?: true) }
-  let(:hidden_facet) { instance_double(Facet, has_ga4_section?: false) }
+  let(:visible_facet) { instance_double(Facet, user_visible?: true) }
+  let(:another_visible_facet) { instance_double(Facet, user_visible?: true) }
+  let(:hidden_facet) { instance_double(Facet, user_visible?: false) }
 
   let(:facets) { [visible_facet, hidden_facet, another_visible_facet] }
 

--- a/spec/lib/facets_iterator_spec.rb
+++ b/spec/lib/facets_iterator_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe FacetsIterator do
+  subject(:facets_iterator) { described_class.new(facets) }
+
+  let(:visible_facet) { instance_double(Facet, has_ga4_section?: true) }
+  let(:another_visible_facet) { instance_double(Facet, has_ga4_section?: true) }
+  let(:hidden_facet) { instance_double(Facet, has_ga4_section?: false) }
+
+  let(:facets) { [visible_facet, hidden_facet, another_visible_facet] }
+
+  describe "#each_with_index_and_count" do
+    it "yields each facet with its index in @facets_with_ga4_section and the count of facets with GA4 section" do
+      expect { |block| facets_iterator.each_with_index_and_count(&block) }
+        .to yield_successive_args(
+          [visible_facet, 0, 2],
+          [hidden_facet, nil, 2],
+          [another_visible_facet, 1, 2],
+        )
+    end
+  end
+end

--- a/spec/lib/facets_iterator_spec.rb
+++ b/spec/lib/facets_iterator_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe FacetsIterator do
 
   let(:facets) { [visible_facet, hidden_facet, another_visible_facet] }
 
-  describe "#each_with_index_and_count" do
-    it "yields each facet with its index in @facets_with_ga4_section and the count of facets with GA4 section" do
-      expect { |block| facets_iterator.each_with_index_and_count(&block) }
+  describe "#each_with_visible_index_and_count" do
+    it "yields each facet with its index (if visible) and the total count of visible facets" do
+      expect { |block| facets_iterator.each_with_visible_index_and_count(&block) }
         .to yield_successive_args(
           [visible_facet, 0, 2],
           [hidden_facet, nil, 2],

--- a/spec/models/checkbox_facet_spec.rb
+++ b/spec/models/checkbox_facet_spec.rb
@@ -14,6 +14,9 @@ describe CheckboxFacet do
       "preposition" => "of value",
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.to be_user_visible }
 
   describe "#sentence_fragment" do
     context "single value" do

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -11,6 +11,9 @@ describe DateFacet do
       "preposition" => "occurred",
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.to be_user_visible }
 
   describe "#sentence_fragment" do
     context "single date value" do

--- a/spec/models/hidden_clearable_facet_spec.rb
+++ b/spec/models/hidden_clearable_facet_spec.rb
@@ -28,6 +28,9 @@ describe HiddenClearableFacet do
       "allowed_values" => allowed_values,
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.not_to be_user_visible }
 
   describe "#sentence_fragment" do
     context "single value" do

--- a/spec/models/hidden_facet_spec.rb
+++ b/spec/models/hidden_facet_spec.rb
@@ -3,8 +3,6 @@ require "spec_helper"
 describe HiddenFacet do
   subject { described_class.new(facet_data, value) }
 
-  let(:value) { nil }
-
   let(:facet_data) do
     {
       "key" => "test_facet",
@@ -13,6 +11,9 @@ describe HiddenFacet do
       "allowed_values" => [{ "value" => "hidden_value" }],
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.not_to be_user_visible }
 
   describe "#to_partial_path" do
     context "with a Facet" do

--- a/spec/models/keyword_facet_spec.rb
+++ b/spec/models/keyword_facet_spec.rb
@@ -4,6 +4,9 @@ describe KeywordFacet do
   subject { described_class.new(query) }
 
   let(:labels) { subject.sentence_fragment["values"].map { |v| v["label"] } }
+  let(:query) { nil }
+
+  it { is_expected.not_to be_user_visible }
 
   describe "#sentence_fragment" do
     context "keywords without quotes" do

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -29,6 +29,9 @@ describe OptionSelectFacet do
       "allowed_values" => allowed_values,
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.to be_user_visible }
 
   describe "#sentence_fragment" do
     context "single value" do

--- a/spec/models/radio_facet_for_multiple_filters_spec.rb
+++ b/spec/models/radio_facet_for_multiple_filters_spec.rb
@@ -13,6 +13,8 @@ describe RadioFacetForMultipleFilters do
     }
   end
 
+  let(:value) { nil }
+
   let(:filter_hashes) do
     [
       {
@@ -39,6 +41,8 @@ describe RadioFacetForMultipleFilters do
       },
     ]
   end
+
+  it { is_expected.to be_user_visible }
 
   describe "#options" do
     context "valid value" do

--- a/spec/models/radio_facet_spec.rb
+++ b/spec/models/radio_facet_spec.rb
@@ -13,6 +13,8 @@ describe RadioFacet do
     }
   end
 
+  it { is_expected.to be_user_visible }
+
   describe "#query_params" do
     specify do
       expect(subject.query_params).to eql("type" => "selected_value")

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -31,6 +31,8 @@ describe TaxonFacet do
     }
   end
 
+  it { is_expected.to be_user_visible }
+
   describe "#topics" do
     subject { described_class.new(facet_data, allowed_values) }
 

--- a/spec/models/topical_facet_spec.rb
+++ b/spec/models/topical_facet_spec.rb
@@ -19,6 +19,9 @@ describe TopicalFacet do
       },
     }
   end
+  let(:value) { nil }
+
+  it { is_expected.to be_user_visible }
 
   describe "#sentence_fragment" do
     context "single value" do


### PR DESCRIPTION
Currently, facets implement a `Facet#has_ga4_section?` method that maps 1:1 onto whether a facet is visible to the user, or hidden (because every visible facet should be tracked in GA4).

This change:
- Adds an explicit and more obvious `Facet#user_visible?` method instead, and removes `#has_ga4_section?`
- Renames `FacetsIterator#each_with_index_and_count` to `#each_with_visible_index_and_count` to more accurately describe what it does
- Adds tests to the currently untested `FacetIterator` and visibility methods