### PR TITLE
requested design tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -32,7 +32,8 @@
 
 .app-c-filter-panel__count {
   margin: 0;
-  @include govuk-font(19, $weight: regular);
+  color: $govuk-secondary-text-colour;
+  @include govuk-font(16, $weight: regular);
 }
 
 .app-c-filter-panel__button {

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,7 +1,7 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-filter-summary {
-  padding-bottom: govuk-spacing(4);
+  padding-bottom: govuk-spacing(3);
   border-bottom: 1px solid $govuk-border-colour;
 }
 

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -37,6 +37,7 @@
             type: 'search',
             value: result_set_presenter.user_supplied_keywords,
             disable_corrections: true,
+            margin_bottom: 4,
           } %>
         </div>
 


### PR DESCRIPTION
requested design tweaks to new finder frontend taken from https://docs.google.com/document/d/1w2ZcC55gytVYN7otNhNneZMUpo9yhV1DfU1JR1qtzc4/edit?pli=1

- Clear all filters margin - Make margin bottom: 15px
- Make search bar margin-bottom: 20px
- Make results count 16px and secondary colour

