### PR TITLE
New all content finder UI: Implement facets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -44,3 +44,16 @@ if ($form && $results) {
     $atomAutodiscoveryLink: $atomAutodiscoveryLink
   })
 }
+
+// For most finders, the taxonomy select is set up in the legacy `LiveSearch` module. We are not
+// using that module in the new all content finder UI, so need to set it up separately.
+var $allContentFinderTaxonomySelect = document.querySelector('.js-all-content-finder-taxonomy-select')
+if ($allContentFinderTaxonomySelect) {
+  // eslint-disable-next-line no-new
+  var taxonomySelect = new GOVUK.TaxonomySelect({ $el: $allContentFinderTaxonomySelect })
+  taxonomySelect.update()
+
+  $allContentFinderTaxonomySelect.addEventListener('change', function () {
+    taxonomySelect.update()
+  })
+}

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -4,6 +4,8 @@
   id: "facet_date_#{date_facet.key}",
   index_section: index,
   index_section_count: count,
+  # Note date is the only validated facet, so if there is an error, it'll be here
+  open: @search_query.invalid?
 } do %>
   <%= render "govuk_publishing_components/components/input", {
     label: {

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -5,5 +5,31 @@
   index_section: index,
   index_section_count: count,
 } do %>
-  TODO: Date facet
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: date_facet.name + " after"
+    },
+    name: date_facet.key + "[from]",
+    id: date_facet.key + "[from]",
+    value: date_facet.user_supplied_from_date,
+    hint: "For example, 2005 or 21/11/2014",
+    error_message: date_facet.error_message_from(@search_query),
+    data: {
+      ga4_section: date_facet.name + " after"
+    }
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: date_facet.name + " before"
+    },
+    name: date_facet.key + "[to]",
+    id: date_facet.key + "[to]",
+    value: date_facet.user_supplied_to_date,
+    hint: "For example, 2005 or 21/11/2014",
+    error_message: date_facet.error_message_to(@search_query),
+    data: {
+      ga4_section: date_facet.name + " before"
+    }
+  } %>
 <% end %>

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -1,3 +1,5 @@
+<% add_gem_component_stylesheet("checkboxes") %>
+
 <%= render "components/filter_section", {
   heading_text: option_select_facet.name,
   visually_hidden_heading_prefix: "Filter by",
@@ -5,5 +7,12 @@
   index_section: index,
   index_section_count: count,
 } do %>
-  TODO: Option select facet
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "#{option_select_facet.key}[]",
+    heading: option_select_facet.name,
+    items: option_select_facet.options(nil, option_select_facet.key),
+    visually_hide_heading: true,
+    no_hint_text: true,
+    small: true,
+  } %>
 <% end %>

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -5,5 +5,21 @@
   index_section: index,
   index_section_count: count,
 } do %>
-  TODO: Taxon facet
+  <div class="js-all-content-finder-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">
+    <%= render "govuk_publishing_components/components/select", {
+      id: 'level_one_taxon',
+      label: "Topic",
+      full_width: true,
+      options: taxon_facet.topics
+    } %>
+
+    <div class="js-required govuk-form-group" data-ga4-section="Sub-topic">
+      <%= render "govuk_publishing_components/components/select", {
+        id: 'level_two_taxon',
+        label: "Sub-topic",
+        full_width: true,
+        options: taxon_facet.sub_topics
+      } %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -48,6 +48,7 @@
         <%= render "components/filter_panel", {
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
+          open: @search_query.invalid?,
         } do %>
           <% facets.each_with_visible_index_and_count do |facet, index, count| %>
             <%=

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -17,6 +17,16 @@ Feature: All content finder ("site search")
     And I open the filter panel
     Then I can see a filter section for every visible facet on the all content finder
 
+  @javascript
+  Scenario: Making a search with filters
+    When I search all content for "chandeliers flickering"
+    And I open the filter panel
+    And I open the "Topic" filter section
+    And I select "Music" as the Topic
+    And I select "Best songs" as the Sub-topic
+    And I apply the filters
+    Then I can see filtered results
+
   Scenario: Changing the sort order of a search
     When I search all content for "dark gray all alone"
     And I open the filter panel

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -27,6 +27,9 @@ Feature: All content finder ("site search")
     And I open the "Type" filter section
     And I check the "Services" option
     And I check the "Research and statistics" option
+    And I open the "Updated" filter section
+    And I enter "1989" for "Updated after"
+    And I enter "13/12/1989" for "Updated before"
     And I apply the filters
     Then I can see filtered results
 

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -24,6 +24,9 @@ Feature: All content finder ("site search")
     And I open the "Topic" filter section
     And I select "Music" as the Topic
     And I select "Best songs" as the Sub-topic
+    And I open the "Type" filter section
+    And I check the "Services" option
+    And I check the "Research and statistics" option
     And I apply the filters
     Then I can see filtered results
 

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -41,6 +41,16 @@ Feature: All content finder ("site search")
     And I apply the filters
     Then I can see sorted results
 
+  @javascript
+  Scenario: Entering an incorrect date
+    When I search all content for "chandeliers flickering"
+    And I open the filter panel
+    And I open the "Updated" filter section
+    And I enter "-1" for "Updated before"
+    And I apply the filters
+    Then the filter panel is open by default
+    And I can see an error message "Enter a real date"
+
   Scenario: Spelling suggestion
     When I search all content for "drving"
     Then I see a "driving" spelling suggestion

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -23,7 +23,16 @@ Then(/^I am able to set search terms$/) do
 end
 
 Given(/^the all content finder exists$/) do
-  topic_taxonomy_has_taxons
+  topic_taxonomy_has_taxons([
+    FactoryBot.build(
+      :level_one_taxon_hash,
+      content_id: "131313",
+      title: "Music",
+      child_taxons: [
+        FactoryBot.build(:taxon_hash, content_id: "1989", title: "Best songs"),
+      ],
+    ),
+  ])
   content_store_has_all_content_finder
   stub_topical_events_api_request
   stub_world_locations_api_request
@@ -35,6 +44,7 @@ Given(/^the all content finder exists$/) do
   stub_search_api_request_with_misspelt_query
   stub_search_api_request_with_query
   stub_search_api_request_with_sorted_query
+  stub_search_api_request_with_filtered_query
 end
 
 Given(/^the new all content finder UI is (\w+)$/) do |state|

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -25,6 +25,10 @@ When(/^I select the "([^"]*)" option$/) do |option|
   choose option
 end
 
+When(/^I check the "([^"]*)" option$/) do |option|
+  check option, allow_label_click: true
+end
+
 When(/^I select "([^"]*)" as the (\S+)$/) do |item, from|
   select item, from:
 end

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -61,3 +61,11 @@ end
 Then("I can see sorted results") do
   expect(page).to have_link("Loving him was red")
 end
+
+Then("the filter panel is open by default") do
+  expect(page).to have_selector("button[aria-expanded='true']", text: "Filter and sort")
+end
+
+Then(/^I can see an error message "([^"]*)"$/) do |text|
+  expect(page).to have_selector(".govuk-error-message", text:, visible: :visible)
+end

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -33,6 +33,10 @@ When(/^I select "([^"]*)" as the (\S+)$/) do |item, from|
   select item, from:
 end
 
+When(/^I enter "([^"]*)" for "([^"]*)"$/) do |text, field|
+  fill_in field, with: text
+end
+
 Then("I can see filtered results") do
   expect(page).to have_link("Death by a thousand cuts")
 end

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -25,6 +25,14 @@ When(/^I select the "([^"]*)" option$/) do |option|
   choose option
 end
 
+When(/^I select "([^"]*)" as the (\S+)$/) do |item, from|
+  select item, from:
+end
+
+Then("I can see filtered results") do
+  expect(page).to have_link("Death by a thousand cuts")
+end
+
 When("I apply the filters") do
   click_on "Apply filters"
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -107,6 +107,23 @@ module DocumentHelper
     )
   end
 
+  def stub_search_api_request_with_filtered_query
+    stub_response(
+      hash_including("q" => "chandeliers flickering"),
+      %({ "results": [], "total": 0, "start": 0}),
+      including_v2: true,
+    )
+
+    stub_response(
+      hash_including(
+        "q" => "chandeliers flickering",
+        "filter_all_part_of_taxonomy_tree" => %w[131313 1989],
+      ),
+      filtered_documents_json,
+      including_v2: true,
+    )
+  end
+
   def stub_search_api_request_with_misspelt_query
     stub_response(hash_including("q" => "drving"), spelling_suggestions_json, including_v2: true)
   end
@@ -647,6 +664,25 @@ module DocumentHelper
           "document_type": "song",
           "link": "/red",
           "_id": "/red"
+        }
+      ],
+      "total": 1,
+      "start": 0,
+      "facets": {},
+      "suggested_queries": []
+    })
+  end
+
+  def filtered_documents_json
+    %({
+      "results": [
+        {
+          "title": "Death by a thousand cuts",
+          "public_timestamp": "2019-08-23",
+          "summary": "I can't pretend it's okay when it's not",
+          "document_type": "song",
+          "link": "/death-by-a-thousand-cuts",
+          "_id": "/death-by-a-thousand-cuts"
         }
       ],
       "total": 1,

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -118,6 +118,7 @@ module DocumentHelper
       hash_including(
         "q" => "chandeliers flickering",
         "filter_all_part_of_taxonomy_tree" => %w[131313 1989],
+        "filter_content_purpose_supergroup" => %w[research_and_statistics services],
       ),
       filtered_documents_json,
       including_v2: true,

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -119,6 +119,7 @@ module DocumentHelper
         "q" => "chandeliers flickering",
         "filter_all_part_of_taxonomy_tree" => %w[131313 1989],
         "filter_content_purpose_supergroup" => %w[research_and_statistics services],
+        "filter_public_timestamp" => "from:1989-01-01,to:1989-12-13",
       ),
       filtered_documents_json,
       including_v2: true,


### PR DESCRIPTION
This implements the remaining facets for the new "all content" finder UI.

For the most part, this reuses markup from the existing facets, but without the expandable sections or the JS support.

## Review app
https://finder-frontend-pr-3483.herokuapp.com/search/all

## UI changes
<img width="710" alt="image" src="https://github.com/user-attachments/assets/57481af0-1699-481c-8ae9-6409e2674b20">
