### PR TITLE
Implement filter summary

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -130,7 +130,7 @@ private
       value_hash: filter_params,
     ).facets.tap do |built_facets|
       if content_item.all_content_finder? && enable_new_all_content_finder_ui?
-        built_facets.prepend(SortFacet.new)
+        built_facets.prepend(SortFacet.new(content_item, filter_params))
       end
     end
   end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -66,7 +66,7 @@ private
 
   attr_reader :search_query
 
-  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets
+  helper_method :facet_tags, :i_am_a_topic_page_finder, :result_set_presenter, :content_item, :signup_links, :filter_params, :facets, :filters_presenter
 
   def redirect_to_destination
     @redirect = content_item.redirect
@@ -164,6 +164,10 @@ private
 
   def sort_presenter
     @sort_presenter ||= content_item.sorter_class.new(content_item, filter_params)
+  end
+
+  def filters_presenter
+    @filters_presenter ||= FiltersPresenter.new(facets, finder_url_builder)
   end
 
   def pagination_presenter

--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -1,5 +1,6 @@
 class FacetsIterator
-  delegate :select, :any?, to: :@facets
+  include Enumerable
+  delegate :each, to: :@facets
 
   def initialize(facets)
     @facets = facets

--- a/app/lib/hash_with_deep_except.rb
+++ b/app/lib/hash_with_deep_except.rb
@@ -1,0 +1,38 @@
+module HashWithDeepExcept
+  refine Hash do
+    # Allows removing arbitarily nested params from a hash, used for clearing specific filters from
+    # a user's search.
+    #
+    # For example, given:
+    #   { a: 1, b: { c: 2, d: 3 } }
+    # Removing
+    #   { b: { c: 2 } }
+    # would result in
+    #   { a: 1, b: { d: 3 } }
+    def deep_except(other)
+      each_with_object({}) do |(key, value), result|
+        if other.key?(key)
+          child = other[key]
+
+          if value.is_a?(Hash) && child.is_a?(Hash)
+            # Recursively remove nested values
+            nested_result = value.deep_except(child)
+            result[key] = nested_result unless nested_result.empty?
+          elsif value.is_a?(Array) && child.is_a?(Array)
+            result[key] = value - child
+          elsif child.is_a?(Array) && child == [value]
+            # Some parameters can be given both as an array and a single value (e.g. `organisation`),
+            # and should be removed if a single value is present that's equal to the only array
+            # element
+            #
+            # Skip this key-value pair, effectively removing it
+          elsif value != child
+            result[key] = value
+          end
+        else
+          result[key] = value
+        end
+      end
+    end
+  end
+end

--- a/app/lib/url_builder.rb
+++ b/app/lib/url_builder.rb
@@ -1,19 +1,29 @@
 # The UrlBuilder class is responsible for creating URLs to be rendered as
 # HTML links.
 class UrlBuilder
+  using HashWithDeepExcept
+
   def initialize(path, query_params = {})
     @path = path
     @query_params = query_params
   end
 
   def url(additional_params = {})
-    [
-      path,
-      query_params.merge(additional_params).to_query,
-    ].reject(&:blank?).join("?")
+    build_url(query_params.merge(additional_params))
+  end
+
+  def url_except(excepted_param)
+    build_url(query_params.deep_except(excepted_param))
   end
 
 private
 
   attr_reader :path, :query_params
+
+  def build_url(params)
+    [
+      path,
+      params.to_query,
+    ].reject(&:blank?).join("?")
+  end
 end

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -37,6 +37,17 @@ class DateFacet < FilterableFacet
     }
   end
 
+  def applied_filters
+    present_values.map do |type, date|
+      preposition = preposition_mappings[type]
+      {
+        name: "#{name} #{preposition}",
+        label: date.date.strftime("%e %B %Y"),
+        query_params: { key => { type => date.original_input } },
+      }
+    end
+  end
+
   def has_filters?
     present_values.any?
   end

--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -56,6 +56,10 @@ class Facet
     facet["allowed_values"] || []
   end
 
+  def applied_filters
+    []
+  end
+
   def query_params
     {}
   end

--- a/app/models/hidden_clearable_facet.rb
+++ b/app/models/hidden_clearable_facet.rb
@@ -23,6 +23,16 @@ class HiddenClearableFacet < FilterableFacet
     selected_values.any?
   end
 
+  def applied_filters
+    selected_values.map do |value|
+      {
+        name:,
+        label: value["label"],
+        query_params: { key => [value["value"]] },
+      }
+    end
+  end
+
   def query_params
     { key => selected_values.map { |value| value["value"] } }
   end

--- a/app/models/option_select_facet.rb
+++ b/app/models/option_select_facet.rb
@@ -36,6 +36,16 @@ class OptionSelectFacet < FilterableFacet
     selected_values.any?
   end
 
+  def applied_filters
+    selected_values.map do |value|
+      {
+        name:,
+        label: value["label"],
+        query_params: { key => [value["value"]] },
+      }
+    end
+  end
+
   def unselected?
     selected_values.empty?
   end

--- a/app/models/sort_facet.rb
+++ b/app/models/sort_facet.rb
@@ -27,6 +27,10 @@ class SortFacet
     false
   end
 
+  def applied_filters
+    []
+  end
+
   def filterable?
     true
   end

--- a/app/models/taxon_facet.rb
+++ b/app/models/taxon_facet.rb
@@ -36,6 +36,30 @@ class TaxonFacet < FilterableFacet
     selected_level_one_value.present?
   end
 
+  def applied_filters
+    return [] unless has_filters?
+
+    level_one_filter = {
+      name: "Topic",
+      label: selected_level_one_value[:text],
+      query_params: {
+        # Note that removing a topic should always remove the sub-topic too
+        LEVEL_ONE_TAXON_KEY => selected_level_one_value[:value],
+        LEVEL_TWO_TAXON_KEY => selected_level_two_value&.fetch(:value),
+      }.compact,
+    }
+
+    if selected_level_two_value
+      level_two_filter = {
+        name: "Sub-topic",
+        label: selected_level_two_value[:text],
+        query_params: { LEVEL_TWO_TAXON_KEY => selected_level_two_value[:value] },
+      }
+    end
+
+    [level_one_filter, level_two_filter].compact
+  end
+
   def query_params
     {
       LEVEL_ONE_TAXON_KEY => (selected_level_one_value || {})[:value],

--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -13,7 +13,7 @@ class FiltersPresenter
       {
         label: filter[:name],
         value: filter[:label],
-        remove_href: "#",
+        remove_href: finder_url_builder.url_except(filter[:query_params]),
         visually_hidden_prefix: "Remove filter",
       }
     end

--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -5,11 +5,18 @@ class FiltersPresenter
   end
 
   def any_filters?
-    false
+    facets.any?(&:has_filters?)
   end
 
   def summary_items
-    []
+    facets.flat_map(&:applied_filters).map do |filter|
+      {
+        label: filter[:name],
+        value: filter[:label],
+        remove_href: "#",
+        visually_hidden_prefix: "Remove filter",
+      }
+    end
   end
 
   def reset_url

--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -1,0 +1,22 @@
+class FiltersPresenter
+  def initialize(facets, finder_url_builder)
+    @facets = facets
+    @finder_url_builder = finder_url_builder
+  end
+
+  def any_filters?
+    false
+  end
+
+  def summary_items
+    []
+  end
+
+  def reset_url
+    "#"
+  end
+
+private
+
+  attr_reader :facets, :finder_url_builder
+end

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -49,6 +49,8 @@
           button_text: "Filter and sort",
           result_text: result_set_presenter.displayed_total,
           open: @search_query.invalid?,
+          show_reset_link: filters_presenter.any_filters?,
+          reset_link_href: filters_presenter.reset_url,
         } do %>
           <% facets.each_with_visible_index_and_count do |facet, index, count| %>
             <%=
@@ -59,32 +61,15 @@
           <% end %>
         <% end %>
 
-        <%= render "components/filter_summary", {
-          clear_all_href: "#",
-          clear_all_text: "Clear all filters",
-          heading_level: 3,
-          heading_text: "Selected filters",
-          filters: [
-            {
-              label: "Filter 1",
-              value: "Value 1",
-              remove_href: "#",
-              visually_hidden_prefix: "Remove filter"
-            },
-            {
-              label: "Filter 2",
-              value: "Value 2",
-              remove_href: "#",
-              visually_hidden_prefix: "Remove filter"
-            },
-            {
-              label: "Filter 3",
-              value: "Value 3",
-              remove_href: "#",
-              visually_hidden_prefix: "Remove filter"
-            }
-          ]
-        } %>
+        <% if filters_presenter.any_filters? %>
+          <%= render "components/filter_summary", {
+            clear_all_href: filters_presenter.reset_url,
+            clear_all_text: "Clear all filters",
+            heading_level: 3,
+            heading_text: "Selected filters",
+            filters: filters_presenter.summary_items,
+          } %>
+        <% end %>
 
         <% if result_set_presenter.total_count.positive? %>
           <%= render "govuk_publishing_components/components/document_list", {

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -41,6 +41,17 @@ Feature: All content finder ("site search")
     And I apply the filters
     Then I can see sorted results
 
+  Scenario: Removing a filter
+    When I search all content for "chandeliers flickering"
+    And I open the filter panel
+    And I open the "Topic" filter section
+    And I select "Music" as the Topic
+    And I select "Best songs" as the Sub-topic
+    And I apply the filters
+    And I click on the "Sub-topic: Best songs" filter tag
+    Then the "Sub-topic: Best songs" filter has been removed
+
+
   @javascript
   Scenario: Entering an incorrect date
     When I search all content for "chandeliers flickering"

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -37,6 +37,14 @@ When(/^I enter "([^"]*)" for "([^"]*)"$/) do |text, field|
   fill_in field, with: text
 end
 
+When(/I click on the "([^"]*)" filter tag/) do |filter|
+  click_on filter
+end
+
+Then(/the "([^"]*)" filter has been removed/) do |filter|
+  expect(page).not_to have_link(filter)
+end
+
 Then("I can see filtered results") do
   expect(page).to have_link("Death by a thousand cuts")
 end

--- a/spec/lib/hash_with_deep_except_spec.rb
+++ b/spec/lib/hash_with_deep_except_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe "Hash#deep_except" do
+  using HashWithDeepExcept
+
+  let(:hash) { { a: 1, b: { c: 2, d: 3 } } }
+
+  context "with top-level keys" do
+    it "removes specified keys" do
+      expect(hash.deep_except(a: 1)).to eq(b: { c: 2, d: 3 })
+    end
+  end
+
+  context "with nested keys" do
+    it "removes specified nested keys" do
+      expect(hash.deep_except(b: { c: 2 })).to eq(a: 1, b: { d: 3 })
+    end
+  end
+
+  context "when all nested keys are removed" do
+    it "removes the entire nested hash" do
+      expect(hash.deep_except(b: { c: 2, d: 3 })).to eq(a: 1)
+    end
+  end
+
+  context "with array values" do
+    let(:hash) { { a: [1, 2, 3], b: 4 } }
+
+    it "removes specified array elements" do
+      expect(hash.deep_except(a: [2])).to eq(a: [1, 3], b: 4)
+    end
+  end
+
+  context "when removing single value given as array" do
+    let(:hash) { { organisation: "Acme", b: 2 } }
+
+    it "removes the value" do
+      expect(hash.deep_except(organisation: %w[Acme])).to eq(b: 2)
+    end
+  end
+
+  context "with non-matching values" do
+    it "does not remove them" do
+      expect(hash.deep_except(a: 2, b: { c: 3 })).to eq(a: 1, b: { c: 2, d: 3 })
+    end
+  end
+
+  context "with empty removal hash" do
+    it "returns original hash" do
+      expect(hash.deep_except({})).to eq(hash)
+    end
+  end
+
+  context "with non-existent keys" do
+    it "returns original hash" do
+      expect(hash.deep_except(x: 1)).to eq(hash)
+    end
+  end
+
+  context "with deeply nested structures" do
+    let(:hash) { { a: { b: { c: { d: 1 } } } } }
+
+    it "removes all nested elements" do
+      expect(hash.deep_except(a: { b: { c: { d: 1 } } })).to eq({})
+    end
+  end
+
+  context "with mixed data types" do
+    let(:hash) { { a: 1, b: [1, 2], c: { d: 3 } } }
+
+    it "handles removal correctly" do
+      expect(hash.deep_except(a: 1, b: [2], c: { d: 3 })).to eq(b: [1])
+    end
+  end
+end

--- a/spec/lib/url_builder_spec.rb
+++ b/spec/lib/url_builder_spec.rb
@@ -5,7 +5,7 @@ describe UrlBuilder do
   let(:extra_params) { {} }
   let(:path) { "/search/all" }
 
-  describe "#url_builder" do
+  describe "#url" do
     context "when given a path and query params" do
       subject(:url) { builder.url }
 
@@ -37,6 +37,26 @@ describe UrlBuilder do
       it "builds a url that includes the additional params" do
         expect(url).to eq("/search/all?keywords=dumbledore&page=20")
       end
+    end
+  end
+
+  describe "#url_except" do
+    subject(:url) { builder.url_except(excepted) }
+
+    let(:query_params) do
+      {
+        keywords: "dumbledore",
+        page: 20,
+        hash: { a: 1, b: 2, c: 2 },
+        array: %w[one two],
+        single_value: "value",
+      }
+    end
+
+    let(:excepted) { { page: 20, hash: { b: 2, c: 3 }, array: %w[one], single_value: %w[value] } }
+
+    it "builds a url without the excluded params, ignoring non-matching values" do
+      expect(url).to eq("/search/all?array%5B%5D=two&hash%5Ba%5D=1&hash%5Bc%5D=2&keywords=dumbledore")
     end
   end
 end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -53,6 +53,52 @@ describe DateFacet do
     end
   end
 
+  describe "#applied_filters" do
+    context "no value" do
+      let(:value) { nil }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([])
+      end
+    end
+
+    context "single date value" do
+      let(:value) { { from: "22/09/1988" } }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([{
+          name: "Occurred after",
+          label: "22 September 1988",
+          query_params: { "date_of_occurrence" => { from: "22/09/1988" } },
+        }])
+      end
+    end
+
+    context "multiple date values" do
+      let(:value) do
+        {
+          from: "22/09/1988",
+          to: "22/09/2014",
+        }
+      end
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Occurred after",
+            label: "22 September 1988",
+            query_params: { "date_of_occurrence" => { from: "22/09/1988" } },
+          },
+          {
+            name: "Occurred before",
+            label: "22 September 2014",
+            query_params: { "date_of_occurrence" => { to: "22/09/2014" } },
+          },
+        ])
+      end
+    end
+  end
+
   describe "#query_params" do
     context "multiple date values" do
       let(:value) do

--- a/spec/models/hidden_clearable_facet_spec.rb
+++ b/spec/models/hidden_clearable_facet_spec.rb
@@ -63,6 +63,57 @@ describe HiddenClearableFacet do
     end
   end
 
+  describe "#applied_filters" do
+    context "single value" do
+      let(:value) { %w[allowed-value-1] }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Test facet",
+            label: "Allowed value 1",
+            query_params: { "test_facet" => %w[allowed-value-1] },
+          },
+        ])
+      end
+    end
+
+    context "multiple values" do
+      let(:value) { %w[allowed-value-1 allowed-value-2] }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Test facet",
+            label: "Allowed value 1",
+            query_params: { "test_facet" => %w[allowed-value-1] },
+          },
+          {
+            name: "Test facet",
+            label: "Allowed value 2",
+            query_params: { "test_facet" => %w[allowed-value-2] },
+          },
+        ])
+      end
+    end
+
+    context "disallowed values" do
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
+
+      it "returns no applied filters" do
+        expect(subject.applied_filters).to be_empty
+      end
+    end
+
+    context "no value" do
+      let(:value) { nil }
+
+      it "returns no applied filters" do
+        expect(subject.applied_filters).to be_empty
+      end
+    end
+  end
+
   describe "#has_filters?" do
     context "no value" do
       let(:value) { nil }

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -64,6 +64,57 @@ describe OptionSelectFacet do
     end
   end
 
+  describe "#applied_filters" do
+    context "single value" do
+      let(:value) { %w[allowed-value-1] }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Test values",
+            label: "Allowed value 1",
+            query_params: { "test_values" => %w[allowed-value-1] },
+          },
+        ])
+      end
+    end
+
+    context "multiple values" do
+      let(:value) { %w[allowed-value-1 allowed-value-2] }
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Test values",
+            label: "Allowed value 1",
+            query_params: { "test_values" => %w[allowed-value-1] },
+          },
+          {
+            name: "Test values",
+            label: "Allowed value 2",
+            query_params: { "test_values" => %w[allowed-value-2] },
+          },
+        ])
+      end
+    end
+
+    context "disallowed values" do
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
+
+      it "returns no applied filters" do
+        expect(subject.applied_filters).to be_empty
+      end
+    end
+
+    context "no value" do
+      let(:value) { nil }
+
+      it "returns no applied filters" do
+        expect(subject.applied_filters).to be_empty
+      end
+    end
+  end
+
   describe "#query_params" do
     context "value selected" do
       let(:value) { "allowed-value-1" }

--- a/spec/models/sort_facet_spec.rb
+++ b/spec/models/sort_facet_spec.rb
@@ -1,7 +1,17 @@
 require "spec_helper"
 
 describe SortFacet do
-  subject(:sort_facet) { described_class.new }
+  subject(:sort_facet) { described_class.new(content_item, filter_params) }
+
+  let(:content_item) { instance_double(ContentItem, sort_options:) }
+  let(:sort_options) do
+    [
+      { "name" => "Most viewed" },
+      { "name" => "Updated (newest)" },
+      { "name" => "Relevance" },
+    ]
+  end
+  let(:filter_params) { {} }
 
   describe "#name" do
     it "returns a value" do
@@ -18,6 +28,67 @@ describe SortFacet do
   describe "#to_partial_path" do
     it "is the underscored class name" do
       expect(sort_facet.to_partial_path).to eq("sort_facet")
+    end
+  end
+
+  describe "#has_filters?" do
+    context "when no sort order is selected" do
+      it { is_expected.not_to have_filters }
+    end
+
+    context "when a sort order is selected but it doesn't exist" do
+      let(:filter_params) { { "order" => "invalid" } }
+
+      it { is_expected.not_to have_filters }
+    end
+
+    context "when a default sort order is selected" do
+      let(:filter_params) { { "order" => "most-viewed" } }
+
+      it { is_expected.not_to have_filters }
+    end
+
+    context "when a custom sort order is selected" do
+      let(:filter_params) { { "order" => "updated-newest" } }
+
+      it { is_expected.to have_filters }
+    end
+  end
+
+  describe "#applied_filters" do
+    context "when no sort order is selected" do
+      it "returns an empty array" do
+        expect(sort_facet.applied_filters).to eq([])
+      end
+    end
+
+    context "when a sort order is selected but it doesn't exist" do
+      let(:filter_params) { { "order" => "invalid" } }
+
+      it "returns an empty array" do
+        expect(sort_facet.applied_filters).to eq([])
+      end
+    end
+
+    context "when a default sort order is selected" do
+      let(:filter_params) { { "order" => "most-viewed" } }
+
+      it "returns an empty array" do
+        expect(sort_facet.applied_filters).to eq([])
+      end
+    end
+
+    context "when a custom sort order is selected" do
+      let(:filter_params) { { "order" => "updated-newest" } }
+
+      it "returns the selected sort order" do
+        expect(sort_facet.applied_filters).to eq([{
+          name: "Sort by",
+          label: "Updated (newest)",
+          query_params: { "order" => "updated-newest" },
+          visually_hidden_prefix: "Remove",
+        }])
+      end
     end
   end
 

--- a/spec/presenters/filters_presenter_spec.rb
+++ b/spec/presenters/filters_presenter_spec.rb
@@ -55,11 +55,16 @@ describe FiltersPresenter do
     context "when there is at least one facet with applied filters" do
       let(:facets) { [facet_without_applied_filters, facet_with_applied_filters] }
 
+      before do
+        allow(finder_url_builder).to receive(:url_except).with({ key: %w[value] })
+          .and_return("/search/foo")
+      end
+
       it "returns the expected summary items" do
         expect(summary_items).to contain_exactly({
           label: "name",
           value: "label",
-          remove_href: "#",
+          remove_href: "/search/foo",
           visually_hidden_prefix: "Remove filter",
         })
       end

--- a/spec/presenters/filters_presenter_spec.rb
+++ b/spec/presenters/filters_presenter_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe FiltersPresenter do
+  subject { described_class.new(facets, finder_url_builder) }
+
+  let(:facets) { [] }
+  let(:finder_url_builder) { instance_double(UrlBuilder) }
+
+  describe "#any_filters" do
+    it "returns false" do
+      expect(subject).not_to be_any_filters
+    end
+  end
+
+  describe "#reset_url" do
+    it "returns a static anchor link" do
+      expect(subject.reset_url).to eq("#")
+    end
+  end
+
+  describe "#summary_items" do
+    it "returns an empty array" do
+      expect(subject.summary_items).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
This implements the filter summary for the new search UI, allowing users to see which filters they have selected, and clear them.

## Review app
Example page with lots of filters:
https://finder-frontend-pr-3484.herokuapp.com/search/all?keywords=&order=updated-newest&level_one_taxon=d6c2de5d-ef90-45d1-82d4-5f2438369eea&level_two_taxon=634fd193-8039-4a70-a059-919c34ff4bfc&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&public_timestamp%5Bfrom%5D=2005&public_timestamp%5Bto%5D=21%2F11%2F2024&organisations=hm-revenue-customs&manual%5B%5D=%2Fguidance%2Fmot-inspection-manual-for-private-passenger-and-light-commercial-vehicles&topical_events=election-2024

## Visual changes
<img width="703" alt="image" src="https://github.com/user-attachments/assets/11836a3f-ecc9-4329-b7af-b6cbd2c771fe">