### PR TITLE
Using RandomExample generator from GovUK Schemas

### DIFF
--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -222,11 +222,11 @@ module DocumentHelper
   end
 
   def content_store_has_mosw_reports_finder
-    stub_content_store_has_item("/mosw-reports", govuk_content_schema_example("finder").to_json)
+    stub_content_store_has_item("/mosw-reports", example_finder.to_json)
   end
 
   def content_store_has_mosw_reports_finder_with_no_facets
-    finder = govuk_content_schema_example("finder")
+    finder = example_finder
     finder["details"]["facets"] = []
     stub_content_store_has_item("/mosw-reports", finder.to_json)
   end
@@ -243,7 +243,7 @@ module DocumentHelper
 
   def content_store_has_government_finder
     base_path = "/government/policies/benefits-reform"
-    finder = govuk_content_schema_example("finder").merge("base_path" => base_path)
+    finder = example_finder.merge("base_path" => base_path)
     finder["details"]["sort"] = [
       {
         "name": "Most viewed",
@@ -267,7 +267,7 @@ module DocumentHelper
 
   def content_store_has_government_finder_with_10_items
     base_path = "/government/policies/benefits-reform"
-    content_item = govuk_content_schema_example("finder").merge("base_path" => base_path)
+    content_item = example_finder.merge("base_path" => base_path)
     content_item["details"]["default_documents_per_page"] = 10
     stub_content_store_has_item(base_path, content_item.to_json)
   end
@@ -303,7 +303,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder
-    schema = govuk_content_schema_example("cma-cases", "finder")
+    schema = example_cma_cases_finder
 
     stub_content_store_has_item(
       schema.fetch("base_path"),
@@ -312,7 +312,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_a_taxon_tagged_finder
-    schema = govuk_content_schema_example("cma-cases", "finder").merge(
+    schema = example_cma_cases_finder.merge(
       "links" => {
         "taxons" => [
           {
@@ -353,7 +353,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder_with_description
-    schema = govuk_content_schema_example("cma-cases", "finder")
+    schema = example_cma_cases_finder
       .merge("description" => "Find reports and updates on current and historical CMA investigations")
 
     stub_content_store_has_item(
@@ -363,7 +363,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder_with_no_index
-    schema = govuk_content_schema_example("cma-cases", "finder")
+    schema = example_cma_cases_finder
     schema["details"]["no_index"] = true
 
     stub_content_store_has_item(
@@ -373,8 +373,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder_with_metadata
-    schema = govuk_content_schema_example("cma-cases", "finder")
-      .merge("from" => "An authority")
+    schema = example_cma_cases_finder.merge("from" => "An authority")
 
     stub_content_store_has_item(
       schema.fetch("base_path"),
@@ -383,8 +382,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder_with_metadata_with_topic_param
-    schema = govuk_content_schema_example("cma-cases", "finder")
-      .merge("from" => "An authority")
+    schema = example_cma_cases_finder.merge("from" => "An authority")
     schema["content_id"] = "c58fdadd-7743-46d6-9629-90bb3ccc4ef0"
 
     stub_content_store_has_item(
@@ -394,7 +392,7 @@ module DocumentHelper
   end
 
   def stub_content_store_with_cma_cases_finder_for_supergroup_checkbox_filter
-    schema = govuk_content_schema_example("cma-cases", "finder")
+    schema = example_cma_cases_finder
     schema["details"]["facets"].map! do |facet|
       if facet["key"] == "case_state"
         {

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -12,22 +12,18 @@ describe FindersController, type: :controller do
   render_views
 
   let(:lunch_finder) do
-    finder = govuk_content_schema_example("finder").to_hash.merge(
-      "title" => "Lunch Finder",
-      "base_path" => "/lunch-finder",
-    )
-
+    finder = example_finder
+    finder["title"] = "Lunch Finder"
+    finder["base_path"] = "/lunch-finder"
     finder["details"]["default_documents_per_page"] = 10
     finder["details"]["sort"] = nil
     finder
   end
 
   let(:all_content_finder) do
-    finder = govuk_content_schema_example("finder").to_hash.merge(
-      "base_path" => "/search/all",
-      "content_id" => "dd395436-9b40-41f3-8157-740a453ac972",
-    )
-
+    finder = example_finder
+    finder["base_path"] = "/search/all"
+    finder["content_id"] = "dd395436-9b40-41f3-8157-740a453ac972"
     finder["details"]["default_documents_per_page"] = 10
     finder["details"]["sort"] = nil
     finder
@@ -300,12 +296,10 @@ describe FindersController, type: :controller do
 
   describe "Spelling suggestions" do
     let(:breakfast_finder) do
-      finder = govuk_content_schema_example("finder").to_hash.merge(
-        "title" => "Breakfast Finder",
-        "base_path" => "/breakfast-finder",
-        "content_id" => "42ce66de-04f3-4192-bf31-8394538e0734",
-      )
-
+      finder = example_finder
+      finder["title"] = "Breakfast Finder"
+      finder["base_path"] = "/breakfast-finder"
+      finder["content_id"] = "42ce66de-04f3-4192-bf31-8394538e0734"
       finder["details"]["default_documents_per_page"] = 10
       finder["details"]["sort"] = nil
       finder
@@ -371,11 +365,9 @@ describe FindersController, type: :controller do
     before do
       search_api_request
 
-      news_finder = govuk_content_schema_example("finder").to_hash.merge(
-        "base_path" => "/search/news-and-communications",
-        "content_id" => "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2",
-      )
-
+      news_finder = example_finder
+      news_finder["base_path"] = "/search/news-and-communications"
+      news_finder["content_id"] = "622e9691-4b4f-4e9c-bce1-098b0c4f5ee2"
       news_finder["details"]["default_documents_per_page"] = 10
       news_finder["details"]["sort"] = nil
 

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -89,7 +89,7 @@ describe FacetsBuilder do
   end
 
   let(:content_item_hash) do
-    govuk_content_schema_example("finder").merge(detail_hash).deep_stringify_keys
+    example_finder.merge(detail_hash).deep_stringify_keys
   end
 
   let(:content_item) do

--- a/spec/presenters/sort_presenter_spec.rb
+++ b/spec/presenters/sort_presenter_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe SortPresenter do
 private
 
   def content_item(sort_options: nil)
-    finder_example = govuk_content_schema_example("finder")
+    finder_example = example_finder
     finder_example["details"]["sort"] = sort_options
     ContentItem.new(finder_example)
   end

--- a/spec/support/content_helper.rb
+++ b/spec/support/content_helper.rb
@@ -9,9 +9,525 @@ module GovukContentSchemaExamples
   included do
     include GdsApi::TestHelpers::ContentStore
 
-    # Returns a hash representing an finder content item from govuk-content-schemas
-    def govuk_content_schema_example(name, format = "finder")
-      GovukSchemas::Example.find(format, example_name: name)
+    def example_finder
+      finder = GovukSchemas::RandomExample.for_schema(frontend_schema: "finder")
+      finder["schema_name"] = "finder"
+      finder["document_type"] = "finder"
+      finder["base_path"] = "/mosw-reports"
+      finder["title"] = "Ministry of Silly Walks reports"
+      finder["details"] = {
+        "document_noun" => "report",
+        "filter" => {
+          "document_type" => "mosw_report",
+        },
+        "show_summaries" => true,
+        "summary" => "The Ministry of Silly Walks researchs silly walks being developed by the British public",
+        "sort" => [
+          {
+            "key" => "-public_timestamp",
+            "name" => "Recently published",
+            "default" => true,
+          },
+          {
+            "key" => "-popularity",
+            "name" => "Most popular",
+          },
+          {
+            "key" => "-relevance",
+            "name" => "Most relevant",
+          },
+        ],
+        "facets" => [
+          {
+            "key" => "walk_type",
+            "name" => "Walk type",
+            "type" => "text",
+            "preposition" => "of type",
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "allowed_values" => [
+              {
+                "value" => "backward",
+                "label" => "Backward",
+              },
+              {
+                "value" => "hopscotch",
+                "label" => "Hopscotch",
+              },
+              {
+                "value" => "start-and-stop",
+                "label" => "Start-and-stop",
+              },
+            ],
+          },
+          {
+            "key" => "place_of_origin",
+            "name" => "Place of origin",
+            "type" => "text",
+            "preposition" => "from",
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "allowed_values" => [
+              {
+                "value" => "england",
+                "label" => "England",
+              },
+              {
+                "value" => "northern-ireland",
+                "label" => "Northern Ireland",
+              },
+              {
+                "value" => "scotland",
+                "label" => "Scotland",
+              },
+              {
+                "value" => "wales",
+                "label" => "Wales",
+              },
+            ],
+          },
+          {
+            "key" => "date_of_introduction",
+            "name" => "Date of Introduction",
+            "short_name" => "Introduced",
+            "type" => "date",
+            "preposition" => "introduced",
+            "display_as_result_metadata" => true,
+            "filterable" => false,
+          },
+          {
+            "key" => "creator",
+            "name" => "Creator",
+            "type" => "text",
+            "filterable" => false,
+            "display_as_result_metadata" => false,
+          },
+        ],
+      }
+      finder["links"] = {
+        "organisations" => [
+          {
+            "content_id" => "3338f283-64a1-4062-842e-677f520c1f15",
+            "title" => "Ministry of Silly Walks",
+            "api_path" => "/api/content/government/organisations/ministry-of-silly-walks",
+            "base_path" => "/government/organisations/ministry-of-silly-walks",
+            "api_url" => "https://www.gov.uk/api/content/government/organisations/government/organisations/ministry-of-silly-walks",
+            "web_url" => "https://www.gov.uk/government/organisations/government/organisations/ministry-of-silly-walks",
+            "locale" => "en",
+          },
+        ],
+        "related" => [],
+        "email_alert_signup" => [
+          {
+            "content_id" => "5c35b119-aebc-4ec8-9413-370bd01c24b3",
+            "title" => "Ministry of Silly Walks reports",
+            "api_path" => "/api/content/mosw-reports/email-signup",
+            "base_path" => "/mosw-reports/email-signup",
+            "api_url" => "https://www.gov.uk/api/content/mosw-reports/email-signup",
+            "web_url" => "https://www.gov.uk/mosw-reports/email-signup",
+            "locale" => "en",
+          },
+        ],
+        "available_translations" => [
+          {
+            "content_id" => "23ec51f6-b1a1-41a7-97bc-59e18041e2e7",
+            "title" => "Ministry of Silly Walks reports",
+            "api_path" => "/api/contnet/mosw-reports",
+            "base_path" => "/mosw-reports",
+            "api_url" => "https://www.gov.uk/api/content/mosw-reports",
+            "web_url" => "https://www.gov.uk/mosw-reports",
+            "locale" => "en",
+          },
+        ],
+      }
+      finder
+    end
+
+    def example_cma_cases_finder
+      finder = GovukSchemas::RandomExample.for_schema(frontend_schema: "finder")
+      finder["schema_name"] = "finder"
+      finder["document_type"] = "finder"
+      finder["base_path"] = "/cma-cases"
+      finder["title"] = "Competition and Markets Authority cases"
+      finder["details"] = {
+        "beta" => false,
+        "document_noun" => "case",
+        "facets" => [
+          {
+            "allowed_values" => [
+              {
+                "label" => "CA98 and civil cartels",
+                "value" => "ca98-and-civil-cartels",
+              },
+              {
+                "label" => "Competition disqualification",
+                "value" => "competition-disqualification",
+              },
+              {
+                "label" => "Criminal cartels",
+                "value" => "criminal-cartels",
+              },
+              {
+                "label" => "Markets",
+                "value" => "markets",
+              },
+              {
+                "label" => "Mergers",
+                "value" => "mergers",
+              },
+              {
+                "label" => "Consumer enforcement",
+                "value" => "consumer-enforcement",
+              },
+              {
+                "label" => "Regulatory references and appeals",
+                "value" => "regulatory-references-and-appeals",
+              },
+              {
+                "label" => "Reviews of orders and undertakings",
+                "value" => "review-of-orders-and-undertakings",
+              },
+            ],
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "key" => "case_type",
+            "name" => "Case type",
+            "preposition" => "of type",
+            "type" => "text",
+          },
+          {
+            "allowed_values" => [
+              {
+                "label" => "Open",
+                "value" => "open",
+              },
+              {
+                "label" => "Closed",
+                "value" => "closed",
+              },
+            ],
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "key" => "case_state",
+            "name" => "Case state",
+            "preposition" => "which are",
+            "type" => "text",
+          },
+          {
+            "allowed_values" => [
+              {
+                "label" => "Aerospace",
+                "value" => "aerospace",
+              },
+              {
+                "label" => "Agriculture, environment and natural resources",
+                "value" => "agriculture-environment-and-natural-resources",
+              },
+              {
+                "label" => "Building and construction",
+                "value" => "building-and-construction",
+              },
+              {
+                "label" => "Chemicals",
+                "value" => "chemicals",
+              },
+              {
+                "label" => "Clothing, footwear and fashion",
+                "value" => "clothing-footwear-and-fashion",
+              },
+              {
+                "label" => "Communications",
+                "value" => "communications",
+              },
+              {
+                "label" => "Defence",
+                "value" => "defence",
+              },
+              {
+                "label" => "Distribution and service industries",
+                "value" => "distribution-and-service-industries",
+              },
+              {
+                "label" => "Electronics",
+                "value" => "electronics-industry",
+              },
+              {
+                "label" => "Energy",
+                "value" => "energy",
+              },
+              {
+                "label" => "Engineering",
+                "value" => "engineering",
+              },
+              {
+                "label" => "Financial services",
+                "value" => "financial-services",
+              },
+              {
+                "label" => "Fire, police and security",
+                "value" => "fire-police-and-security",
+              },
+              {
+                "label" => "Food manufacturing",
+                "value" => "food-manufacturing",
+              },
+              {
+                "label" => "Giftware, jewellery and tableware",
+                "value" => "giftware-jewellery-and-tableware",
+              },
+              {
+                "label" => "Healthcare and medical equipment",
+                "value" => "healthcare-and-medical-equipment",
+              },
+              {
+                "label" => "Household goods, furniture and furnishings",
+                "value" => "household-goods-furniture-and-furnishings",
+              },
+              {
+                "label" => "Mineral extraction, mining and quarrying",
+                "value" => "mineral-extraction-mining-and-quarrying",
+              },
+              {
+                "label" => "Motor industry",
+                "value" => "motor-industry",
+              },
+              {
+                "label" => "Oil and gas refining and petrochemicals",
+                "value" => "oil-and-gas-refining-and-petrochemicals",
+              },
+              {
+                "label" => "Paper printing and packaging",
+                "value" => "paper-printing-and-packaging",
+              },
+              {
+                "label" => "Pharmaceuticals",
+                "value" => "pharmaceuticals",
+              },
+              {
+                "label" => "Public markets",
+                "value" => "public-markets",
+              },
+              {
+                "label" => "Recreation and leisure",
+                "value" => "recreation-and-leisure",
+              },
+              {
+                "label" => "Retail and wholesale",
+                "value" => "retail-and-wholesale",
+              },
+              {
+                "label" => "Telecommunications",
+                "value" => "telecommunications",
+              },
+              {
+                "label" => "Textiles",
+                "value" => "textiles",
+              },
+              {
+                "label" => "Transport",
+                "value" => "transport",
+              },
+              {
+                "label" => "Utilities",
+                "value" => "utilities",
+              },
+            ],
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "key" => "market_sector",
+            "name" => "Market sector",
+            "preposition" => "about",
+            "type" => "text",
+          },
+          {
+            "allowed_values" => [
+              {
+                "label" => "CA98 - no grounds for action",
+                "value" => "ca98-no-grounds-for-action-non-infringement",
+              },
+              {
+                "label" => "CA98 - infringement Chapter I",
+                "value" => "ca98-infringement-chapter-i",
+              },
+              {
+                "label" => "CA98 - infringement Chapter II",
+                "value" => "ca98-infringement-chapter-ii",
+              },
+              {
+                "label" => "CA98 - administrative priorities",
+                "value" => "ca98-administrative-priorities",
+              },
+              {
+                "label" => "CA98 - commitments",
+                "value" => "ca98-commitment",
+              },
+              {
+                "label" => "Competition disqualification - order granted",
+                "value" => "competition-disqualification-order-granted",
+              },
+              {
+                "label" => "Competition disqualification - undertaking given",
+                "value" => "competition-disqualification-undertaking-given",
+              },
+              {
+                "label" => "Competition disqualification - no order granted or undertaking given",
+                "value" => "competition-disqualification-no-order-granted-or-undertaking-given",
+              },
+              {
+                "label" => "Criminal cartels - verdict",
+                "value" => "criminal-cartels-verdict",
+              },
+              {
+                "label" => "Markets - phase 1 no enforcement action",
+                "value" => "markets-phase-1-no-enforcement-action",
+              },
+              {
+                "label" => "Markets - phase 1 undertakings in lieu of reference",
+                "value" => "markets-phase-1-undertakings-in-lieu-of-reference",
+              },
+              {
+                "label" => "Markets - phase 1 referral",
+                "value" => "markets-phase-1-referral",
+              },
+              {
+                "label" => "Mergers - phase 1 clearance",
+                "value" => "mergers-phase-1-clearance",
+              },
+              {
+                "label" => "Mergers - phase 1 clearance with undertakings in lieu",
+                "value" => "mergers-phase-1-clearance-with-undertakings-in-lieu",
+              },
+              {
+                "label" => "Mergers - phase 1 referral",
+                "value" => "mergers-phase-1-referral",
+              },
+              {
+                "label" => "Mergers - phase 1 found not to qualify",
+                "value" => "mergers-phase-1-found-not-to-qualify",
+              },
+              {
+                "label" => "Mergers - phase 1 public interest intervention",
+                "value" => "mergers-phase-1-public-interest-interventions",
+              },
+              {
+                "label" => "Markets - phase 2 clearance - no adverse effect on competition",
+                "value" => "markets-phase-2-clearance-no-adverse-effect-on-competition",
+              },
+              {
+                "label" => "Markets - phase 2 adverse effect on competition leading to remedies",
+                "value" => "markets-phase-2-adverse-effect-on-competition-leading-to-remedies",
+              },
+              {
+                "label" => "Markets - phase 2 decision to dispense with procedural obligations",
+                "value" => "markets-phase-2-decision-to-dispense-with-procedural-obligations",
+              },
+              {
+                "label" => "Mergers - phase 2 clearance",
+                "value" => "mergers-phase-2-clearance",
+              },
+              {
+                "label" => "Mergers - phase 2 clearance with remedies",
+                "value" => "mergers-phase-2-clearance-with-remedies",
+              },
+              {
+                "label" => "Mergers - phase 2 prohibition",
+                "value" => "mergers-phase-2-prohibition",
+              },
+              {
+                "label" => "Mergers - phase 2 cancellation",
+                "value" => "mergers-phase-2-cancellation",
+              },
+              {
+                "label" => "Consumer enforcement - no formal action",
+                "value" => "consumer-enforcement-no-action",
+              },
+              {
+                "label" => "Consumer enforcement - court order",
+                "value" => "consumer-enforcement-court-order",
+              },
+              {
+                "label" => "Consumer enforcement - undertakings",
+                "value" => "consumer-enforcement-undertakings",
+              },
+              {
+                "label" => "Consumer enforcement - changes to business practices agreed",
+                "value" => "consumer-enforcement-changes-to-business-practices-agreed",
+              },
+              {
+                "label" => "Regulatory references and appeals - final determination",
+                "value" => "regulatory-references-and-appeals-final-determination",
+              },
+            ],
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "key" => "outcome_type",
+            "name" => "Outcome",
+            "preposition" => "with outcome",
+            "type" => "text",
+          },
+          {
+            "display_as_result_metadata" => true,
+            "filterable" => false,
+            "key" => "opened_date",
+            "name" => "Opened",
+            "short_name" => "Opened",
+            "type" => "date",
+          },
+          {
+            "display_as_result_metadata" => true,
+            "filterable" => true,
+            "key" => "closed_date",
+            "name" => "Closed",
+            "preposition" => "closed",
+            "short_name" => "Closed",
+            "type" => "date",
+          },
+        ],
+        "filter" => {
+          "document_type" => "cma_case",
+        },
+        "format_name" => "Competition and Markets Authority case",
+        "show_summaries" => false,
+      }
+      finder["links"] = {
+        "email_alert_signup" => [
+          {
+            "content_id" => "b269c38b-6e5a-4258-9735-66389749e341",
+            "title" => "Competition and Markets Authority cases",
+            "api_path" => "/api/content/cma-cases/email-signup",
+            "base_path" => "/cma-cases/email-signup",
+            "description" => "You'll get an email each time a case is updated or a new case is published.",
+            "api_url" => "https://www.gov.uk/api/content/cma-cases/email-signup",
+            "web_url" => "https://www.gov.uk/cma-cases/email-signup",
+            "locale" => "en",
+          },
+        ],
+        "organisations" => [
+          {
+            "content_id" => "271e858a-6b44-4c9c-9282-6f599d268895",
+            "title" => "Competition and Markets Authority",
+            "api_path" => "/api/content/government/organisations/competition-and-markets-authority",
+            "base_path" => "/government/organisations/competition-and-markets-authority",
+            "api_url" => "https://www.gov.uk/api/content/government/organisations/competition-and-markets-authority",
+            "web_url" => "https://www.gov.uk/government/organisations/competition-and-markets-authority",
+            "locale" => "en",
+          },
+        ],
+        "related" => [],
+        "available_translations" => [
+          {
+            "content_id" => "3631309f-b9c0-4942-afe6-3ae3819fc6a1",
+            "title" => "Competition and Markets Authority cases",
+            "api_path" => "/api/content/cma-cases",
+            "base_path" => "/cma-cases",
+            "description" => "",
+            "api_url" => "https://www.gov.uk/api/content/cma-cases",
+            "web_url" => "https://www.gov.uk/cma-cases",
+            "locale" => "en",
+          },
+        ],
+      }
+      finder
     end
   end
 end


### PR DESCRIPTION
Instead of using an example file that has to be manually added and maintained, we should load an example generated from the schema itself and override any specific values to be tested

This will enable us to delete the example files from Publishing API
https://trello.com/c/7fzxocSX/2813-remove-specialist-document-examples-from-publishing-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
