### PR TITLE
Prevent filter toggle icon from reducing in size

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -48,9 +48,10 @@
 
 .app-c-expander__icon {
   display: none;
+  flex-shrink: 0;
   width: 30px;
   height: 40px;
-  margin-inline: 9px 4px;
+  margin-inline: 10px 4px;
   fill: govuk-colour("black");
 }
 


### PR DESCRIPTION
## What
A small issue was identified where icons in filter buttons reduce in size if the associated label is too big. This PR applies `flex-shrink: 0` to prevent this behaviour and keep the icon at the intended size. A small adjustment was made to horizontal spacing to match [the same change in the `option-select`](https://github.com/alphagov/govuk_publishing_components/pull/4256) component in the gem. 

This is part of the work to improve the layout and behaviour of search filters on mobile. [Trello](https://trello.com/c/65zYsdtH/275-type-scale-finder-frontend-improve-spacing-and-alignment-in-search-filters-on-mobile), [Jira issue PNP-8551](https://gov-uk.atlassian.net/browse/PNP-8551)

## Why
Icons should always retain their expected size to avoid inconsistencies in the user experience.

## Visual Changes

| Before      | After |
| ----------- | ----------- |
|<img width="" alt="image" src="https://github.com/user-attachments/assets/3fa2e63f-a4f8-412b-b3ee-3dd5b4fab44b">|<img width="" alt="image" src="https://github.com/user-attachments/assets/08e8f2db-4c34-4906-878c-b763c3848207">|
