### PR TITLE
All content finder: Implement filter section status text

### DIFF
--- a/app/models/facet.rb
+++ b/app/models/facet.rb
@@ -60,6 +60,12 @@ class Facet
     []
   end
 
+  def status_text
+    return nil unless has_filters?
+
+    "#{applied_filters.size} selected"
+  end
+
   def query_params
     {}
   end

--- a/app/models/sort_facet.rb
+++ b/app/models/sort_facet.rb
@@ -42,6 +42,12 @@ class SortFacet
     }]
   end
 
+  def status_text
+    return nil unless has_filters?
+
+    sort_options[selected_sort_option]
+  end
+
   # The methods below are the minimum required for this virtual facet to take the place of a real
   # `Facet`
 

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -1,6 +1,7 @@
 <%= render "components/filter_section", {
   heading_text: date_facet.name,
   visually_hidden_heading_prefix: "Filter by",
+  status_text: date_facet.status_text,
   id: "facet_date_#{date_facet.key}",
   index_section: index,
   index_section_count: count,

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -3,6 +3,7 @@
 <%= render "components/filter_section", {
   heading_text: option_select_facet.name,
   visually_hidden_heading_prefix: "Filter by",
+  status_text: option_select_facet.status_text,
   id: "facet_option_select_#{option_select_facet.key}",
   index_section: index,
   index_section_count: count,

--- a/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
@@ -1,5 +1,6 @@
 <%= render "components/filter_section", {
   heading_text: sort_facet.name,
+  status_text: sort_facet.status_text,
   id: "facet_sort",
   index_section: index,
   index_section_count: count,

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -1,6 +1,7 @@
 <%= render "components/filter_section", {
   heading_text: taxon_facet.name,
   visually_hidden_heading_prefix: "Filter by",
+  status_text: taxon_facet.status_text,
   id: "facet_taxon_#{taxon_facet.key}",
   index_section: index,
   index_section_count: count,

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -32,6 +32,7 @@ Feature: All content finder ("site search")
     And I enter "13/12/1989" for "Updated before"
     And I apply the filters
     Then I can see filtered results
+    And the filter panel shows status text for each section
 
   Scenario: Changing the sort order of a search
     When I search all content for "dark gray all alone"

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -70,6 +70,16 @@ Then("I can see sorted results") do
   expect(page).to have_link("Loving him was red")
 end
 
+Then("the filter panel shows status text for each section") do
+  click_on "Filter and sort"
+
+  within(".app-c-filter-panel") do
+    expect(page).to have_selector("summary", text: "Filter by Topic 2 selected", normalize_ws: true)
+    expect(page).to have_selector("summary", text: "Filter by Type 2 selected", normalize_ws: true)
+    expect(page).to have_selector("summary", text: "Filter by Updated 2 selected", normalize_ws: true)
+  end
+end
+
 Then("the filter panel is open by default") do
   expect(page).to have_selector("button[aria-expanded='true']", text: "Filter and sort")
 end

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -99,6 +99,37 @@ describe DateFacet do
     end
   end
 
+  describe "#status_text" do
+    context "no value" do
+      let(:value) { nil }
+
+      it "returns no status text" do
+        expect(subject.status_text).to be_nil
+      end
+    end
+
+    context "single date value" do
+      let(:value) { { from: "22/09/1988" } }
+
+      it "returns the expected status text" do
+        expect(subject.status_text).to eq("1 selected")
+      end
+    end
+
+    context "multiple date values" do
+      let(:value) do
+        {
+          from: "22/09/1988",
+          to: "22/09/2014",
+        }
+      end
+
+      it "returns the expected status text" do
+        expect(subject.status_text).to eq("2 selected")
+      end
+    end
+  end
+
   describe "#query_params" do
     context "multiple date values" do
       let(:value) do

--- a/spec/models/option_select_facet_spec.rb
+++ b/spec/models/option_select_facet_spec.rb
@@ -115,6 +115,40 @@ describe OptionSelectFacet do
     end
   end
 
+  describe "#status_text" do
+    context "single value" do
+      let(:value) { %w[allowed-value-1] }
+
+      it "returns the expected status text" do
+        expect(subject.status_text).to eq("1 selected")
+      end
+    end
+
+    context "multiple values" do
+      let(:value) { %w[allowed-value-1 allowed-value-2] }
+
+      it "returns the expected status text" do
+        expect(subject.status_text).to eq("2 selected")
+      end
+    end
+
+    context "disallowed values" do
+      let(:value) { ["disallowed-value-1, disallowed-value-2"] }
+
+      it "returns no status text" do
+        expect(subject.status_text).to be_nil
+      end
+    end
+
+    context "no value" do
+      let(:value) { nil }
+
+      it "returns no status text" do
+        expect(subject.status_text).to be_nil
+      end
+    end
+  end
+
   describe "#query_params" do
     context "value selected" do
       let(:value) { "allowed-value-1" }

--- a/spec/models/sort_facet_spec.rb
+++ b/spec/models/sort_facet_spec.rb
@@ -92,6 +92,32 @@ describe SortFacet do
     end
   end
 
+  describe "#status_text" do
+    subject(:status_text) { sort_facet.status_text }
+
+    context "when no sort order is selected" do
+      it { is_expected.to be_nil }
+    end
+
+    context "when a sort order is selected but it doesn't exist" do
+      let(:filter_params) { { "order" => "invalid" } }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a default sort order is selected" do
+      let(:filter_params) { { "order" => "most-viewed" } }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when a custom sort order is selected" do
+      let(:filter_params) { { "order" => "updated-newest" } }
+
+      it { is_expected.to eq("Updated (newest)") }
+    end
+  end
+
   it { is_expected.to be_user_visible }
   it { is_expected.to be_filterable }
   it { is_expected.not_to be_hide_facet_tag }

--- a/spec/models/taxon_facet_spec.rb
+++ b/spec/models/taxon_facet_spec.rb
@@ -165,4 +165,39 @@ describe TaxonFacet do
       specify { expect(subject.applied_filters).to be_empty }
     end
   end
+
+  describe "#status_text" do
+    context "when no filters are applied" do
+      let(:allowed_values) { {} }
+
+      it "returns nil" do
+        expect(subject.status_text).to be_nil
+      end
+    end
+
+    context "when a topic filter is applied" do
+      let(:allowed_values) do
+        {
+          "level_one_taxon" => "allowed-value-1",
+        }
+      end
+
+      it "returns that one topic is selected" do
+        expect(subject.status_text).to eql("1 selected")
+      end
+    end
+
+    context "when a subtopic filter is applied" do
+      let(:allowed_values) do
+        {
+          "level_one_taxon" => "allowed-value-1",
+          "level_two_taxon" => "allowed-child-value",
+        }
+      end
+
+      it "returns that two topics are selected" do
+        expect(subject.status_text).to eql("2 selected")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This implements the filter sections' status text, which shows the number of selected filters (or the currently selected non-default sort option in the case of the sort facet) for every facet/filter section in the new all content finder's filter panel.

## Review app example link with lots of selected filters
https://finder-frontend-pr-3489.herokuapp.com/search/all?keywords=&order=updated-newest&level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&level_two_taxon=13fb7519-c48e-4577-90f8-aaf483fa0c03&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=news_and_communications&content_purpose_supergroup%5B%5D=research_and_statistics&content_purpose_supergroup%5B%5D=policy_and_engagement&content_purpose_supergroup%5B%5D=transparency&public_timestamp%5Bfrom%5D=2005&public_timestamp%5Bto%5D=2012&commit=Apply+filters

## Visual changes
<img width="754" alt="image" src="https://github.com/user-attachments/assets/4698f4df-a101-4f2d-8e12-7ecf662430b5">
