### PR TITLE
All content finder: Implement hidden clearable facet

### DIFF
--- a/app/models/hidden_clearable_facet.rb
+++ b/app/models/hidden_clearable_facet.rb
@@ -1,4 +1,6 @@
 class HiddenClearableFacet < FilterableFacet
+  attr_reader :value
+
   def initialize(facet, value_hash)
     @value = Array(value_hash)
     super(facet)

--- a/app/views/finders/all_content_finder_facets/_hidden_clearable_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_hidden_clearable_facet.html.erb
@@ -1,1 +1,3 @@
-<%# TODO: Hidden clearable facet %>
+<% hidden_clearable_facet.value.each do |value| %>
+  <%= hidden_field_tag "#{hidden_clearable_facet.key}[]", value %>
+<% end %>

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -12,6 +12,11 @@ Feature: All content finder ("site search")
     Then I can see results for my search
     And I can see how many results there are
 
+  Scenario: Making a search with a hidden clearable filter
+    When I search for "search-term" with a hidden clearable manual filter
+    And I change my search term to "search-term-updated" and submit
+    Then my search is still filtered by manual
+
   Scenario: Filtering results
     When I search all content for "how to walk silly"
     And I open the filter panel

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -2,6 +2,15 @@ When(/^I search all content for "([^"]*)"$/) do |search_term|
   visit "/search/all?q=#{search_term}"
 end
 
+When(/^I search for "([^"]*)" with a hidden clearable manual filter$/) do |search_term|
+  visit "/search/all?q=#{search_term}&manual%5B%5D=how-to-be-a-wizard"
+end
+
+When(/^I change my search term to "([^"]*)" and submit$/) do |search_term|
+  fill_in "Search", with: search_term
+  click_on "Search"
+end
+
 Then("I can see results for my search") do
   expect(page).to have_link("West London wobbley walk")
   expect(page).to have_link("The Gerry Anderson")
@@ -9,6 +18,10 @@ end
 
 Then("I can see how many results there are") do
   expect(page).to have_selector("h2", text: "2 results")
+end
+
+Then("my search is still filtered by manual") do
+  expect(page).to have_link("Remove filter Manual: How to be a Wizard", normalize_ws: true)
 end
 
 When("I open the filter panel") do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -136,6 +136,11 @@ module DocumentHelper
       filtered_by_manual_all_content_results_json,
       including_v2: true,
     )
+    stub_response(
+      hash_including("q" => "search-term-updated", "filter_manual" => %w[how-to-be-a-wizard]),
+      filtered_by_manual_all_content_results_json,
+      including_v2: true,
+    )
   end
 
   def stub_search_api_request_with_filtered_policy_papers_results


### PR DESCRIPTION
This implements _persisting_ the hidden clearable facet for the new "all content" finder UI across searches (they already work, but are lost when modifying the user-changeable filters or search terms).

These are facets that are able to be used with the finder as query parameters, and if used are shown to the user, but do not have UI to manually select. We can have a much simpler implementation than the existing finder UI because we do not need to consider Javascript.

## Testing on review app
- Visit [a page with hidden clearable manual, organisation, and topical events filters](https://finder-frontend-pr-3490.herokuapp.com/search/all?keywords=test&order=most-viewed&level_one_taxon=&manual%5B%5D=%2Fguidance%2Fmot-inspection-manual-for-private-passenger-and-light-commercial-vehicles&organisations%5B%5D=hm-revenue-customs&public_timestamp%5Bfrom%5D=&public_timestamp%5Bto%5D=&topical_events%5B%5D=election-2024) (note that obviously there's no content matching all three of these filters)
- Change any user-facing filter and/or change the search term
- Note that the hidden clearable filters persist