### PR TITLE
All content finder UI: Persist feature flag query param

### DIFF
--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -15,6 +15,7 @@
 
 <form method="get" action="<%= content_item.base_path %>" data-ga4-change-category="clear-all-filters">
   <%= hidden_field_tag :parent, @parent if @parent.present? %>
+  <%= hidden_field_tag :enable_new_all_content_finder_ui, params[:enable_new_all_content_finder_ui] if params[:enable_new_all_content_finder_ui].present? %>
 
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>


### PR DESCRIPTION
This will make it easier for the team to test the new UI in production by persisting the feature flag query parameter across form submissions.

We can remove this once the new UI is live.