### PR TITLE
Implement `FiltersPresenter#reset_url`

### DIFF
--- a/app/lib/url_builder.rb
+++ b/app/lib/url_builder.rb
@@ -16,6 +16,10 @@ class UrlBuilder
     build_url(query_params.deep_except(excepted_param))
   end
 
+  def url_except_keys(keys)
+    build_url(query_params.except(*keys))
+  end
+
 private
 
   attr_reader :path, :query_params

--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -5,11 +5,11 @@ class FiltersPresenter
   end
 
   def any_filters?
-    facets.any?(&:has_filters?)
+    applied_filters.any?
   end
 
   def summary_items
-    facets.flat_map(&:applied_filters).map do |filter|
+    applied_filters.map do |filter|
       {
         label: filter[:name],
         value: filter[:label],
@@ -20,10 +20,22 @@ class FiltersPresenter
   end
 
   def reset_url
-    "#"
+    return unless any_filters?
+
+    finder_url_builder.url_except_keys(all_filter_keys)
   end
 
 private
 
   attr_reader :facets, :finder_url_builder
+
+  def applied_filters
+    @applied_filters ||= facets.flat_map(&:applied_filters)
+  end
+
+  def all_filter_keys
+    applied_filters
+      .flat_map { |filter| filter[:query_params].keys }
+      .uniq
+  end
 end

--- a/spec/lib/url_builder_spec.rb
+++ b/spec/lib/url_builder_spec.rb
@@ -59,4 +59,22 @@ describe UrlBuilder do
       expect(url).to eq("/search/all?array%5B%5D=two&hash%5Ba%5D=1&hash%5Bc%5D=2&keywords=dumbledore")
     end
   end
+
+  describe "#url_except_keys" do
+    subject(:url) { builder.url_except_keys(excepted_keys) }
+
+    let(:query_params) do
+      {
+        keywords: "dumbledore",
+        hash: { a: 1, b: 2, c: 2 },
+        array: %w[one two],
+        single_value: "value",
+      }
+    end
+    let(:excepted_keys) { %i[hash array single_value] }
+
+    it "builds a URL without the excluded keys" do
+      expect(url).to eq("/search/all?keywords=dumbledore")
+    end
+  end
 end


### PR DESCRIPTION
This returns the URL used for the "Clear all" link on both the filter
summary and filter panel in the new "all content" finder UI.

- Add real implementation for `FiltersPresenter#reset_url`, merging the
  query parameters keys from every applied facet and then removing them
  from the current URL
- Add `UrlBuilder#url_except_keys` to remove all given keys from the
  current finder URL's query parameters
- Refactor duplication into a `#applied_filters` private method

Note this code _could_ be simpler if we just removed all query params except the keyword, but then we would also lose any other query parameters that are unrelated to the filtering/sorting.

## Review app testing
- Go to a [page with lots of applied filters](https://finder-frontend-pr-3493.herokuapp.com/search/all?keywords=&order=updated-newest&level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&level_two_taxon=13fb7519-c48e-4577-90f8-aaf483fa0c03&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=news_and_communications&content_purpose_supergroup%5B%5D=research_and_statistics&content_purpose_supergroup%5B%5D=policy_and_engagement&content_purpose_supergroup%5B%5D=transparency&public_timestamp%5Bfrom%5D=2005&public_timestamp%5Bto%5D=2012&topical_events=election-2024&organisations[]=hm-revenue-customs&manual=%2Fguidance%2Fmot-inspection-manual-for-private-passenger-and-light-commercial-vehicles)
- Try out both the "Clear all filters" links (next to "Apply filters" in the filter panel, and underneath the filter tags in the summary)