### PR TITLE
New "all content" finder UI tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -26,7 +26,7 @@
   display: flex;
   flex-wrap: wrap;
   place-content: space-between;
-  align-items: center;
+  align-items: baseline;
   gap: govuk-spacing(2);
 }
 

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -51,8 +51,13 @@
   }
 
   &:hover {
-    @include govuk-link-decoration;
-    @include govuk-link-hover-decoration;
+    // Webkit does not respect `text-decoration-thickness` on <button> elements, so we add an inner
+    // span to apply the underline to.
+    // Possibly related to https://bugs.webkit.org/show_bug.cgi?id=257992
+    .app-c-filter-panel__button-inner {
+      @include govuk-link-decoration;
+      @include govuk-link-hover-decoration;
+    }
   }
 
   &:focus,
@@ -61,6 +66,10 @@
     background-color: $govuk-focus-colour;
     @include govuk-link-hover-decoration;
     @include govuk-focused-text;
+
+    .app-c-filter-panel__button-inner {
+      text-decoration: none;
+    }
   }
 
   &::before {

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -82,7 +82,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: govuk-spacing(3);
-  padding: govuk-spacing(3) 0;
+  padding: govuk-spacing(4) 0;
 }
 
 .app-c-filter-panel__action--submit {

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -81,7 +81,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: govuk-spacing(2);
+  gap: govuk-spacing(3);
   padding: govuk-spacing(3) 0;
 }
 

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -2,7 +2,7 @@
 @import "mixins/chevron";
 
 .app-c-filter-panel {
-  padding-bottom: govuk-spacing(2);
+  padding: govuk-spacing(3) 0;
   margin-bottom: govuk-spacing(1);
   border-bottom: 1px solid $govuk-border-colour;
 }
@@ -11,6 +11,7 @@
   background-color:  govuk-colour("light-grey");
   padding: 0 govuk-spacing(3);
   margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
 
   // GOV.UK Frontend radio and checkboxes are rendered with a transparent background, which makes
   // them look wrong on this component's grey background. This is intentional in GOV.UK Frontend and

--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -25,7 +25,15 @@
   width: 100%;
   cursor: pointer;
   color: $govuk-text-colour;
+  list-style: none;
   @include chevron;
+
+  // Ensure default disclosure triangle does not get shown in browsers that aren't spec-conformant
+  // around `list-style: none` (current Webkit and some older other browsers)
+  &::marker,
+  &::-webkit-details-marker {
+    display: none;
+  }
 
   &:hover .app-c-filter-section__summary-heading {
     @include govuk-link-decoration;

--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -26,6 +26,7 @@
   cursor: pointer;
   color: $govuk-text-colour;
   list-style: none;
+  padding: govuk-spacing(1) 0;
   @include chevron;
 
   // Ensure default disclosure triangle does not get shown in browsers that aren't spec-conformant

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,8 +1,7 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-filter-summary {
-  padding-bottom: govuk-spacing(5);
-  border-bottom: 1px solid $govuk-border-colour;
+  padding-bottom: govuk-spacing(1);
 }
 
 .app-c-filter-summary__heading {

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,7 +1,7 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-filter-summary {
-  padding-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(5);
   border-bottom: 1px solid $govuk-border-colour;
 }
 
@@ -12,10 +12,11 @@
 
 .app-c-filter-summary__remove-filters {
   list-style-type: none;
+  margin-block-start: 0;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: govuk-spacing(1);
+  gap: govuk-spacing(2);
 }
 
 .app-c-filter-summary__remove-filter {

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -7,7 +7,7 @@
 
 .app-c-filter-summary__heading {
   margin-bottom: govuk-spacing(2);
-  @include govuk-font(16);
+  @include govuk-font(19);
 }
 
 .app-c-filter-summary__remove-filters {
@@ -27,7 +27,7 @@
   align-items: center;
   color: $govuk-text-colour;
   background-color: govuk-colour("light-grey");
-  @include govuk-font(16);
+  @include govuk-font(19);
 
   &:focus {
     background-color: $govuk-focus-colour;
@@ -48,4 +48,8 @@
     padding-right: govuk-spacing(1);
     font-size: 22px;
   }
+}
+
+.app-c-filter-summary__clear-filters {
+  @include govuk-font(19);
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -379,3 +379,8 @@ mark {
     margin-top: govuk-spacing(4);
   }
 }
+
+.app-all-content-finder__spelling-suggestions {
+  margin-top: -(govuk-spacing(2));
+  margin-bottom: govuk-spacing(5);
+}

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -373,3 +373,9 @@ mark {
   overflow: hidden;
   padding-top: govuk-spacing(3);
 }
+
+.app-all-content-finder {
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(4);
+  }
+}

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -34,7 +34,11 @@
         index_section: 0,
         index_section_count: section_count
       }.to_json
-    ) { button_text } %>
+    ) do %>
+      <span class="app-c-filter-panel__button-inner">
+        <%= button_text %>
+      </span>
+    <% end %>
 
     <% if result_text.present? %>
       <%= content_tag("h2", class: "app-c-filter-panel__count") do %>

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -55,6 +55,7 @@
     <div class="app-c-filter-panel__actions">
       <%= submit_tag "Apply filters",
         class: "govuk-button app-c-filter-panel__action app-c-filter-panel__action--submit",
+        name: nil,
         "data-ga4-event" => {
           event_name: "select_content",
           type: "finder",

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -26,13 +26,6 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: sanitize("Search <span class='govuk-visually-hidden'>all content on</span> GOV.UK"),
-            heading_level: 1,
-            font_size: "xl",
-            margin_bottom: 4,
-          } %>
-
           <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
             <%= render "govuk_publishing_components/components/search", {
               id: "finder-keyword-search",
@@ -40,6 +33,14 @@
               type: 'search',
               value: result_set_presenter.user_supplied_keywords,
               disable_corrections: true,
+              label_size: "xl",
+              label_text: safe_join([
+                "Search ",
+                tag.span("all content on", class: "govuk-visually-hidden"),
+                " GOV.UK",
+              ]),
+              wrap_label_in_a_heading: true,
+              heading_level: 1,
               margin_bottom: 4,
             } %>
           </div>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -96,6 +96,7 @@
           <% if result_set_presenter.total_count.positive? %>
             <%= render "govuk_publishing_components/components/document_list", {
               remove_top_border_from_first_child: true,
+              margin_bottom: 5,
               disable_ga4: true,
               items: result_set_presenter.search_results_content[:document_list_component_data],
             } %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -14,39 +14,36 @@
 <% end %>
 <% content_for :meta_title, content_item.title %>
 
-<div class="govuk-width-container">
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
-</div>
+<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
 
 <div class="app-all-content-finder">
   <form method="get" action="<%= content_item.base_path %>" data-ga4-change-category="clear-all-filters" id="all-content-finder-form">
     <%= hidden_field_tag :parent, @parent if @parent.present? %>
     <%= hidden_field_tag :enable_new_all_content_finder_ui, params[:enable_new_all_content_finder_ui] if params[:enable_new_all_content_finder_ui].present? %>
 
-    <div class="govuk-width-container">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds-from-desktop">
-          <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
-            <%= render "govuk_publishing_components/components/search", {
-              id: "finder-keyword-search",
-              name: "keywords",
-              type: 'search',
-              value: result_set_presenter.user_supplied_keywords,
-              disable_corrections: true,
-              label_size: "xl",
-              label_text: safe_join([
-                "Search ",
-                tag.span("all content on", class: "govuk-visually-hidden"),
-                " GOV.UK",
-              ]),
-              wrap_label_in_a_heading: true,
-              heading_level: 1,
-              margin_bottom: 4,
-            } %>
-          </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
+          <%= render "govuk_publishing_components/components/search", {
+            id: "finder-keyword-search",
+            name: "keywords",
+            type: 'search',
+            value: result_set_presenter.user_supplied_keywords,
+            disable_corrections: true,
+            label_size: "xl",
+            label_text: safe_join([
+              "Search ",
+              tag.span("all content on", class: "govuk-visually-hidden"),
+              " GOV.UK",
+            ]),
+            wrap_label_in_a_heading: true,
+            heading_level: 1,
+            margin_bottom: 4,
+          } %>
+        </div>
 
-          <% if @spelling_suggestion_presenter.suggestions.any? %>
-            <% suggestion = @spelling_suggestion_presenter.suggestions.first %>
+        <% if @spelling_suggestion_presenter.suggestions.any? %>
+          <% suggestion = @spelling_suggestion_presenter.suggestions.first %>
 
             <div class="app-all-content-finder__spelling-suggestions">
               Did you mean <%= link_to(
@@ -66,55 +63,54 @@
             </div>
           <% end %>
 
-          <%= render "components/filter_panel", {
-            button_text: "Filter and sort",
-            result_text: result_set_presenter.displayed_total,
-            open: @search_query.invalid?,
-            show_reset_link: filters_presenter.any_filters?,
-            reset_link_href: filters_presenter.reset_url,
-            section_count: facets.user_visible_count,
-          } do %>
-            <% facets.each_with_visible_index_and_count do |facet, index, count| %>
-              <%=
-                render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
-                  object: facet,
-                  locals: { index:, count: }
-              %>
-            <% end %>
+        <%= render "components/filter_panel", {
+          button_text: "Filter and sort",
+          result_text: result_set_presenter.displayed_total,
+          open: @search_query.invalid?,
+          show_reset_link: filters_presenter.any_filters?,
+          reset_link_href: filters_presenter.reset_url,
+          section_count: facets.user_visible_count,
+        } do %>
+          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
+            <%=
+              render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
+                object: facet,
+                locals: { index:, count: }
+            %>
           <% end %>
+        <% end %>
 
-          <% if filters_presenter.any_filters? %>
-            <%= render "components/filter_summary", {
-              clear_all_href: filters_presenter.reset_url,
-              clear_all_text: "Clear all filters",
-              heading_level: 3,
-              heading_text: "Active filters",
-              filters: filters_presenter.summary_items,
-            } %>
-          <% end %>
+        <% if filters_presenter.any_filters? %>
+          <%= render "components/filter_summary", {
+            clear_all_href: filters_presenter.reset_url,
+            clear_all_text: "Clear all filters",
+            heading_level: 3,
+            heading_text: "Active filters",
+            filters: filters_presenter.summary_items,
+          } %>
+        <% end %>
 
-          <% if result_set_presenter.total_count.positive? %>
-            <%= render "govuk_publishing_components/components/document_list", {
-              remove_top_border_from_first_child: true,
-              margin_bottom: 5,
-              disable_ga4: true,
-              items: result_set_presenter.search_results_content[:document_list_component_data],
-            } %>
-          <% else %>
-            <div class='no-results govuk-!-font-size-19 govuk-!-margin-top-4'>
-              <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
-              <p class='govuk-body'>Improve your search results by:</p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>removing filters</li>
-                <li>double-checking your spelling</li>
-                <li>using fewer keywords</li>
-                <li>searching for something less specific</li>
-              </ul>
-            </div>
-          <% end %>
+        <% if result_set_presenter.total_count.positive? %>
+          <%= render "govuk_publishing_components/components/document_list", {
+            remove_top_border_from_first_child: true,
+            margin_bottom: 5,
+            disable_ga4: true,
+            items: result_set_presenter.search_results_content[:document_list_component_data],
+          } %>
+        <% else %>
+          <div class='no-results govuk-!-font-size-19 govuk-!-margin-top-4'>
+            <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
+            <p class='govuk-body'>Improve your search results by:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>removing filters</li>
+              <li>double-checking your spelling</li>
+              <li>using fewer keywords</li>
+              <li>searching for something less specific</li>
+            </ul>
+          </div>
+        <% end %>
 
-          <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
-        </div>
+        <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
       </div>
     </div>
   </div>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -38,7 +38,7 @@
             ]),
             wrap_label_in_a_heading: true,
             heading_level: 1,
-            margin_bottom: 4,
+            margin_bottom: 0,
           } %>
         </div>
 

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -17,7 +17,15 @@
 <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
 
 <div class="app-all-content-finder">
-  <form method="get" action="<%= content_item.base_path %>" data-ga4-change-category="clear-all-filters" id="all-content-finder-form">
+  <%= tag.form(
+    method: "get",
+    action: content_item.base_path,
+    id: "all-content-finder-form",
+    class: "js-all-content-finder-form",
+    data: {
+      ga4_change_category: "clear-all-filters",
+    }
+  ) do %>
     <%= hidden_field_tag :parent, @parent if @parent.present? %>
     <%= hidden_field_tag :enable_new_all_content_finder_ui, params[:enable_new_all_content_finder_ui] if params[:enable_new_all_content_finder_ui].present? %>
 
@@ -113,5 +121,5 @@
         <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -100,8 +100,9 @@
 
         <% if result_set_presenter.total_count.positive? %>
           <%= render "govuk_publishing_components/components/document_list", {
-            remove_top_border_from_first_child: true,
+            margin_top: 0,
             margin_bottom: 5,
+            equal_item_spacing: true,
             disable_ga4: true,
             items: result_set_presenter.search_results_content[:document_list_component_data],
           } %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -10,6 +10,7 @@
   <% if result_set_presenter.discovery_engine_attribution_token %>
     <meta name="govuk:discovery-engine-attribution-token" content="<%= result_set_presenter.discovery_engine_attribution_token %>">
   <% end %>
+  <meta name="govuk:spelling-suggestion" content="<%= @spelling_suggestion_presenter.suggestions.first&.fetch(:keywords, "") %>">
 <% end %>
 <% content_for :meta_title, content_item.title %>
 
@@ -43,9 +44,26 @@
             } %>
           </div>
 
-          <div class="spelling-suggestions">
-            <%= render 'spelling_suggestion' %>
-          </div>
+          <% if @spelling_suggestion_presenter.suggestions.any? %>
+            <% suggestion = @spelling_suggestion_presenter.suggestions.first %>
+
+            <div class="app-all-content-finder__spelling-suggestions">
+              Did you mean <%= link_to(
+                sanitize(suggestion[:highlighted], tags: %w[mark], attributes: []),
+                suggestion[:link],
+                class: "govuk-link",
+                data: {
+                  module: "ga4-link-tracker",
+                  ga4_link: {
+                    event_name: "navigation",
+                    type: "spelling suggestion",
+                    section: "Search",
+                    text: suggestion[:keywords],
+                  }
+                }
+              ) %>?
+            </div>
+          <% end %>
 
           <%= render "components/filter_panel", {
             button_text: "Filter and sort",

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -13,86 +13,88 @@
 <% end %>
 <% content_for :meta_title, content_item.title %>
 
-<form method="get" action="<%= content_item.base_path %>" data-ga4-change-category="clear-all-filters" id="all-content-finder-form">
-  <%= hidden_field_tag :parent, @parent if @parent.present? %>
-  <%= hidden_field_tag :enable_new_all_content_finder_ui, params[:enable_new_all_content_finder_ui] if params[:enable_new_all_content_finder_ui].present? %>
+<div class="govuk-width-container">
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
+</div>
 
-  <div class="govuk-width-container">
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
-  </div>
+<div class="app-all-content-finder">
+  <form method="get" action="<%= content_item.base_path %>" data-ga4-change-category="clear-all-filters" id="all-content-finder-form">
+    <%= hidden_field_tag :parent, @parent if @parent.present? %>
+    <%= hidden_field_tag :enable_new_all_content_finder_ui, params[:enable_new_all_content_finder_ui] if params[:enable_new_all_content_finder_ui].present? %>
 
-  <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: sanitize("Search <span class='govuk-visually-hidden'>all content on</span> GOV.UK"),
-          heading_level: 1,
-          font_size: "xl",
-          margin_bottom: 4,
-        } %>
-
-        <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
-          <%= render "govuk_publishing_components/components/search", {
-            id: "finder-keyword-search",
-            name: "keywords",
-            type: 'search',
-            value: result_set_presenter.user_supplied_keywords,
-            disable_corrections: true,
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: sanitize("Search <span class='govuk-visually-hidden'>all content on</span> GOV.UK"),
+            heading_level: 1,
+            font_size: "xl",
             margin_bottom: 4,
           } %>
-        </div>
 
-        <div class="spelling-suggestions">
-          <%= render 'spelling_suggestion' %>
-        </div>
-
-        <%= render "components/filter_panel", {
-          button_text: "Filter and sort",
-          result_text: result_set_presenter.displayed_total,
-          open: @search_query.invalid?,
-          show_reset_link: filters_presenter.any_filters?,
-          reset_link_href: filters_presenter.reset_url,
-          section_count: facets.user_visible_count,
-        } do %>
-          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
-            <%=
-              render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
-                object: facet,
-                locals: { index:, count: }
-            %>
-          <% end %>
-        <% end %>
-
-        <% if filters_presenter.any_filters? %>
-          <%= render "components/filter_summary", {
-            clear_all_href: filters_presenter.reset_url,
-            clear_all_text: "Clear all filters",
-            heading_level: 3,
-            heading_text: "Selected filters",
-            filters: filters_presenter.summary_items,
-          } %>
-        <% end %>
-
-        <% if result_set_presenter.total_count.positive? %>
-          <%= render "govuk_publishing_components/components/document_list", {
-            remove_top_border_from_first_child: true,
-            disable_ga4: true,
-            items: result_set_presenter.search_results_content[:document_list_component_data],
-          } %>
-        <% else %>
-          <div class='no-results govuk-!-font-size-19 govuk-!-margin-top-4'>
-            <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
-            <p class='govuk-body'>Improve your search results by:</p>
-            <ul class="govuk-list govuk-list--bullet">
-              <li>removing filters</li>
-              <li>double-checking your spelling</li>
-              <li>using fewer keywords</li>
-              <li>searching for something less specific</li>
-            </ul>
+          <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
+            <%= render "govuk_publishing_components/components/search", {
+              id: "finder-keyword-search",
+              name: "keywords",
+              type: 'search',
+              value: result_set_presenter.user_supplied_keywords,
+              disable_corrections: true,
+              margin_bottom: 4,
+            } %>
           </div>
-        <% end %>
 
-        <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
+          <div class="spelling-suggestions">
+            <%= render 'spelling_suggestion' %>
+          </div>
+
+          <%= render "components/filter_panel", {
+            button_text: "Filter and sort",
+            result_text: result_set_presenter.displayed_total,
+            open: @search_query.invalid?,
+            show_reset_link: filters_presenter.any_filters?,
+            reset_link_href: filters_presenter.reset_url,
+            section_count: facets.user_visible_count,
+          } do %>
+            <% facets.each_with_visible_index_and_count do |facet, index, count| %>
+              <%=
+                render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
+                  object: facet,
+                  locals: { index:, count: }
+              %>
+            <% end %>
+          <% end %>
+
+          <% if filters_presenter.any_filters? %>
+            <%= render "components/filter_summary", {
+              clear_all_href: filters_presenter.reset_url,
+              clear_all_text: "Clear all filters",
+              heading_level: 3,
+              heading_text: "Selected filters",
+              filters: filters_presenter.summary_items,
+            } %>
+          <% end %>
+
+          <% if result_set_presenter.total_count.positive? %>
+            <%= render "govuk_publishing_components/components/document_list", {
+              remove_top_border_from_first_child: true,
+              disable_ga4: true,
+              items: result_set_presenter.search_results_content[:document_list_component_data],
+            } %>
+          <% else %>
+            <div class='no-results govuk-!-font-size-19 govuk-!-margin-top-4'>
+              <p class='govuk-body govuk-!-font-weight-bold'>There are no matching results.</p>
+              <p class='govuk-body'>Improve your search results by:</p>
+              <ul class="govuk-list govuk-list--bullet">
+                <li>removing filters</li>
+                <li>double-checking your spelling</li>
+                <li>using fewer keywords</li>
+                <li>searching for something less specific</li>
+              </ul>
+            </div>
+          <% end %>
+
+          <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -25,7 +25,7 @@
 
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
           <div id="keywords" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
             <%= render "govuk_publishing_components/components/search", {
               id: "finder-keyword-search",

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -88,7 +88,7 @@
               clear_all_href: filters_presenter.reset_url,
               clear_all_text: "Clear all filters",
               heading_level: 3,
-              heading_text: "Selected filters",
+              heading_text: "Active filters",
               filters: filters_presenter.summary_items,
             } %>
           <% end %>

--- a/spec/components/filter_panel_spec.rb
+++ b/spec/components/filter_panel_spec.rb
@@ -65,6 +65,12 @@ describe "Filter panel component", type: :view do
     assert_select ".app-c-filter-panel input.govuk-button.app-c-filter-panel__action.app-c-filter-panel__action--submit", value: "Apply filters"
   end
 
+  it "doesn't render any buttons with a name attribute" do
+    render_component(button_text: "Filter")
+
+    assert_select ".app-c-filter-panel input[name]", false
+  end
+
   it "renders the reset link if the show_reset_link option is given" do
     render_component(button_text: "Filter", show_reset_link: true, reset_link_href: "/reset")
 


### PR DESCRIPTION
This implements a number of small UI tweaks following a design review:
- Apply button should not have `name` attr (this causes the button's text to be added to the query parameters, which we don't need and clutters up the analytics)
- Improve spacing of page heading by moving overall UI into a container and adjusting margins
- Fix garbled disclosure marker on filter section `details` element on Webkit and older Blink browsers (by hiding the `::marker` pseudo-element)
- Fix incorrect "Filter and sort" button underline on Webkit (caused by Webkit not respecting `text-decoration-thickness` on `button` elements, and fixed by applying it to an extra inner `span` instead)
- Tweak vertical alignment of result count in filter panel summary
- Improve display of spelling suggestion (by inlining only the bits we need from the existing old finder partial, and tweaking whitespace)
- Remove standalone page heading and use non-inline label search field with a heading-wrapped label
- Increase gap between filter panel action buttons
- Increase padding of filter sections
- Make text in filter summary more consistently sized (19px)
- Tweak spacing of tags in filter summary and increase spacing underneath
- Remove duplicate width container causing display issues at some breakpoints
- Only use two thirds layout on desktop breakpoint and above (remaining full width on tablet)
- Tidy and fix broken form markup (tag wasn't closed), and use ERB to generate the form so the view code looks more manageable
- Use document list component's new `equal_item_spacing` option to tighten up display of results
- Remove bottom border on summary component and stop removing the top border on the first document list element instead

**Review app: https://finder-frontend-pr-3495.herokuapp.com/search/all**

### Before
> ![image](https://github.com/user-attachments/assets/52a0426d-c57c-4387-995e-acc8c7baae82)

### After
> ![image](https://github.com/user-attachments/assets/f4e778e6-dac9-49b7-b613-985c4f5cd93c)
