### PR TITLE
All content finder: Use full size result description

### DIFF
--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -82,6 +82,7 @@ private
         content_item:,
         debug_score:,
         include_ecommerce:,
+        full_size_description: content_item.all_content_finder?,
       ).document_list_component_data
     end
   end

--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -14,7 +14,7 @@ class SearchResultPresenter
            :original_rank,
            to: :document
 
-  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, result_number:, include_ecommerce: true)
+  def initialize(document:, rank:, metadata_presenter_class:, doc_count:, facets:, content_item:, debug_score:, result_number:, include_ecommerce: true, full_size_description: false)
     @document = document
     @rank = rank
     @metadata = metadata_presenter_class.new(document.metadata(facets)).present
@@ -23,6 +23,7 @@ class SearchResultPresenter
     @result_number = result_number
     @content_item = content_item
     @include_ecommerce = include_ecommerce
+    @full_size_description = full_size_description
   end
 
   def document_list_component_data
@@ -31,6 +32,7 @@ class SearchResultPresenter
         text: title,
         path: link,
         description: sanitize(summary_text),
+        full_size_description:,
         data_attributes: ga4_ecommerce_data(link),
       },
       metadata: structure_metadata,
@@ -110,5 +112,5 @@ private
     }
   end
 
-  attr_reader :document, :metadata, :content_item, :result_number
+  attr_reader :document, :metadata, :content_item, :result_number, :full_size_description
 end

--- a/spec/presenters/result_set_presenter_spec.rb
+++ b/spec/presenters/result_set_presenter_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe ResultSetPresenter do
             text: "document_title",
             path: "/path/to/doc",
             description: "document_description",
+            full_size_description: false,
             data_attributes: {
               ga4_ecommerce_path: "/path/to/doc",
               ga4_ecommerce_content_id: "content_id",
@@ -157,6 +158,16 @@ RSpec.describe ResultSetPresenter do
 
         search_result_objects = subject.search_results_content[:document_list_component_data]
         expect(search_result_objects.first).to eql(expected_hash)
+      end
+
+      context "on the all content finder" do
+        before do
+          allow(content_item).to receive(:all_content_finder?).and_return(true)
+        end
+
+        it "shows the full size description" do
+          expect(subject.search_results_content[:document_list_component_data].first[:link][:full_size_description]).to be true
+        end
       end
     end
 

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SearchResultPresenter do
       content_item:,
       facets:,
       debug_score:,
+      full_size_description:,
     )
   end
 
@@ -50,6 +51,7 @@ RSpec.describe SearchResultPresenter do
   let(:description) { "I am a document. I am full of words and that." }
   let(:content_id) { "content_id" }
   let(:show_summaries) { true }
+  let(:full_size_description) { false }
 
   let(:facets) { [] }
 
@@ -63,6 +65,7 @@ RSpec.describe SearchResultPresenter do
           text: title,
           path: link,
           description: "I am a document. I am full of words and that.",
+          full_size_description: false,
           data_attributes: {
             ga4_ecommerce_path: link,
             ga4_ecommerce_content_id: "content_id",
@@ -153,6 +156,14 @@ RSpec.describe SearchResultPresenter do
         it "does not show any parts" do
           expect(subject.document_list_component_data[:parts]).to be_nil
         end
+      end
+    end
+
+    context "with full size description" do
+      let(:full_size_description) { true }
+
+      it "returns link items with the full_size_description attribute set to true" do
+        expect(subject.document_list_component_data[:link][:full_size_description]).to be(true)
       end
     end
   end


### PR DESCRIPTION
This enables the `full_size_description` option on the document list component for search results to match the new search UI design, if the results are presented for the all content finder.

## Visual changes
### Before
![image](https://github.com/user-attachments/assets/339663c5-4b6c-49e8-b3bc-06fdea400875)

### After
![image](https://github.com/user-attachments/assets/0385320d-66f3-489b-a0e7-c42faf38a02a)