### PR TITLE
All content finder: More small styling fixes

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -2,9 +2,7 @@
 @import "mixins/chevron";
 
 .app-c-filter-panel {
-  padding: govuk-spacing(3) 0;
-  margin-bottom: govuk-spacing(1);
-  border-bottom: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
 }
 
 .app-c-filter-panel__content {

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,7 +1,9 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-filter-summary {
+  margin-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(1);
+  border-top: 1px solid $govuk-border-colour;
 }
 
 .app-c-filter-summary__heading {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -381,6 +381,5 @@ mark {
 }
 
 .app-all-content-finder__spelling-suggestions {
-  margin-top: -(govuk-spacing(2));
-  margin-bottom: govuk-spacing(5);
+  margin: govuk-spacing(2) 0;
 }

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -53,7 +53,7 @@
         <% if @spelling_suggestion_presenter.suggestions.any? %>
           <% suggestion = @spelling_suggestion_presenter.suggestions.first %>
 
-            <div class="app-all-content-finder__spelling-suggestions">
+            <p class="govuk-body-s app-all-content-finder__spelling-suggestions">
               Did you mean <%= link_to(
                 sanitize(suggestion[:highlighted], tags: %w[mark], attributes: []),
                 suggestion[:link],
@@ -68,7 +68,7 @@
                   }
                 }
               ) %>?
-            </div>
+            </p>
           <% end %>
 
         <%= render "components/filter_panel", {


### PR DESCRIPTION
- Fix missing border when filter summary is shown
- Fix slightly wonky padding when filter
- Fix misaligned spelling suggestions (and move from `div` to `p` with appropriate style)

## Before
![image](https://github.com/user-attachments/assets/8392fdea-300e-43cb-b6fe-de6f9817d509)

## After
![image](https://github.com/user-attachments/assets/ae861307-2bfc-4cbd-8216-1aab358f3ffb)