### PR TITLE
Resolve Sass deprecation warnings

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -7,8 +7,8 @@
 }
 
 .app-c-expander__title {
-  @include govuk-font(19);
   cursor: pointer;
+  @include govuk-font(19);
 }
 
 .app-c-expander__content {
@@ -56,13 +56,13 @@
 }
 
 .app-c-expander__button {
-  @include govuk-font(19);
   border: 0;
   background: none;
   text-align: left;
   cursor: pointer;
   padding: 0;
   color: $govuk-link-colour;
+  @include govuk-font(19);
 
   &:hover {
     text-decoration: underline;
@@ -89,8 +89,8 @@
 }
 
 .app-c-expander__selected-counter {
-  @include govuk-font($size: 14);
   display: block;
   color: $govuk-text-colour;
   margin-top: 3px;
+  @include govuk-font($size: 14);
 }

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -12,13 +12,12 @@
     margin-left: govuk-spacing(3);
     margin-bottom: govuk-spacing(4);
     text-decoration: none;
+    position: relative;
 
     @include govuk-typography-weight-bold;
     @include govuk-media-query($from: tablet) {
       display: none;
     }
-
-    position: relative;
   }
 
   &[aria-expanded="false"] ~ .mobile-filters-expander__icon--down {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -62,7 +62,7 @@ mark {
   @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
-    max-width: (100% / 3) * 2;
+    max-width: calc(100% / 3) * 2;
   }
 }
 
@@ -290,11 +290,11 @@ mark {
 }
 
 .result-info {
+  border-bottom: solid 1px govuk-colour("black");
+  margin: 0 0 govuk-spacing(4) 0;
   @include govuk-media-query($until: tablet) {
     padding-bottom: govuk-spacing(2);
   }
-  border-bottom: solid 1px govuk-colour("black");
-  margin: 0 0 govuk-spacing(4) 0;
 }
 
 // NOTE: Reset from element level styles inherited from the deprecated `govuk-template`.

--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -8,9 +8,9 @@
   }
 
   h1 {
-    @include govuk-font(24);
     font-weight: bold;
     padding-bottom: 10px;
+    @include govuk-font(24);
   }
 
   .search-header {
@@ -33,8 +33,8 @@
 .search-wrapper--no-search-term {
   @include govuk-media-query($from: tablet) {
     h1 {
-      @include govuk-font(48, $weight: bold);
       padding-bottom: 15px;
+      @include govuk-font(48, $weight: bold);
     }
   }
 }


### PR DESCRIPTION
- Move vanilla declarations above Sass `@include`s
- Wrap division in a `calc()`