### PR TITLE
All content finder: Clean up templates

### DIFF
--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -34,7 +34,7 @@
           text: button_text,
           index_section: 0,
           index_section_count: section_count
-        }.to_json
+        }
       }
     ) do %>
       <%= tag.span(button_text, class: "app-c-filter-panel__button-inner") %>
@@ -67,7 +67,7 @@
             action: "search",
             index_section: 0,
             index_section_count: section_count,
-          }.to_json
+          }
         }
       ) %>
 
@@ -83,7 +83,7 @@
               text: button_text,
               section: button_text,
               action: "remove",
-            }.to_json
+            }
           }
         ) %>
       <% end %>

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -25,25 +25,23 @@
       id: button_id,
       class: "app-c-filter-panel__button govuk-link",
       aria: { expanded: "false", controls: panel_content_id },
-      "data-ga4-expandable": "",
-      "data-ga4-event": {
-        event_name: "select_content",
-        type: "finder",
-        section: button_text,
-        text: button_text,
-        index_section: 0,
-        index_section_count: section_count
-      }.to_json
+      data: {
+        ga4_expandable: "",
+        ga4_event: {
+          event_name: "select_content",
+          type: "finder",
+          section: button_text,
+          text: button_text,
+          index_section: 0,
+          index_section_count: section_count
+        }.to_json
+      }
     ) do %>
-      <span class="app-c-filter-panel__button-inner">
-        <%= button_text %>
-      </span>
+      <%= tag.span(button_text, class: "app-c-filter-panel__button-inner") %>
     <% end %>
 
     <% if result_text.present? %>
-      <%= content_tag("h2", class: "app-c-filter-panel__count") do %>
-        <%= result_text %>
-      <% end %>
+      <%= tag.h2(result_text, class: "app-c-filter-panel__count") %>
     <% end %>
   </div>
 
@@ -55,34 +53,39 @@
   ) do %>
     <%= yield %>
 
-
     <div class="app-c-filter-panel__actions">
-      <%= submit_tag "Apply filters",
+      <%= submit_tag(
+        "Apply filters",
         class: "govuk-button app-c-filter-panel__action app-c-filter-panel__action--submit",
         name: nil,
-        "data-ga4-event" => {
-          event_name: "select_content",
-          type: "finder",
-          text: button_text,
-          section: button_text,
-          action: "search",
-          index_section: 0,
-          index_section_count: section_count,
-        }.to_json %>
+        data: {
+          ga4_event: {
+            event_name: "select_content",
+            type: "finder",
+            text: button_text,
+            section: button_text,
+            action: "search",
+            index_section: 0,
+            index_section_count: section_count,
+          }.to_json
+        }
+      ) %>
 
       <% if show_reset_link %>
-        <%=
-          link_to "Clear all filters",
-            reset_link_href,
-            class: "govuk-link govuk-link--no-visited-state app-c-filter-panel__action app-c-filter-panel__action--reset",
-            "data-ga4-event" => {
+        <%= link_to(
+          "Clear all filters",
+          reset_link_href,
+          class: "govuk-link govuk-link--no-visited-state app-c-filter-panel__action app-c-filter-panel__action--reset",
+          data: {
+            ga4_event: {
               event_name: "select_content",
               type: "finder",
               text: button_text,
               section: button_text,
               action: "remove",
             }.to_json
-        %>
+          }
+        ) %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/components/_filter_section.html.erb
+++ b/app/views/components/_filter_section.html.erb
@@ -6,43 +6,48 @@
   status_text ||= ""
   visually_hidden_heading_prefix ||= ""
   heading_level ||= 2
-  summary_aria_attributes ||= {}
   index_section ||= 0
   index_section_count ||= 0
   change_category ||= nil
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_data_attribute({ module: "filter-section" })
-  component_helper.add_data_attribute({ "ga4-section": heading_text, "ga4-filter-parent": heading_text })
-  component_helper.add_data_attribute("ga4-change-category": change_category)
+  component_helper.add_data_attribute({
+    module: "filter-section",
+    ga4_section: heading_text,
+    ga4_filter_parent: heading_text,
+    ga4_change_category: change_category,
+  })
   component_helper.add_class("app-c-filter-section")
   component_helper.set_open(open)
 %>
 
 <%= tag.details(**component_helper.all_attributes) do %>
-  <%= tag.summary class: "app-c-filter-section__summary", aria: summary_aria_attributes,
-      "data-ga4-expandable": "",
-      "data-ga4-event" => {
+  <%= tag.summary(
+    class: "app-c-filter-section__summary",
+    data: {
+      ga4_expandable: "",
+      ga4_event: {
         event_name: "select_content",
         type: "finder",
         section: heading_text,
         text: heading_text,
         index_section: index_section,
         index_section_count: index_section_count,
-      }.to_json do %>
-      <%= content_tag("h#{heading_level}", class: "app-c-filter-section__summary-heading") do %>
-        <% if visually_hidden_heading_prefix.present? %>
-          <span class="govuk-visually-hidden"><%= visually_hidden_heading_prefix %></span>
-        <% end %>
-        <%= heading_text %>
+      }.to_json
+    }
+  ) do %>
+    <%= content_tag("h#{heading_level}", class: "app-c-filter-section__summary-heading") do %>
+      <% if visually_hidden_heading_prefix.present? %>
+        <%= tag.span(visually_hidden_heading_prefix, class: "govuk-visually-hidden") %>
       <% end %>
+      <%= heading_text %>
+    <% end %>
 
-      <% if status_text.present? %>
-        <span class="app-c-filter-section__summary-status">
-          <%= status_text %>
-        </span>
-      <% end %>
+    <% if status_text.present? %>
+      <%= tag.span(status_text, class: "app-c-filter-section__summary-status") %>
+    <% end %>
   <% end %>
+
   <div class="app-c-filter-section__content">
     <%= yield %>
   </div>

--- a/app/views/components/_filter_section.html.erb
+++ b/app/views/components/_filter_section.html.erb
@@ -33,7 +33,7 @@
         text: heading_text,
         index_section: index_section,
         index_section_count: index_section_count,
-      }.to_json
+      }
     }
   ) do %>
     <%= content_tag("h#{heading_level}", class: "app-c-filter-section__summary-heading") do %>

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -35,7 +35,7 @@
                 type: "finder",
                 section: filter[:label],
                 action: "remove"
-              }.to_json
+              }
             }
           ) do %>
             <span class="app-c-filter-summary__remove-filter-text">
@@ -60,7 +60,7 @@
               text: clear_all_text,
               section: heading_text,
               action: "remove"
-            }.to_json
+            }
           },
         ) %>
       </div>

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -19,23 +19,27 @@
   <%= tag.div(**component_helper.all_attributes) do %>
     <% if heading_text.present? %>
       <%= content_tag("h#{heading_level}", class: "app-c-filter-summary__heading") do %>
-        <% heading_text %>
+        <%= heading_text %>
       <% end %>
     <% end %>
 
     <ul class="app-c-filter-summary__remove-filters">
       <% filters.each do |filter| %>
         <li>
-          <%= link_to filter[:remove_href],
-          class: "app-c-filter-summary__remove-filter",
-          "data-ga4-event" => {
-            event_name: "select_content",
-            type: "finder",
-            section: filter[:label],
-            action: "remove"
-          }.to_json do %>
+          <%= link_to(
+            filter[:remove_href],
+            class: "app-c-filter-summary__remove-filter",
+            data: {
+              ga4_event: {
+                event_name: "select_content",
+                type: "finder",
+                section: filter[:label],
+                action: "remove"
+              }.to_json
+            }
+          ) do %>
             <span class="app-c-filter-summary__remove-filter-text">
-              <span class="govuk-visually-hidden"><%= filter[:visually_hidden_prefix] %></span>
+              <%= tag.span(filter[:visually_hidden_prefix], class: "govuk-visually-hidden") %>
               <%= filter[:label] %>: <%= filter[:value] %>
             </span>
           <% end %>
@@ -45,15 +49,20 @@
 
     <% if clear_all_text.present? && clear_all_href.present? %>
       <div>
-        <%= link_to clear_all_text, clear_all_href,
-        class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state",
-        "data-ga4-event" => {
-          event_name: "select_content",
-          type: "finder",
-          text: clear_all_text,
-          section: heading_text,
-          action: "remove"
-        }.to_json %>
+        <%= link_to(
+          clear_all_text,
+          clear_all_href,
+          class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state",
+          data: {
+            ga4_event: {
+              event_name: "select_content",
+              type: "finder",
+              text: clear_all_text,
+              section: heading_text,
+              action: "remove"
+            }.to_json
+          },
+        ) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -7,7 +7,7 @@
   index_section_count: count,
   # Note date is the only validated facet, so if there is an error, it'll be here
   open: @search_query.invalid?,
-  data_attributes: { "ga4-index": { index_section: index + 1, index_section_count: count } },
+  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
   change_category: "update-filter text",
 } do %>
   <%= render "govuk_publishing_components/components/input", {

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -7,7 +7,7 @@
   id: "facet_option_select_#{option_select_facet.key}",
   index_section: index,
   index_section_count: count,
-  data_attributes: { "ga4-index": { index_section: index + 1, index_section_count: count } },
+  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
   change_category: "update-filter checkbox",
 } do %>
   <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
@@ -4,7 +4,7 @@
   id: "facet_sort",
   index_section: index,
   index_section_count: count,
-  data_attributes: { "ga4-index": { index_section: index + 1, index_section_count: count } },
+  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
   change_category: "update-filter radio",
 } do %>
   <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -5,7 +5,7 @@
   id: "facet_taxon_#{taxon_facet.key}",
   index_section: index,
   index_section_count: count,
-  data_attributes: { "ga4-index": { index_section: index + 1, index_section_count: count } },
+  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
   change_category: "update-filter select",
   classes: "js-all-content-finder-taxonomy-select"
 } do %>


### PR DESCRIPTION
The component and facet templates have a fair bit of unidiomatic code in them, including:
- Using symbols with dashes in them for data attributes, instead of letting Rails automatically dasherise more idiomatic underscored symbols
- Setting data attributes directly on top level of tags instead of `data` hash
- Verbose manual tags with basic string content where tag helper can be more succinct

This tidies these templates up a bit to make them more readable, consistent, and maintainable.

> [!NOTE]
> The diff for this PR is best viewed with whitespace changes hidden (`?w=1`)