### PR TITLE
Improve handling of facet sections for GA4

### DIFF
--- a/app/lib/facets_iterator.rb
+++ b/app/lib/facets_iterator.rb
@@ -1,6 +1,5 @@
 class FacetsIterator
   include Enumerable
-  delegate :each, to: :@facets
 
   def initialize(facets)
     @facets = facets
@@ -11,9 +10,9 @@ class FacetsIterator
     @user_visible_facets.count
   end
 
-  def each_with_visible_index_and_count
+  def each
     @facets.each do |facet|
-      yield facet, @user_visible_facets.index(facet), user_visible_count
+      yield FacetPresenter.new(facet, @user_visible_facets.index(facet), user_visible_count)
     end
   end
 end

--- a/app/presenters/facet_presenter.rb
+++ b/app/presenters/facet_presenter.rb
@@ -1,0 +1,11 @@
+class FacetPresenter < SimpleDelegator
+  attr_reader :section_index, :section_count
+
+  def initialize(facet, section_index, section_count)
+    super(facet)
+
+    # Facet index is 1-based for GOV.UK analytics
+    @section_index = section_index + 1 if section_index
+    @section_count = section_count
+  end
+end

--- a/app/views/finders/_date_facet.html.erb
+++ b/app/views/finders/_date_facet.html.erb
@@ -7,15 +7,21 @@
     aria_controls_id: "js-search-results-info",
     date_errors_to: date_facet.error_message_to(@search_query),
     date_errors_from: date_facet.error_message_from(@search_query),
-    data_attributes:  { "ga4-filter-parent": date_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    data_attributes: {
+      ga4_filter_parent: date_facet.ga4_section,
+      ga4_index: {
+        index_section: date_facet.section_index,
+        index_section_count: date_facet.section_count,
+      }
+    },
     button_data_attributes: {
       ga4_expandable: "",
       ga4_event: {
         event_name: 'select_content',
         type: 'finder',
         section: date_facet.name,
-        index_section: index + 1,
-        index_section_count: count,
+        index_section: date_facet.section_index,
+        index_section_count: date_facet.section_count,
       }
     }
   } %>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -44,8 +44,10 @@
           </div>
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
-          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
-            <%= render partial: facet, object: facet, locals: { index:, count: } %>
+          <% facets.each do |facet| %>
+            <%= render partial: facet, object: facet, locals: {
+              index: facet.section_index, count: facet.section_count,
+            } %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -45,9 +45,7 @@
         </div>
         <div class="facets__content" data-module="ga4-event-tracker" data-ga4-filter-container>
           <% facets.each do |facet| %>
-            <%= render partial: facet, object: facet, locals: {
-              index: facet.section_index, count: facet.section_count,
-            } %>
+            <%= render facet %>
           <% end %>
           <div class="facets__tags-block js-mobile-facet-tag-block"  data-module="remove-filter">
             <%= render "facet_tags", facet_tags.present %>

--- a/app/views/finders/_option_select_facet.html.erb
+++ b/app/views/finders/_option_select_facet.html.erb
@@ -4,29 +4,41 @@
   # caching is used
   add_gem_component_stylesheet("option-select")
   add_gem_component_stylesheet("checkboxes")
-  index_section = index + 1
-  index_section_count = count
 %>
-<% cache_if option_select_facet.cacheable?, option_select_facet.cache_key(index_section, index_section_count) do %>
+<% cache_if(
+  option_select_facet.cacheable?,
+  option_select_facet.cache_key(
+    option_select_facet.section_index,
+    option_select_facet.section_count,
+  ),
+) do %>
   <%= render partial: 'govuk_publishing_components/components/option_select', locals: {
-    :key => option_select_facet.key,
-    :title => option_select_facet.name,
-    :aria_controls_id => "js-search-results-info",
-    :options_container_id => option_select_facet.key,
-    :options => option_select_facet.options("js-search-results-info", option_select_facet.key),
-    :closed_on_load => option_select_facet.closed_on_load?(index),
-    :closed_on_load_mobile => option_select_facet.closed_on_load_mobile?,
-    :show_filter => option_select_facet.show_option_select_filter,
-    :large => option_select_facet.large?,
-    :data_attributes => { "ga4-change-category": "update-filter checkbox", "ga4-filter-parent": "", "ga4-section": option_select_facet.ga4_section, "ga4-index": { index_section: index_section, index_section_count: index_section_count } },
-    :button_data_attributes => {
-      "ga4-expandable": "",
-      "ga4-event": {
+    key: option_select_facet.key,
+    title: option_select_facet.name,
+    aria_controls_id: "js-search-results-info",
+    options_container_id: option_select_facet.key,
+    options: option_select_facet.options("js-search-results-info", option_select_facet.key),
+    closed_on_load: option_select_facet.closed_on_load?(option_select_facet.section_index),
+    closed_on_load_mobile: option_select_facet.closed_on_load_mobile?,
+    show_filter: option_select_facet.show_option_select_filter,
+    large: option_select_facet.large?,
+    data_attributes: {
+      ga4_change_category: "update-filter checkbox",
+      ga4_filter_parent: "",
+      ga4_section: option_select_facet.ga4_section,
+      ga4_index: {
+        index_section: option_select_facet.section_index,
+        index_section_count: option_select_facet.section_count,
+      },
+    },
+    button_data_attributes: {
+      ga4_expandable: "",
+      ga4_event: {
         event_name: 'select_content',
         type: 'finder',
         section: option_select_facet.name,
-        index_section: index_section,
-        index_section_count: index_section_count
+        index_section: option_select_facet.section_index,
+        index_section_count: option_select_facet.section_count,
       }
     }
   } %>

--- a/app/views/finders/_radio_facet.html.erb
+++ b/app/views/finders/_radio_facet.html.erb
@@ -1,4 +1,15 @@
-<%= tag.div(class: "facet-container", data: { "ga4-change-category": "update-filter radio", "ga4-filter-parent": radio_facet.ga4_section, "ga4-section": "", "ga4-index": { index_section: index + 1, index_section_count: count } }) do %>
+<%= tag.div(
+  class: "facet-container",
+  data: {
+    ga4_change_category: "update-filter radio",
+    ga4_filter_parent: radio_facet.ga4_section,
+    ga4_section: "",
+    ga4_index: {
+      index_section: radio_facet.section_index,
+      index_section_count: radio_facet.section_count,
+    },
+  }
+) do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: radio_facet.key,
     small: true,

--- a/app/views/finders/_taxon_facet.html.erb
+++ b/app/views/finders/_taxon_facet.html.erb
@@ -6,14 +6,20 @@
         event_name: 'select_content',
         type: 'finder',
         section: "Topic",
-        index_section: index + 1,
-        index_section_count: count,
+        index_section: taxon_facet.section_index,
+        index_section_count: taxon_facet.section_count,
       }
     }
   %>
   <%= render "components/expander", {
     title: "Topic",
-    data_attributes: { "ga4-filter-parent": taxon_facet.ga4_section, "ga4-index": { index_section: index + 1, index_section_count: count } },
+    data_attributes: {
+      ga4_filter_parent: taxon_facet.ga4_section,
+      ga4_index: {
+        index_section: taxon_facet.section_index,
+        index_section_count: taxon_facet.section_count,
+      },
+    },
     button_data_attributes:
   } do %>
     <div class="js-taxonomy-select" data-ga4-change-category="update-filter select" data-ga4-section="Topic">

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -3,11 +3,16 @@
   visually_hidden_heading_prefix: "Filter by",
   status_text: date_facet.status_text,
   id: "facet_date_#{date_facet.key}",
-  index_section: index,
-  index_section_count: count,
+  index_section: date_facet.section_index,
+  index_section_count: date_facet.section_count,
   # Note date is the only validated facet, so if there is an error, it'll be here
   open: @search_query.invalid?,
-  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
+  data_attributes: {
+    ga4_index: {
+      index_section: date_facet.section_index,
+      index_section_count: date_facet.section_count,
+    },
+  },
   change_category: "update-filter text",
 } do %>
   <%= render "govuk_publishing_components/components/input", {

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -5,9 +5,14 @@
   visually_hidden_heading_prefix: "Filter by",
   status_text: option_select_facet.status_text,
   id: "facet_option_select_#{option_select_facet.key}",
-  index_section: index,
-  index_section_count: count,
-  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
+  index_section: option_select_facet.section_index,
+  index_section_count: option_select_facet.section_count,
+  data_attributes: {
+    ga4_index: {
+      index_section: option_select_facet.section_index,
+      index_section_count: option_select_facet.section_count,
+    },
+  },
   change_category: "update-filter checkbox",
 } do %>
   <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
@@ -2,9 +2,14 @@
   heading_text: sort_facet.name,
   status_text: sort_facet.status_text,
   id: "facet_sort",
-  index_section: index,
-  index_section_count: count,
-  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
+  index_section: sort_facet.section_index,
+  index_section_count: sort_facet.section_count,
+  data_attributes: {
+    ga4_index: {
+      index_section: sort_facet.section_index,
+      index_section_count: sort_facet.section_count,
+    },
+  },
   change_category: "update-filter radio",
 } do %>
   <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -3,9 +3,14 @@
   visually_hidden_heading_prefix: "Filter by",
   status_text: taxon_facet.status_text,
   id: "facet_taxon_#{taxon_facet.key}",
-  index_section: index,
-  index_section_count: count,
-  data_attributes: { ga4_index: { index_section: index + 1, index_section_count: count } },
+  index_section: taxon_facet.section_index,
+  index_section_count: taxon_facet.section_count,
+  data_attributes: {
+    ga4_index: {
+      index_section: taxon_facet.section_index,
+      index_section_count: taxon_facet.section_count,
+    },
+  },
   change_category: "update-filter select",
   classes: "js-all-content-finder-taxonomy-select"
 } do %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -89,11 +89,11 @@
           reset_link_href: filters_presenter.reset_url,
           section_count: facets.user_visible_count,
         } do %>
-          <% facets.each_with_visible_index_and_count do |facet, index, count| %>
+          <% facets.each do |facet| %>
             <%=
               render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
                 object: facet,
-                locals: { index:, count: }
+                locals: { index: facet.section_index, count: facet.section_count }
             %>
           <% end %>
         <% end %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -92,8 +92,7 @@
           <% facets.each do |facet| %>
             <%=
               render partial: "finders/all_content_finder_facets/#{facet.to_partial_path}",
-                object: facet,
-                locals: { index: facet.section_index, count: facet.section_count }
+                object: facet
             %>
           <% end %>
         <% end %>

--- a/spec/lib/facets_iterator_spec.rb
+++ b/spec/lib/facets_iterator_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 RSpec.describe FacetsIterator do
   subject(:facets_iterator) { described_class.new(facets) }
 
-  let(:visible_facet) { instance_double(Facet, user_visible?: true) }
-  let(:another_visible_facet) { instance_double(Facet, user_visible?: true) }
-  let(:hidden_facet) { instance_double(Facet, user_visible?: false) }
+  let(:visible_facet) { instance_double(Facet, key: "visible", user_visible?: true) }
+  let(:another_visible_facet) { instance_double(Facet, key: "another", user_visible?: true) }
+  let(:hidden_facet) { instance_double(Facet, key: "hidden", user_visible?: false) }
 
   let(:facets) { [visible_facet, hidden_facet, another_visible_facet] }
 
@@ -15,13 +15,13 @@ RSpec.describe FacetsIterator do
     end
   end
 
-  describe "#each_with_visible_index_and_count" do
-    it "yields each facet with its index (if visible) and the total count of visible facets" do
-      expect { |block| facets_iterator.each_with_visible_index_and_count(&block) }
+  describe "#each" do
+    it "yields each facet as a FacetPresenter" do
+      expect { |block| facets_iterator.each(&block) }
         .to yield_successive_args(
-          [visible_facet, 0, 2],
-          [hidden_facet, nil, 2],
-          [another_visible_facet, 1, 2],
+          an_object_having_attributes(key: "visible", section_index: 2, section_count: 2),
+          an_object_having_attributes(key: "hidden", section_index: nil, section_count: 2),
+          an_object_having_attributes(key: "another", section_index: 2, section_count: 2),
         )
     end
   end

--- a/spec/lib/facets_iterator_spec.rb
+++ b/spec/lib/facets_iterator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FacetsIterator do
     it "yields each facet as a FacetPresenter" do
       expect { |block| facets_iterator.each(&block) }
         .to yield_successive_args(
-          an_object_having_attributes(key: "visible", section_index: 2, section_count: 2),
+          an_object_having_attributes(key: "visible", section_index: 1, section_count: 2),
           an_object_having_attributes(key: "hidden", section_index: nil, section_count: 2),
           an_object_having_attributes(key: "another", section_index: 2, section_count: 2),
         )

--- a/spec/presenters/facet_presenter_spec.rb
+++ b/spec/presenters/facet_presenter_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe FacetPresenter do
+  subject(:facet_presenter) { described_class.new(facet, section_index, section_count) }
+
+  let(:facet) { instance_double(Facet, key: "a_facet") }
+  let(:section_index) { 1 }
+  let(:section_count) { 2 }
+
+  it "delegates methods to the facet" do
+    expect(facet_presenter.key).to eq("a_facet")
+  end
+
+  describe "#section_index" do
+    it "exposes the section index as a 1-based index" do
+      expect(facet_presenter.section_index).to eq(2)
+    end
+
+    context "when no section index is provided" do
+      let(:section_index) { nil }
+
+      it "exposes nil as the section index" do
+        expect(facet_presenter.section_index).to be_nil
+      end
+    end
+  end
+
+  describe "#section_count" do
+    it "exposes the section count" do
+      expect(facet_presenter.section_count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
The current logic for dealing with section indices and counts is quite
messy, with the `FacetsIterator` yielding several values that are then
passed through several layers of views and partials.

This introduces a `FacetPresenter` that holds section index/count values
(appropriately using 1-based indexing) and makes the iterator yield that
instead.

It then changes all facet partials (both current UI and new all content
finder UI) to use `FacetPresenter` instead of manipulating and passing
index and count values through several layers of view code.

Where appropriate, it also cleans up the old partials to use idiomatic
modern Ruby syntax, better spacing, and Rails-y underscored data
attribute values.
