### PR TITLE
All content finder: Assorted GA4 tracking fixes

### DIFF
--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -13,6 +13,7 @@ class FiltersPresenter
       {
         label: filter[:name],
         value: filter[:label],
+        displayed_text: "#{filter[:name]}: #{filter[:label]}",
         remove_href: finder_url_builder.url_except(filter[:query_params]),
         visually_hidden_prefix: "Remove filter",
       }

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -62,7 +62,7 @@
           ga4_event: {
             event_name: "select_content",
             type: "finder",
-            text: button_text,
+            text: "Apply filters",
             section: button_text,
             action: "search",
             index_section: 0,
@@ -80,7 +80,6 @@
             ga4_event: {
               event_name: "select_content",
               type: "finder",
-              text: button_text,
               section: button_text,
               action: "remove",
               index_section: 0,

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -83,6 +83,8 @@
               text: button_text,
               section: button_text,
               action: "remove",
+              index_section: 0,
+              index_section_count: section_count,
             }
           }
         ) %>

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -41,7 +41,7 @@
     <% end %>
 
     <% if result_text.present? %>
-      <%= tag.h2(result_text, class: "app-c-filter-panel__count") %>
+      <%= tag.h2(result_text, id: "js-result-count", class: "app-c-filter-panel__count") %>
     <% end %>
   </div>
 

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -33,6 +33,7 @@
               ga4_event: {
                 event_name: "select_content",
                 type: "finder",
+                text: filter[:displayed_text],
                 section: filter[:label],
                 action: "remove"
               }
@@ -40,7 +41,7 @@
           ) do %>
             <span class="app-c-filter-summary__remove-filter-text">
               <%= tag.span(filter[:visually_hidden_prefix], class: "govuk-visually-hidden") %>
-              <%= filter[:label] %>: <%= filter[:value] %>
+              <%= filter[:displayed_text] %>
             </span>
           <% end %>
         </li>

--- a/spec/components/filter_summary_spec.rb
+++ b/spec/components/filter_summary_spec.rb
@@ -10,18 +10,21 @@ describe "Filter summary component", type: :view do
       {
         label: "Filter 1",
         value: "Value 1",
+        displayed_text: "Displayed text 1",
         remove_href: "/remove_url",
         visually_hidden_prefix: "Remove filter",
       },
       {
         label: "Filter 2",
         value: "Value 2",
+        displayed_text: "Displayed text 21",
         remove_href: "/remove_url",
         visually_hidden_prefix: "Remove filter",
       },
       {
         label: "Filter 3",
         value: "Value that is so long that the styling needs to handle it correctly",
+        displayed_text: "Displayed text 3",
         remove_href: "/remove_url",
         visually_hidden_prefix: "Remove filter",
       },
@@ -80,6 +83,7 @@ describe "Filter summary component", type: :view do
     link_event_attributes = {
       event_name: "select_content",
       type: "finder",
+      text: "Displayed text 1",
       section: "Filter 1",
       action: "remove",
     }

--- a/spec/presenters/filters_presenter_spec.rb
+++ b/spec/presenters/filters_presenter_spec.rb
@@ -106,6 +106,7 @@ describe FiltersPresenter do
         expect(summary_items).to contain_exactly({
           label: "name",
           value: "label",
+          displayed_text: "name: label",
           remove_href: "/search/foo",
           visually_hidden_prefix: "Remove filter",
         })


### PR DESCRIPTION
This fixes a number of paper cuts with GA4 tracking on the new all content finder UI, including:
* Missing result count on eCommerce tracking
* Filter removal through tags in filter summary including the visually hidden text
* "Clear all filters" button missing section index/count
* "Apply filters"/"Clear all filters" buttons including the wrong text (panel open button's text instead of their own)