### PR TITLE
All content finder: Assorted component tidying

### DIFF
--- a/app/views/components/_filter_section.html.erb
+++ b/app/views/components/_filter_section.html.erb
@@ -4,7 +4,6 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   open ||= nil
   status_text ||= ""
-  visually_hidden_heading_prefix ||= ""
   heading_level ||= 2
   index_section ||= 0
   index_section_count ||= 0
@@ -37,8 +36,8 @@
     }
   ) do %>
     <%= content_tag("h#{heading_level}", class: "app-c-filter-section__summary-heading") do %>
-      <% if visually_hidden_heading_prefix.present? %>
-        <%= tag.span(visually_hidden_heading_prefix, class: "govuk-visually-hidden") %>
+      <% unless local_assigns[:disable_visually_hidden_heading_prefix] %>
+        <span class="govuk-visually-hidden">Filter by</span>
       <% end %>
       <%= heading_text %>
     <% end %>

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -6,8 +6,8 @@
   heading_level ||= 3
   heading_text ||= "Active filters"
 
-  clear_all_href ||= nil
-  clear_all_text ||= "Clear all filters"
+  reset_link_href ||= nil
+  reset_link_text ||= "Clear all filters"
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
@@ -44,17 +44,17 @@
     <% end %>
   </ul>
 
-  <% if clear_all_href.present? %>
+  <% if reset_link_href.present? %>
     <div>
       <%= link_to(
-        clear_all_text,
-        clear_all_href,
+        reset_link_text,
+        reset_link_href,
         class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state",
         data: {
           ga4_event: {
             event_name: "select_content",
             type: "finder",
-            text: clear_all_text,
+            text: reset_link_text,
             section: heading_text,
             action: "remove"
           }

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -1,70 +1,65 @@
 <%
   add_app_component_stylesheet("filter-summary")
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   filters ||= []
 
-  clear_all_href ||= nil
-  clear_all_text ||= nil
   heading_level ||= 3
-  heading_text ||= nil
+  heading_text ||= "Active filters"
 
+  clear_all_href ||= nil
+  clear_all_text ||= "Clear all filters"
+
+  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_class(shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
   component_helper.add_data_attribute({ module: "ga4-event-tracker" })
   component_helper.add_class("app-c-filter-summary")
 %>
 
-<% if filters && filters.length > 0  %>
-  <%= tag.div(**component_helper.all_attributes) do %>
-    <% if heading_text.present? %>
-      <%= content_tag("h#{heading_level}", class: "app-c-filter-summary__heading") do %>
-        <%= heading_text %>
-      <% end %>
-    <% end %>
+<%= tag.div(**component_helper.all_attributes) do %>
+  <%= content_tag("h#{heading_level}", heading_text, class: "app-c-filter-summary__heading") %>
 
-    <ul class="app-c-filter-summary__remove-filters">
-      <% filters.each do |filter| %>
-        <li>
-          <%= link_to(
-            filter[:remove_href],
-            class: "app-c-filter-summary__remove-filter",
-            data: {
-              ga4_event: {
-                event_name: "select_content",
-                type: "finder",
-                text: filter[:displayed_text],
-                section: filter[:label],
-                action: "remove"
-              }
-            }
-          ) do %>
-            <span class="app-c-filter-summary__remove-filter-text">
-              <%= tag.span(filter[:visually_hidden_prefix], class: "govuk-visually-hidden") %>
-              <%= filter[:displayed_text] %>
-            </span>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-
-    <% if clear_all_text.present? && clear_all_href.present? %>
-      <div>
+  <ul class="app-c-filter-summary__remove-filters">
+    <% filters.each do |filter| %>
+      <li>
         <%= link_to(
-          clear_all_text,
-          clear_all_href,
-          class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state",
+          filter[:remove_href],
+          class: "app-c-filter-summary__remove-filter",
           data: {
             ga4_event: {
               event_name: "select_content",
               type: "finder",
-              text: clear_all_text,
-              section: heading_text,
+              text: filter[:displayed_text],
+              section: filter[:label],
               action: "remove"
             }
-          },
-        ) %>
-      </div>
+          }
+        ) do %>
+          <span class="app-c-filter-summary__remove-filter-text">
+            <%= tag.span(filter[:visually_hidden_prefix], class: "govuk-visually-hidden") %>
+            <%= filter[:displayed_text] %>
+          </span>
+        <% end %>
+      </li>
     <% end %>
+  </ul>
+
+  <% if clear_all_href.present? %>
+    <div>
+      <%= link_to(
+        clear_all_text,
+        clear_all_href,
+        class: "app-c-filter-summary__clear-filters govuk-link govuk-link--no-visited-state",
+        data: {
+          ga4_event: {
+            event_name: "select_content",
+            type: "finder",
+            text: clear_all_text,
+            section: heading_text,
+            action: "remove"
+          }
+        },
+      ) %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/components/docs/filter_section.yml
+++ b/app/views/components/docs/filter_section.yml
@@ -24,11 +24,14 @@ examples:
       open: true
       block: |
         <span>Filter form controls open by default</span>
-  with_visually_hidden_heading_prefix:
-    description: Prefix the heading text with visually hidden text for screenreaders to make it more descriptive.
+  with_disabled_visually_hidden_heading_prefix:
+    description: |
+      The heading text is prefixed with visually hidden text ("Filter by") for screenreaders to make
+      it more descriptive. In some circumstances, for example when the heading is already
+      descriptive on its own like "Sort by", this should be able to be disabled.
     data:
       heading_text: Some metadata field
-      visually_hidden_heading_prefix: Filter by
+      disable_visually_hidden_heading_prefix: true
       block: |
         <span>Filter form controls</span>
   status_text:

--- a/app/views/components/docs/filter_summary.yml
+++ b/app/views/components/docs/filter_summary.yml
@@ -12,8 +12,8 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      clear_all_href: "#"
-      clear_all_text: "Clear all filters"
+      reset_link_href: "#"
+      reset_link_text: "Clear all filters"
       heading_level: 3
       heading_text: "Selected filters"
       filters: [

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -1,6 +1,5 @@
 <%= render "components/filter_section", {
   **date_facet.section_attributes,
-  visually_hidden_heading_prefix: "Filter by",
   change_category: "update-filter text",
   # Note date is the only validated facet, so if there is an error, it'll be here
   open: @search_query.invalid?,

--- a/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_option_select_facet.html.erb
@@ -2,7 +2,6 @@
 
 <%= render "components/filter_section", {
   **option_select_facet.section_attributes,
-  visually_hidden_heading_prefix: "Filter by",
   change_category: "update-filter checkbox",
 } do %>
   <%= render "govuk_publishing_components/components/checkboxes", {

--- a/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_sort_facet.html.erb
@@ -1,5 +1,6 @@
 <%= render "components/filter_section", {
   **sort_facet.section_attributes,
+  disable_visually_hidden_heading_prefix: true,
   change_category: "update-filter radio",
 } do %>
   <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_taxon_facet.html.erb
@@ -1,6 +1,5 @@
 <%= render "components/filter_section", {
   **taxon_facet.section_attributes,
-  visually_hidden_heading_prefix: "Filter by",
   change_category: "update-filter select",
   classes: "js-all-content-finder-taxonomy-select"
 } do %>

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -99,8 +99,8 @@
 
         <% if filters_presenter.any_filters? %>
           <%= render "components/filter_summary", {
-            clear_all_href: filters_presenter.reset_url,
-            clear_all_text: "Clear all filters",
+            reset_link_href: filters_presenter.reset_url,
+            reset_link_text: "Clear all filters",
             heading_level: 3,
             heading_text: "Active filters",
             filters: filters_presenter.summary_items,

--- a/spec/components/filter_section_spec.rb
+++ b/spec/components/filter_section_spec.rb
@@ -26,17 +26,21 @@ describe "Filter section component", type: :view do
     assert_select ".app-c-filter-section[open=open]"
   end
 
-  it "sets the heading text" do
+  it "sets the heading text with a visually hidden prefix by default" do
     render_component({ heading_text: "section heading" })
 
-    assert_select ".app-c-filter-section__summary-heading", text: "section heading"
+    assert_select ".app-c-filter-section__summary-heading", text: /Filter by\s+section heading/
+    assert_select ".app-c-filter-section__summary-heading .govuk-visually-hidden", text: "Filter by"
   end
 
-  it "adds the visually hidden heading prefix if given" do
-    render_component({ heading_text: "section heading", visually_hidden_heading_prefix: "Filter by" })
+  it "allows disabling the visually hidden heading prefix" do
+    render_component({
+      heading_text: "section heading",
+      disable_visually_hidden_heading_prefix: true,
+    })
 
-    assert_select ".app-c-filter-section__summary-heading", include: "section heading"
-    assert_select ".app-c-filter-section__summary-heading .govuk-visually-hidden", text: "Filter by"
+    assert_select ".app-c-filter-section__summary-heading", text: "section heading"
+    assert_select ".app-c-filter-section__summary-heading .govuk-visually-hidden", false
   end
 
   it "set section heading text to different value to default renders correct heading level" do

--- a/spec/components/filter_summary_spec.rb
+++ b/spec/components/filter_summary_spec.rb
@@ -35,18 +35,6 @@ describe "Filter summary component", type: :view do
     render "components/#{component_name}", locals
   end
 
-  it "does not render a filter summary when no filters array passed" do
-    render_component({ heading_text: "Selected filters" })
-
-    assert_select ".app-c-filter-summary", false
-  end
-
-  it "does not render a filter summary when empty filters array passed" do
-    render_component({ heading_text: "Selected filters", filters: [] })
-
-    assert_select ".app-c-filter-summary", false
-  end
-
   it "renders correct number of filters with hidden accesibilty text" do
     render_component({ filters: })
 
@@ -54,20 +42,20 @@ describe "Filter summary component", type: :view do
     assert_select ".app-c-filter-summary__remove-filter-text .govuk-visually-hidden", text: "Remove filter"
   end
 
-  it "renders a heading if supplied" do
-    render_component({ heading_text: "Selected filters", filters: })
+  it "renders a different heading if supplied" do
+    render_component({ heading_text: "My awesome filters", filters: })
 
-    assert_select ".app-c-filter-summary__heading", text: "Selected filters"
+    assert_select ".app-c-filter-summary__heading", text: "My awesome filters"
   end
 
   it "renders a clear all link if supplied" do
-    render_component({ filters:, clear_all_href: "/url", clear_all_text: "Clear all" })
+    render_component({ filters:, clear_all_href: "/url", clear_all_text: "Get rid of it all" })
 
     assert_select ".app-c-filter-summary__clear-filters", count: 1
-    assert_select ".app-c-filter-summary__clear-filters", href: "/url"
+    assert_select ".app-c-filter-summary__clear-filters", href: "/url", text: "Get rid of it all"
   end
 
-  it "does not render a clear all link if one of text and href are omitted" do
+  it "does not render a clear all link if href is omitted" do
     render_component({ filters:, clear_all_text: "Clear all" })
 
     assert_select ".app-c-filter-summary__clear-filters", false

--- a/spec/components/filter_summary_spec.rb
+++ b/spec/components/filter_summary_spec.rb
@@ -48,21 +48,21 @@ describe "Filter summary component", type: :view do
     assert_select ".app-c-filter-summary__heading", text: "My awesome filters"
   end
 
-  it "renders a clear all link if supplied" do
-    render_component({ filters:, clear_all_href: "/url", clear_all_text: "Get rid of it all" })
+  it "renders a reset link if href is supplied" do
+    render_component({ filters:, reset_link_href: "/url", reset_link_text: "Get rid of it all" })
 
     assert_select ".app-c-filter-summary__clear-filters", count: 1
     assert_select ".app-c-filter-summary__clear-filters", href: "/url", text: "Get rid of it all"
   end
 
-  it "does not render a clear all link if href is omitted" do
-    render_component({ filters:, clear_all_text: "Clear all" })
+  it "does not render a reset link if href is omitted" do
+    render_component({ filters:, reset_link_text: "Clear all" })
 
     assert_select ".app-c-filter-summary__clear-filters", false
   end
 
   it "set summary heading text to different value to default renders correct heading level" do
-    render_component({ heading_text: "Selected filters", filters:, clear_all_href: "/url", heading_level: 4 })
+    render_component({ heading_text: "Selected filters", filters:, reset_link_href: "/url", heading_level: 4 })
 
     assert_select "h4.app-c-filter-summary__heading", count: 1
   end
@@ -82,18 +82,18 @@ describe "Filter summary component", type: :view do
   end
 
   it "renders ga4 tracking attributes to clear all link" do
-    clear_all_text = "Clear all the things"
-    clear_all_href = "#"
+    reset_link_text = "Clear all the things"
+    reset_link_href = "#"
     heading_text = "Selected filters"
     link_event_attributes = {
       event_name: "select_content",
       type: "finder",
-      text: clear_all_text,
+      text: reset_link_text,
       section: heading_text,
       action: "remove",
     }
 
-    render_component(heading_text: "Selected filters", clear_all_text:, clear_all_href:, filters:)
+    render_component(heading_text: "Selected filters", reset_link_text:, reset_link_href:, filters:)
 
     assert_select ".app-c-filter-summary__clear-filters[data-ga4-event='#{link_event_attributes.to_json}']"
   end


### PR DESCRIPTION
This is an assortment of tech debt fixes and improvements for the filter-related components on the new all content finder UI:

* Hardcode the "filter by" prefix in the filter section component (as this is always either "filter by" or `nil` and we have no need to change it)
* Simplify the filter summary component by removing various unnecessary nil checks and providing default values
* Use consistent "reset" instead of "clear all" terminology across all components