### PR TITLE
`DateParser`: Allow nil input

### DIFF
--- a/app/parsers/date_parser.rb
+++ b/app/parsers/date_parser.rb
@@ -9,7 +9,9 @@ class DateParser
       DateStringParser.new(date_param).parse
     when Hash
       DateHashParser.new(date_param).parse
-    else raise ArgumentError, "date_param must be a String or a Hash"
+    when nil
+      nil
+    else raise ArgumentError, "date_param must be a String, Hash, or nil"
     end
   end
 

--- a/spec/parsers/date_parser_spec.rb
+++ b/spec/parsers/date_parser_spec.rb
@@ -19,5 +19,21 @@ describe DateParser do
         expect(date_parser.parse).to eq(Date.new(2024, 8, 17))
       end
     end
+
+    context "when given nil" do
+      let(:date_param) { nil }
+
+      it "returns nil" do
+        expect(date_parser.parse).to be_nil
+      end
+    end
+
+    context "when given an unexpected object" do
+      let(:date_param) { Object.new }
+
+      it "raises an error" do
+        expect { date_parser.parse }.to raise_error(ArgumentError, /be a String, Hash, or nil/)
+      end
+    end
   end
 end


### PR DESCRIPTION
There are edge cases where a date parameter is provided but left empty, e.g. `public_timestamp%5Bto%5D`. In those cases, rather than an empty string (which would be the case for `public_timestamp%5Bto%5D=`), Rails will return nil for the param's value, breaking `DateParser`.