### PR TITLE
Filters presenter: Use `visually_hidden_prefix` from facet

### DIFF
--- a/app/presenters/filters_presenter.rb
+++ b/app/presenters/filters_presenter.rb
@@ -23,7 +23,7 @@ class FiltersPresenter
         value: filter[:label],
         displayed_text: "#{filter[:name]}: #{filter[:label]}",
         remove_href: finder_url_builder.url_except(filter[:query_params]),
-        visually_hidden_prefix: "Remove filter",
+        visually_hidden_prefix: filter[:visually_hidden_prefix] || "Remove filter",
       }
     end
   end

--- a/spec/presenters/filters_presenter_spec.rb
+++ b/spec/presenters/filters_presenter_spec.rb
@@ -19,7 +19,15 @@ describe FiltersPresenter do
       "Facet",
       key: "facet_with_applied_filters",
       has_filters?: true,
-      applied_filters: [{ name: "name", label: "label", query_params: { key: %w[value] } }],
+      applied_filters: [
+        { name: "name", label: "label", query_params: { key: %w[value] } },
+        {
+          name: "name2",
+          label: "label2",
+          visually_hidden_prefix: "Get rid of",
+          query_params: { key2: %w[value2] },
+        },
+      ],
     )
   end
   let(:another_facet_with_applied_filters) do
@@ -111,16 +119,27 @@ describe FiltersPresenter do
       before do
         allow(finder_url_builder).to receive(:url_except).with({ key: %w[value] })
           .and_return("/search/foo")
+        allow(finder_url_builder).to receive(:url_except).with({ key2: %w[value2] })
+          .and_return("/search/foo2")
       end
 
       it "returns the expected summary items" do
-        expect(summary_items).to contain_exactly({
-          label: "name",
-          value: "label",
-          displayed_text: "name: label",
-          remove_href: "/search/foo",
-          visually_hidden_prefix: "Remove filter",
-        })
+        expect(summary_items).to contain_exactly(
+          {
+            label: "name",
+            value: "label",
+            displayed_text: "name: label",
+            remove_href: "/search/foo",
+            visually_hidden_prefix: "Remove filter",
+          },
+          {
+            label: "name2",
+            value: "label2",
+            displayed_text: "name2: label2",
+            remove_href: "/search/foo2",
+            visually_hidden_prefix: "Get rid of",
+          },
+        )
       end
     end
   end


### PR DESCRIPTION
If a facet provides a `visually_hidden_prefix`, that should take precedence over the hardcoded default prefix for summary items.
