### PR TITLE
Change date validation error message

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -503,7 +503,7 @@
     var errorMessageElement = document.createElement('span')
     errorMessageElement.setAttribute('id', 'error-' + type)
     errorMessageElement.setAttribute('class', 'gem-c-error-message govuk-error-message')
-    errorMessageElement.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Enter a real date'
+    errorMessageElement.innerHTML = '<span class="govuk-visually-hidden">Error:</span> Enter a date'
 
     var errorMessages = $input.parentNode.querySelectorAll('.gem-c-error-message')
     if (errorMessages.length === 0) {

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -55,6 +55,6 @@ private
   end
 
   def error_message
-    "Enter a real date"
+    "Enter a date"
   end
 end

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -68,7 +68,7 @@ Feature: All content finder ("site search")
     And I enter "-1" for "Year" under "Updated before"
     And I apply the filters
     Then the filter panel is open by default
-    And I can see an error message "Enter a real date"
+    And I can see an error message "Enter a date"
 
   Scenario: Spelling suggestion
     When I search all content for "drving"

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -623,7 +623,7 @@ describe('liveSearch', function () {
       'For example, 2005 or 21/11/2014' +
     '</div>' +
     '<span id="error-to" class="gem-c-error-message govuk-error-message">' +
-    '<span class="govuk-visually-hidden">Error:</span> Enter a real date</span>' +
+    '<span class="govuk-visually-hidden">Error:</span> Enter a date</span>' +
     '<input name="public_timestamp[to]" value="" class="gem-c-input govuk-input govuk-input--error" id="public_timestamp[to]" ' +
     'type="text" aria-describedby="hint-3626790f error-to" aria-controls="js-search-results-info">' +
     '</div></div>')

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -362,13 +362,13 @@ describe Search::Query do
         it "stores an error for bad 'to date'" do
           query = described_class.new(content_item, invalid_to_date_params)
           expect(query.valid?).to be false
-          expect(query.errors.messages).to eq(to_date: ["Enter a real date"])
+          expect(query.errors.messages).to eq(to_date: ["Enter a date"])
         end
 
         it "stores an error for bad 'from date'" do
           query = described_class.new(content_item, invalid_from_date_params)
           expect(query.valid?).to be false
-          expect(query.errors.messages).to eq(from_date: ["Enter a real date"])
+          expect(query.errors.messages).to eq(from_date: ["Enter a date"])
         end
       end
     end


### PR DESCRIPTION
"Enter a real date" isn't very GOV.UK - this should just be "enter a date".