### PR TITLE
All content finder: GA4 improvements

### DIFF
--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -96,16 +96,16 @@
             schema.section = section.getAttribute('data-ga4-section')
           }
 
+          var index = this.getSectionIndex(filterParent)
           if (wasFilterRemoved) {
             schema.action = 'remove'
             schema.text = elementType === 'text' ? undefined : elementValue
           } else {
             schema.action = elementType === 'text' ? 'search' : 'select'
-            var index = this.getSectionIndex(filterParent)
-            schema.index_link = index.index_link || undefined
-            schema.index_section = index.index_section || undefined
-            schema.index_section_count = index.index_section_count || undefined
           }
+          schema.index_link = index.index_link || undefined
+          schema.index_section = index.index_section || undefined
+          schema.index_section_count = index.index_section_count || undefined
           break
 
         case 'update-keyword':

--- a/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
+++ b/app/assets/javascripts/analytics-ga4/ga4-finder-tracker.js
@@ -24,6 +24,9 @@
       data.event_name = 'select_content'
 
       var elementInfo = this.getElementInfo(eventTarget, elementType, section)
+      if (!elementInfo) {
+        return
+      }
       var elementValue = elementInfo.elementValue
       data.text = elementValue
       var wasFilterRemoved = elementInfo.wasFilterRemoved
@@ -83,6 +86,25 @@
             wasFilterRemoved = true
           }
           break
+
+        case 'date': {
+          // The GOV.UK Design System date input consists of three grouped but separate fields (day,
+          // month, year). We want to fire a single event when all three fields are filled in to
+          // avoid firing excessive events.
+          const inputs = [...eventTarget.closest('.govuk-date-input').querySelectorAll('input')]
+          const allInputsSet = inputs.every(input => input.value)
+          const noInputsSet = inputs.every(input => !input.value)
+
+          if (allInputsSet) {
+            elementValue = inputs.map(input => input.value).join('/')
+          } else if (noInputsSet) {
+            wasFilterRemoved = true
+          } else {
+            // Do not track partially filled in fields
+            return null
+          }
+          break
+        }
       }
 
       return { elementValue: elementValue, wasFilterRemoved: wasFilterRemoved }

--- a/app/helpers/input_helper.rb
+++ b/app/helpers/input_helper.rb
@@ -3,31 +3,32 @@ module InputHelper
     legend_text = [display_name, legend_suffix].compact.join(" ")
     value ||= {}
 
-    render(
-      "govuk_publishing_components/components/date_input",
-      id:,
-      name: id,
-      legend_text:,
-      hint:,
-      error_message:,
-      data: { ga4_section: legend_text },
-      items: [
-        {
-          name: "day",
-          width: 2,
-          value: value[:day],
-        },
-        {
-          name: "month",
-          width: 2,
-          value: value[:month],
-        },
-        {
-          name: "year",
-          width: 4,
-          value: value[:year],
-        },
-      ],
-    )
+    tag.div(data: { ga4_section: legend_text }) do
+      render(
+        "govuk_publishing_components/components/date_input",
+        id:,
+        name: id,
+        legend_text:,
+        hint:,
+        error_message:,
+        items: [
+          {
+            name: "day",
+            width: 2,
+            value: value[:day],
+          },
+          {
+            name: "month",
+            width: 2,
+            value: value[:month],
+          },
+          {
+            name: "year",
+            width: 4,
+            value: value[:year],
+          },
+        ],
+      )
+    end
   end
 end

--- a/app/helpers/input_helper.rb
+++ b/app/helpers/input_helper.rb
@@ -2,8 +2,21 @@ module InputHelper
   def date_input(id, display_name, value, hint: nil, error_message: nil, legend_suffix: nil)
     legend_text = [display_name, legend_suffix].compact.join(" ")
     value ||= {}
+    container_data_attrs = { ga4_section: legend_text }
 
-    tag.div(data: { ga4_section: legend_text }) do
+    if error_message
+      container_data_attrs[:module] = "ga4-auto-tracker"
+      container_data_attrs[:ga4_auto] = {
+        event_name: "form_error",
+        type: "finder",
+        text: error_message,
+        section: legend_text,
+        action: "error",
+        tool_name: "Search GOV.UK",
+      }
+    end
+
+    tag.div(data: container_data_attrs) do
       render(
         "govuk_publishing_components/components/date_input",
         id:,

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -1,6 +1,6 @@
 <%= render "components/filter_section", {
   **date_facet.section_attributes,
-  change_category: "update-filter text",
+  change_category: "update-filter date",
   # Note date is the only validated facet, so if there is an error, it'll be here
   open: @search_query.invalid?,
 } do %>

--- a/docs/analytics-ga4/ga4-finder-tracker.md
+++ b/docs/analytics-ga4/ga4-finder-tracker.md
@@ -71,9 +71,12 @@ If the filter `<select>` element changes and is set to their _first option_, we 
 
 Radio buttons have `data-ga4-change-category="update-filter radio"` on them. If the changed radio button is not the _first radio button_ (i.e. the default selection), then, the `update-filter` event will build an "Filter added" GTM Object. If the changed radio button is the _first radio button_, it will build a "Filter removed" GTM Object. This is because the first radio button in a list is typically the default "All XYZ" filter state. The value we grab for a radio button is the user friendly label associated with the `<input>`.
 
-### Date filters (`<input type="text">`)
+### Date filters with single input field (`<input type="text">`)
 
 Our date filters have `data-ga4-change-category="update-filter text"` on them. The value we grab is the text that is input into its text field. If the text is an empty string, we treat this as a "Filter removed" event, as this means the date was removed. If text is available in the text box, we treat this as a "Filter added" event.
+
+### Date filters with three input fields (day/month/year)
+These use the GOV.UK Design System date input pattern/component and have `data-ga4-change-category="update-filter date"` on them. To avoid excessive events and cardinality, despite technically allowing partial values, we expect users to mostly fill in complete dates and only track them as an entire value triggered by all fields being present, and combine the three into a single D/M/Y string. Conversely, it only counts as removed if all fields have been cleared.
 
 ### Search keyword changes (`<input type="text">`)
 

--- a/spec/helpers/input_helper_spec.rb
+++ b/spec/helpers/input_helper_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+RSpec.describe InputHelper, type: :helper do
+  describe "#date_input" do
+    subject { helper.date_input(id, display_name, value) }
+
+    let(:id) { "test_date" }
+    let(:display_name) { "Test Date" }
+    let(:value) { { day: "1", month: "1", year: "2023" } }
+
+    it "renders a div with correct data attributes" do
+      expect(subject).to have_css('div[data-ga4-section="Test Date"]')
+    end
+
+    it "renders the govuk_publishing_components date_input partial" do
+      expect(helper).to receive(:render).with(
+        "govuk_publishing_components/components/date_input",
+        hash_including(
+          id: "test_date",
+          name: "test_date",
+          legend_text: "Test Date",
+          items: [
+            { name: "day", width: 2, value: "1" },
+            { name: "month", width: 2, value: "1" },
+            { name: "year", width: 4, value: "2023" },
+          ],
+        ),
+      )
+      subject
+    end
+
+    context "with a legend suffix" do
+      subject { helper.date_input(id, display_name, value, legend_suffix: "after") }
+
+      it "includes the suffix in the legend text" do
+        expect(helper).to receive(:render).with(
+          "govuk_publishing_components/components/date_input",
+          hash_including(
+            legend_text: "Test Date after",
+          ),
+        )
+        expect(subject).to have_css('div[data-ga4-section="Test Date after"]')
+      end
+    end
+
+    context "with a hint" do
+      subject { helper.date_input(id, display_name, value, hint: "For example, 13 12 1989") }
+
+      it "passes the hint to the partial" do
+        expect(helper).to receive(:render).with(
+          "govuk_publishing_components/components/date_input",
+          hash_including(hint: "For example, 13 12 1989"),
+        )
+        subject
+      end
+    end
+
+    context "with an error message" do
+      subject { helper.date_input(id, display_name, value, error_message:) }
+
+      let(:error_message) { "Invalid date" }
+      let(:expected_ga4_auto_data) do
+        {
+          event_name: "form_error",
+          type: "finder",
+          text: "Invalid date",
+          section: "Test Date",
+          action: "error",
+          tool_name: "Search GOV.UK",
+        }
+      end
+
+      it "adds GA4 data attributes for error tracking" do
+        expect(subject).to have_css('div[data-module="ga4-auto-tracker"]')
+        expect(subject).to have_css("div[data-ga4-auto='#{expected_ga4_auto_data.to_json}']")
+      end
+
+      it "passes the error message to the partial" do
+        expect(helper).to receive(:render).with(
+          "govuk_publishing_components/components/date_input",
+          hash_including(error_message: "Invalid date"),
+        )
+        subject
+      end
+    end
+  end
+end

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -152,7 +152,7 @@ describe('GA4 finder change tracker', function () {
     window.GOVUK.triggerEvent(input, 'change')
 
     expected.event_data.action = 'remove'
-    expected.event_data.index = { index_section: undefined, index_section_count: undefined, index_link: undefined }
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
 
     expect(window.dataLayer[1]).toEqual(expected)
   })
@@ -205,7 +205,7 @@ describe('GA4 finder change tracker', function () {
     window.GOVUK.triggerEvent(option1, 'change')
 
     expected.event_data.action = 'remove'
-    expected.event_data.index = { index_section: undefined, index_section_count: undefined, index_link: undefined }
+    expected.event_data.index = { index_section: '1', index_section_count: '1', index_link: undefined }
     expected.event_data.text = 'All types of chocolate (default)'
 
     expect(window.dataLayer[1]).toEqual(expected)
@@ -253,7 +253,7 @@ describe('GA4 finder change tracker', function () {
     window.GOVUK.triggerEvent(input, 'change')
 
     expected.event_data.action = 'remove'
-    expected.event_data.index = { index_link: undefined, index_section: undefined, index_section_count: undefined }
+    expected.event_data.index = { index_link: undefined, index_section: '5', index_section_count: '15' }
     expected.event_data.text = 'All types of chocolate (default)'
 
     expect(window.dataLayer[1]).toEqual(expected)
@@ -305,7 +305,7 @@ describe('GA4 finder change tracker', function () {
     window.GOVUK.triggerEvent(input, 'change')
 
     expected.event_data.action = 'remove'
-    expected.event_data.index = { index_section: undefined, index_section_count: undefined, index_link: undefined }
+    expected.event_data.index = { index_section: '2', index_section_count: '2', index_link: undefined }
     expected.event_data.text = undefined
 
     expect(window.dataLayer[1]).toEqual(expected)

--- a/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
+++ b/spec/javascripts/analytics-ga4/ga4-finder-tracker.spec.js
@@ -311,6 +311,67 @@ describe('GA4 finder change tracker', function () {
     expect(window.dataLayer[1]).toEqual(expected)
   })
 
+  it('creates the correct GA4 object for adding/removing a date filter', function () {
+    inputParent = document.createElement('div')
+    inputParent.setAttribute('class', 'govuk-date-input')
+    inputParent.setAttribute('data-ga4-change-category', 'update-filter date')
+    inputParent.setAttribute('data-ga4-filter-parent', '')
+    inputParent.setAttribute('data-ga4-section', 'Last time you ate chocolate')
+    const index = { index_section: 3, index_section_count: 3 }
+    inputParent.setAttribute('data-ga4-index', JSON.stringify(index))
+
+    const legend = document.createElement('legend')
+    inputParent.appendChild(legend)
+    const dayInput = document.createElement('input')
+    dayInput.setAttribute('type', 'number')
+    inputParent.appendChild(dayInput)
+    const monthInput = document.createElement('input')
+    monthInput.setAttribute('type', 'number')
+    inputParent.appendChild(monthInput)
+    const yearInput = document.createElement('input')
+    yearInput.setAttribute('type', 'number')
+    inputParent.appendChild(yearInput)
+    form.appendChild(inputParent)
+
+    // Filling in just day does not trigger event
+    dayInput.value = '13'
+    window.GOVUK.triggerEvent(dayInput, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+
+    // Filling in month still does not trigger event
+    monthInput.value = '12'
+    window.GOVUK.triggerEvent(monthInput, 'change')
+    expect(window.dataLayer.length).toEqual(0)
+
+    // Finally filling in year triggers event
+    yearInput.value = '1989'
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    expected.event_data.event_name = 'select_content'
+    expected.event_data.section = 'Last time you ate chocolate'
+    expected.event_data.text = '13/12/1989'
+    expected.event_data.action = 'select'
+    expected.event_data.index = { index_section: '3', index_section_count: '3', index_link: undefined }
+    expect(window.dataLayer.length).toEqual(1)
+    expect(window.dataLayer[0]).toEqual(expected)
+
+    dayInput.value = ''
+    monthInput.value = ''
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    // Clearing two out of three fields does not trigger an event
+    expect(window.dataLayer.length).toEqual(1)
+
+    yearInput.value = ''
+    window.GOVUK.triggerEvent(yearInput, 'change')
+
+    // Removing the final field triggers an event
+    expected.event_data.action = 'remove'
+    expected.event_data.text = ''
+    expect(window.dataLayer.length).toEqual(2)
+    expect(window.dataLayer[1]).toEqual(expected)
+  })
+
   it('creates the correct GA4 object for clearing all filters', function () {
     form.setAttribute('data-ga4-change-category', 'clear-all-filters')
 


### PR DESCRIPTION
This PR improves the GA4 tracking for finders, mostly for the benefit of the new all content finder UI (but some changes also apply to the old UI).

In particular, it:
- Changes the finder tracker to include section details (index/count/link) on removal and not just on adding
- Adds a new `date` update type for the finder tracker to handle the three-field date input on the new UI
- Enables tracking date input errors on the new UI using `ga4-auto-tracker`