### PR TITLE
All content finder: Enable parent breadcrumb

### DIFF
--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -14,7 +14,16 @@
 <% end %>
 <% content_for :meta_title, content_item.title %>
 
-<%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash %>
+<% if @breadcrumbs.breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      breadcrumbs: @breadcrumbs.breadcrumbs,
+      collapse_on_mobile: true,
+  } %>
+<% else %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {
+      content_item: content_item.as_hash,
+  } %>
+<% end %>
 
 <%= tag.div(
   class: "app-all-content-finder",

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -12,6 +12,8 @@ Feature: All content finder ("site search")
     Then I can see results for my search
     And I can see how many results there are
     And the GA4 ecommerce tracking tags are present
+    And I can see a breadcrumb for home
+    And no breadcrumb for all organisations
 
   Scenario: Making a search with a hidden clearable filter
     When I search for "search-term" with a hidden clearable manual filter
@@ -73,3 +75,13 @@ Feature: All content finder ("site search")
   Scenario: Spelling suggestion
     When I search all content for "drving"
     Then I see a "driving" spelling suggestion
+
+  Scenario: Search with an organisation (parent) finder
+    When I search all content with a parent for "search-term"
+    And I open the filter panel
+    And I open the "Sort by" filter section
+    And I select the "Updated (newest)" option
+    And I apply the filters
+    Then I can see a breadcrumb for home
+    And I can see a breadcrumb for all organisations
+    And I can see a breadcrumb for the organisation

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -2,6 +2,10 @@ When(/^I search all content for "([^"]*)"$/) do |search_term|
   visit "/search/all?q=#{search_term}"
 end
 
+When(/^I search all content with a parent for "([^"]*)"$/) do |search_term|
+  visit "/search/all?parent=ministry-of-magic&organisations[]=ministry-of-magic&q=#{search_term}"
+end
+
 When(/^I search for "([^"]*)" with a hidden clearable manual filter$/) do |search_term|
   visit "/search/all?q=#{search_term}&manual%5B%5D=how-to-be-a-wizard"
 end


### PR DESCRIPTION
This implements the parent breadcrumb feature analogous to the existing finders: if specific breadcrumbs are set, they are rendered instead of the regular contextual breadcrumbs.