### PR TITLE
All content finder: Change GA4 action of "apply filters"

### DIFF
--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -64,7 +64,7 @@
             type: "finder",
             text: "Apply filters",
             section: button_text,
-            action: "search",
+            action: "apply",
             index_section: 0,
             index_section_count: section_count,
           }

--- a/spec/components/filter_panel_spec.rb
+++ b/spec/components/filter_panel_spec.rb
@@ -111,7 +111,7 @@ describe "Filter panel component", type: :view do
       type: "finder",
       text: button_text,
       section: button_text,
-      action: "search",
+      action: "apply",
       index_section: 0,
       index_section_count: 4,
     }


### PR DESCRIPTION
`apply` is more useful as it helps us differentiate in reports.