### PR TITLE
All content finder: Rename panel apply/clear buttons

### DIFF
--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -55,14 +55,14 @@
 
     <div class="app-c-filter-panel__actions">
       <%= submit_tag(
-        "Apply filters",
+        "Apply",
         class: "govuk-button app-c-filter-panel__action app-c-filter-panel__action--submit",
         name: nil,
         data: {
           ga4_event: {
             event_name: "select_content",
             type: "finder",
-            text: "Apply filters",
+            text: "Apply",
             section: button_text,
             action: "search",
             index_section: 0,
@@ -73,7 +73,7 @@
 
       <% if show_reset_link %>
         <%= link_to(
-          "Clear all filters",
+          "Clear all",
           reset_link_href,
           class: "govuk-link govuk-link--no-visited-state app-c-filter-panel__action app-c-filter-panel__action--reset",
           data: {

--- a/features/step_definitions/site_search_steps.rb
+++ b/features/step_definitions/site_search_steps.rb
@@ -84,7 +84,7 @@ Then("I can see filtered results") do
 end
 
 When("I apply the filters") do
-  click_on "Apply filters"
+  click_on "Apply"
 end
 
 Then("I can see a filter section for every visible facet on the all content finder") do

--- a/spec/components/filter_panel_spec.rb
+++ b/spec/components/filter_panel_spec.rb
@@ -62,7 +62,7 @@ describe "Filter panel component", type: :view do
   it "renders the submit button" do
     render_component(button_text: "Filter")
 
-    assert_select ".app-c-filter-panel input.govuk-button.app-c-filter-panel__action.app-c-filter-panel__action--submit", value: "Apply filters"
+    assert_select ".app-c-filter-panel input.govuk-button.app-c-filter-panel__action.app-c-filter-panel__action--submit", value: "Apply"
   end
 
   it "doesn't render any buttons with a name attribute" do
@@ -74,7 +74,7 @@ describe "Filter panel component", type: :view do
   it "renders the reset link if the show_reset_link option is given" do
     render_component(button_text: "Filter", show_reset_link: true, reset_link_href: "/reset")
 
-    assert_select ".app-c-filter-panel a.govuk-link.govuk-link--no-visited-state.app-c-filter-panel__action.app-c-filter-panel__action--reset[href='/reset']", text: "Clear all filters"
+    assert_select ".app-c-filter-panel a.govuk-link.govuk-link--no-visited-state.app-c-filter-panel__action.app-c-filter-panel__action--reset[href='/reset']", text: "Clear all"
   end
 
   it "does not render the reset link if the show_reset_link option is not given" do
@@ -103,7 +103,7 @@ describe "Filter panel component", type: :view do
   end
 
   it "renders ga4 tracking attributes to submit button element" do
-    button_text = "Apply filters"
+    button_text = "Apply"
     section_count = 4
 
     button_event_attributes = {


### PR DESCRIPTION
These aren't necessarily just filters (i.e. can be sorting too), but there isn't enough space and it would be faffy to change the text dynamically based on what is selected.

This makes the button text more clear and concise.