### PR TITLE
`DateHashParser`: Be less lenient with invalid values

### DIFF
--- a/app/parsers/date_hash_parser.rb
+++ b/app/parsers/date_hash_parser.rb
@@ -22,11 +22,10 @@ class DateHashParser
       .slice(:day, :month, :year)
       .compact_blank
       .transform_values(&:to_i)
-      .select { |_, value| value.positive? } # Avoid negative or zero values
   end
 
   def parse
-    return if date_hash.empty? || day_without_month?
+    return if date_hash.empty? || any_non_positive_values? || day_without_month?
 
     Date.new(year, month, day)
   rescue Date::Error
@@ -39,6 +38,12 @@ private
 
   def day_without_month?
     date_hash.key?(:day) && !date_hash.key?(:month)
+  end
+
+  def any_non_positive_values?
+    # If the user enters a zero or negative value, or a string that `#to_i` converts to zero, we
+    # consider the whole date invalid
+    !date_hash.values.all?(&:positive?)
   end
 
   def day

--- a/spec/parsers/date_hash_parser_spec.rb
+++ b/spec/parsers/date_hash_parser_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe DateHashParser do
         it { is_expected.to be_nil }
       end
 
+      context "with hash with any non-numeric values (even if others are good)" do
+        let(:date_hash) { { day: 13, month: 12, year: "baz" } }
+
+        it { is_expected.to be_nil }
+      end
+
       context "with hash with non-numeric year only" do
         let(:date_hash) { { year: "baz" } }
 


### PR DESCRIPTION
The current logic in `DateHashParser` discards invalid (non-positive or string) values, which can be confusing as the user's input is partially accepted without triggering a validation failure.

This makes the parser less lenient, and bails out on parsing if any present part of the date hash isn't a positive number.