### PR TITLE
All content finder: Properly track empty keywords

### DIFF
--- a/app/assets/javascripts/modules/all-content-finder.js
+++ b/app/assets/javascripts/modules/all-content-finder.js
@@ -71,9 +71,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           event_name: 'search',
           section: 'Search',
           action: 'search',
+          // standardiseSearchTerm returns undefined for empty strings, which we do _not_ want in
+          // this scenario as it would lead to the analytics tracking not picking up on the change
           text: GOVUK.analyticsGa4.core.trackFunctions.standardiseSearchTerm(
             this.$keywordInput.value
-          ),
+          ) || '',
           url: window.location.pathname
         }, 'event_data')
 

--- a/spec/javascripts/modules/all-content-finder.spec.js
+++ b/spec/javascripts/modules/all-content-finder.spec.js
@@ -9,7 +9,7 @@ describe('AllContentFinder module', () => {
         <div class="govuk-grid-column-two-thirds-from-desktop">
           <div id="keywords" role="search" aria-label="Sitewide">
             <div class="gem-c-search">
-              <input enterkeyhint="search" class="gem-c-search__input js-class-toggle" id="finder-keyword-search" name="keywords" type="search" value="" />
+              <input enterkeyhint="search" class="gem-c-search__input js-class-toggle" id="finder-keyword-search" name="keywords" type="search" value="hello" />
               <button class="gem-c-search__submit" type="submit">Search</button>
             </div>
           </div>
@@ -94,9 +94,9 @@ describe('AllContentFinder module', () => {
       expect(mockSubmitHandler).toHaveBeenCalled()
       const submittedData = mockSubmitHandler.calls.mostRecent().args[0]
 
+      expect(submittedData.has('keywords')).toBe(true)
       expect(submittedData.has('foo')).toBe(true)
       expect(submittedData.has('bar')).toBe(false)
-      expect(submittedData.has('keywords')).toBe(false)
     })
 
     it('removes relevance sort order from the form data', () => {
@@ -231,6 +231,23 @@ describe('AllContentFinder module', () => {
             event_name: 'search',
             type: 'finder',
             text: 'new keyword',
+            action: 'search',
+            section: 'Search'
+          })
+        }))
+      })
+
+      it('fires a `search` event with the right text if the keyword has been removed', () => {
+        const form = fixture.querySelector('.js-all-content-finder-form')
+        form.querySelector('input[type="search"]').value = ''
+        form.dispatchEvent(new Event('submit', { bubbles: true }))
+
+        expect(GOVUK.analyticsGa4.core.sendData).toHaveBeenCalledWith(jasmine.objectContaining({
+          event: 'event_data',
+          event_data: jasmine.objectContaining({
+            event_name: 'search',
+            type: 'finder',
+            text: '',
             action: 'search',
             section: 'Search'
           })


### PR DESCRIPTION
GOV.UK Analytics's `standardiseSearchTerm` returns undefined for empty queries, whereas for the `search` event we are sending, we _do_ want to keep track of the search term even if a blank string, and using undefined there will not update the state properly.

Because this adds a default value for the keyword form field, we need to adjust the test for the empty field submission logic to consider the keyword present.