### PR TITLE
SortFacet: Add `#sentence_fragment`

### DIFF
--- a/app/models/sort_facet.rb
+++ b/app/models/sort_facet.rb
@@ -63,6 +63,10 @@ class SortFacet
     false
   end
 
+  def sentence_fragment
+    nil
+  end
+
 private
 
   attr_reader :content_item, :filter_params

--- a/spec/models/sort_facet_spec.rb
+++ b/spec/models/sort_facet_spec.rb
@@ -118,6 +118,12 @@ describe SortFacet do
     end
   end
 
+  describe "#sentence_fragment" do
+    subject(:sentence_fragment) { sort_facet.sentence_fragment }
+
+    it { is_expected.to be_nil }
+  end
+
   it { is_expected.to be_user_visible }
   it { is_expected.to be_filterable }
   it { is_expected.not_to be_hide_facet_tag }


### PR DESCRIPTION
This is required for compatibility with the other ("real") facets when rendering the page as JSON or Atom.

We can safely return nil though as it's just called but not actually used in the response.