### PR TITLE
Manuals registry: Include HMRC manuals

### DIFF
--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -38,7 +38,7 @@ module Registries
 
     def fetch_manuals_from_rummager
       params = {
-        filter_document_type: %w[manual service_manual_homepage service_manual_guide],
+        filter_document_type: %w[hmrc_manual manual service_manual_homepage service_manual_guide],
         fields: %w[title],
         count: 1500,
       }

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Registries::ManualsRegistry do
   let(:slug) { "/guidance/care-and-use-of-a-nimbus-2000" }
   let(:rummager_params) do
     {
-      filter_document_type: %w[manual service_manual_homepage service_manual_guide],
+      filter_document_type: %w[hmrc_manual manual service_manual_homepage service_manual_guide],
       fields: %w[title],
       count: 1500,
     }

--- a/spec/support/registry_helper.rb
+++ b/spec/support/registry_helper.rb
@@ -123,7 +123,7 @@ module RegistrySpecHelper
   def stub_manuals_registry_request
     stub_request(:get, "http://search-api.dev.gov.uk/search.json")
       .with(query: {
-        filter_document_type: %w[manual service_manual_homepage service_manual_guide],
+        filter_document_type: %w[hmrc_manual manual service_manual_homepage service_manual_guide],
         fields: %w[title],
         count: 1500,
       })


### PR DESCRIPTION
For some reason, these aren't fetched, which means that searches filtered by HMRC manuals don't show a filter tag.

## Before
<img width="770" alt="image" src="https://github.com/user-attachments/assets/4a0a309e-e152-4c46-9808-346041c82d2e">

## After
<img width="715" alt="image" src="https://github.com/user-attachments/assets/55cbdef7-e8de-447c-9895-1fe06837e987">
