### PR TITLE
All content finder: Minor design/content tweaks

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -72,7 +72,7 @@
   }
 
   &::before {
-    margin: 0 govuk-spacing(3) govuk-spacing(1) 0;
+    margin: 0 govuk-spacing(2) govuk-spacing(1) 0;
   }
 }
 

--- a/app/models/date_facet.rb
+++ b/app/models/date_facet.rb
@@ -41,7 +41,7 @@ class DateFacet < FilterableFacet
     present_values.map do |type, date|
       preposition = preposition_mappings[type]
       {
-        name: "#{name} #{preposition}",
+        name: "#{short_name} #{preposition}",
         label: date.date.strftime("%e %B %Y"),
         query_params: { key => { type => date.original_input } },
       }

--- a/app/views/finders/all_content_finder_facets/_date_facet.html.erb
+++ b/app/views/finders/all_content_finder_facets/_date_facet.html.erb
@@ -6,7 +6,7 @@
 } do %>
   <%= date_input(
     "#{date_facet.key}[from]",
-    date_facet.name,
+    date_facet.short_name,
     date_facet.parsed_from_date&.to_hash,
     hint: "For example, 28 2 #{Date.current.year - 2}",
     error_message: date_facet.error_message_from(@search_query),
@@ -15,7 +15,7 @@
 
   <%= date_input(
     "#{date_facet.key}[to]",
-    date_facet.name,
+    date_facet.short_name,
     date_facet.parsed_to_date&.to_hash,
     hint: "For example, 13 12 #{Date.current.year - 1}",
     error_message: date_facet.error_message_to(@search_query),

--- a/features/all_content_finder.feature
+++ b/features/all_content_finder.feature
@@ -35,7 +35,7 @@ Feature: All content finder ("site search")
     And I open the "Type" filter section
     And I check the "Services" option
     And I check the "Research and statistics" option
-    And I open the "Updated" filter section
+    And I open the "Date" filter section
     And I enter "1989" for "Year" under "Updated after"
     And I enter "1989" for "Year" under "Updated before"
     And I enter "12" for "Month" under "Updated before"
@@ -66,7 +66,7 @@ Feature: All content finder ("site search")
   Scenario: Entering an incorrect date
     When I search all content for "chandeliers flickering"
     And I open the filter panel
-    And I open the "Updated" filter section
+    And I open the "Date" filter section
     And I enter "-1" for "Year" under "Updated before"
     And I apply the filters
     Then the filter panel is open by default

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -8,6 +8,15 @@
     "document_noun": "result",
     "facets": [
       {
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "key": "public_timestamp",
+        "name": "Date",
+        "preposition": "Updated",
+        "short_name": "Updated",
+        "type": "date"
+      },
+      {
         "display_as_result_metadata": false,
         "filter_key": "all_part_of_taxonomy_tree",
         "filterable": true,
@@ -88,15 +97,6 @@
         "type": "hidden_clearable"
       },
       {
-        "display_as_result_metadata": true,
-        "filterable": true,
-        "key": "public_timestamp",
-        "name": "Updated",
-        "preposition": "Updated",
-        "short_name": "Updated",
-        "type": "date"
-      },
-      {
         "allowed_values": [],
         "display_as_result_metadata": false,
         "filterable": true,
@@ -141,30 +141,30 @@
     "available_translations": [
       {
         "api_path": "/api/content/search/all",
-        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/search/all",
+        "api_url": "https://www.gov.uk/api/content/search/all",
         "base_path": "/search/all",
         "content_id": "dd395436-9b40-41f3-8157-740a453ac972",
         "document_type": "finder",
         "links": {},
         "locale": "en",
-        "public_updated_at": "2024-09-20T09:17:24Z",
+        "public_updated_at": "2024-10-24T11:19:57Z",
         "schema_name": "finder",
         "title": "Search",
-        "web_url": "https://www.integration.publishing.service.gov.uk/search/all",
+        "web_url": "https://www.gov.uk/search/all",
         "withdrawn": false
       }
     ]
   },
   "locale": "en",
   "phase": "live",
-  "public_updated_at": "2024-09-20T10:17:24+01:00",
+  "public_updated_at": "2024-10-24T12:19:57+01:00",
   "publishing_app": "search-api",
-  "publishing_request_id": "21-1726823845.044-10.1.34.217-616",
+  "publishing_request_id": "21-1729768797.580-10.13.32.238-615",
   "publishing_scheduled_at": null,
   "rendering_app": "finder-frontend",
   "scheduled_publishing_delay_seconds": null,
   "schema_name": "finder",
   "title": "Search",
-  "updated_at": "2024-09-20T10:17:25+01:00",
+  "updated_at": "2024-10-24T12:19:57+01:00",
   "withdrawn_notice": {}
 }

--- a/features/step_definitions/all_content_finder_steps.rb
+++ b/features/step_definitions/all_content_finder_steps.rb
@@ -88,7 +88,7 @@ Then("I can see a filter section for every visible facet on the all content find
   expect(page).to have_selector("h2", text: "Sort by")
   expect(page).to have_selector("h2", text: "Filter by Topic")
   expect(page).to have_selector("h2", text: "Filter by Type")
-  expect(page).to have_selector("h2", text: "Filter by Updated")
+  expect(page).to have_selector("h2", text: "Filter by Date")
 
   # These are hidden clearable filters and should not have a section
   expect(page).not_to have_selector("h2", text: "Filter by Organisation")
@@ -106,7 +106,7 @@ Then("the filter panel shows status text for each section") do
   within(".app-c-filter-panel") do
     expect(page).to have_selector("summary", text: "Filter by Topic 2 selected", normalize_ws: true)
     expect(page).to have_selector("summary", text: "Filter by Type 2 selected", normalize_ws: true)
-    expect(page).to have_selector("summary", text: "Filter by Updated 2 selected", normalize_ws: true)
+    expect(page).to have_selector("summary", text: "Filter by Date 2 selected", normalize_ws: true)
   end
 end
 

--- a/spec/models/date_facet_spec.rb
+++ b/spec/models/date_facet_spec.rb
@@ -7,6 +7,7 @@ describe DateFacet do
     {
       "type" => "date",
       "name" => "Occurred",
+      "short_name" => "Happened",
       "key" => "date_of_occurrence",
       "preposition" => "occurred",
     }
@@ -67,7 +68,7 @@ describe DateFacet do
 
       it "returns the expected applied filters" do
         expect(subject.applied_filters).to eql([{
-          name: "Occurred after",
+          name: "Happened after",
           label: "22 September 1988",
           query_params: { "date_of_occurrence" => { from: "22/09/1988" } },
         }])
@@ -85,12 +86,12 @@ describe DateFacet do
       it "returns the expected applied filters" do
         expect(subject.applied_filters).to eql([
           {
-            name: "Occurred after",
+            name: "Happened after",
             label: "22 September 1988",
             query_params: { "date_of_occurrence" => { from: "22/09/1988" } },
           },
           {
-            name: "Occurred before",
+            name: "Happened before",
             label: "22 September 2014",
             query_params: { "date_of_occurrence" => { to: "22/09/2014" } },
           },


### PR DESCRIPTION
This PR updates the all content finder to:
- use the `short_name` for displaying date facet names (slightly counterintuitively, the `short_name` for this field is actually _longer_ than the `name` 😵‍💫)
- slightly tweaks the spacing between the chevron and text on the "Filter and sort" panel button

### Before
<img width="735" alt="image" src="https://github.com/user-attachments/assets/a876032e-b3e8-43b7-8cc7-75ae8f8c9cd0">

### After
<img width="734" alt="image" src="https://github.com/user-attachments/assets/1b535b1c-8826-4c25-9a6a-6dae8aa952c5">

