### PR TITLE
Set up `SearchAutocomplete` AB test

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/search-with-autocomplete
 //
 //= require support
 //

--- a/app/controllers/ab_test/search_autocomplete_ab_testable.rb
+++ b/app/controllers/ab_test/search_autocomplete_ab_testable.rb
@@ -1,0 +1,22 @@
+module AbTest::SearchAutocompleteAbTestable
+  def search_autocomplete_ab_test
+    GovukAbTesting::AbTest.new(
+      "SearchAutocomplete",
+      allowed_variants: [
+        "A", # No autocomplete
+        "B", # Autocomplete
+        "Z", # No autocomplete
+      ],
+      control_variant: "Z",
+    )
+  end
+
+  def set_search_autocomplete_ab_test_requested_variant
+    @requested_variant = search_autocomplete_ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+  end
+
+  def use_autocomplete?
+    @requested_variant&.variant?("B")
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,8 +1,11 @@
 class FindersController < ApplicationController
   layout "finder_layout"
 
+  include AbTest::SearchAutocompleteAbTestable
+
   before_action do
     set_expiry(content_item)
+    set_search_autocomplete_ab_test_requested_variant if content_item.all_content_finder?
   end
 
   def show
@@ -58,6 +61,8 @@ class FindersController < ApplicationController
     @sort_presenter = sort_presenter
     @pagination = pagination_presenter
     @spelling_suggestion_presenter = spelling_suggestion_presenter
+    @ab_test_search_component = use_autocomplete? ? "search_with_autocomplete" : "search"
+    @autocomplete_url = ENV.fetch("SEARCH_AUTOCOMPLETE_API_URL", "")
   end
 
 private

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -11,6 +11,7 @@
     <meta name="govuk:discovery-engine-attribution-token" content="<%= result_set_presenter.discovery_engine_attribution_token %>">
   <% end %>
   <meta name="govuk:spelling-suggestion" content="<%= @spelling_suggestion_presenter.suggestions.first&.fetch(:keywords, "") %>">
+  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>
 <% end %>
 <% content_for :meta_title, content_item.title %>
 
@@ -53,7 +54,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <div id="keywords" role="search" aria-label="Sitewide">
-          <%= render "govuk_publishing_components/components/search", {
+          <%= render "govuk_publishing_components/components/#{@ab_test_search_component}", {
             id: "finder-keyword-search",
             name: "keywords",
             type: 'search',
@@ -68,6 +69,8 @@
             wrap_label_in_a_heading: true,
             heading_level: 1,
             margin_bottom: 0,
+            source_url: @autocomplete_url,
+            source_key: "suggestions"
           } %>
         </div>
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -251,6 +251,32 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template("finders/show_all_content_finder")
       end
+
+      describe "SearchAutocomplete AB test" do
+        it "does not render the search_with_autocomplete component in the A variant" do
+          with_variant SearchAutocomplete: "A" do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+          end
+
+          expect(response.body).not_to include('"gem-c-search-with-autocomplete"')
+        end
+
+        it "renders the search_with_autocomplete component in the B variant" do
+          with_variant SearchAutocomplete: "B" do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+          end
+
+          expect(response.body).to include('"gem-c-search-with-autocomplete"')
+        end
+
+        it "does not render the search_with_autocomplete component in the Z variant" do
+          with_variant SearchAutocomplete: "Z" do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+          end
+
+          expect(response.body).not_to include('"gem-c-search-with-autocomplete"')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This sets up an AB test for using the new `search_with_autocomplete` component on the all content finder.

> [!NOTE]
> This AB test is live, but currently at 100% `Z` (baseline). We'll be using the AB test as a feature flag for final testing in production before sending any traffic to the control (`A`) and experiment (`B`) variants.

- Add GOV.UK Publishing Components Javascript for the `search_with_autocomplete` component
- Set up the usual AB testing helper module
- Use component if and only if AB test in experiment variant (`B`)