### PR TITLE
All content finder: Prepare for autocomplete testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (45.0.0)
+    govuk_publishing_components (45.1.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -70,7 +70,7 @@
             heading_level: 1,
             margin_bottom: 0,
             source_url: @autocomplete_url,
-            source_key: "suggestions"
+            source_key: "suggested_autocomplete"
           } %>
         </div>
 


### PR DESCRIPTION
- Use the correct JSON field for suggestions from the v1 API, until we switch over to v2
- Bump `govuk_publishing_components`