### PR TITLE
Update app.json used by heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,6 +43,9 @@
   "image": "heroku/ruby",
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }
   ],


### PR DESCRIPTION
Review apps are failing when installing yarn-v1.22.22. 
The error message from Heroku suggested specifically adding a buildpack for node.js before the ruby buildpack is fetched.

See logs [here](https://dashboard.heroku.com/pipelines/46c99bab-13dd-4510-bab0-9b5f48b7cc51/app-setup/21fe2cbd-8358-4a25-8d31-3fc1a30c055c)

Related PR https://github.com/alphagov/government-frontend/pull/3413
