### PR TITLE
Add and use API endpoint for search suggestions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.0)
-    gds-api-adapters (97.1.0)
+    gds-api-adapters (97.3.0)
       addressable
       link_header
       null_logger
@@ -191,7 +191,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (45.2.0)
+    govuk_publishing_components (45.3.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/controllers/api/autocompletes_controller.rb
+++ b/app/controllers/api/autocompletes_controller.rb
@@ -1,0 +1,14 @@
+class Api::AutocompletesController < ApplicationController
+  def index
+    render json: autocomplete_response
+  end
+
+private
+
+  def autocomplete_response
+    Services
+      .search_api_v2
+      .autocomplete(params.require(:q))
+      .to_hash
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -62,7 +62,10 @@ class FindersController < ApplicationController
     @pagination = pagination_presenter
     @spelling_suggestion_presenter = spelling_suggestion_presenter
     @ab_test_search_component = use_autocomplete? ? "search_with_autocomplete" : "search"
-    @autocomplete_url = ENV.fetch("SEARCH_AUTOCOMPLETE_API_URL", "")
+    @autocomplete_source_url = ENV.fetch(
+      "SEARCH_AUTOCOMPLETE_API_URL",
+      helpers.absolute_url_for(api_search_autocomplete_path(format: :json)),
+    )
   end
 
 private

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -69,8 +69,8 @@
             wrap_label_in_a_heading: true,
             heading_level: 1,
             margin_bottom: 0,
-            source_url: @autocomplete_url,
-            source_key: "suggested_autocomplete"
+            source_url: @autocomplete_source_url,
+            source_key: "suggestions"
           } %>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: proc { [200, {}, [JSON.generate({ status: :ok })]] }
 
+  namespace :api do
+    get "/search/autocomplete" => "autocompletes#index"
+  end
+
   root to: redirect("/development") unless Rails.env.test?
   get "/development" => "development#index"
 

--- a/spec/requests/api/autocomplete_spec.rb
+++ b/spec/requests/api/autocomplete_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe "autocomplete API", type: :request do
+  let(:search_api_v2) { double(:search_api_v2, autocomplete: autocomplete_response) }
+
+  let(:suggestions) { %w[blue grey red] }
+  let(:autocomplete_response) { instance_double(GdsApi::Response, to_hash: { suggestions: }) }
+
+  before do
+    allow(Services).to receive(:search_api_v2).and_return(search_api_v2)
+  end
+
+  it "returns suggestions from Search API v2" do
+    get "/api/search/autocomplete?q=loving+him+was"
+
+    expect(search_api_v2).to have_received(:autocomplete).with("loving him was")
+    expect(response).to be_successful
+    expect(JSON.parse(response.body)).to eq("suggestions" => suggestions)
+  end
+
+  it "fails if the query parameter is missing" do
+    get "/api/search/autocomplete"
+
+    expect(response).to have_http_status(:bad_request)
+  end
+end


### PR DESCRIPTION
This returns suggestions from the (internal) Search API v2, for
consumption by the autocomplete component soon to be used across GOV.UK for site search.

- Update `gds-api-adapters` to get access to new `autocomplete` method
  for Search API v2
- Add basic API endpoint controller and route proxying to Search API v2
- Reconfigure autocomplete setup to use v2 `source_key` and the new
  endpoint's path (with an override option for local development)
- Update `govuk_publishing_components` for autocomplete tracking
  improvements