### PR TITLE
Autocomplete: Use URL helper instead of `absolute_url_for`

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -62,10 +62,6 @@ class FindersController < ApplicationController
     @pagination = pagination_presenter
     @spelling_suggestion_presenter = spelling_suggestion_presenter
     @ab_test_search_component = use_autocomplete? ? "search_with_autocomplete" : "search"
-    @autocomplete_source_url = ENV.fetch(
-      "SEARCH_AUTOCOMPLETE_API_URL",
-      helpers.absolute_url_for(api_search_autocomplete_path(format: :json)),
-    )
   end
 
 private

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -69,7 +69,7 @@
             wrap_label_in_a_heading: true,
             heading_level: 1,
             margin_bottom: 0,
-            source_url: @autocomplete_source_url,
+            source_url: api_search_autocomplete_url(format: :json),
             source_key: "suggestions"
           } %>
         </div>


### PR DESCRIPTION
This uses Rails's standard URL helper instead of the custom one in the app to establish the absolute URL for the autocomplete endpoint.