### PR TITLE
Add GOV.UK Chat promo banner to business finance support finder

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -13,7 +13,7 @@ $app-colour-true-black: #000000;
   max-width: 100%;
 }
 
-.related-links {
+.title-side {
   margin-top: govuk-spacing(8);
   margin-bottom: govuk-spacing(8);
 }

--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,0 +1,9 @@
+module GovukChatPromoHelper
+  GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+    /business-finance-support
+  ].freeze
+
+  def show_govuk_chat_promo?(base_path)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_PATHS.include?(base_path)
+  end
+end

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -69,15 +69,25 @@
       </div>
     <% end %>
 
-    <% if content_item.related.any? %>
-      <div class="related-links govuk-grid-column-one-third">
-        <ul class="js-finder-results">
-          <% content_item.related.each do |link| %>
-            <li class="related-links__item">
-              <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
-            </li>
-          <% end %>
-        </ul>
+    <% if content_item.related.any? || show_govuk_chat_promo?(content_item.base_path) %>
+      <div class="govuk-grid-column-one-third title-side">
+        <% if show_govuk_chat_promo?(content_item.base_path) %>
+          <%= render "govuk_publishing_components/components/chat_entry", {
+            margin_top_until_tablet: true,
+          } %>
+        <% end %>
+
+        <% if content_item.related.any? %>
+          <div class="related-links">
+            <ul class="js-finder-results">
+              <% content_item.related.each do |link| %>
+                <li class="related-links__item">
+                  <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -93,6 +93,39 @@ describe FindersController, type: :controller do
         get :show, params: { slug: "lunch-finder" }
         expect(response.status).to eq(406)
       end
+
+      context "when the base_path is in the GOVUK_CHAT_PROMO_BASE_PATHS constant" do
+        before do
+          stub_const("GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS", [lunch_finder["base_path"]])
+        end
+
+        context "and the GOVUK_CHAT_PROMO_ENABLED env var is set to true" do
+          it "renders the GOV.UK Chat entry promo banner" do
+            ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+              get :show, params: { slug: "lunch-finder" }
+              expect(response.body).to have_selector(".gem-c-chat-entry")
+            end
+          end
+        end
+
+        context "and the GOVUK_CHAT_PROMO_ENABLED env var is set to false" do
+          it "does not render the GOV.UK Chat entry promo banner" do
+            ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "false" do
+              get :show, params: { slug: "lunch-finder" }
+              expect(response.body).not_to have_selector(".gem-c-chat-entry")
+            end
+          end
+        end
+
+        context "and the GOVUK_CHAT_PROMO_ENABLED env var is not set" do
+          it "does not render the GOV.UK Chat entry promo banner" do
+            ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: nil do
+              get :show, params: { slug: "lunch-finder" }
+              expect(response.body).not_to have_selector(".gem-c-chat-entry")
+            end
+          end
+        end
+      end
     end
 
     describe "a finder content item with a default order exists" do

--- a/spec/helpers/govuk_chat_promo_helper_spec.rb
+++ b/spec/helpers/govuk_chat_promo_helper_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe GovukChatPromoHelper, type: :helper do
+  let(:base_path_with_chat_promo) { described_class::GOVUK_CHAT_PROMO_BASE_PATHS.first }
+
+  describe "#show_govuk_chat_promo?" do
+    it "returns false when ENV[GOVUK_CHAT_PROMO_ENABLED] isn't configured" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "false" do
+        expect(show_govuk_chat_promo?(base_path_with_chat_promo)).to be false
+      end
+    end
+
+    it "returns false when base_path not in configuration" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+        expect(show_govuk_chat_promo?("/non-matching-path")).to be false
+      end
+    end
+
+    it "returns true when base_path is in configuration" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+        expect(show_govuk_chat_promo?(base_path_with_chat_promo)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

We want to bring more users to the GOV.UK Chat app, so we'd like to render a promo component on one specific page: https://www.gov.uk/business-finance-support.

This follows a similar approach to that taken for [Government Frontend](https://github.com/alphagov/government-frontend/pull/3303) and [Collections](https://github.com/alphagov/collections/pull/3742) of adding a helper, modifying views, adding an env var to govuk-helm-charts and having appropriate tests.

This follows the pattern established in [Collections](https://github.com/alphagov/collections/pull/3742) and [Government Frontend](https://github.com/alphagov/government-frontend/pull/3303)

## Screenshots 

<img width="372" alt="image" src="https://github.com/user-attachments/assets/c0248763-5c91-4dc0-8525-7ea9021dee32">

<img width="807" alt="image" src="https://github.com/user-attachments/assets/640f7983-fe69-49f8-9421-cb5a53f1a555">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️