### PR TITLE
Exclude top margin on intervention on taxon page with inverse design 

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,14 +1,14 @@
 <div class="govuk-width-container">
-  <div class="govuk-!-margin-top-4">
-    <% if content_item.has_user_research_banner? %>
-        <%= render "govuk_publishing_components/components/intervention", {
-            suggestion_text: "Help improve GOV.UK",
-            suggestion_link_text: "Sign up to take part in user research (opens in a new tab)",
-            suggestion_link_url: "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_2bggmg6xlelrO0S",
-            new_tab: true,
-          } %>
-    <% end %>
-  </div>
+  <% if content_item.has_user_research_banner? %>
+    <div class="<% if !inverse %> govuk-!-margin-top-4 <% end %>">
+      <%= render "govuk_publishing_components/components/intervention", {
+          suggestion_text: "Help improve GOV.UK",
+          suggestion_link_text: "Sign up to take part in user research (opens in a new tab)",
+          suggestion_link_url: "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_2bggmg6xlelrO0S",
+          new_tab: true,
+      } %>
+    </div>
+  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>


### PR DESCRIPTION
## What
Fix a bug with an overlapping margin caused by the user research banner on taxon pages when the page has the relevant query string eg. /search/guidance-and-regulation?topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0 This fix simply excludes the top margin on the inverse design (instead of doing something more complicated like adding a wrapper for the intervention banner which could have the blue background colour which would enable the top margin also on the inverse design). This is because the taxon inverse design got added for some historical page migration and we'll probably look to remove it at some point (but as of a couple of months ago, we still weren't confident we can do it).

### Before

<img width="835" alt="Screenshot 2024-12-03 at 11 33 48" src="https://github.com/user-attachments/assets/4d8af959-d50c-42da-a062-1e9620d52982">


### After

<img width="833" alt="Screenshot 2024-12-03 at 11 32 08" src="https://github.com/user-attachments/assets/2f31083c-f9ee-4304-b5ae-67abdcc3f184">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
