### PR TITLE
Add a GOV.UK Chat banner to search results

### DIFF
--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -144,6 +144,14 @@
 
         <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
       </div>
+      <% if ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" %>
+        <div class="govuk-grid-column-one-third-from-desktop">
+          <%= render "govuk_publishing_components/components/chat_entry", {
+            heading_text: "Ask GOV.UK Chat about business and tax",
+            description_text: "Get quick, tailored answers with GOV.UK’s experimental AI chat",
+          } %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -277,6 +277,26 @@ describe FindersController, type: :controller do
           expect(response.body).not_to include('"gem-c-search-with-autocomplete"')
         end
       end
+
+      context "when GOVUK_CHAT_PROMO_ENABLED is set to 'true'" do
+        it "shows a GOV.UK Chat promo" do
+          ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+
+            expect(response.body).to have_selector(".gem-c-chat-entry")
+          end
+        end
+      end
+
+      context "when GOVUK_CHAT_PROMO_ENABLED isn't set" do
+        it "doesn't show a GOV.UK Chat promo" do
+          ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: nil do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+
+            expect(response.body).not_to have_selector(".gem-c-chat-entry")
+          end
+        end
+      end
     end
   end
 

--- a/startup.sh
+++ b/startup.sh
@@ -8,6 +8,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   GOVUK_PROXY_STATIC_ENABLED=true \
   PLEK_SERVICE_SEARCH_API_URI=${PLEK_SERVICE_SEARCH_API_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_SEARCH_API_V2_URI=${PLEK_SERVICE_SEARCH_API_V2_URI-https://search.publishing.service.gov.uk/v0_1} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk} \
   PLEK_SERVICE_WHITEHALL_FRONTEND_URI=https://www.gov.uk \


### PR DESCRIPTION
This adds the GOV.UK Chat promo banner to be shown on the right hand
side of the GOV.UK Search results page. It uses an env var defined in
GOV.UK Helm Charts [1].

It will be shown on every GOV.UK search results page. It is expected to
be removed on December 20th - first by env var and then later by code
removal.

This design and wording has been through various people for approval:

- GOV.UK AI design
- GOV.UK AI Lead PM
- GOV.UK Director

[1]: https://github.com/alphagov/govuk-helm-charts/pull/2837

## Visuals

<img width="1496" alt="Screenshot 2024-12-10 at 16 17 48" src="https://github.com/user-attachments/assets/c516af19-a765-4d62-9299-69cfb2da0ff1">

<img width="176" alt="Screenshot 2024-12-10 at 16 21 01" src="https://github.com/user-attachments/assets/7fb7e405-35c5-4a20-b268-075789463882">