### PR TITLE
Remove hardcoded banner code

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -164,10 +164,6 @@ class ContentItem
     base_path == "/find-licences"
   end
 
-  def has_user_research_banner?
-    base_path == "/business-finance-support"
-  end
-
 private
 
   attr_reader :content_item_hash

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -1,14 +1,4 @@
 <div class="govuk-width-container">
-  <% if content_item.has_user_research_banner? %>
-    <div class="<% if !inverse %> govuk-!-margin-top-4 <% end %>">
-      <%= render "govuk_publishing_components/components/intervention", {
-          suggestion_text: "Help improve GOV.UK",
-          suggestion_link_text: "Sign up to take part in user research (opens in a new tab)",
-          suggestion_link_url: "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_2bggmg6xlelrO0S",
-          new_tab: true,
-      } %>
-    </div>
-  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
 
   <%= yield :before_content %>
-
+  <%= render "govuk_web_banners/recruitment_banner" %>
   <main id="content" class="finder-frontend-content">
     <div class="finder-frontend">
       <%= yield %>


### PR DESCRIPTION
This banner is now being configured in v0.2.0 of the govuk_web_banners gem.
https://github.com/alphagov/finder-frontend/pull/3557

There are no user facing changes

[Trello](https://trello.com/c/da3iVv8m/3117-update-finder-frontend-to-render-the-ai-user-research-banner-with-release-020-of-the-web-banners-gem), [Jira issue NAV-15400](https://gov-uk.atlassian.net/browse/NAV-15400)
