### PR TITLE
Remove require of search-with-autocomplete JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,7 +17,6 @@
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/radio
-//= require govuk_publishing_components/components/search-with-autocomplete
 //
 //= require govuk_web_banners/dependencies
 //


### PR DESCRIPTION
This javascript is now provided by static [1] and is thus removed from this repo to ensure that we don't send the same asset to users multiple times unnecessarily.

It continues the convention of applications only adding the JS of components which are not provided by static [2].

[1]: https://github.com/alphagov/static/pull/3532
[2]: https://github.com/alphagov/finder-frontend/pull/2819

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
