### PR TITLE
Add autocomplete to search index

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -58,7 +58,6 @@ class FindersController < ApplicationController
     @sort_presenter = sort_presenter
     @pagination = pagination_presenter
     @spelling_suggestion_presenter = spelling_suggestion_presenter
-    @search_component = use_autocomplete? ? "search_with_autocomplete" : "search"
   end
 
 private
@@ -386,9 +385,5 @@ private
     if arr.respond_to? "reject"
       arr.reject { |v| v == "all" }.compact.presence
     end
-  end
-
-  def use_autocomplete?
-    true unless ENV["GOVUK_DISABLE_SEARCH_AUTOCOMPLETE"]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,10 @@ module ApplicationHelper
   def absolute_url_for(path)
     URI.join(Plek.new.website_root, path)
   end
+
+  def search_component
+    use_autocomplete = true unless ENV["GOVUK_DISABLE_SEARCH_AUTOCOMPLETE"]
+
+    use_autocomplete ? "search_with_autocomplete" : "search"
+  end
 end

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -53,7 +53,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <div id="keywords" role="search" aria-label="Sitewide">
-          <%= render "govuk_publishing_components/components/#{@search_component}", {
+          <%= render "govuk_publishing_components/components/#{search_component}", {
             id: "finder-keyword-search",
             name: "keywords",
             type: 'search',

--- a/app/views/search/_search_field.html.erb
+++ b/app/views/search/_search_field.html.erb
@@ -6,12 +6,14 @@
 } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/search", {
+<%= render "govuk_publishing_components/components/#{search_component}", {
   inline_label: false,
   label_text: label_text,
   size: "large",
   id: "search-main",
   disable_corrections: true,
+  source_url: api_search_autocomplete_url(format: :json),
+  source_key: "suggestions",
 } %>
 
 <%= hidden_field_tag("filter_manual[]", params[:filter_manual]) if params[:filter_manual] %>

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+
+describe SearchController, type: :controller do
+  include GdsApi::TestHelpers::ContentStore
+
+  before do
+    stub_content_store_has_item("/search")
+  end
+
+  describe "GET index" do
+    render_views
+
+    it "renders the search page" do
+      get :index
+      expect(response.status).to eq(200)
+      expect(response).to render_template("search/no_search_term")
+    end
+
+    context "when given search parameters" do
+      it "redirects to the all content finder" do
+        get :index, params: { q: "my search" }
+        
+        destination = finder_path("search/all",
+                                  params: { keywords: "my search", order: "relevance" })
+        expect(response).to redirect_to(destination)
+      end
+    end
+
+    context "when JSON is requested" do
+      it "redirects to the all content finder" do
+        get :index, format: :json
+        
+        destination = finder_path("search/all",
+                                  params: { order: "relevance", format: "json" })
+        expect(response).to redirect_to(destination)
+      end
+    end
+  end
+end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -20,7 +20,7 @@ describe SearchController, type: :controller do
     context "when given search parameters" do
       it "redirects to the all content finder" do
         get :index, params: { q: "my search" }
-        
+
         destination = finder_path("search/all",
                                   params: { keywords: "my search", order: "relevance" })
         expect(response).to redirect_to(destination)
@@ -30,10 +30,31 @@ describe SearchController, type: :controller do
     context "when JSON is requested" do
       it "redirects to the all content finder" do
         get :index, format: :json
-        
+
         destination = finder_path("search/all",
                                   params: { order: "relevance", format: "json" })
         expect(response).to redirect_to(destination)
+      end
+    end
+
+    context "when GOVUK_DISABLE_SEARCH_AUTOCOMPLETE is not set" do
+      it "renders the search autocomplete component" do
+        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: nil do
+          get :index
+
+          expect(response.body).to include("gem-c-search-with-autocomplete")
+        end
+      end
+    end
+
+    context "when GOVUK_DISABLE_SEARCH_AUTOCOMPLETE is set" do
+      it "renders the search component instead of the autocomplete component" do
+        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1" do
+          get :index
+
+          expect(response.body).not_to include("gem-c-search-with-autocomplete")
+          expect(response.body).to include("gem-c-search")
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#search_component" do
+    context "when ENV['GOVUK_DISABLE_SEARCH_AUTOCOMPLETE'] is not set" do
+      it "returns 'search_with_autocomplete'" do
+        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: nil do
+          expect(helper.search_component).to eq("search_with_autocomplete")
+        end
+      end
+    end
+
+    context "when ENV['GOVUK_DISABLE_SEARCH_AUTOCOMPLETE'] is set" do
+      it "returns 'search'" do
+        ClimateControl.modify GOVUK_DISABLE_SEARCH_AUTOCOMPLETE: "1" do
+          expect(helper.search_component).to eq("search")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've tried to add autocomplete to each site search input on GOV.UK. When reviewing this we noticed that one of them was missed, the one on https://www.gov.uk/search.

This PR corrects this by adding it to this page, with the first two commits doing foundational work for this change. More info in the commits.