### PR TITLE
Remove use of shared helper for margin

### DIFF
--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -2,16 +2,13 @@
 <%
   title ||= false
   open_on_load ||= false
-  margin_bottom ||= 0
 
   content_id = "expander-content-#{SecureRandom.hex(4)}"
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
   component_helper.add_data_attribute({ module: "expander" })
   component_helper.add_data_attribute({ "open-on-load": open_on_load })
   component_helper.add_class("app-c-expander")
-  component_helper.add_class(shared_helper.get_margin_bottom) unless margin_bottom == 0
   component_helper.add_data_attribute({ "button-data-attributes": button_data_attributes }) if local_assigns.include?(:button_data_attributes)
 %>
 <% if title %>

--- a/app/views/components/_filter_panel.html.erb
+++ b/app/views/components/_filter_panel.html.erb
@@ -13,12 +13,9 @@
   raise ArgumentError, "reset_link_href is required" if show_reset_link && !local_assigns[:reset_link_href]
 
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper.add_data_attribute({ module: "filter-panel ga4-event-tracker" })
   component_helper.add_class("app-c-filter-panel")
-  component_helper.add_class(shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
 %>
-
 <%= tag.div(**component_helper.all_attributes) do %>
   <div class="app-c-filter-panel__header">
     <%= tag.button(

--- a/app/views/components/_filter_section.html.erb
+++ b/app/views/components/_filter_section.html.erb
@@ -1,7 +1,6 @@
 <% add_app_component_stylesheet("filter-section") %>
 <%
   raise ArgumentError, "heading_text is required" unless local_assigns[:heading_text]
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   open ||= nil
   status_text ||= ""
   heading_level ||= 2
@@ -19,7 +18,6 @@
   component_helper.add_class("app-c-filter-section")
   component_helper.set_open(open)
 %>
-
 <%= tag.details(**component_helper.all_attributes) do %>
   <%= tag.summary(
     class: "app-c-filter-section__summary",

--- a/app/views/components/_filter_summary.html.erb
+++ b/app/views/components/_filter_summary.html.erb
@@ -9,13 +9,10 @@
   reset_link_href ||= nil
   reset_link_text ||= "Clear all filters"
 
-  shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns)
-  component_helper.add_class(shared_helper.get_margin_bottom) if local_assigns[:margin_bottom]
   component_helper.add_data_attribute({ module: "ga4-event-tracker" })
   component_helper.add_class("app-c-filter-summary")
 %>
-
 <%= tag.div(**component_helper.all_attributes) do %>
   <%= content_tag("h#{heading_level}", heading_text, class: "app-c-filter-summary__heading") %>
 

--- a/app/views/components/docs/expander.yml
+++ b/app/views/components/docs/expander.yml
@@ -8,6 +8,7 @@ accessibility_criteria: |
   - indicate where the state of expandable content has changed
   - be operable with a keyboard
   - be expanded by default without Javascript enabled
+uses_component_wrapper_helper: true
 examples:
   default:
     data:
@@ -19,13 +20,6 @@ examples:
     data:
       title: Location
       open_on_load: true
-      block: |
-        This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.
-  with_margin_bottom:
-    description: The component accepts a number for margin bottom from 0 to 9 (0px to 60px) using the [GOV.UK Frontend spacing scale](http://govuk-frontend-review.herokuapp.com/docs/#settings/spacing-variable-govuk-spacing-points). It defaults to a margin bottom of 0.
-    data:
-      title: Person
-      margin_bottom: 9
       block: |
         This is some content that is passed to the component. It should be distinct from the component, in that the component should not style or interact with it, other than to show and hide it.
   with_counter:

--- a/app/views/components/docs/filter_panel.yml
+++ b/app/views/components/docs/filter_panel.yml
@@ -98,12 +98,3 @@ examples:
             ]
           } %>
         </div>
-  with_margin_bottom:
-    description: |
-      Allows the spacing at the bottom of the component to be adjusted.
-
-      This accepts a number from `0` to `9` (`0px` to `60px`) using the [GOV.UK Frontend spacing scale](https://design-system.service.gov.uk/styles/spacing/#the-responsive-spacing-scale). It defaults to having no margin bottom.
-    data:
-      result_text: 1 partridge in a pear tree
-      button_text: Loooooads of space
-      margin_bottom: 9


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- removes the shared helper call to set margin, as this is now handled by the component wrapper helper, which all of these components already use
- one of these didn't seem to be using the shared helper at all

## Why

The component wrapper helper now handles margin bottom in the same way that the shared helper does, but automatically, so only a default needs to be set. In the case of these components their default behaviour is for no bottom margin, which is the default behaviour for the wrapper anyway, so doesn't need to be set.

## Visual changes
None, hopefully.

Trello card: https://trello.com/c/hnfXA4lu/451-move-marginbottom-option-into-component-wrapper, [Jira issue PNP-7369](https://gov-uk.atlassian.net/browse/PNP-7369)