### PR TITLE
Remove GOV.UK Chat promo banner

### DIFF
--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -143,14 +143,6 @@
 
         <%= render "govuk_publishing_components/components/previous_and_next_navigation", @pagination.next_and_prev_links %>
       </div>
-      <% if ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" %>
-        <div class="govuk-grid-column-one-third-from-desktop">
-          <%= render "govuk_publishing_components/components/chat_entry", {
-            heading_text: "Ask GOV.UK Chat about business and tax",
-            description_text: "Get quick, tailored answers with GOV.UK’s experimental AI chat",
-          } %>
-        </div>
-      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -270,26 +270,6 @@ describe FindersController, type: :controller do
           end
         end
       end
-
-      context "when GOVUK_CHAT_PROMO_ENABLED is set to 'true'" do
-        it "shows a GOV.UK Chat promo" do
-          ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
-            get :show, params: { slug: "search/all", keywords: "hello" }
-
-            expect(response.body).to have_selector(".gem-c-chat-entry")
-          end
-        end
-      end
-
-      context "when GOVUK_CHAT_PROMO_ENABLED isn't set" do
-        it "doesn't show a GOV.UK Chat promo" do
-          ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: nil do
-            get :show, params: { slug: "search/all", keywords: "hello" }
-
-            expect(response.body).not_to have_selector(".gem-c-chat-entry")
-          end
-        end
-      end
     end
   end
 


### PR DESCRIPTION

https://trello.com/c/GoYhHWGw/2205

We no longer want to render the promo now that the pilot has finished,
so this cleans up the codebase to remove the additions.
