### PR TITLE
Adapt CORS policy for autocomplete_spec

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  # Allow the autocomplete API to be accessed from any GOV.UK domain, including
-  # non-production ones. This enables autocomplete on CSV preview GOV.UK pages,
-  # which are hosted on assets.publishing.service.gov.uk.
-  # This also allows for local development usage.
+  # Allow the autocomplete API to be accessed from any GOV.UK domain, including non-production ones,
+  # as well as Heroku preview apps. Note that the header is rendered on some arbitrary GOV.UK
+  # subdomains (such as assets.publishing.service.gov.uk for CSV preview pages) so www alone is not
+  # enough, and we may need autocomplete on local dev environments and Heroku preview apps as well.
   allow do
-    origins %r{(www|dev|publishing\.service)\.gov\.uk\z}
+    origins %r{(\.gov\.uk|\.herokuapp.com)\z}
 
     resource "/api/search/autocomplete*",
              headers: :any,

--- a/spec/requests/api/autocomplete_spec.rb
+++ b/spec/requests/api/autocomplete_spec.rb
@@ -26,7 +26,12 @@ RSpec.describe "autocomplete API", type: :request do
   end
 
   describe "CORS headers" do
-    %w[https://www.gov.uk http://example.dev.gov.uk https://example.publishing.service.gov.uk].each do |allowed_host|
+    %w[
+      https://www.gov.uk
+      http://example.dev.gov.uk
+      https://example.publishing.service.gov.uk
+      https://preview-app-abcd123.herokuapp.com
+    ].each do |allowed_host|
       it "returns CORS headers for #{allowed_host}" do
         get "/api/search/autocomplete", params:, headers: { Origin: allowed_host }
 


### PR DESCRIPTION
This updates the CORS policy to be more relaxed about GOV.UK subdomains, as well as allow Heroku preview apps.

This adds a negligible risk that third-party Heroku hosted apps (as well as non-GDS operated GOV.UK subdomains) could in theory use the autocomplete endpoint from Javascript, but we don't consider this to have enough impact or likelihood to be worth mitigating against.