### PR TITLE
Upgrade govuk_publishing_components to 48.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (47.0.0)
+    govuk_publishing_components (48.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/finders/_facet_collection.html.erb
+++ b/app/views/finders/_facet_collection.html.erb
@@ -6,7 +6,7 @@
       <% end %>
       <%= render "govuk_publishing_components/components/search", {
         aria_controls: "js-search-results-info",
-        id: "finder-keyword-search",
+        label_id: "finder-keyword-search",
         name: "keywords",
         type: 'search',
         value: result_set_presenter.user_supplied_keywords,

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -12,7 +12,7 @@
         <div id="keywords" class="app-patch--search-input-override" role="search" aria-label="Sitewide" data-ga4-change-category="update-keyword text">
           <%= render "govuk_publishing_components/components/search", {
             aria_controls: "js-search-results-info",
-            id: "finder-keyword-search",
+            label_id: "finder-keyword-search",
             name: "keywords",
             type: 'search',
             value: result_set_presenter.user_supplied_keywords,


### PR DESCRIPTION
## What / Why
- Upgrades to `govuk_publishing_components` 48.0.0
- Renames two parameters as a result to prevent breaking. Though I don't think the search component on `_show_header.html.erb` is used anymore.
- The changes in this PR are because of this PR:  https://github.com/alphagov/govuk_publishing_components/pull/4540 Specifically, `id` refers to ids on the parent HTML element of the component now, so to preserve the ids being for the labels/inputs of this repo they are now called `label_id`.