### PR TITLE
Derive search result metadata labels from allowed values on facet where present

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -68,10 +68,10 @@ private
     metadata_facets(facets).select { |f| f.type == "date" }.map(&:key)
   end
 
-  def text_metadata_keys(facets)
-    keys = metadata_facets(facets).select { |f| f.type == "text" }.map(&:key)
-    keys.reject do |key|
-      key == "organisations" && is_mainstream_content?
+  def text_metadata_facets(facets)
+    facets = metadata_facets(facets).select { |f| f.type == "text" }
+    facets.reject do |facet|
+      facet.key == "organisations" && is_mainstream_content?
     end
   end
 
@@ -100,36 +100,44 @@ private
   end
 
   def text_metadata(facets)
-    text_metadata_keys(facets)
-      .map(&method(:build_text_metadata))
-      .select(&method(:metadata_value_present?))
-  end
+    metadata_labels = {}
+    text_metadata_facets(facets).each do |facet|
+      document_values = document_hash[facet.key]
+      next if document_values.nil?
 
-  def text_labels_for(key)
-    labels = Array(document_hash.fetch(key, []))
-               .map { |label| get_metadata_label(key, label) }
-               .select(&:present?)
-
-    if key == "organisations"
-      labels = labels.sort_by do |label|
-        label.sub("Closed organisation: ", "ZZ").upcase
-      end
+      metadata_labels[facet.key] = if facet.allowed_values.empty?
+                                     metadata_labels_from_document_values(document_values, facet.key)
+                                   else
+                                     metadata_labels_from_allowed_values(facet.allowed_values, document_values, facet.key)
+                                   end
     end
-
-    labels
+    metadata_labels.map(&method(:build_text_metadata)).select(&method(:metadata_value_present?))
   end
 
-  def build_text_metadata(key)
-    labels = text_labels_for(key)
-    value = format_value(labels)
-
+  def build_text_metadata(facet_key, values)
     {
-      id: key,
-      name: key,
-      value:,
-      labels:,
+      id: facet_key,
+      name: facet_key,
+      value: format_value(values),
+      labels: values,
       type: "text",
     }
+  end
+
+  def metadata_labels_from_document_values(document_values, facet_key)
+    if document_values.is_a?(Array)
+      document_values.map { |document_value| get_metadata_label(facet_key, document_value) }
+    else
+      [get_metadata_label(facet_key, document_values)]
+    end
+  end
+
+  def metadata_labels_from_allowed_values(allowed_values, document_values, facet_key)
+    document_values.map do |document_value|
+      document_value_key = document_value.is_a?(Hash) ? document_value["value"] : document_value
+      matched_value = allowed_values.find { |allowed_value| allowed_value["value"] == document_value_key }
+      matched_value ? matched_value["label"] : get_metadata_label(facet_key, document_value)
+    end
   end
 
   def format_value(labels)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -65,7 +65,7 @@ describe Document do
         [FactoryBot.build(:option_select_facet, key: "a_filter_key")]
       end
 
-      describe "The document is not tagged to any values of the facet filter key" do
+      describe "and the document is not tagged to any values of the facet filter key" do
         let(:document_hash) do
           FactoryBot.build(:document_hash, a_filter_key: nil)
         end
@@ -75,7 +75,7 @@ describe Document do
         end
       end
 
-      describe "The document values do not match the expected format" do
+      describe "and the document values do not match the expected format" do
         let(:document_hash) do
           FactoryBot.build(:document_hash, a_filter_key: [{ slug: "some-url" }])
         end
@@ -85,7 +85,7 @@ describe Document do
         end
       end
 
-      describe "The document is tagged to a single value of the facet filter key" do
+      describe "and the document is tagged to a single value of the facet filter key" do
         let(:document_hash) do
           FactoryBot.build(:document_hash, a_filter_key: "metadata_label")
         end
@@ -102,18 +102,18 @@ describe Document do
           expect(described_class.new(document_hash, 1).metadata(facets)).to eq([expected_hash])
         end
 
-        describe "There is a short name in the facet" do
+        describe "and there is a short name in the facet" do
           let(:facets) do
             [FactoryBot.build(:option_select_facet, short_name: "short name")]
           end
 
-          it "replaces the name field in the metafata by the short name from the facet" do
+          it "replaces the name field in the metadata by the short name from the facet" do
             expect(described_class.new(document_hash, 1).metadata(facets)).to match([include(name: "short name")])
           end
         end
       end
 
-      describe "The document is tagged to a multiple values of the facet filter key" do
+      describe "and the document is tagged to multiple values of the facet filter key" do
         let(:document_hash) do
           FactoryBot.build(
             :document_hash,
@@ -151,7 +151,7 @@ describe Document do
           [FactoryBot.build(:option_select_facet, key: "a_filter_key", allowed_values:)]
         end
 
-        describe "The document is tagged to multiple values of the facet filter key" do
+        describe "and the document is tagged to multiple values of the facet filter key" do
           let(:document_hash) do
             FactoryBot.build(
               :document_hash,
@@ -176,7 +176,7 @@ describe Document do
           end
         end
 
-        describe "The document is tagged to a multiple values of the facet filter key that do not match any allowed values" do
+        describe "and the document is tagged to a multiple values of the facet filter key that do not match any allowed values" do
           let(:document_hash) do
             FactoryBot.build(
               :document_hash,
@@ -201,7 +201,7 @@ describe Document do
           end
         end
 
-        describe "The document is tagged to a multiple values of the facet filter key without search result expansion" do
+        describe "and the document is tagged to a multiple values of the facet filter key without search result expansion" do
           let(:document_hash) do
             FactoryBot.build(
               :document_hash,

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -65,6 +65,26 @@ describe Document do
         [FactoryBot.build(:option_select_facet, key: "a_filter_key")]
       end
 
+      describe "The document is not tagged to any values of the facet filter key" do
+        let(:document_hash) do
+          FactoryBot.build(:document_hash, a_filter_key: nil)
+        end
+
+        it "does not return any metadata" do
+          expect(described_class.new(document_hash, 1).metadata(facets)).to eq([])
+        end
+      end
+
+      describe "The document values do not match the expected format" do
+        let(:document_hash) do
+          FactoryBot.build(:document_hash, a_filter_key: [{ slug: "some-url" }])
+        end
+
+        it "does not return any metadata" do
+          expect(described_class.new(document_hash, 1).metadata(facets)).to eq([])
+        end
+      end
+
       describe "The document is tagged to a single value of the facet filter key" do
         let(:document_hash) do
           FactoryBot.build(:document_hash, a_filter_key: "metadata_label")
@@ -116,6 +136,91 @@ describe Document do
               type: "text",
             }
           expect(described_class.new(document_hash, 1).metadata(facets)).to eq([expected_hash])
+        end
+      end
+
+      context "and the facet has a set of allowed values" do
+        let(:allowed_values) do
+          [
+            { "label" => "metadata label 1", value: "metadata_label_1" },
+            { "label" => "metadata label 2", value: "metadata_label_2" },
+            { "label" => "metadata label 3", value: "metadata_label_3" },
+          ]
+        end
+        let(:facets) do
+          [FactoryBot.build(:option_select_facet, key: "a_filter_key", allowed_values:)]
+        end
+
+        describe "The document is tagged to multiple values of the facet filter key" do
+          let(:document_hash) do
+            FactoryBot.build(
+              :document_hash,
+              a_filter_key:
+                [
+                  { "label" => "metadata label 1", value: "metadata_label_1" },
+                  { "label" => "metadata label 3", value: "metadata_label_3" },
+                ],
+            )
+          end
+
+          it "gets the metadata" do
+            expected_hash =
+              {
+                id: "a_filter_key",
+                name: "A filter key",
+                value: "metadata label 1 and 1 others",
+                labels: ["metadata label 1", "metadata label 3"],
+                type: "text",
+              }
+            expect(described_class.new(document_hash, 1).metadata(facets)).to eq([expected_hash])
+          end
+        end
+
+        describe "The document is tagged to a multiple values of the facet filter key that do not match any allowed values" do
+          let(:document_hash) do
+            FactoryBot.build(
+              :document_hash,
+              a_filter_key:
+                [
+                  { "label" => "mismatched label 1", value: "mismatched_label_1" },
+                  { "label" => "mismatched label 3", value: "mismatched_label_3" },
+                ],
+            )
+          end
+
+          it "gets the metadata" do
+            expected_hash =
+              {
+                id: "a_filter_key",
+                name: "A filter key",
+                value: "mismatched label 1 and 1 others",
+                labels: ["mismatched label 1", "mismatched label 3"],
+                type: "text",
+              }
+            expect(described_class.new(document_hash, 1).metadata(facets)).to eq([expected_hash])
+          end
+        end
+
+        describe "The document is tagged to a multiple values of the facet filter key without search result expansion" do
+          let(:document_hash) do
+            FactoryBot.build(
+              :document_hash,
+              a_filter_key:
+                %w[metadata_label_1 metadata_label_3],
+            )
+          end
+
+          it "gets the metadata" do
+            expected_hash =
+              {
+                id: "a_filter_key",
+                name: "A filter key",
+                value: "metadata label 1 and 1 others",
+                labels: ["metadata label 1", "metadata label 3"],
+                type: "text",
+              }
+            expect(described_class.new(document_hash, 1).metadata(facets)).to eq([expected_hash])
+          end
         end
       end
     end


### PR DESCRIPTION
For many document types, the values indexed in Elasticsearch for its metadata fields are the kebab case value from the select option value in the Publishing app.

These values are not suitable for presenting on GOV.UK, so there is a configuration in each content type defined in Search API called `expanded_search_result_fields`. This configuration is used to replace the kebab case value with a hash containing the original value and the human friendly label it relates to in the Search API query results.

Maintaining this configuration is painful, particularly for specialist document types, because it means that every time a department wants to add, change or remove an option on a facet (a frequent occurrence), we have to update the configuration in both the Publishing tool and in Search API.

However, given the label provided in the expanded search result fields configuration never varies* from the label present in the `allowed_values` attribute on the facet configuration, we may as well fetch the label from there and remove the `expanded_search_result_fields` from Search API, which will reduce the effort required from Publishing teams to maintain Specialist Finders.

This commit extracts the appropriate metadata labels from the `allowed_values` configuration on the facet if one is provided. It will work both for search results that have had the field expansion applied, and those that haven't, so should be safe to release before the removal of the configuration. It also preserves the existing behaviour for facets that do not set `allowed_values`.

\* as far as we are aware having checked the finder schemas - it would be strange for users if it did

https://trello.com/c/PZmDZD6l

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://finder-frontend-pr-3627.herokuapp.com/search/all
- https://finder-frontend-pr-3627.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-3627.herokuapp.com/drug-device-alerts
