### PR TITLE
Remove unused pluralisation logic from email alert title builder (take 2!)

### DIFF
--- a/app/lib/email_alert_title_builder.rb
+++ b/app/lib/email_alert_title_builder.rb
@@ -18,17 +18,11 @@ private
   attr_reader :filter, :subscription_list_title_prefix, :facets
 
   def prefix
-    if facets.size == 1 && subscription_list_title_prefix.is_a?(Hash)
-      subscription_list_title_prefix[plural_or_single].to_s.strip
-    elsif selected_facets.empty?
+    if selected_facets.empty?
       subscription_list_title_prefix.to_s.strip
     elsif subscription_list_title_prefix.present?
       "#{subscription_list_title_prefix.strip} with"
     end
-  end
-
-  def plural_or_single
-    filter.fetch(facets.first["facet_id"], []).length == 1 ? "singular" : "plural"
   end
 
   def suffix

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -1,5 +1,5 @@
-# Facade that speaks to rummager. Combines a content item with
-# search results from rummager.
+# Facade that speaks to Search API. Combines a content item with
+# search results from Search API.
 module Search
   class Query
     SITE_SEARCH_FINDER_BASE_PATH = "/search/all".freeze

--- a/features/fixtures/bad_input_email_signup.json
+++ b/features/fixtures/bad_input_email_signup.json
@@ -68,10 +68,6 @@
     "filter": {
       "document_type": "cma_case"
     },
-    "subscription_list_title_prefix": {
-      "singular": "CMA cases with the following case type: ",
-      "plural": "CMA cases with the following case types: ",
-      "many": "Competition and Markets Authority (CMA) cases: "
-    }
+    "subscription_list_title_prefix": "CMA cases"
   }
 }

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -141,10 +141,6 @@
     "filter": {
       "format": "cma_case"
     },
-    "subscription_list_title_prefix": {
-      "singular": "CMA cases with the following case type: ",
-      "plural": "CMA cases with the following case types: ",
-      "many": "Competition and Markets Authority (CMA) cases: "
-    }
+    "subscription_list_title_prefix": "CMA cases"
   }
 }

--- a/spec/lib/email_alert_title_builder_spec.rb
+++ b/spec/lib/email_alert_title_builder_spec.rb
@@ -38,10 +38,9 @@ describe EmailAlertTitleBuilder do
     it { is_expected.to eq(subscription_list_title_prefix) }
   end
 
-  context "when there is one facet" do
-    let(:subscription_list_title_prefix) do
-      { "singular" => "Prefix:", "plural" => "Prefixes:" }
-    end
+  context "when there is one facet with a string subscription_list_title_prefix" do
+    let(:subscription_list_title_prefix) { "Prefix" }
+
     let(:facets) do
       [
         {
@@ -68,19 +67,19 @@ describe EmailAlertTitleBuilder do
     context "when no choice is selected" do
       let(:filter) { {} }
 
-      it { is_expected.to eq("Prefixes:") }
+      it { is_expected.to eq("Prefix") }
     end
 
     context "when one choice is selected" do
       let(:filter) { { "facet_id" => %w[key_one] } }
 
-      it { is_expected.to eq("Prefix: topic name one") }
+      it { is_expected.to eq("Prefix with topic name one") }
     end
 
     context "when two choices are selected" do
       let(:filter) { { "facet_id" => %w[key_one key_two] } }
 
-      it { is_expected.to eq("Prefixes: topic name one and topic name two") }
+      it { is_expected.to eq("Prefix with topic name one and topic name two") }
     end
   end
 


### PR DESCRIPTION
Re-implements https://github.com/alphagov/finder-frontend/pull/3626 (which was reverted in alphagov/finder-frontend#3633).

Tested on integration: https://www.integration.publishing.service.gov.uk/email/subscriptions/new?topic_id=cma-cases-with-competition-disqualification-and-digital-markets-unit