### PR TITLE
Change inverse header padding top

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (50.0.1)
+    govuk_publishing_components (51.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -26,7 +26,7 @@
   <% if is_inverse? %>
     <%= render "govuk_publishing_components/components/inverse_header", {
       full_width: true,
-      padding_top: false
+      padding_top: 0
     } do %>
       <%= render partial: 'show_header', locals: {
         inverse: is_inverse?,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the padding top option call in the inverse header on some search pages.

## Why
The option in the component has been changed to a scale, instead of true/false, see this PR: https://github.com/alphagov/govuk_publishing_components/pull/4590

Note that this change will not be merged until a new version of the components gem including this change is included here.

## Visual changes
I couldn't actually find a search page that uses an inverse header (although the code is there https://github.com/alphagov/finder-frontend/blob/main/app/views/finders/show.html.erb#L26) but I've tested this locally with forced inverse on a search page and the layout looks correct.

Trello card: https://trello.com/c/hRL2Nmyp/450-improve-inverse-header-component-padding, [Jira issue PNP-7385](https://gov-uk.atlassian.net/browse/PNP-7385)

