### PR TITLE
Remove unused `format_name` property

### DIFF
--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -54,13 +54,6 @@ For example, rejecting all documents which don't have a policy would need a hash
 }
 ```
 
-## `format_name`
-
-A string. Optional.
-
-Not specifically used by the Finder. Usually a singularised version of the title of the Finder - `"Competition and Markets Authority case"` for [`/cma-cases`](https://www.gov.uk/cma-cases) for example.
-However there are edge cases where it's not the same such as `"Medical safety alert"` for [Alerts and recalls for drugs and medical devices](https://www.gov.uk/drug-device-alerts).
-
 ## `default_order`
 
 A string. Optional.

--- a/features/fixtures/aaib_reports_example.json
+++ b/features/fixtures/aaib_reports_example.json
@@ -95,7 +95,6 @@
     "filter":{
       "document_type":"aaib_report"
     },
-    "format_name":"Air Accidents Investigation Branch report",
     "show_summaries":true,
     "facets":[
       {

--- a/features/fixtures/all_content.json
+++ b/features/fixtures/all_content.json
@@ -108,7 +108,6 @@
         "type": "hidden_clearable"
       }
     ],
-    "format_name": "Documents",
     "reject": {
       "link": [
         "/search/all"

--- a/features/fixtures/cma_cases_content_item.json
+++ b/features/fixtures/cma_cases_content_item.json
@@ -733,7 +733,6 @@
     "filter": {
       "document_type": "cma_case"
     },
-    "format_name": "Competition and Markets Authority case",
     "show_summaries": false,
     "facets": [
       {

--- a/features/fixtures/news_and_communications.json
+++ b/features/fixtures/news_and_communications.json
@@ -47,7 +47,6 @@
     "filter":{
       "content_purpose_subgroup": ["news", "speeches_and_statements"]
     },
-    "format_name":"News or communiqué",
     "show_summaries":true,
     "sort": [
       {

--- a/features/fixtures/news_and_communications_with_checkboxes.json
+++ b/features/fixtures/news_and_communications_with_checkboxes.json
@@ -46,7 +46,6 @@
     "filter":{
       "content_purpose_supergroup":"news_and_communications"
     },
-    "format_name":"News or communiqué",
     "show_summaries":true,
     "sort": [
       {

--- a/features/fixtures/official_documents.json
+++ b/features/fixtures/official_documents.json
@@ -26,7 +26,6 @@
   "filter": {
     "has_official_document": true
   },
-  "format_name": "Official documents",
   "show_summaries": true,
   "sort": [
     {

--- a/features/fixtures/policy_and_engagement.json
+++ b/features/fixtures/policy_and_engagement.json
@@ -58,7 +58,6 @@
         "policy_and_engagement"
       ]
     },
-    "format_name": "document",
     "show_summaries": true,
     "sort": [
       {

--- a/features/fixtures/statistics.json
+++ b/features/fixtures/statistics.json
@@ -43,7 +43,6 @@
     "beta_message": "This is in beta. Please take our <a href='https://www.gov.uk'>survey</a>.",
     "document_noun":"result",
     "filter":{},
-    "format_name":"statistic",
     "show_summaries":true,
     "sort": [
       {

--- a/spec/support/content_helper.rb
+++ b/spec/support/content_helper.rb
@@ -486,7 +486,6 @@ module GovukContentSchemaExamples
         "filter" => {
           "document_type" => "cma_case",
         },
-        "format_name" => "Competition and Markets Authority case",
         "show_summaries" => false,
       }
       finder["links"] = {


### PR DESCRIPTION
See https://github.com/alphagov/specialist-publisher/pull/2998

Trello: https://trello.com/c/ZiFU2o6B

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
