### PR TITLE
Fetch Publishing API's main branch for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: alphagov/publishing-api
-          ref: deployed-to-production
+          ref: main
           path: vendor/publishing-api
 
       - name: Setup Ruby


### PR DESCRIPTION
The `deployed-to-*` branches don't appear to have been used (read: kept up-to-date) in 2 years. Potentially coinciding with replatforming?

The `main` branch should accurately reflect what's deployed to production, though, give or take a few minutes.
