### PR TITLE
Allow previewing serving configurations on Search API v2

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -86,6 +86,7 @@ module Search
         finder_content_item: content_item,
         params: filter_params,
         override_sort_for_feed:,
+        use_v2_api: use_v2_api?,
       ).call
 
       if use_v2_api?

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -14,11 +14,18 @@ module Search
 
     LICENCE_STOPWORDS = %w[licence license permit certification].freeze
 
-    def initialize(finder_content_item:, params: {}, ab_params: {}, override_sort_for_feed: false)
+    def initialize(
+      finder_content_item:,
+      params: {},
+      ab_params: {},
+      override_sort_for_feed: false,
+      use_v2_api: false
+    )
       @finder_content_item = finder_content_item
       @params = params
       @ab_params = ab_params
       @override_sort_for_feed = override_sort_for_feed
+      @use_v2_api = use_v2_api
     end
 
     def call
@@ -46,6 +53,10 @@ module Search
   private
 
     attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed
+
+    def use_v2_api?
+      @use_v2_api
+    end
 
     def pagination_query
       {
@@ -234,9 +245,15 @@ module Search
     end
 
     def debug_query
-      {
-        "debug" => params["debug"],
-      }.compact
+      if use_v2_api?
+        {
+          "serving_config" => params["debug_serving_config"],
+        }.compact
+      else
+        {
+          "debug" => params["debug"],
+        }.compact
+      end
     end
 
     def ab_query

--- a/app/presenters/result_set_presenter.rb
+++ b/app/presenters/result_set_presenter.rb
@@ -66,6 +66,10 @@ class ResultSetPresenter
     sort_presenter.to_hash.blank? ? true : false
   end
 
+  def debug_serving_config
+    @filter_params[:debug_serving_config].presence
+  end
+
 private
 
   attr_reader :metadata_presenter_class, :sort_presenter, :total, :documents, :facets, :content_item

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -38,6 +38,23 @@
     ga4_ecommerce_variant: result_set_presenter.sort_option&.fetch(:data_ga4_track_label, nil),
   },
 ) do %>
+
+  <% if result_set_presenter.debug_serving_config %>
+    <%= render "govuk_publishing_components/components/notice", {
+      title: "Previewing different serving configuration",
+    } do %>
+      <p class="govuk-body">
+        You are temporarily using the
+        <strong><%= result_set_presenter.debug_serving_config %></strong>
+        serving configuration for results from Search API v2.
+      </p>
+
+      <p class="govuk-body">
+        <%= link_to "Return to default serving configuration", url_for(filter_params.except(:debug_serving_config)), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
+  <% end %>
+
   <%= tag.form(
     method: "get",
     action: content_item.base_path,
@@ -51,6 +68,7 @@
     },
   ) do %>
     <%= hidden_field_tag :parent, @parent if @parent.present? %>
+    <%= hidden_field_tag :debug_serving_config, result_set_presenter.debug_serving_config if result_set_presenter.debug_serving_config %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/spec/lib/search/query_builder_spec.rb
+++ b/spec/lib/search/query_builder_spec.rb
@@ -4,6 +4,7 @@ describe Search::QueryBuilder do
   subject(:queries) do
     described_class.new(
       finder_content_item:,
+      use_v2_api:,
       params:,
     ).call
   end
@@ -22,6 +23,7 @@ describe Search::QueryBuilder do
       },
     )
   end
+  let(:use_v2_api) { false }
 
   let(:facets) { [] }
   let(:filter) { {} }
@@ -336,17 +338,33 @@ describe Search::QueryBuilder do
     let(:params) do
       {
         "debug" => "yes",
+        "debug_serving_config" => "my-special-serving-config",
       }
     end
 
-    it "includes a debug query" do
-      expect(query).to include("debug" => "yes")
+    context "for Search API v1" do
+      let(:use_v2_api) { false }
+
+      it "includes a debug query but no serving config one" do
+        expect(query).to include("debug" => "yes")
+        expect(query).not_to have_key("serving_config")
+      end
+    end
+
+    context "for Search API v2" do
+      let(:use_v2_api) { true }
+
+      it "includes a serving config query but not a debug one" do
+        expect(query).to include("serving_config" => "my-special-serving-config")
+        expect(query).not_to have_key("debug")
+      end
     end
   end
 
   context "without debug parameters" do
-    it "does not include a debug query" do
+    it "does not include a debug or serving config query" do
       expect(query).not_to include("debug")
+      expect(query).not_to include("serving_config")
     end
   end
 


### PR DESCRIPTION
Search API v2 now supports getting results through different serving configs [1]. This allows us to (among other things) have a "preview" serving config on which we can test out different boosting options.

We considered having a preview feature in Search Admin, but having the ability here in Finder Frontend instead allows administrative users to test different configurations more comprehensively, for example by using filters and sorting, without having to reimplement half of Finder Frontend in another app.

Having some (non-sensitive) debugging functionality in Finder Frontend is also an existing pattern (see `debug` parameter for Search API v1 searches).

- Pass through the API used to `Search::QueryBuilder`
- Send `serving_config` parameter to Search API v2 if that is currently in use and the `debug_serving_config` parameter is in the request
- Add a banner to the UI to show when a non-default serving configuration is applied, and allow removing it
- Add a hidden field for the overridden serving config if given, so it persists across searches

[1]: https://github.com/alphagov/search-api-v2/pull/385

## Screenshots

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/d29415ab-510f-4de8-a555-8731d6aac8a1" />