### PR TITLE
Remove margin top from filter summary component

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -3,6 +3,7 @@
 
 .app-c-filter-panel {
   padding-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-c-filter-panel__content {

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,7 +1,6 @@
 @import "govuk_publishing_components/individual_component_support";
 
 .app-c-filter-summary {
-  margin-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(1);
   border-top: 1px solid $govuk-border-colour;
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR removes `margin-top: 10px` from the filter summary component and adds `margin-bottom: 10px` on the filter panel component. This should not result in any visual differences as the filter summary always renders below the filter panel and the original 10px of spacing is maintained - the only difference is in how it is applied.

## Why
[Trello card](https://trello.com/c/08VGz74q/503-investigate-filter-summary-margin-top), [Jira issue PNP-7376](https://gov-uk.atlassian.net/browse/PNP-7376)

## Visual changes
Hopefully none but these are some pages that can be checked:

[Local](http://127.0.0.1:3062/search/all) / [live](https://www.gov.uk/search/all) (only filter panel rendered)
[Local](http://127.0.0.1:3062/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=news_and_communications) / [live](https://www.gov.uk/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&level_two_taxon=272308f4-05c8-4d0d-abc7-b7c2e3ccd249&content_purpose_supergroup%5B%5D=services&content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=news_and_communications) (filter panel rendered with filter summary)