### PR TITLE
Add support for Nested facets

### DIFF
--- a/app/assets/javascripts/modules/nested-facets.js
+++ b/app/assets/javascripts/modules/nested-facets.js
@@ -1,0 +1,77 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  function NestedFacets (module) {
+    this.module = module
+    this.mainFacet = document.querySelector('#' + this.module.getAttribute('data-main-facet-id'))
+    this.subFacet = document.querySelector('#' + this.module.getAttribute('data-sub-facet-id'))
+    this.options = this.instantiateOptions()
+  }
+
+  NestedFacets.prototype.init = function () {
+    this.updateFacets()
+    this.module.addEventListener('change', () => {
+      this.updateFacets()
+    })
+  }
+
+  NestedFacets.prototype.updateFacets = function () {
+    this.setSubFacetSelectDisabledState()
+    this.resetSubFacetValue()
+    this.populateSubFacets()
+  }
+
+  NestedFacets.prototype.setSubFacetSelectDisabledState = function () {
+    const mainFacetSelected = !!this.mainFacet.value
+    if (mainFacetSelected) {
+      this.subFacet.removeAttribute('disabled')
+    } else {
+      this.subFacet.setAttribute('disabled', true)
+    }
+  }
+
+  NestedFacets.prototype.populateSubFacets = function () {
+    const subFacetOptionsForSelectedMain = this.options[this.mainFacet.value]
+    const subFacet = this.subFacet
+    const subFacetOptions = subFacet.querySelectorAll('option')
+
+    for (let o = 0; o < subFacetOptions.length; o++) {
+      if (subFacetOptions[o].value) {
+        subFacetOptions[o].parentNode.removeChild(subFacetOptions[o])
+      }
+    }
+    if (subFacetOptionsForSelectedMain) {
+      for (let i = 0; i < subFacetOptionsForSelectedMain.length; i++) {
+        subFacet.appendChild(subFacetOptionsForSelectedMain[i])
+      }
+    }
+  }
+
+  NestedFacets.prototype.instantiateOptions = function () {
+    const options = {}
+    const optionElements = this.subFacet.querySelectorAll('option')
+
+    for (let o = 0; o < optionElements.length; o++) {
+      const mainFacetValue = optionElements[o].getAttribute('data-main-facet-value')
+
+      options[mainFacetValue] = options[mainFacetValue] || []
+      options[mainFacetValue].push(optionElements[o])
+    }
+    return options
+  }
+
+  NestedFacets.prototype.resetSubFacetValue = function () {
+    const selected = this.subFacet.options[this.subFacet.selectedIndex]
+    const mainFacetValue = this.mainFacet.value
+    const isOrphanedChild = selected && selected.getAttribute('data-main-facet-value') !== mainFacetValue
+
+    if (isOrphanedChild) {
+      this.subFacet.value = ''
+    }
+  }
+
+  Modules.NestedFacets = NestedFacets
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/nested-facets.js
+++ b/app/assets/javascripts/modules/nested-facets.js
@@ -57,6 +57,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     for (let o = 0; o < optionElements.length; o++) {
       const mainFacetValue = optionElements[o].getAttribute('data-main-facet-value')
 
+      const mainFacetLabelPrefix = optionElements[o].getAttribute('data-main-facet-label') + ' - '
+      optionElements[o].text = optionElements[o].text.replace(mainFacetLabelPrefix, '')
+
       options[mainFacetValue] = options[mainFacetValue] || []
       options[mainFacetValue].push(optionElements[o])
     }

--- a/app/lib/facets_builder.rb
+++ b/app/lib/facets_builder.rb
@@ -23,7 +23,9 @@ private
   def build_facet(facet_hash)
     if facet_hash["filterable"]
       case facet_hash["type"]
-      when "text", "content_id"
+      when "text"
+        facet_hash["nested_facet"] ? NestedFacet.new(facet_hash, value_hash[facet_hash["key"]]) : OptionSelectFacet.new(facet_hash, value_hash[facet_hash["key"]])
+      when "content_id"
         OptionSelectFacet.new(facet_hash, value_hash[facet_hash["key"]])
       when "topical"
         TopicalFacet.new(facet_hash, value_hash[facet_hash["key"]])

--- a/app/models/nested_facet.rb
+++ b/app/models/nested_facet.rb
@@ -1,0 +1,12 @@
+class NestedFacet < OptionSelectFacet
+  attr_accessor :sub_facet_key
+
+  def initialize(facet, values)
+    @sub_facet_key = facet["sub_facet_key"]
+    super
+  end
+
+  def is_main_facet?
+    sub_facet_key.present?
+  end
+end

--- a/app/models/nested_facet.rb
+++ b/app/models/nested_facet.rb
@@ -6,7 +6,22 @@ class NestedFacet < OptionSelectFacet
     super
   end
 
+  def facet_options
+    default_selection_options = [{ text: "All #{pluralized_facet_short_name}", value: "" }]
+    allowed_values.inject(default_selection_options) do |options, allowed_value|
+      option = { text: allowed_value["label"], value: allowed_value["value"] }
+      option.merge!(data_attributes: { main_facet_value: allowed_value["main_facet_value"] }) unless is_main_facet?
+      options << option
+    end
+  end
+
   def is_main_facet?
     sub_facet_key.present?
+  end
+
+private
+
+  def pluralized_facet_short_name
+    (short_name || name).downcase.pluralize
   end
 end

--- a/app/models/nested_facet.rb
+++ b/app/models/nested_facet.rb
@@ -12,6 +12,7 @@ class NestedFacet < OptionSelectFacet
       option = {
         text: facet_text(allowed_value),
         value: allowed_value["value"],
+        selected: selected_values.include?(allowed_value),
       }
       option.merge!(data_attributes: { main_facet_value: allowed_value["main_facet_value"], main_facet_label: allowed_value["main_facet_label"] }) unless is_main_facet?
       options << option

--- a/app/models/nested_facet.rb
+++ b/app/models/nested_facet.rb
@@ -9,8 +9,11 @@ class NestedFacet < OptionSelectFacet
   def facet_options
     default_selection_options = [{ text: "All #{pluralized_facet_short_name}", value: "" }]
     allowed_values.inject(default_selection_options) do |options, allowed_value|
-      option = { text: allowed_value["label"], value: allowed_value["value"] }
-      option.merge!(data_attributes: { main_facet_value: allowed_value["main_facet_value"] }) unless is_main_facet?
+      option = {
+        text: facet_text(allowed_value),
+        value: allowed_value["value"],
+      }
+      option.merge!(data_attributes: { main_facet_value: allowed_value["main_facet_value"], main_facet_label: allowed_value["main_facet_label"] }) unless is_main_facet?
       options << option
     end
   end
@@ -20,6 +23,10 @@ class NestedFacet < OptionSelectFacet
   end
 
 private
+
+  def facet_text(value)
+    value["main_facet_label"] ? "#{value['main_facet_label']} - #{value['label']}" : value["label"]
+  end
 
   def pluralized_facet_short_name
     (short_name || name).downcase.pluralize

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <% if nested_facet.is_main_facet? %>
-  <div class="govuk-!-margin-top-3">
+  <div class="govuk-!-margin-top-3" data-module="nested-facets"  data-main-facet-id="<%= nested_facet.key %>" data-sub-facet-id="<%= nested_facet.sub_facet_key %>">
     <%= content %>
   </div>
 <% else %>

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,8 +1,19 @@
 <% add_gem_component_stylesheet("select") %>
 
-<%= render "govuk_publishing_components/components/select", {
-  id: nested_facet.key,
-  label: nested_facet.name,
-  full_width: true,
-  options: nested_facet.facet_options
-} %>
+<% content = capture do %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: nested_facet.key,
+    label: nested_facet.name,
+    full_width: true,
+    options: nested_facet.facet_options
+  } %>
+<% end %>
+
+<% if nested_facet.is_main_facet? %>
+  <div class="govuk-!-margin-top-3">
+    <%= content %>
+  </div>
+<% else %>
+  <%= content %>
+  <hr class="govuk-section-break govuk-section-break--visible">
+<% end %>

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,0 +1,8 @@
+<% add_gem_component_stylesheet("select") %>
+
+<%= render "govuk_publishing_components/components/select", {
+  id: nested_facet.key,
+  label: nested_facet.name,
+  full_width: true,
+  options: nested_facet.facet_options
+} %>

--- a/spec/javascripts/modules/nested-facets-spec.js
+++ b/spec/javascripts/modules/nested-facets-spec.js
@@ -18,10 +18,10 @@ describe('nested-facets', function () {
     <label for='sub_facet_key'>Subcategory</label> 
     <select name='sub_facet_key' id='sub_facet_key'> 
     <option value=''>All subcategories</option> 
-    <option data-main-facet-value='main-facet-1' value='main-1-sub-facet-1'>Main 1 Sub Facet 1</option> 
-    <option data-main-facet-value='main-facet-1' value='main-1-sub-facet-2'>Main 1 Sub Facet 2</option> 
-    <option data-main-facet-value='main-facet-2' value='main-2-sub-facet-1'>Main 2 Sub Facet 1</option> 
-    <option data-main-facet-value='main-facet-2' value='main-2-sub-facet-2'>Main 2 Sub Facet 2</option> 
+    <option data-main-facet-value='main-facet-1' data-main-facet-label='Main 1' value='main-1-sub-facet-1'>Main 1 - Main 1 Sub Facet 1</option> 
+    <option data-main-facet-value='main-facet-1' data-main-facet-label='Main 1' value='main-1-sub-facet-2'>Main 1 - Main 1 Sub Facet 2</option> 
+    <option data-main-facet-value='main-facet-2' data-main-facet-label='Main 2' value='main-2-sub-facet-1'>Main 1 - Main 2 Sub Facet 1</option> 
+    <option data-main-facet-value='main-facet-2' data-main-facet-label='Main 2' value='main-2-sub-facet-2'>Main 2 - Main 2 Sub Facet 2</option> 
     </select> 
    `
 

--- a/spec/javascripts/modules/nested-facets-spec.js
+++ b/spec/javascripts/modules/nested-facets-spec.js
@@ -1,0 +1,82 @@
+describe('nested-facets', function () {
+  'use strict'
+
+  const GOVUK = window.GOVUK
+  let mainFacets
+  let subFacets
+
+  const mainFacetsHTML = `
+    <label for='main_facet_key'>Category</label> 
+    <select name='main_facet_key' id='main_facet_key'> 
+    <option value=''>All</option> 
+    <option value='main-facet-1'>Main Facet 1</option> 
+    <option value='main-facet-2'>Main Facet 2</option> 
+    </select>
+  `
+
+  const subFacetsHTML = `
+    <label for='sub_facet_key'>Subcategory</label> 
+    <select name='sub_facet_key' id='sub_facet_key'> 
+    <option value=''>All subcategories</option> 
+    <option data-main-facet-value='main-facet-1' value='main-1-sub-facet-1'>Main 1 Sub Facet 1</option> 
+    <option data-main-facet-value='main-facet-1' value='main-1-sub-facet-2'>Main 1 Sub Facet 2</option> 
+    <option data-main-facet-value='main-facet-2' value='main-2-sub-facet-1'>Main 2 Sub Facet 1</option> 
+    <option data-main-facet-value='main-facet-2' value='main-2-sub-facet-2'>Main 2 Sub Facet 2</option> 
+    </select> 
+   `
+
+  beforeEach(function () {
+    mainFacets = document.createElement('div')
+    mainFacets.setAttribute('data-main-facet-id', 'main_facet_key')
+    mainFacets.setAttribute('data-sub-facet-id', 'sub_facet_key')
+    mainFacets.innerHTML = mainFacetsHTML
+
+    subFacets = document.createElement('div')
+    subFacets.innerHTML = subFacetsHTML
+
+    document.body.appendChild(mainFacets)
+    document.body.appendChild(subFacets)
+    new GOVUK.Modules.NestedFacets(mainFacets).init()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(mainFacets)
+    document.body.removeChild(subFacets)
+  })
+
+  it('renders corresponding sub facets when selecting the main facet', function () {
+    const mainSelect = document.getElementById('main_facet_key')
+    mainSelect.value = 'main-facet-1'
+    const event = new Event('change', { bubbles: true })
+    mainSelect.dispatchEvent(event)
+
+    const subSelect = document.querySelector('select[name=sub_facet_key]')
+    const subValues = Array.from(subSelect.options).map((option) => option.value)
+    const subLabels = Array.from(subSelect.options).map((option) => option.text)
+    expect(subValues).toEqual(['', 'main-1-sub-facet-1', 'main-1-sub-facet-2'])
+    expect(subLabels).toEqual(['All subcategories', 'Main 1 Sub Facet 1', 'Main 1 Sub Facet 2'])
+  })
+
+  it('defaults to "All" subcategories ', () => {
+    const mainSelect = document.getElementById('main_facet_key')
+    mainSelect.value = 'main-facet-2'
+    const event = new Event('change', { bubbles: true })
+    mainSelect.dispatchEvent(event)
+
+    const subSelect = document.querySelector('select[name=sub_facet_key]')
+    expect(subSelect.value).toEqual('')
+    expect(subSelect.options[subSelect.selectedIndex].text).toEqual('All subcategories')
+  })
+
+  it('disables the sub facet select when main selection is "All"', () => {
+    const mainSelect = document.getElementById('main_facet_key')
+    mainSelect.value = ''
+    const event = new Event('change', { bubbles: true })
+    mainSelect.dispatchEvent(event)
+
+    const subSelect = document.querySelector('select[name=sub_facet_key]')
+    const subLabels = Array.from(subSelect.options).map((option) => option.text)
+    expect(subLabels).toEqual(['All subcategories'])
+    expect(subSelect.disabled).toBe(true)
+  })
+})

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -11,6 +11,52 @@ describe FacetsBuilder do
       "allowed_values": [{ "value" => "me" }, { "value" => "you" }],
     }
   end
+  let(:hash_including_nested_facets) do
+    [
+      {
+        "filterable": true,
+        "type": "text",
+        "name": "Facet Name",
+        "key": "facet_key",
+        "preposition": "with",
+        "sub_facet_key": "sub_facet_key",
+        "sub_facet_name": "Sub Facet Name",
+        "nested_facet": true,
+        "allowed_values": [
+          {
+            "label": "Allowed value 1",
+            "value": "allowed-value-1",
+          },
+          {
+            "label": "Allowed value 2",
+            "value": "allowed-value-2",
+          },
+        ],
+      },
+      {
+        "filterable": true,
+        "type": "text",
+        "name": "Sub Facet Name",
+        "key": "sub_facet_key",
+        "preposition": "with",
+        "nested_facet": true,
+        "allowed_values": [
+          {
+            "label": "Allowed value 1 Sub facet Value 1",
+            "value": "allowed-value-1-sub-facet-value-1",
+            "main_facet_label": "Allowed value 1",
+            "main_facet_value": "allowed-value-1",
+          },
+          {
+            "label": "Allowed value 1 Sub facet Value 2",
+            "value": "allowed-value-1-sub-facet-value-2",
+            "main_facet_label": "Allowed value 1",
+            "main_facet_value": "allowed-value-1",
+          },
+        ],
+      },
+    ]
+  end
   let(:taxon_facet_hash) do
     {
       "key": "_unused",
@@ -119,6 +165,33 @@ describe FacetsBuilder do
       it "builds a option_select facet" do
         expect(facet).to be_a(OptionSelectFacet)
         expect(facet.key).to eq("people")
+      end
+    end
+
+    context "nested hash facet" do
+      subject(:facets) do
+        described_class.new(content_item:, search_results: {}, value_hash: {}).facets
+      end
+
+      let(:detail_hash) do
+        {
+          "details" => {
+            "facets" => hash_under_test,
+          },
+        }
+      end
+      let(:hash_under_test) do
+        hash_including_nested_facets
+      end
+
+      it "builds two nested facets for main and sub hashes" do
+        expect(facets.count).to eq 2
+
+        main_facet = facets.select { |f| f.key == hash_under_test.first[:key] }.first
+        sub_facet = facets.select { |f| f.key == hash_under_test.second[:key] }.first
+
+        expect(main_facet.name).to eq("Facet Name")
+        expect(sub_facet.name).to eq("Sub Facet Name")
       end
     end
 

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -72,48 +72,62 @@ describe NestedFacet do
       end
       let(:allowed_values) do
         [
-          { "label" => "Allowed value 1 Sub facet Value 1",
+          {
+            "label" => "Allowed value 1 Sub facet Value 1",
             "value" => "allowed-value-1-sub-facet-value-1",
-            "main_facet_value" => "allowed-value-1" },
-          { "label" => "Allowed value 1 Sub facet Value 2",
+            "main_facet_label" => "Allowed value 1",
+            "main_facet_value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 1 Sub facet Value 2",
             "value" => "allowed-value-1-sub-facet-value-2",
-            "main_facet_value" => "allowed-value-1" },
-          { "label" => "Allowed value 2 Sub facet Value 1",
+            "main_facet_label" => "Allowed value 1",
+            "main_facet_value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 2 Sub facet Value 1",
             "value" => "allowed-value-2-sub-facet-value-1",
-            "main_facet_value" => "allowed-value-2" },
+            "main_facet_label" => "Allowed value 2",
+            "main_facet_value" => "allowed-value-2",
+          },
         ]
       end
 
       it "returns text, value and main data attributes" do
         expect(subject.facet_options).to eq(
-          [{
-            "text": "All sub facet names",
-            "value": "",
-          },
-           {
-             text: "Allowed value 1 Sub facet Value 1",
-             value: "allowed-value-1-sub-facet-value-1",
-             "data_attributes":
-               {
-                 "main_facet_value": "allowed-value-1",
-               },
-           },
-           {
-             text: "Allowed value 1 Sub facet Value 2",
-             value: "allowed-value-1-sub-facet-value-2",
-             "data_attributes":
-               {
-                 "main_facet_value": "allowed-value-1",
-               },
-           },
-           {
-             text: "Allowed value 2 Sub facet Value 1",
-             value: "allowed-value-2-sub-facet-value-1",
-             "data_attributes":
-               {
-                 "main_facet_value": "allowed-value-2",
-               },
-           }],
+          [
+            {
+              "text": "All sub facet names",
+              "value": "",
+            },
+            {
+              text: "Allowed value 1 - Allowed value 1 Sub facet Value 1",
+              value: "allowed-value-1-sub-facet-value-1",
+              "data_attributes":
+                {
+                  "main_facet_label": "Allowed value 1",
+                  "main_facet_value": "allowed-value-1",
+                },
+            },
+            {
+              text: "Allowed value 1 - Allowed value 1 Sub facet Value 2",
+              value: "allowed-value-1-sub-facet-value-2",
+              "data_attributes":
+                {
+                  "main_facet_label": "Allowed value 1",
+                  "main_facet_value": "allowed-value-1",
+                },
+            },
+            {
+              text: "Allowed value 2 - Allowed value 2 Sub facet Value 1",
+              value: "allowed-value-2-sub-facet-value-1",
+              "data_attributes":
+                {
+                  "main_facet_label": "Allowed value 2",
+                  "main_facet_value": "allowed-value-2",
+                },
+            },
+          ],
         )
       end
     end

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe NestedFacet do
   subject { described_class.new(facet_hash, values) }
+
   let(:values) { {} }
 
   describe "#facet_options" do
@@ -45,14 +46,17 @@ describe NestedFacet do
            {
              "text": "Allowed value 1",
              "value": "allowed-value-1",
+             "selected": false,
            },
            {
              "text": "Allowed value 2",
              "value": "allowed-value-2",
+             "selected": false,
            },
            {
              "text": "Allowed value 3",
              "value": "allowed-value-3",
+             "selected": false,
            }],
         )
       end
@@ -103,6 +107,7 @@ describe NestedFacet do
             {
               text: "Allowed value 1 - Allowed value 1 Sub facet Value 1",
               value: "allowed-value-1-sub-facet-value-1",
+              "selected": false,
               "data_attributes":
                 {
                   "main_facet_label": "Allowed value 1",
@@ -112,6 +117,7 @@ describe NestedFacet do
             {
               text: "Allowed value 1 - Allowed value 1 Sub facet Value 2",
               value: "allowed-value-1-sub-facet-value-2",
+              "selected": false,
               "data_attributes":
                 {
                   "main_facet_label": "Allowed value 1",
@@ -121,6 +127,7 @@ describe NestedFacet do
             {
               text: "Allowed value 2 - Allowed value 2 Sub facet Value 1",
               value: "allowed-value-2-sub-facet-value-1",
+              "selected": false,
               "data_attributes":
                 {
                   "main_facet_label": "Allowed value 2",
@@ -128,6 +135,47 @@ describe NestedFacet do
                 },
             },
           ],
+        )
+      end
+    end
+
+    context "when there is a selection" do
+      let(:values) { "allowed-value-1" }
+      let(:facet_hash) do
+        {
+          "allowed_values" => [
+            {
+              "label" => "Allowed value 1",
+              "value" => "allowed-value-1",
+            },
+            {
+              "label" => "Allowed value 2",
+              "value" => "allowed-value-2",
+            },
+          ],
+          "key" => "facet_key",
+          "name" => "Facet Name",
+          "nested_facet" => true,
+          "sub_facet_key" => "some_sub_facet_key",
+        }
+      end
+
+      it "returns `selected` flag for each option" do
+        expect(subject.facet_options).to eq(
+          [{
+            "text": "All facet names",
+            "value": "",
+          },
+           {
+             "text": "Allowed value 1",
+             "value": "allowed-value-1",
+             "selected": true,
+           },
+           {
+             "text": "Allowed value 2",
+             "value": "allowed-value-2",
+             "selected": false,
+           }],
         )
       end
     end

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+
+describe NestedFacet do
+  subject { described_class.new(facet_hash, values) }
+  let(:values) { {} }
+
+  describe "#facet_options" do
+    context "when the facet is a main facet" do
+      let(:allowed_values) do
+        [
+          {
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1",
+          },
+          {
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2",
+          },
+          {
+            "label" => "Allowed value 3",
+            "value" => "allowed-value-3",
+          },
+        ]
+      end
+      let(:facet_hash) do
+        {
+          "allowed_values" => allowed_values,
+          "filterable" => true,
+          "key" => "sub_facet_key",
+          "name" => "Facet Name",
+          "preposition" => "with",
+          "nested_facet" => true,
+          "sub_facet_key" => "some_sub_facet_key",
+          "sub_facet_name" => "Some sub facet key",
+          "type" => "text",
+        }
+      end
+
+      it "returns text and value pairs" do
+        expect(subject.facet_options).to eq(
+          [{
+            "text": "All facet names",
+            "value": "",
+          },
+           {
+             "text": "Allowed value 1",
+             "value": "allowed-value-1",
+           },
+           {
+             "text": "Allowed value 2",
+             "value": "allowed-value-2",
+           },
+           {
+             "text": "Allowed value 3",
+             "value": "allowed-value-3",
+           }],
+        )
+      end
+    end
+
+    context "when the facet is a sub facet" do
+      let(:facet_hash) do
+        {
+          "allowed_values" => allowed_values,
+          "filterable" => true,
+          "key" => "sub_facet_key",
+          "name" => "Sub Facet Name",
+          "nested_facet" => true,
+          "preposition" => "with",
+          "type" => "text",
+        }
+      end
+      let(:allowed_values) do
+        [
+          { "label" => "Allowed value 1 Sub facet Value 1",
+            "value" => "allowed-value-1-sub-facet-value-1",
+            "main_facet_value" => "allowed-value-1" },
+          { "label" => "Allowed value 1 Sub facet Value 2",
+            "value" => "allowed-value-1-sub-facet-value-2",
+            "main_facet_value" => "allowed-value-1" },
+          { "label" => "Allowed value 2 Sub facet Value 1",
+            "value" => "allowed-value-2-sub-facet-value-1",
+            "main_facet_value" => "allowed-value-2" },
+        ]
+      end
+
+      it "returns text, value and main data attributes" do
+        expect(subject.facet_options).to eq(
+          [{
+            "text": "All sub facet names",
+            "value": "",
+          },
+           {
+             text: "Allowed value 1 Sub facet Value 1",
+             value: "allowed-value-1-sub-facet-value-1",
+             "data_attributes":
+               {
+                 "main_facet_value": "allowed-value-1",
+               },
+           },
+           {
+             text: "Allowed value 1 Sub facet Value 2",
+             value: "allowed-value-1-sub-facet-value-2",
+             "data_attributes":
+               {
+                 "main_facet_value": "allowed-value-1",
+               },
+           },
+           {
+             text: "Allowed value 2 Sub facet Value 1",
+             value: "allowed-value-2-sub-facet-value-1",
+             "data_attributes":
+               {
+                 "main_facet_value": "allowed-value-2",
+               },
+           }],
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes implement a custom NestedFacet, which allows us to filter based on a main facet - subfacet relationship. 

We do send some additional data in the raw facets, in order to be able to represent the relationship between the facets, but otherwise the behaviour is contained in the NestedFacet model, and the respective nested facets are stand-alone facets.

JS from the prototype here https://github.com/alphagov/nested-facet-prototype by @gtvj. 

[Trello](https://trello.com/c/skH2B2fH/3373-nested-facets-finder-frontend)


### No JS
- The two selects, main and sub, render the entirety of the possible options. The subfacet labels are dasherised to help distinguish between duplicate values.
- !Note the full width of the select and left alignment of the facet names against the other facet types.
> ![Screenshot 2025-02-26 at 16 37 17](https://github.com/user-attachments/assets/1223ad64-279c-4949-b5fb-b1804be57af3)



> ![Screenshot 2025-02-25 at 14 04 23](https://github.com/user-attachments/assets/e3cadefa-dd83-4466-908d-284220e8b231)

> ![Screenshot 2025-02-25 at 14 04 42](https://github.com/user-attachments/assets/080ab983-07c0-464f-ae50-e8542e0e348c)


### JS enabled

- Compared to the other facets (slightly out of place in that it does not use the accordion pattern).

> ![Screenshot 2025-02-26 at 16 37 42](https://github.com/user-attachments/assets/8d580c56-6f9c-49f8-97a7-11f0f5d8ffe2)


- The subfacet options are related to the selection in the mainfacet only. The labels are not dasherised.

> ![Screenshot 2025-02-25 at 14 10 31](https://github.com/user-attachments/assets/812ef616-3cdb-4f6c-ba1c-3165643f8f0f)

### Filtering - no search results found
- The metadata tags at the top are correctly rendering the prepositions

> ![Screenshot 2025-02-25 at 14 12 07](https://github.com/user-attachments/assets/654ebe70-e390-4a17-8ecf-a4ba0435696e)


### Filtering - with a search result
- The metadata tags for the document are correctly rendering the short names of the facets
- The URL shows the correct query: `http://finder-frontend.dev.gov.uk/trademark-decisions?trademark_decision_grounds_section=section-5-1-5-2-and-5-3-earlier-trade-marks&trademark_decision_grounds_sub_section=section-5-1-5-2-and-5-3-earlier-trade-marks-not-applicable`

> ![Screenshot 2025-02-25 at 14 12 17](https://github.com/user-attachments/assets/b73a83d9-f385-485c-a1d9-4061c5a80fd1)


For reference, a document created by Specialist Publisher would be tagged like this:
> ![Screenshot 2025-02-25 at 14 09 25](https://github.com/user-attachments/assets/a22b0092-cece-4d01-bdcd-06a81d58c117)

