### PR TITLE
Set up site search freshness boost AB test

### DIFF
--- a/app/controllers/ab_test/search_freshness_boost_ab_testable.rb
+++ b/app/controllers/ab_test/search_freshness_boost_ab_testable.rb
@@ -1,0 +1,26 @@
+module AbTest::SearchFreshnessBoostAbTestable
+  def search_freshness_boost_ab_test
+    GovukAbTesting::AbTest.new(
+      "SearchFreshnessBoost",
+      allowed_variants: [
+        "A", # default serving config (legacy freshness boost)
+        "B", # variant serving config (new control-based freshness boost)
+        "Z", # default serving config (legacy freshness boost)
+      ],
+      control_variant: "Z",
+    )
+  end
+
+  def set_search_freshness_boost_ab_test_requested_variant
+    @requested_variant = search_freshness_boost_ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+  end
+
+  def v2_serving_config
+    if @requested_variant&.variant?("B")
+      "variant_search"
+    else
+      "default_search"
+    end
+  end
+end

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -1,8 +1,11 @@
 class FindersController < ApplicationController
   layout "finder_layout"
 
+  include AbTest::SearchFreshnessBoostAbTestable
+
   before_action do
     set_expiry(content_item)
+    set_search_freshness_boost_ab_test_requested_variant if content_item.all_content_finder?
   end
 
   def show
@@ -144,6 +147,7 @@ private
       filter_params,
       override_sort_for_feed: is_for_feed,
       ab_params: {},
+      v2_serving_config:,
     )
   end
 

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -12,7 +12,13 @@ module Search
       ParamValidator.new(query).validate
     end
 
-    def initialize(content_item, filter_params, ab_params: {}, override_sort_for_feed: false)
+    def initialize(
+      content_item,
+      filter_params,
+      ab_params: {},
+      override_sort_for_feed: false,
+      v2_serving_config: nil
+    )
       @content_item = content_item
       @filter_params = filter_params
       @ab_params = ab_params
@@ -23,6 +29,7 @@ module Search
         else
           filter_params["order"]
         end
+      @v2_serving_config = v2_serving_config
     end
 
     def search_results
@@ -35,7 +42,7 @@ module Search
 
   private
 
-    attr_reader :ab_params, :override_sort_for_feed, :content_item
+    attr_reader :ab_params, :override_sort_for_feed, :content_item, :v2_serving_config
 
     def merge_and_deduplicate(search_response)
       results = search_response.fetch("results")
@@ -87,6 +94,7 @@ module Search
         params: filter_params,
         override_sort_for_feed:,
         use_v2_api: use_v2_api?,
+        v2_serving_config:,
       ).call
 
       if use_v2_api?

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -12,6 +12,7 @@ module Search
     # find anything useful, too much noise.
     MAX_QUERY_LENGTH = 512
 
+    DEFAULT_V2_SERVING_CONFIG = "default_search".freeze
     LICENCE_STOPWORDS = %w[licence license permit certification].freeze
 
     def initialize(
@@ -19,13 +20,15 @@ module Search
       params: {},
       ab_params: {},
       override_sort_for_feed: false,
-      use_v2_api: false
+      use_v2_api: false,
+      v2_serving_config: nil
     )
       @finder_content_item = finder_content_item
       @params = params
       @ab_params = ab_params
       @override_sort_for_feed = override_sort_for_feed
       @use_v2_api = use_v2_api
+      @v2_serving_config = v2_serving_config
     end
 
     def call
@@ -37,6 +40,7 @@ module Search
         reject_query,
         order_query,
         facet_query,
+        v2_serving_config_query,
         debug_query,
         ab_query,
         suggest_query,
@@ -52,7 +56,8 @@ module Search
 
   private
 
-    attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed
+    attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed,
+                :v2_serving_config
 
     def use_v2_api?
       @use_v2_api
@@ -242,6 +247,14 @@ module Search
       @facet_params ||= FacetQueryBuilder.new(
         facets: raw_facets,
       ).call
+    end
+
+    def v2_serving_config_query
+      return {} unless use_v2_api?
+
+      {
+        "serving_config" => v2_serving_config || DEFAULT_V2_SERVING_CONFIG,
+      }
     end
 
     def debug_query

--- a/app/views/finders/show_all_content_finder.html.erb
+++ b/app/views/finders/show_all_content_finder.html.erb
@@ -11,6 +11,7 @@
     <meta name="govuk:discovery-engine-attribution-token" content="<%= result_set_presenter.discovery_engine_attribution_token %>">
   <% end %>
   <meta name="govuk:spelling-suggestion" content="<%= @spelling_suggestion_presenter.suggestions.first&.fetch(:keywords, "") %>">
+  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant.present? %>
 <% end %>
 <% content_for :meta_title, content_item.title %>
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -334,6 +334,53 @@ describe FindersController, type: :controller do
         expect(response).to render_template("finders/show_all_content_finder")
       end
     end
+
+    describe "all content finder SearchFreshnessBoost AB test" do
+      before do
+        search_api_request(
+          search_api_app: "search-api-v2",
+          discovery_engine_attribution_token: "123ABC",
+          query: { q: "hello", order: nil, serving_config: expected_serving_config },
+        )
+        stub_content_store_has_item(
+          "/search/all",
+          all_content_finder,
+        )
+      end
+
+      context "when the variant is A" do
+        let(:expected_serving_config) { "default_search" }
+
+        it "uses the expected serving config" do
+          with_variant(SearchFreshnessBoost: "A") do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+            expect(response.status).to eq(200)
+          end
+        end
+      end
+
+      context "when the variant is B" do
+        let(:expected_serving_config) { "variant_search" }
+
+        it "uses the expected serving config" do
+          with_variant(SearchFreshnessBoost: "B") do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+            expect(response.status).to eq(200)
+          end
+        end
+      end
+
+      context "when the variant is Z" do
+        let(:expected_serving_config) { "default_search" }
+
+        it "uses the expected serving config" do
+          with_variant(SearchFreshnessBoost: "Z") do
+            get :show, params: { slug: "search/all", keywords: "hello" }
+            expect(response.status).to eq(200)
+          end
+        end
+      end
+    end
   end
 
   describe "Spelling suggestions" do

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -321,7 +321,7 @@ describe FindersController, type: :controller do
 
     describe "the finder is the all content finder" do
       before do
-        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil })
+        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil, serving_config: "default_search" })
         stub_content_store_has_item(
           "/search/all",
           all_content_finder,

--- a/spec/lib/search/query_builder_spec.rb
+++ b/spec/lib/search/query_builder_spec.rb
@@ -5,6 +5,7 @@ describe Search::QueryBuilder do
     described_class.new(
       finder_content_item:,
       use_v2_api:,
+      v2_serving_config:,
       params:,
     ).call
   end
@@ -24,6 +25,7 @@ describe Search::QueryBuilder do
     )
   end
   let(:use_v2_api) { false }
+  let(:v2_serving_config) { nil }
 
   let(:facets) { [] }
   let(:filter) { {} }
@@ -330,6 +332,37 @@ describe Search::QueryBuilder do
         ).call.first
 
         expect(query).to include("q" => "50")
+      end
+    end
+  end
+
+  context "with a custom v2 serving config" do
+    context "for Search API v1" do
+      let(:use_v2_api) { false }
+      let(:v2_serving_config) { "my-special-serving-config" }
+
+      it "does not include a serving config query even if one is given" do
+        expect(query).not_to have_key("serving_config")
+      end
+    end
+
+    context "for Search API v2" do
+      let(:use_v2_api) { true }
+
+      context "if a custom serving config is given" do
+        let(:v2_serving_config) { "my-special-serving-config" }
+
+        it "includes a serving config query" do
+          expect(query).to include("serving_config" => "my-special-serving-config")
+        end
+      end
+
+      context "if no custom serving config is given" do
+        let(:v2_serving_config) { nil }
+
+        it "includes the default serving config query" do
+          expect(query).to include("serving_config" => "default_search")
+        end
       end
     end
   end


### PR DESCRIPTION
, [Jira issue SCH-458](https://gov-uk.atlassian.net/browse/SCH-458)This sets up the upcoming `SearchFreshnessBoost` AB test for site search, which uses a different Vertex AI Search serving config through Search API v2.

For the `B` variant, this uses the `variant_search` serving config. Otherwise we'll continue to use the `default_search` serving config, but do so explicitly (rather than implicitly as up until now).

see also:
- [Trello card](https://trello.com/c/7vbzHU0K)
- https://github.com/alphagov/search-api-v2/pull/397
- https://github.com/alphagov/govuk-fastly/pull/142
- https://github.com/alphagov/govuk-infrastructure/pull/1798