### PR TITLE
Remodel NestedFacet to behave more like a TaxonFacet

### DIFF
--- a/app/assets/javascripts/modules/nested-facets.js
+++ b/app/assets/javascripts/modules/nested-facets.js
@@ -6,8 +6,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   function NestedFacets (module) {
     this.module = module
-    this.mainFacet = document.querySelector('#' + this.module.getAttribute('data-main-facet-id'))
-    this.subFacet = document.querySelector('#' + this.module.getAttribute('data-sub-facet-id'))
+    this.mainFacet = this.module.querySelector('#' + this.module.getAttribute('data-main-facet-id'))
+    this.subFacet = this.module.querySelector('#' + this.module.getAttribute('data-sub-facet-id'))
     this.options = this.instantiateOptions()
   }
 

--- a/app/lib/facets_builder.rb
+++ b/app/lib/facets_builder.rb
@@ -23,9 +23,7 @@ private
   def build_facet(facet_hash)
     if facet_hash["filterable"]
       case facet_hash["type"]
-      when "text"
-        facet_hash["nested_facet"] ? NestedFacet.new(facet_hash, value_hash[facet_hash["key"]]) : OptionSelectFacet.new(facet_hash, value_hash[facet_hash["key"]])
-      when "content_id"
+      when "text", "content_id"
         OptionSelectFacet.new(facet_hash, value_hash[facet_hash["key"]])
       when "topical"
         TopicalFacet.new(facet_hash, value_hash[facet_hash["key"]])
@@ -45,6 +43,8 @@ private
         RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash["key"]], ::Filters::ResearchAndStatsHashes.new.call)
       when "official_documents"
         RadioFacetForMultipleFilters.new(facet_hash, value_hash[facet_hash["key"]], ::Filters::OfficialDocumentsHashes.new.call)
+      when "nested"
+        NestedFacet.new(facet_hash, value_hash.slice(facet_hash["key"], facet_hash["sub_facet_key"]))
       else
         raise ArgumentError, "Unknown filterable facet type: #{facet_hash['type']}"
       end
@@ -66,15 +66,15 @@ private
 
   def allowed_values_for_facet_details(facet_key, facet_details)
     facet_details.fetch("options", {})
-      .map { |f| f.fetch("value", {}) }
-      .map { |value| present_facet_option(value, facet_key) }
-      .reject { |f| f["label"].blank? || f["value"].blank? }
+                 .map { |f| f.fetch("value", {}) }
+                 .map { |value| present_facet_option(value, facet_key) }
+                 .reject { |f| f["label"].blank? || f["value"].blank? }
   end
 
   def allowed_values_from_registry(facet_key)
     registries.all[facet_key].values
-      .map { |_, results| present_facet_option(results, facet_key) }
-      .reject { |f| f["label"].blank? || f["value"].blank? }
+              .map { |_, results| present_facet_option(results, facet_key) }
+              .reject { |f| f["label"].blank? || f["value"].blank? }
   end
 
   def present_facet_option(value, facet_key)

--- a/app/lib/filters/nested_filter.rb
+++ b/app/lib/filters/nested_filter.rb
@@ -1,0 +1,32 @@
+module Filters
+  class NestedFilter < Filter
+    def initialize(facet, params)
+      super
+
+      return if params.blank?
+
+      @main_facet_key = params["main_facet_key"]
+      @sub_facet_key = params["sub_facet_key"]
+      @main_facet_value = params[@main_facet_key]
+      @sub_facet_value = params[@sub_facet_key]
+    end
+
+    def query_hash
+      result = {}
+      result.merge!(@main_facet_key => [@main_facet_value]) if @main_facet_value
+      result.merge!(@sub_facet_key => [@sub_facet_value]) if @sub_facet_value
+
+      result
+    end
+
+  private
+
+    def value
+      @value ||= begin
+        return nil unless @main_facet_value || @sub_facet_value
+
+        [@main_facet_value, @sub_facet_value].compact
+      end
+    end
+  end
+end

--- a/app/lib/search/filter_query_builder.rb
+++ b/app/lib/search/filter_query_builder.rb
@@ -35,6 +35,7 @@ module Search
         "hidden_clearable" => Filters::HiddenClearableFilter,
         "research_and_statistics" => Filters::ResearchAndStatisticsFilter,
         "official_documents" => Filters::OfficialDocumentsFilter,
+        "nested" => Filters::NestedFilter,
       }.fetch(facet["type"])
 
       filter_class.new(facet, params(facet))
@@ -43,6 +44,12 @@ module Search
     def params(facet)
       facet_key = facet["key"]
       facet_keys = facet["keys"]
+
+      if facet["sub_facet_key"]
+        return [facet_key, facet["sub_facet_key"]]
+                 .index_with { |key| user_params.fetch(key, nil) }
+                 .merge("main_facet_key" => facet_key, "sub_facet_key" => facet["sub_facet_key"])
+      end
 
       if facet_keys
         return facet_keys.index_with { |key| user_params.fetch(key, nil) }

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -112,9 +112,13 @@ module Search
     end
 
     def metadata_fields
-      raw_facets.map do |f|
-        unfilterise(f["filter_key"] || f["key"])
-      end
+      raw_facets.map { |f|
+        if f["sub_facet_key"]
+          [unfilterise(f["filter_key"] || f["key"]), unfilterise(f["sub_facet_key"])]
+        else
+          unfilterise(f["filter_key"] || f["key"])
+        end
+      }.flatten
     end
 
     def raw_facets

--- a/app/models/nested_facet.rb
+++ b/app/models/nested_facet.rb
@@ -17,6 +17,7 @@ class NestedFacet < FilterableFacet
       option = {
         text: allowed_value["label"],
         value: allowed_value["value"],
+        selected: @value_hash[key] == allowed_value["value"],
       }
       options << option
     end
@@ -33,6 +34,7 @@ class NestedFacet < FilterableFacet
       option = {
         text: facet_text(sub_facet_value),
         value: sub_facet_value["value"],
+        selected: @value_hash[sub_facet_key] == sub_facet_value["value"],
       }
       option.merge!(data_attributes: { main_facet_value: sub_facet_value["main_facet_value"], main_facet_label: sub_facet_value["main_facet_label"] })
 

--- a/app/presenters/metadata_presenter.rb
+++ b/app/presenters/metadata_presenter.rb
@@ -8,7 +8,7 @@ class MetadataPresenter
       case datum.fetch(:type)
       when "date"
         build_date_metadata(datum)
-      when "text", "content_id"
+      when "text", "content_id", "nested"
         build_text_metadata(datum)
       end
     end

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,19 +1,13 @@
-<% add_gem_component_stylesheet("select") %>
-
-<% content = capture do %>
   <%= render "govuk_publishing_components/components/select", {
     id: nested_facet.key,
     label: nested_facet.name,
     full_width: true,
-    options: nested_facet.facet_options
+    options: nested_facet.main_facet_options
   } %>
-<% end %>
 
-<% if nested_facet.is_main_facet? %>
-  <div class="govuk-!-margin-top-3" data-module="nested-facets"  data-main-facet-id="<%= nested_facet.key %>" data-sub-facet-id="<%= nested_facet.sub_facet_key %>">
-    <%= content %>
-  </div>
-<% else %>
-  <%= content %>
-  <hr class="govuk-section-break govuk-section-break--visible">
-<% end %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: nested_facet.sub_facet_key,
+    label: nested_facet.sub_facet_name,
+    full_width: true,
+    options: nested_facet.sub_facet_options
+  } %>

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,15 +1,19 @@
-<div data-module="nested-facets" data-main-facet-id="<%= nested_facet.main_facet_key %>" data-sub-facet-id="<%= nested_facet.sub_facet_key %>">
-  <%= render "govuk_publishing_components/components/select", {
-    id: nested_facet.key,
-    label: nested_facet.name,
-    full_width: true,
-    options: nested_facet.main_facet_options
-  } %>
+<%= render "components/expander", {
+  title: nested_facet.name,
+} do %>
+  <div data-module="nested-facets" data-main-facet-id="<%= nested_facet.main_facet_key %>" data-sub-facet-id="<%= nested_facet.sub_facet_key %>">
+    <%= render "govuk_publishing_components/components/select", {
+      id: nested_facet.key,
+      label: nested_facet.name,
+      full_width: true,
+      options: nested_facet.main_facet_options
+    } %>
 
-  <%= render "govuk_publishing_components/components/select", {
-    id: nested_facet.sub_facet_key,
-    label: nested_facet.sub_facet_name,
-    full_width: true,
-    options: nested_facet.sub_facet_options
-  } %>
-</div>
+    <%= render "govuk_publishing_components/components/select", {
+      id: nested_facet.sub_facet_key,
+      label: nested_facet.sub_facet_name,
+      full_width: true,
+      options: nested_facet.sub_facet_options
+    } %>
+  </div>
+<% end %>

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,13 +1,15 @@
-<%= render "govuk_publishing_components/components/select", {
-  id: nested_facet.key,
-  label: nested_facet.name,
-  full_width: true,
-  options: nested_facet.main_facet_options
-} %>
+<div data-module="nested-facets" data-main-facet-id="<%= nested_facet.main_facet_key %>" data-sub-facet-id="<%= nested_facet.sub_facet_key %>">
+  <%= render "govuk_publishing_components/components/select", {
+    id: nested_facet.key,
+    label: nested_facet.name,
+    full_width: true,
+    options: nested_facet.main_facet_options
+  } %>
 
-<%= render "govuk_publishing_components/components/select", {
-  id: nested_facet.sub_facet_key,
-  label: nested_facet.sub_facet_name,
-  full_width: true,
-  options: nested_facet.sub_facet_options
-} %>
+  <%= render "govuk_publishing_components/components/select", {
+    id: nested_facet.sub_facet_key,
+    label: nested_facet.sub_facet_name,
+    full_width: true,
+    options: nested_facet.sub_facet_options
+  } %>
+</div>

--- a/app/views/finders/_nested_facet.html.erb
+++ b/app/views/finders/_nested_facet.html.erb
@@ -1,13 +1,13 @@
-  <%= render "govuk_publishing_components/components/select", {
-    id: nested_facet.key,
-    label: nested_facet.name,
-    full_width: true,
-    options: nested_facet.main_facet_options
-  } %>
+<%= render "govuk_publishing_components/components/select", {
+  id: nested_facet.key,
+  label: nested_facet.name,
+  full_width: true,
+  options: nested_facet.main_facet_options
+} %>
 
-  <%= render "govuk_publishing_components/components/select", {
-    id: nested_facet.sub_facet_key,
-    label: nested_facet.sub_facet_name,
-    full_width: true,
-    options: nested_facet.sub_facet_options
-  } %>
+<%= render "govuk_publishing_components/components/select", {
+  id: nested_facet.sub_facet_key,
+  label: nested_facet.sub_facet_name,
+  full_width: true,
+  options: nested_facet.sub_facet_options
+} %>

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -109,7 +109,6 @@ describe FindersController, type: :controller do
               "filterable": true,
               "key": "some_facet_key",
               "name": "Some facet",
-              "nested_facet": true,
               "type": "text",
             },
           ]
@@ -142,7 +141,7 @@ describe FindersController, type: :controller do
             )
             .to_return(status: 200, body: rummager_response, headers: {})
 
-          expect(NestedFacet).to receive(:new).with(
+          expect(OptionSelectFacet).to receive(:new).with(
             {
               "allowed_values" => [
                 {
@@ -157,7 +156,6 @@ describe FindersController, type: :controller do
               "filterable" => true,
               "key" => "some_facet_key",
               "name" => "Some facet",
-              "nested_facet" => true,
               "type" => "text",
             },
             "allowed-value-1",

--- a/spec/factories/nested_facet.rb
+++ b/spec/factories/nested_facet.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :nested_facet, class: NestedFacet do
+    key { "main_facet_key_value" }
+    name { "Main Facet name" }
+    sub_facet_key { "sub_facet_key_value" }
+    sub_facet_name { "Sub Facet Name" }
+    filterable { true }
+    type { "nested" }
+    nested_facet { true }
+    display_as_result_metadata { true }
+    transient do
+      values { nil }
+    end
+    initialize_with do
+      new(attributes.deep_stringify_keys, values)
+    end
+  end
+end

--- a/spec/javascripts/modules/nested-facets-spec.js
+++ b/spec/javascripts/modules/nested-facets-spec.js
@@ -2,19 +2,14 @@ describe('nested-facets', function () {
   'use strict'
 
   const GOVUK = window.GOVUK
-  let mainFacets
-  let subFacets
-
-  const mainFacetsHTML = `
+  let facetsWrapper
+  const facetsHTML = `
     <label for='main_facet_key'>Category</label> 
     <select name='main_facet_key' id='main_facet_key'> 
     <option value=''>All</option> 
     <option value='main-facet-1'>Main Facet 1</option> 
     <option value='main-facet-2'>Main Facet 2</option> 
     </select>
-  `
-
-  const subFacetsHTML = `
     <label for='sub_facet_key'>Subcategory</label> 
     <select name='sub_facet_key' id='sub_facet_key'> 
     <option value=''>All subcategories</option> 
@@ -26,22 +21,17 @@ describe('nested-facets', function () {
    `
 
   beforeEach(function () {
-    mainFacets = document.createElement('div')
-    mainFacets.setAttribute('data-main-facet-id', 'main_facet_key')
-    mainFacets.setAttribute('data-sub-facet-id', 'sub_facet_key')
-    mainFacets.innerHTML = mainFacetsHTML
+    facetsWrapper = document.createElement('div')
+    facetsWrapper.setAttribute('data-main-facet-id', 'main_facet_key')
+    facetsWrapper.setAttribute('data-sub-facet-id', 'sub_facet_key')
+    facetsWrapper.innerHTML = facetsHTML
 
-    subFacets = document.createElement('div')
-    subFacets.innerHTML = subFacetsHTML
-
-    document.body.appendChild(mainFacets)
-    document.body.appendChild(subFacets)
-    new GOVUK.Modules.NestedFacets(mainFacets).init()
+    document.body.appendChild(facetsWrapper)
+    new GOVUK.Modules.NestedFacets(facetsWrapper).init()
   })
 
   afterEach(function () {
-    document.body.removeChild(mainFacets)
-    document.body.removeChild(subFacets)
+    document.body.removeChild(facetsWrapper)
   })
 
   it('renders corresponding sub facets when selecting the main facet', function () {

--- a/spec/lib/filters/nested_filter_spec.rb
+++ b/spec/lib/filters/nested_filter_spec.rb
@@ -1,0 +1,134 @@
+require "spec_helper"
+
+describe Filters::NestedFilter do
+  subject(:nested_filter) do
+    described_class.new(facet, params)
+  end
+
+  let(:facet) { double }
+  let(:params) { nil }
+
+  describe "#active?" do
+    context "when params is nil" do
+      it "is false" do
+        expect(nested_filter).not_to be_active
+      end
+    end
+
+    context "when params is empty" do
+      let(:params) { {} }
+
+      it "is false" do
+        expect(nested_filter).not_to be_active
+      end
+    end
+
+    context "when params is missing facet keys" do
+      let(:params) do
+        { "random_key" => "random_value" }
+      end
+
+      it "is false" do
+        expect(nested_filter).not_to be_active
+      end
+    end
+
+    context "when params is missing facet values" do
+      let(:params) do
+        {
+          "main_facet_key" => "main_facet",
+          "sub_facet_key" => "sub_facet",
+        }
+      end
+
+      it "is false" do
+        expect(nested_filter).not_to be_active
+      end
+    end
+
+    context "when params contain both main and sub facet keys and corresponding values" do
+      let(:params) do
+        {
+          "main_facet_key" => "main_facet",
+          "sub_facet_key" => "sub_facet",
+          "main_facet" => "main-facet-allowed-value-1",
+          "sub_facet" => "main-facet-allowed-value-1-sub-facet-allowed-value-1",
+        }
+      end
+
+      it "is true" do
+        expect(nested_filter).to be_active
+      end
+    end
+  end
+
+  describe "#query_hash" do
+    let(:facet) do
+      {
+        "key" => "main_facet",
+        "sub_facet_key" => "sub_facet",
+        "allowed_values" => [
+          {
+            "label" => "Allowed value 1",
+            "value" => "main-facet-allowed-value-1",
+            "sub_facets" => [
+              {
+                "label" => "Sub facet allowed value 1",
+                "value" => "main-facet-allowed-value-1-sub-facet-allowed-value-1",
+              },
+              {
+                "label" => "Sub facet allowed value 2",
+                "value" => "main-facet-allowed-value-1-sub-facet-allowed-value-2",
+              },
+            ],
+          },
+          {
+            "label" => "Allowed value 2",
+            "value" => "main-facet-allowed-value-2",
+          },
+        ],
+      }
+    end
+
+    context "when params includes both main and sub facet keys" do
+      let(:params) do
+        {
+          "main_facet_key" => "main_facet",
+          "sub_facet_key" => "sub_facet",
+          "main_facet" => "main-facet-allowed-value-1",
+          "sub_facet" => "main-facet-allowed-value-1-sub-facet-allowed-value-1",
+        }
+      end
+
+      it "contains both facet values" do
+        expect(nested_filter.query_hash).to eq("main_facet" => %w[main-facet-allowed-value-1], "sub_facet" => %w[main-facet-allowed-value-1-sub-facet-allowed-value-1])
+      end
+    end
+
+    context "when params only include the main facet key" do
+      let(:params) do
+        {
+          "main_facet_key" => "main_facet",
+          "main_facet" => "main-facet-allowed-value-1",
+        }
+      end
+
+      it "contains main facet values" do
+        expect(nested_filter.query_hash).to eq("main_facet" => %w[main-facet-allowed-value-1])
+      end
+    end
+
+    context "when params only include the sub facet key" do
+      let(:params) do
+        {
+          "sub_facet_key" => "sub_facet",
+          "sub_facet" => "main-facet-allowed-value-1-sub-facet-allowed-value-1",
+        }
+      end
+
+      it "contains sub facet values" do
+        expect(nested_filter.query_hash).to eq("sub_facet" => %w[main-facet-allowed-value-1-sub-facet-allowed-value-1])
+      end
+    end
+  end
+end

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -206,4 +206,122 @@ describe NestedFacet do
       end
     end
   end
+
+  describe "#sentence_fragment" do
+    context "no allowed value selected" do
+      specify do
+        expect(subject.sentence_fragment).to be_nil
+      end
+    end
+
+    context "both main facet and sub-facet allowed values selected" do
+      let(:value_hash) do
+        { "facet_key" => "allowed-value-1", "sub_facet_key" => "allowed-value-1-sub-facet-value-1" }
+      end
+
+      specify do
+        expect(subject.sentence_fragment["preposition"]).to eql("with")
+        expect(subject.sentence_fragment["values"].count).to be(2)
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].second["label"]).to eql("Allowed value 1 - Sub facet Value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("facet_key")
+      end
+    end
+
+    context "main facet allowed value selected, and no sub-facet allowed value selected" do
+      let(:value_hash) do
+        { "facet_key" => "allowed-value-1" }
+      end
+
+      specify do
+        expect(subject.sentence_fragment["preposition"]).to eql("with")
+        expect(subject.sentence_fragment["values"].count).to be(1)
+        expect(subject.sentence_fragment["values"].first["label"]).to eql("Allowed value 1")
+        expect(subject.sentence_fragment["values"].first["parameter_key"]).to eql("facet_key")
+      end
+    end
+
+    context "sub-facet allowed value selected, and no main facet allowed value selected" do
+      let(:value_hash) do
+        { "sub_facet_key" => "allowed-value-1-sub-facet-value-1" }
+      end
+
+      specify do
+        expect(subject.sentence_fragment).to be_nil
+      end
+    end
+
+    context "disallowed value selected" do
+      let(:value_hash) do
+        {
+          "facet_key" => "disallowed-value-1",
+          "sub_facet_key" => "disallowed-value-2",
+        }
+      end
+
+      specify { expect(subject.sentence_fragment).to be_nil }
+    end
+  end
+
+  describe "#applied_filters" do
+    context "only main facet selected" do
+      let(:value_hash) do
+        {
+          "facet_key" => "allowed-value-1",
+        }
+      end
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Facet Name",
+            label: "Allowed value 1",
+            query_params: {
+              "facet_key" => "allowed-value-1",
+            },
+          },
+        ])
+      end
+    end
+
+    context "both main and sub-facet selected" do
+      let(:value_hash) do
+        {
+          "facet_key" => "allowed-value-1",
+          "sub_facet_key" => "allowed-value-1-sub-facet-value-1",
+        }
+      end
+
+      it "returns the expected applied filters" do
+        expect(subject.applied_filters).to eql([
+          {
+            name: "Facet Name",
+            label: "Allowed value 1",
+            query_params: {
+              "facet_key" => "allowed-value-1",
+              "sub_facet_key" => "allowed-value-1-sub-facet-value-1",
+            },
+          },
+          {
+            name: "Sub Facet Name",
+            label: "Allowed value 1 - Sub facet Value 1",
+            query_params: {
+              "sub_facet_key" => "allowed-value-1-sub-facet-value-1",
+            },
+          },
+        ])
+      end
+    end
+
+    context "disallowed value selected" do
+      let(:value_hash) do
+        {
+          "facet_key" => "disallowed-value-1",
+          "sub_facet_key" => "disallowed-value-2",
+        }
+      end
+
+      specify { expect(subject.applied_filters).to be_empty }
+    end
+  end
 end

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe NestedFacet do
-  subject { described_class.new(facet_hash, {}) }
+  subject { described_class.new(facet_hash, value_hash) }
 
   let(:facet_hash) do
     {
@@ -54,6 +54,7 @@ describe NestedFacet do
       },
     ]
   end
+  let(:value_hash) { {} }
 
   describe "facet options" do
     it "returns main facet options" do
@@ -66,14 +67,17 @@ describe NestedFacet do
           {
             "text": "Allowed value 1",
             "value": "allowed-value-1",
+            "selected": false,
           },
           {
             "text": "Allowed value 2",
             "value": "allowed-value-2",
+            "selected": false,
           },
           {
             "text": "Allowed value 3",
             "value": "allowed-value-3",
+            "selected": false,
           },
         ],
       )
@@ -89,6 +93,7 @@ describe NestedFacet do
           {
             text: "Allowed value 1 - Sub facet Value 1",
             value: "allowed-value-1-sub-facet-value-1",
+            "selected": false,
             "data_attributes":
               {
                 "main_facet_label": "Allowed value 1",
@@ -98,6 +103,7 @@ describe NestedFacet do
           {
             text: "Allowed value 1 - Sub facet Value 2",
             value: "allowed-value-1-sub-facet-value-2",
+            "selected": false,
             "data_attributes":
               {
                 "main_facet_label": "Allowed value 1",
@@ -107,6 +113,7 @@ describe NestedFacet do
           {
             text: "Allowed value 2 - Sub facet Value 1",
             value: "allowed-value-2-sub-facet-value-1",
+            "selected": false,
             "data_attributes":
               {
                 "main_facet_label": "Allowed value 2",
@@ -115,6 +122,88 @@ describe NestedFacet do
           },
         ],
       )
+    end
+
+    context "when there is a selection" do
+      let(:allowed_values) do
+        [
+          {
+            "label" => "Allowed value 1",
+            "value" => "allowed-value-1",
+            "sub_facets" => [
+              {
+                "label" => "Sub facet Value 1",
+                "value" => "allowed-value-1-sub-facet-value-1",
+                "main_facet_label" => "Allowed value 1",
+                "main_facet_value" => "allowed-value-1",
+              },
+              {
+                "label" => "Sub facet Value 2",
+                "value" => "allowed-value-1-sub-facet-value-2",
+                "main_facet_label" => "Allowed value 1",
+                "main_facet_value" => "allowed-value-1",
+              },
+            ],
+          },
+          {
+            "label" => "Allowed value 2",
+            "value" => "allowed-value-2",
+          },
+        ]
+      end
+      let(:value_hash) do
+        { "facet_key" => "allowed-value-1", "sub_facet_key" => "allowed-value-1-sub-facet-value-1" }
+      end
+
+      it "returns `selected` flag for each option" do
+        expect(subject.main_facet_options).to eq(
+          [
+            {
+              "text": "All facet names",
+              "value": "",
+            },
+            {
+              "text": "Allowed value 1",
+              "value": "allowed-value-1",
+              "selected": true,
+            },
+            {
+              "text": "Allowed value 2",
+              "value": "allowed-value-2",
+              "selected": false,
+            },
+          ],
+        )
+
+        expect(subject.sub_facet_options).to eq(
+          [
+            {
+              "text": "All sub facet names",
+              "value": "",
+            },
+            {
+              text: "Allowed value 1 - Sub facet Value 1",
+              value: "allowed-value-1-sub-facet-value-1",
+              "selected": true,
+              "data_attributes":
+                {
+                  "main_facet_label": "Allowed value 1",
+                  "main_facet_value": "allowed-value-1",
+                },
+            },
+            {
+              text: "Allowed value 1 - Sub facet Value 2",
+              value: "allowed-value-1-sub-facet-value-2",
+              "selected": false,
+              "data_attributes":
+                {
+                  "main_facet_label": "Allowed value 1",
+                  "main_facet_value": "allowed-value-1",
+                },
+            },
+          ],
+        )
+      end
     end
   end
 end

--- a/spec/models/nested_facet_spec.rb
+++ b/spec/models/nested_facet_spec.rb
@@ -1,183 +1,120 @@
 require "spec_helper"
 
 describe NestedFacet do
-  subject { described_class.new(facet_hash, values) }
+  subject { described_class.new(facet_hash, {}) }
 
-  let(:values) { {} }
-
-  describe "#facet_options" do
-    context "when the facet is a main facet" do
-      let(:allowed_values) do
-        [
+  let(:facet_hash) do
+    {
+      "allowed_values" => allowed_values,
+      "filterable" => true,
+      "key" => "facet_key",
+      "name" => "Facet Name",
+      "preposition" => "with",
+      "nested_facet" => true,
+      "sub_facet_key" => "sub_facet_key",
+      "sub_facet_name" => "Sub Facet Name",
+      "type" => "nested",
+    }
+  end
+  let(:allowed_values) do
+    [
+      {
+        "label" => "Allowed value 1",
+        "value" => "allowed-value-1",
+        "sub_facets" => [
           {
-            "label" => "Allowed value 1",
-            "value" => "allowed-value-1",
-          },
-          {
-            "label" => "Allowed value 2",
-            "value" => "allowed-value-2",
-          },
-          {
-            "label" => "Allowed value 3",
-            "value" => "allowed-value-3",
-          },
-        ]
-      end
-      let(:facet_hash) do
-        {
-          "allowed_values" => allowed_values,
-          "filterable" => true,
-          "key" => "sub_facet_key",
-          "name" => "Facet Name",
-          "preposition" => "with",
-          "nested_facet" => true,
-          "sub_facet_key" => "some_sub_facet_key",
-          "sub_facet_name" => "Some sub facet key",
-          "type" => "text",
-        }
-      end
-
-      it "returns text and value pairs" do
-        expect(subject.facet_options).to eq(
-          [{
-            "text": "All facet names",
-            "value": "",
-          },
-           {
-             "text": "Allowed value 1",
-             "value": "allowed-value-1",
-             "selected": false,
-           },
-           {
-             "text": "Allowed value 2",
-             "value": "allowed-value-2",
-             "selected": false,
-           },
-           {
-             "text": "Allowed value 3",
-             "value": "allowed-value-3",
-             "selected": false,
-           }],
-        )
-      end
-    end
-
-    context "when the facet is a sub facet" do
-      let(:facet_hash) do
-        {
-          "allowed_values" => allowed_values,
-          "filterable" => true,
-          "key" => "sub_facet_key",
-          "name" => "Sub Facet Name",
-          "nested_facet" => true,
-          "preposition" => "with",
-          "type" => "text",
-        }
-      end
-      let(:allowed_values) do
-        [
-          {
-            "label" => "Allowed value 1 Sub facet Value 1",
+            "label" => "Sub facet Value 1",
             "value" => "allowed-value-1-sub-facet-value-1",
             "main_facet_label" => "Allowed value 1",
             "main_facet_value" => "allowed-value-1",
           },
           {
-            "label" => "Allowed value 1 Sub facet Value 2",
+            "label" => "Sub facet Value 2",
             "value" => "allowed-value-1-sub-facet-value-2",
             "main_facet_label" => "Allowed value 1",
             "main_facet_value" => "allowed-value-1",
           },
+        ],
+      },
+      {
+        "label" => "Allowed value 2",
+        "value" => "allowed-value-2",
+        "sub_facets" => [
           {
-            "label" => "Allowed value 2 Sub facet Value 1",
+            "label" => "Sub facet Value 1",
             "value" => "allowed-value-2-sub-facet-value-1",
             "main_facet_label" => "Allowed value 2",
             "main_facet_value" => "allowed-value-2",
           },
-        ]
-      end
+        ],
+      },
+      {
+        "label" => "Allowed value 3",
+        "value" => "allowed-value-3",
+      },
+    ]
+  end
 
-      it "returns text, value and main data attributes" do
-        expect(subject.facet_options).to eq(
-          [
-            {
-              "text": "All sub facet names",
-              "value": "",
-            },
-            {
-              text: "Allowed value 1 - Allowed value 1 Sub facet Value 1",
-              value: "allowed-value-1-sub-facet-value-1",
-              "selected": false,
-              "data_attributes":
-                {
-                  "main_facet_label": "Allowed value 1",
-                  "main_facet_value": "allowed-value-1",
-                },
-            },
-            {
-              text: "Allowed value 1 - Allowed value 1 Sub facet Value 2",
-              value: "allowed-value-1-sub-facet-value-2",
-              "selected": false,
-              "data_attributes":
-                {
-                  "main_facet_label": "Allowed value 1",
-                  "main_facet_value": "allowed-value-1",
-                },
-            },
-            {
-              text: "Allowed value 2 - Allowed value 2 Sub facet Value 1",
-              value: "allowed-value-2-sub-facet-value-1",
-              "selected": false,
-              "data_attributes":
-                {
-                  "main_facet_label": "Allowed value 2",
-                  "main_facet_value": "allowed-value-2",
-                },
-            },
-          ],
-        )
-      end
-    end
-
-    context "when there is a selection" do
-      let(:values) { "allowed-value-1" }
-      let(:facet_hash) do
-        {
-          "allowed_values" => [
-            {
-              "label" => "Allowed value 1",
-              "value" => "allowed-value-1",
-            },
-            {
-              "label" => "Allowed value 2",
-              "value" => "allowed-value-2",
-            },
-          ],
-          "key" => "facet_key",
-          "name" => "Facet Name",
-          "nested_facet" => true,
-          "sub_facet_key" => "some_sub_facet_key",
-        }
-      end
-
-      it "returns `selected` flag for each option" do
-        expect(subject.facet_options).to eq(
-          [{
+  describe "facet options" do
+    it "returns main facet options" do
+      expect(subject.main_facet_options).to eq(
+        [
+          {
             "text": "All facet names",
             "value": "",
           },
-           {
-             "text": "Allowed value 1",
-             "value": "allowed-value-1",
-             "selected": true,
-           },
-           {
-             "text": "Allowed value 2",
-             "value": "allowed-value-2",
-             "selected": false,
-           }],
-        )
-      end
+          {
+            "text": "Allowed value 1",
+            "value": "allowed-value-1",
+          },
+          {
+            "text": "Allowed value 2",
+            "value": "allowed-value-2",
+          },
+          {
+            "text": "Allowed value 3",
+            "value": "allowed-value-3",
+          },
+        ],
+      )
+    end
+
+    it "returns sub-facet options" do
+      expect(subject.sub_facet_options).to eq(
+        [
+          {
+            "text": "All sub facet names",
+            "value": "",
+          },
+          {
+            text: "Allowed value 1 - Sub facet Value 1",
+            value: "allowed-value-1-sub-facet-value-1",
+            "data_attributes":
+              {
+                "main_facet_label": "Allowed value 1",
+                "main_facet_value": "allowed-value-1",
+              },
+          },
+          {
+            text: "Allowed value 1 - Sub facet Value 2",
+            value: "allowed-value-1-sub-facet-value-2",
+            "data_attributes":
+              {
+                "main_facet_label": "Allowed value 1",
+                "main_facet_value": "allowed-value-1",
+              },
+          },
+          {
+            text: "Allowed value 2 - Sub facet Value 1",
+            value: "allowed-value-2-sub-facet-value-1",
+            "data_attributes":
+              {
+                "main_facet_label": "Allowed value 2",
+                "main_facet_value": "allowed-value-2",
+              },
+          },
+        ],
+      )
     end
   end
 end

--- a/spec/presenters/metadata_presenter_spec.rb
+++ b/spec/presenters/metadata_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MetadataPresenter do
       { id: "case-state", name: "Case state", value: "Open", type: "text" },
       { id: "opened-date", name: "Opened date", value: "2006-7-14", type: "date" },
       { id: "case-type", name: "Case type", value: "CA98 and civil cartels", type: "text" },
+      { id: "grounds-section", name: "Grounds section", value: "Graphical representation", type: "nested" },
     ]
   end
   let(:formatted_metadata) do
@@ -15,6 +16,7 @@ RSpec.describe MetadataPresenter do
       { id: "case-state", label: "Case state", value: "Open", is_text: true, labels: nil },
       { label: "Opened date", is_date: true, machine_date: "2006-07-14", human_date: "14 July 2006" },
       { id: "case-type", label: "Case type", value: "CA98 and civil cartels", is_text: true, labels: nil },
+      { id: "grounds-section", label: "Grounds section", value: "Graphical representation", is_text: true, labels: nil },
     ]
   end
 


### PR DESCRIPTION
## Remodel NestedFacet to behave more like a TaxonFacet


This PR attempts to make the newly added `NestedFacet` a bit more consistent with the pre-existent, and somewhat similar, `TaxonFacet`. There are two behaviour points that are ultimately the goal:
- getting the applied filters/metadata tags at the top of the search results to behave similarly to taxon, i.e. visually represent that there is a logical unit of a nested facet rather than two distinct facets
- wrapping the nested facet in an expander/accordion behaviour, similar to how other facets behave.

From a technical point of view, this is acknowledging that Taxon was already there doing ✨ _similar but slightly different things_ ✨, and it's worth exploring it properly in the context of the nested facet implementation - as @andysellick rightly pointed out when reviewing the [previous PR here](https://github.com/alphagov/finder-frontend/pull/3679).

In the previous implementation, the `NestedFacet` was written up as two distinct facets of type "text", with some additional fields to keep track of which is the "main" and which is the "sub". The scope of that change was a lot smaller than if we implemented a custom facet, with most of the changes in the originating finder repo, "Specialist Publisher".

The view ( I mean .erb) that served each facet in the previous implementation did not lend itself to the accordion/expander behaviour (basically: I could not wrap the two selects in the expander div in the no-js implementation 😅), so I looked into making a single nested facet again. Taxon is a good example to follow, as it, too, has two selects/facets under the hood, but behaves like a "single" facet.

Nonetheless, there are differences between the two: `TaxonFacet` populates its options in a unique way, whilst `NestedFacet` will get its options from Content Store, and ultimately from the schema defined in Specialist Publisher. There are also differences in how the two are implemented in Search API. For `NestedFacet`, we have opted to maintain two facets both in Search API and Publishing API schemas, whilst `TaxonFacet` seemingly has its own custom rules in Search API, and likely send a unified query (from what I can tell).

The approach for this PR is to build a single `NestedFacet` from the raw "nested" data facet we get from Content Store, and in doing so, replicate desired behaviours from `TaxonFacet`, and follow its implementation as far as we can. To this end, the new implementation uses a new "type" - "nested" - to make it easier to carve out the custom logic further down the line.

Whilst further refactoring is possible - abstract out common behaviours between the two classes, or use inheritance - I believe it is too early to make that call. Further steps in the `NestedFacets` work will include expanding the selection to multiple options, which will diverge from taxon behaviour. The test coverage of nested behaviours in this and upcoming commits should also support this future behaviour expansion.

These changes are accompanied by corresponding changes in [Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3049) and [Publishing API](https://github.com/alphagov/publishing-api/pull/3203).


## Screenshots


- Before (left) and after (right)
> <img width="1630" alt="Screenshot 2025-03-12 at 12 22 16" src="https://github.com/user-attachments/assets/c8cdd49d-4f16-4da8-90c0-1388dd8ad882" />

- For reference, this is a taxon example:
- Link [here](https://www.gov.uk/search/news-and-communications?level_one_taxon=ba951b09-5146-43be-87af-44075eac3ae9&level_two_taxon=58643944-9cc3-4f61-8805-4c1d090bf21d&order=updated-newest).
> ![Screenshot 2025-03-12 at 16 24 33](https://github.com/user-attachments/assets/60c46259-2a7e-4fb5-bbf1-afb0c81c8339)


| Taxon | Nested |
|--------|--------|
| Collapsed with selection | |
| ![Screenshot 2025-03-12 at 16 30 06](https://github.com/user-attachments/assets/03a3063a-2a61-43a2-8383-e9da0a49790e) | ![Screenshot 2025-03-12 at 09 28 33](https://github.com/user-attachments/assets/51737b0f-5d37-458e-809b-d1991dc8ab3e) | 
| Collapsed with no selection | |
| ![Screenshot 2025-03-12 at 16 39 32](https://github.com/user-attachments/assets/a058a5dc-ea35-4634-a870-d1320a7f1656) | ![Screenshot 2025-03-12 at 09 29 20](https://github.com/user-attachments/assets/f278bebb-bd5b-41c0-8f0c-97727352d26a) |
| Expanded | |
| ![Screenshot 2025-03-12 at 16 25 34](https://github.com/user-attachments/assets/81148e50-2322-4462-b0f3-cd1933894e58) | ![Screenshot 2025-03-12 at 09 28 44](https://github.com/user-attachments/assets/f568e353-18d0-43f1-8bd0-5a0cf1c9097e) |
| All selected | |
| ![Screenshot 2025-03-12 at 16 24 47](https://github.com/user-attachments/assets/1e26d407-4e58-4b36-b66a-88d17fcb93c9) | ![Screenshot 2025-03-12 at 16 42 40](https://github.com/user-attachments/assets/e6188dca-eb12-443d-986b-5ed998aa3157) |
| Applied filters | |
| ![Screenshot 2025-03-12 at 16 43 40](https://github.com/user-attachments/assets/4ddafda5-6c20-4e66-b629-5000c8a7c19e) | ![Screenshot 2025-03-12 at 16 43 54](https://github.com/user-attachments/assets/85e9ea8d-ba43-4b6e-8b53-3779ab54767b) |

## Links


[Trello](https://trello.com/c/EeZOA3iW/3534-spike-replicating-taxons-approach-for-nested-facets)
[Previous PR](https://github.com/alphagov/finder-frontend/pull/3679)
[Draft finder link where previous changes are visible](https://draft-origin.publishing.service.gov.uk/trademark-decisions)
Sister PRs: [Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3049) and [Publishing API](https://github.com/alphagov/publishing-api/pull/3203)