### PR TITLE
Don't use Google Vertex for feeds with keywords

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -145,7 +145,7 @@ private
     Search::Query.new(
       content_item,
       filter_params,
-      override_sort_for_feed: is_for_feed,
+      is_for_feed: is_for_feed,
       ab_params: {},
       v2_serving_config:,
     )

--- a/app/lib/search/order_query_builder.rb
+++ b/app/lib/search/order_query_builder.rb
@@ -1,16 +1,16 @@
 module Search
   class OrderQueryBuilder
-    def initialize(content_item, keywords, params, override_sort_for_feed: false)
+    def initialize(content_item, keywords, params, is_for_feed: false)
       @content_item = content_item
       @params = params
       @keywords = keywords
-      @override_sort_for_feed = override_sort_for_feed
+      @is_for_feed = is_for_feed
     end
 
     def call
       return order_by_release_timestamp if sort_option.present? && order_by_release_timestamp?(sort_option)
 
-      return order_by_public_timestamp if override_sort_for_feed
+      return order_by_public_timestamp if is_for_feed
       return order_by_public_timestamp if sort_option.present? && order_by_public_timestamp?(sort_option)
 
       return order_by_relevance_query if sort_option.present? && order_by_relevance?(sort_option)
@@ -26,7 +26,7 @@ module Search
 
   private
 
-    attr_reader :content_item, :params, :keywords, :override_sort_for_feed
+    attr_reader :content_item, :params, :keywords, :is_for_feed
 
     def order_by_relevance?(sort_option)
       %w[relevance -relevance topic -topic].include?(sort_option["key"])

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -138,6 +138,10 @@ module Search
       ## implications as well when it comes to bot traffic.
       return false if filter_params["keywords"].blank?
 
+      ## Feeds with keywords are sorted newest to oldest, so the relevance benefits of Vertex are
+      ## not realised.
+      return false if @override_sort_for_feed
+
       # Use v2 iff the current finder is site search (the only migrated finder so far)
       content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH
     end

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -16,15 +16,15 @@ module Search
       content_item,
       filter_params,
       ab_params: {},
-      override_sort_for_feed: false,
+      is_for_feed: false,
       v2_serving_config: nil
     )
       @content_item = content_item
       @filter_params = filter_params
       @ab_params = ab_params
-      @override_sort_for_feed = override_sort_for_feed
+      @is_for_feed = is_for_feed
       @order =
-        if override_sort_for_feed
+        if is_for_feed
           "most-recent"
         else
           filter_params["order"]
@@ -42,7 +42,7 @@ module Search
 
   private
 
-    attr_reader :ab_params, :override_sort_for_feed, :content_item, :v2_serving_config
+    attr_reader :ab_params, :is_for_feed, :content_item, :v2_serving_config
 
     def merge_and_deduplicate(search_response)
       results = search_response.fetch("results")
@@ -92,7 +92,7 @@ module Search
       queries = QueryBuilder.new(
         finder_content_item: content_item,
         params: filter_params,
-        override_sort_for_feed:,
+        is_for_feed:,
         use_v2_api: use_v2_api?,
         v2_serving_config:,
       ).call
@@ -140,7 +140,7 @@ module Search
 
       ## Feeds with keywords are sorted newest to oldest, so the relevance benefits of Vertex are
       ## not realised.
-      return false if @override_sort_for_feed
+      return false if @is_for_feed
 
       # Use v2 iff the current finder is site search (the only migrated finder so far)
       content_item.base_path == SITE_SEARCH_FINDER_BASE_PATH

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -19,14 +19,14 @@ module Search
       finder_content_item:,
       params: {},
       ab_params: {},
-      override_sort_for_feed: false,
+      is_for_feed: false,
       use_v2_api: false,
       v2_serving_config: nil
     )
       @finder_content_item = finder_content_item
       @params = params
       @ab_params = ab_params
-      @override_sort_for_feed = override_sort_for_feed
+      @is_for_feed = is_for_feed
       @use_v2_api = use_v2_api
       @v2_serving_config = v2_serving_config
     end
@@ -56,7 +56,7 @@ module Search
 
   private
 
-    attr_reader :finder_content_item, :params, :ab_params, :override_sort_for_feed,
+    attr_reader :finder_content_item, :params, :ab_params, :is_for_feed,
                 :v2_serving_config
 
     def use_v2_api?
@@ -132,7 +132,7 @@ module Search
         finder_content_item,
         keywords,
         params,
-        override_sort_for_feed:,
+        is_for_feed:,
       ).call
     end
 

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -152,7 +152,7 @@ describe Search::Query do
   end
 
   context "when it's a query for a feed" do
-    subject { described_class.new(content_item, { "keywords" => "feed me" }, override_sort_for_feed: true).search_results }
+    subject { described_class.new(content_item, { "keywords" => "feed me" }, is_for_feed: true).search_results }
 
     let(:content_item) do
       ContentItem.new({

--- a/spec/lib/search/query_spec.rb
+++ b/spec/lib/search/query_spec.rb
@@ -151,6 +151,33 @@ describe Search::Query do
     end
   end
 
+  context "when it's a query for a feed" do
+    subject { described_class.new(content_item, { "keywords" => "feed me" }, override_sort_for_feed: true).search_results }
+
+    let(:content_item) do
+      ContentItem.new({
+        "base_path" => "/search/all",
+        "details" => {
+          "facets" => facets,
+        },
+      })
+    end
+
+    before do
+      stub_search.to_return(body: {
+        "results" => [
+          result_item("/i-am-the-v1-api", "I am the v1 API", score: nil, updated: "14-12-19", popularity: 1),
+        ],
+      }.to_json)
+    end
+
+    it "calls the v1 API" do
+      results = subject.fetch("results")
+      expect(results.length).to eq(1)
+      expect(results.first).to match(hash_including("_id" => "/i-am-the-v1-api"))
+    end
+  end
+
   context "when on the site search finder without any keywords given" do
     subject { described_class.new(content_item, { "keywords" => "" }).search_results }
 


### PR DESCRIPTION
Feeds are overridden so that they (rightly) order items newest to oldest.

This negates the relevance benefits of Google Vertex and means we're paying over the odds. Feed readers are also voracious, so are likely costing us a chunk of money for little benefit for users.

(First commit is the actual small change, second one is a rename as the meaning has changed)

## Some search page examples to sense check:
- https://finder-frontend-pr-3705.herokuapp.com/search/all.atom?q=steve
- https://finder-frontend-pr-3705.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-3705.herokuapp.com/drug-device-alerts
