### PR TITLE
Fix expander component layout

### DIFF
--- a/app/assets/javascripts/components/expander.js
+++ b/app/assets/javascripts/components/expander.js
@@ -9,6 +9,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
   function Expander ($module) {
     this.$module = $module
     this.$toggle = this.$module.querySelector('.js-toggle')
+    this.$toggleContainer = this.$module.querySelector('.js-toggle-container')
     this.$content = this.$module.querySelector('.js-content')
     this.$allInteractiveElements = this.$content.querySelectorAll('select, input[type=text]')
   }
@@ -102,7 +103,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}; // if this ; is omitted, none
     $selectedCounter.classList.add('app-c-expander__selected-counter')
     $selectedCounter.classList.add('js-selected-counter')
     $selectedCounter.innerHTML = selectedString
-    this.$toggleButton.parentNode.insertBefore($selectedCounter, this.$toggleButton.nextSibling)
+    this.$toggleContainer.parentNode.insertBefore($selectedCounter, null)
   }
 
   Expander.prototype.updateSelectedCount = function updateSelectedCount () {

--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -22,11 +22,14 @@
 .govuk-frontend-supported {
   .app-c-expander__heading {
     position: relative;
+    margin: 0;
+  }
+
+  .app-c-expander__toggle {
     display: flex;
     flex-direction: row-reverse;
     justify-content: start;
     align-items: center;
-    margin: 0;
   }
 
   .app-c-expander__content {
@@ -92,5 +95,6 @@
   display: block;
   color: $govuk-text-colour;
   margin-top: 3px;
+  margin-left: 44px;
   @include govuk-font($size: 14);
 }

--- a/app/views/components/_expander.html.erb
+++ b/app/views/components/_expander.html.erb
@@ -14,9 +14,11 @@
 <% if title %>
   <%= tag.div(**component_helper.all_attributes) do %>
     <h3 class="app-c-expander__heading">
-      <span class="app-c-expander__title js-toggle"><%= title %></span>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
-      <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+      <div class="app-c-expander__toggle js-toggle-container">
+        <span class="app-c-expander__title js-toggle"><%= title %></span>
+        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--up" aria-hidden="true" focusable="false"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="0" height="0" class="app-c-expander__icon app-c-expander__icon--down" aria-hidden="true" focusable="false"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+      </div>
     </h3>
     <div class="app-c-expander__content js-content <%= 'app-c-expander__content--visible' if open_on_load %>" id="<%= content_id %>">
       <%= yield %>

--- a/spec/javascripts/components/expander-spec.js
+++ b/spec/javascripts/components/expander-spec.js
@@ -4,17 +4,19 @@ describe('An expander module', function () {
   var $element
 
   /* eslint-disable */
-  var html = '\
-    <div class="app-c-expander" data-module="expander" data-ga4-index=\'{\"index_section\":1, \"index_section_count\": 3}\'>\
-      <h2 class="app-c-expander__heading">\
-        <span class="app-c-expander__title js-toggle">Organisation</span>\
-        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>\
-        <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>\
-      </h2>\
-      <div class="app-c-expander__content js-content" id="expander-content-2386afad">\
-        This is some content that could appear inside this component. Its not very interesting or complicated but its still here, and thats fine.\
-      </div>\
-    </div>'
+  var html = `
+    <div class="app-c-expander" data-module="expander" data-ga4-index=\'{\"index_section\":1, \"index_section_count\": 3}\'>
+      <h3 class="app-c-expander__heading">
+        <div class="app-c-expander__toggle js-toggle-container">
+          <span class="app-c-expander__title js-toggle">Organisation</span>
+          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+        </div>
+      </h3>
+      <div class="app-c-expander__content js-content" id="expander-content-2386afad">
+        This is some content that could appear inside this component. Its not very interesting or complicated but its still here, and thats fine.
+      </div>
+    </div>`
   /* eslint-enable */
 
   describe('in default mode', function () {
@@ -81,27 +83,29 @@ describe('An expander module', function () {
 
   describe('with user selected items', function () {
     /* eslint-disable */
-    var html = '\
-      <div class="app-c-expander" data-module="expander">\
-        <h2 class="app-c-expander__heading">\
-          <span class="app-c-expander__title js-toggle">Topic</span>\
-          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>\
-          <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>\
-        </h2>\
-        <div class="app-c-expander__content js-content" id="expander-content-2386afad">\
-          <select>\
-            <option value="">All topics</option>\
-            <option value="e48ab80a-de80-4e83-bf59-26316856a5f9" selected>Government</option>\
-          </select>\
-          <select>\
-            <option value="">All sub topics</option>\
-            <option value="a">Department A</option>\
-            <option value="b" selected>Department B</option>\
-          </select>\
-          <input name="public_timestamp[from]" value="" type="text">\
-          <input name="public_timestamp[to]" value="november" type="text">\
-        </div>\
-      </div>'
+    var html = `
+      <div class="app-c-expander" data-module="expander">
+        <h3 class="app-c-expander__heading">
+          <div class="app-c-expander__toggle js-toggle-container">
+            <span class="app-c-expander__title js-toggle">Topic</span>
+            <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"/></svg>
+            <svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="app-c-expander__icon app-c-expander__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"/></svg>
+          </div>
+        </h3>
+        <div class="app-c-expander__content js-content" id="expander-content-2386afad">
+          <select>
+            <option value="">All topics</option>
+            <option value="e48ab80a-de80-4e83-bf59-26316856a5f9" selected>Government</option>
+          </select>
+          <select>
+            <option value="">All sub topics</option>
+            <option value="a">Department A</option>
+            <option value="b" selected>Department B</option>
+          </select>
+          <input name="public_timestamp[from]" value="" type="text">
+          <input name="public_timestamp[to]" value="november" type="text">
+        </div>
+      </div>`
     /* eslint-enable */
     beforeEach(function () {
       $element = document.createElement('div')


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes a problem where the JavaScript inserted `X selected` element was being mispositioned owing to use of flexbox to layout the elements in the top of this component.

## Why
Noticed as part of unrelated work on something to go inside this component.

## Visual changes

Normal page fix.

Before | After
------ | ------
![Screenshot 2025-03-27 at 08 57 01](https://github.com/user-attachments/assets/0aa10a43-fdb7-4a0b-b751-46a0eeec0402) | ![Screenshot 2025-03-27 at 08 56 36](https://github.com/user-attachments/assets/234932e2-31d8-4285-93d5-b19e7514611e)

The reason flexbox was introduced was to make the layout look more consistent when the page is zoomed, and particularly when the font size is increased (you can simulate this in Firefox with the 'zoom text only' option). This change preserves that, as shown.

<img width="267" alt="Screenshot 2025-03-27 at 08 58 46" src="https://github.com/user-attachments/assets/c97c881e-7b48-4a4a-8cda-8b79e04022f2" />

