### PR TITLE
Improve naming of exported Prometheus metrics

### DIFF
--- a/app/lib/metrics.rb
+++ b/app/lib/metrics.rb
@@ -3,14 +3,14 @@ module Metrics
   COUNTERS = {
     searches: CLIENT.register(
       :counter,
-      "finder_frontend_searches",
+      "finder_frontend_searches_total",
       "Total number of requests performed to a backend search API",
     ),
   }.freeze
   HISTOGRAMS = {
     search_request_duration: CLIENT.register(
       :histogram,
-      "finder_frontend_search_request_duration",
+      "finder_frontend_search_request_duration_seconds",
       "Time taken to perform a request to a backend search API",
     ),
   }.freeze


### PR DESCRIPTION
These should end in `_total` for counter metrics, and should include a unit for histogram metrics.

Note that we are only using these on an experimental temporary dashboard at the moment, so the name change won't cause any particular monitoring headaches.