### PR TITLE
Fix bst date parsing

### DIFF
--- a/app/parsers/date_string_parser.rb
+++ b/app/parsers/date_string_parser.rb
@@ -20,6 +20,7 @@ private
   attr_reader :date_string, :chronic_date
 
   def try_parse_chronic_date
+    Chronic.time_class = Time.zone
     Chronic.parse(normalized_date_string, guess: :begin, endian_precedence: :little)
   rescue StandardError
     nil

--- a/app/presenters/metadata_presenter.rb
+++ b/app/presenters/metadata_presenter.rb
@@ -29,7 +29,7 @@ private
   end
 
   def build_date_metadata(data)
-    date = Date.parse(data.fetch(:value))
+    date = Time.zone.parse(data.fetch(:value)).to_date
     {
       label: data.fetch(:name),
       is_date: true,

--- a/spec/parsers/date_string_parser_spec.rb
+++ b/spec/parsers/date_string_parser_spec.rb
@@ -51,6 +51,11 @@ describe DateStringParser do
     # Dates should be interpretted as UK not US
     "01/11/2014" => Date.new(2014, 11, 1),
 
+    # Datetime strings with timezones (BST & GMT)
+    "2025-04-10 23:00:05 +0000" => Date.new(2025, 4, 11),
+    "2025-04-10 23:00:05 +0100" => Date.new(2025, 4, 10),
+    "2025-02-10 23:00:05 +0000" => Date.new(2025, 2, 10),
+
     # Future date
     "22/09/25" => Date.new(2025, 9, 22),
 

--- a/spec/presenters/metadata_presenter_spec.rb
+++ b/spec/presenters/metadata_presenter_spec.rb
@@ -24,5 +24,12 @@ RSpec.describe MetadataPresenter do
     it "presents the metadata" do
       expect(subject.present).to eq(formatted_metadata)
     end
+
+    it "presents the metadata for BST timezones correctly" do
+      raw_metadata = [{ id: "opened-date", name: "Opened date", value: "2025-04-10 23:00:01 +0000", type: "date" }]
+      expected_metadata = [{ label: "Opened date", is_date: true, machine_date: "2025-04-11", human_date: "11 April 2025" }]
+
+      expect(described_class.new(raw_metadata).present).to eq expected_metadata
+    end
   end
 end


### PR DESCRIPTION
ZenDesk issue raised by user about search metadata being one day out compared to the document updated at date. 
The reason is Search API is still operating in UTC (same as Publishing API). 

Changing all date parsing to take into account timezone. 

https://trello.com/c/qXxubdj7/3630-published-date-inconsistent-between-whitehall-and-search-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
