### PR TITLE
Add delimiters to search result pagination

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,6 +1,8 @@
 # The PaginationPresenter class is responsible for creating the next and
 # previous links to be displayed on finders.
 class PaginationPresenter
+  include ActiveSupport::NumberHelper
+
   def initialize(per_page:, start_offset:, total_results:, url_builder:)
     @per_page = per_page
     @start_offset = start_offset
@@ -53,7 +55,7 @@ private
   def build_page_link(page_label, page)
     {
       title: page_label,
-      label: "#{page} of #{total_pages}",
+      label: "#{number_to_delimited(page)} of #{number_to_delimited(total_pages)}",
       url: url_builder.url(page:),
     }
   end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -85,5 +85,16 @@ describe PaginationPresenter do
         )
       end
     end
+
+    context "when the page numbers are large" do
+      let(:per_page) { 1 }
+      let(:total_results) { 1989 }
+      let(:start_offset) { 1312 }
+
+      it "returns links with separators" do
+        expect(subject[:previous_page][:label]).to eq("1,312 of 1,989")
+        expect(subject[:next_page][:label]).to eq("1,314 of 1,989")
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds delimiters to the `previous_and_next_navigation` component used in search results to make large numbers for some searches easier to read.

## Before
<img width="220" alt="image" src="https://github.com/user-attachments/assets/d5fd9253-d779-4040-b0bf-79f975e8e0ba" />

## After
<img width="195" alt="image" src="https://github.com/user-attachments/assets/54c095ab-6465-4313-b256-01721453973e" />
