### PR TITLE
Add GA4 meta tags to email signup confirmation page

### DIFF
--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -20,6 +20,14 @@ class SignupPresenter
     content_item["details"]["beta"]
   end
 
+  def document_type
+    content_item["document_type"]
+  end
+
+  def schema_name
+    content_item["schema_name"]
+  end
+
   def email_filter_by
     content_item.dig("details", "email_filter_by")
   end

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,3 +1,8 @@
+<% content_for :meta_tags do %>
+  <meta name="govuk:format" content="<%= @signup_presenter.document_type %>" />
+  <meta name="govuk:schema-name" content="<%= @signup_presenter.schema_name %>" />
+<% end %>
+
 <% if @signup_presenter.can_modify_choices? %>
   <% content_for :title, @signup_presenter.page_title %>
 <% else %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
