### PR TITLE
Let Search API v2 decide default serving config

### DIFF
--- a/app/controllers/ab_test/search_freshness_boost_ab_testable.rb
+++ b/app/controllers/ab_test/search_freshness_boost_ab_testable.rb
@@ -17,10 +17,9 @@ module AbTest::SearchFreshnessBoostAbTestable
   end
 
   def v2_serving_config
-    if @requested_variant&.variant?("B")
-      "variant_search"
-    else
-      "default_search"
-    end
+    return "variant_search" if @requested_variant&.variant?("B")
+
+    # Let Search API v2 decide which "default" serving config to use.
+    nil
   end
 end

--- a/app/lib/search/query_builder.rb
+++ b/app/lib/search/query_builder.rb
@@ -12,7 +12,6 @@ module Search
     # find anything useful, too much noise.
     MAX_QUERY_LENGTH = 512
 
-    DEFAULT_V2_SERVING_CONFIG = "default_search".freeze
     LICENCE_STOPWORDS = %w[licence license permit certification].freeze
 
     def initialize(
@@ -257,8 +256,8 @@ module Search
       return {} unless use_v2_api?
 
       {
-        "serving_config" => v2_serving_config || DEFAULT_V2_SERVING_CONFIG,
-      }
+        "serving_config" => v2_serving_config,
+      }.compact
     end
 
     def debug_query

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -319,7 +319,7 @@ describe FindersController, type: :controller do
 
     describe "the finder is the all content finder" do
       before do
-        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil, serving_config: "default_search" })
+        search_api_request(search_api_app: "search-api-v2", discovery_engine_attribution_token: "123ABC", query: { q: "hello", order: nil })
         stub_content_store_has_item(
           "/search/all",
           all_content_finder,
@@ -347,7 +347,7 @@ describe FindersController, type: :controller do
       end
 
       context "when the variant is A" do
-        let(:expected_serving_config) { "default_search" }
+        let(:expected_serving_config) { nil }
 
         it "uses the expected serving config" do
           with_variant(SearchFreshnessBoost: "A") do
@@ -369,7 +369,7 @@ describe FindersController, type: :controller do
       end
 
       context "when the variant is Z" do
-        let(:expected_serving_config) { "default_search" }
+        let(:expected_serving_config) { nil }
 
         it "uses the expected serving config" do
           with_variant(SearchFreshnessBoost: "Z") do

--- a/spec/lib/search/query_builder_spec.rb
+++ b/spec/lib/search/query_builder_spec.rb
@@ -446,8 +446,8 @@ describe Search::QueryBuilder do
       context "if no custom serving config is given" do
         let(:v2_serving_config) { nil }
 
-        it "includes the default serving config query" do
-          expect(query).to include("serving_config" => "default_search")
+        it "does not include a serving config query" do
+          expect(query).not_to have_key("serving_config")
         end
       end
     end


### PR DESCRIPTION
We currently define a "default" serving config (when neither an AB test nor a debug flag needs to override it) both in this app and in Search API v2 itself.

This makes it harder to update what the default is as we'd have to do it in two places at the same time.

Instead, this changes Finder Frontend to just not specify a serving config in situations where we don't want to override the default, and leaves it to Search API v2 to figure out.