### PR TITLE
Skip parts that arrive without a `slug`

### DIFF
--- a/app/presenters/search_result_presenter.rb
+++ b/app/presenters/search_result_presenter.rb
@@ -85,6 +85,10 @@ private
 
   def structure_parts
     structured_parts = parts.map do |part|
+      # Silently skip parts that have no slug
+      # this is an interim conditional until `slug` is replaced by `link` in Search API
+      next if part[:slug].blank?
+
       has_required_data = %i[title slug body].all? { |key| part.key? key }
       unless has_required_data
         GovukError.notify(MalformedPartError.new, extra: { part:, link: })

--- a/spec/presenters/search_result_presenter_spec.rb
+++ b/spec/presenters/search_result_presenter_spec.rb
@@ -157,6 +157,47 @@ RSpec.describe SearchResultPresenter do
           expect(subject.document_list_component_data[:parts]).to be_nil
         end
       end
+
+      context "when a part has a blank slug" do
+        let(:parts) do
+          [
+            {
+              title: "I am a part title",
+              slug: "part-path",
+              body: "Part description",
+            },
+            {
+              title: "I am missing slug",
+              slug: "",
+              body: "Body text",
+            },
+          ]
+        end
+
+        let(:result_number) { 3 }
+
+        let(:expected_parts) do
+          [
+            {
+              link: {
+                text: "I am a part title",
+                path: "#{link}/part-path",
+                description: "Part description",
+                data_attributes: {
+                  ga4_ecommerce_path: "#{link}/part-path",
+                  ga4_ecommerce_content_id: "content_id",
+                  ga4_ecommerce_row: 1,
+                  ga4_ecommerce_index: 1,
+                },
+              },
+            },
+          ]
+        end
+
+        it "skips the part with a blank slug without notifying" do
+          expect(subject.document_list_component_data[:parts]).to eq(expected_parts)
+        end
+      end
     end
 
     context "with full size description" do


### PR DESCRIPTION
Trello: https://trello.com/c/L3TUHrsG/2564-fix-broken-search-api-links

The upcoming Search API re-index (https://github.com/alphagov/search-api/pull/3271) will introduce a new `link` field on each part that stores the full attachment path, replacing the current approach of supplying only a `slug`.
This change is required because some consultation-outcome attachments live under an extra `/outcome/` directory, so concatenating the parent URL with their `slug` produces a 404.  Supplying the whole path in `link` fixes that.

During the back-fill there will be a transition period where Search API re-presents documents with `link` populated but potentially a blank `slug`.  If finder-frontend tries to render such a part it would produce a broken URL and raise a presenter error.

This commit adds a guard that simply skips parts with a blank `slug`. It clears the path for a follow-up commit that will start using `link` and ultimately retire `slug`

This safeguard can be removed once all documents carry `link` and the legacy `slug` field has been fully phased out.