### PR TITLE
Remove legacy routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,11 +14,6 @@ Rails.application.routes.draw do
   get "/search" => "search#index", as: :search
   get "/search/opensearch" => "search#opensearch"
 
-  if ENV["GOVUK_WEBSITE_ROOT"] =~ /integration/ || ENV["GOVUK_WEBSITE_ROOT"] =~ /staging/
-    get "/test-search/search" => "search#index"
-    get "/test-search/search/opensearch" => "search#opensearch"
-  end
-
   # Helper to generate email signup routes
   get "/email/subscriptions/new", to: proc { [200, {}, [""]] }, as: :email_alert_frontend_signup
 


### PR DESCRIPTION
Looks like these were added [8 years ago as part of a spike](https://github.com/alphagov/finder-frontend/commit/fcbef72c5e1fa71e7559aac9bb570ac84a58f71e) I can't see any requests for `/test-search/` in kibana, or think of anything that could be using them.



