### PR TITLE
Remove static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "govuk_publishing_components"
 gem "govuk_web_banners"
 gem "rack-cors"
 gem "rest-client"
-gem "slimmer"
 gem "sprockets-rails"
 gem "terser"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,13 +628,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    slimmer (18.7.0)
-      json
-      nokogiri (~> 1.7)
-      null_logger
-      plek (>= 1.1.0)
-      rack (>= 3.0)
-      rest-client
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -707,7 +700,6 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   simplecov
-  slimmer
   sprockets-rails
   terser
   timecop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,14 +9,21 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
+//= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/intervention
+//= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/option-select
 //= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/search-with-autocomplete
+//= require govuk_publishing_components/components/skip-link
 //
 //= require govuk_web_banners/dependencies
 //

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,21 @@
-// This flag stops the font from being included in this application's
-// stylesheet - the font is being served by Static across all of GOV.UK, so is
-// not needed here.
-$govuk-include-default-font-face: false;
-
 // see /component-guide for sass imports and
 // https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components
 // for guidance
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/cookie-banner";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-for-public";
+@import "govuk_publishing_components/components/layout-super-navigation-header";
+@import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/search-with-autocomplete";
+@import "govuk_publishing_components/components/skip-link";
 
 @import "finder_frontend";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,4 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
-  include Slimmer::Template
-
-  slimmer_template "gem_layout"
-
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -9,7 +9,7 @@ class FindersController < ApplicationController
 
     validate_finder_params!
 
-    slimmer_template "gem_layout_full_width" if i_am_a_topic_page_finder
+    # TODO: slimmer_template "gem_layout_full_width" if i_am_a_topic_page_finder
 
     respond_to do |format|
       format.html do

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,13 +18,6 @@ class SearchController < ApplicationController
 
 protected
 
-  def fill_in_slimmer_headers(result_count)
-    set_slimmer_headers(
-      result_count:,
-      section: "search",
-    )
-  end
-
   def redirect_to_all_content_finder(search_params)
     all_content_params = {
       keywords: search_params.search_term,

--- a/app/views/layouts/development_layout.html.erb
+++ b/app/views/layouts/development_layout.html.erb
@@ -5,21 +5,20 @@
     </div>
   </div>
 <% end %>
-<!DOCTYPE html>
-<html>
-  <head>
-    <title><%= yield :title %> - GOV.UK</title>
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application", integrity: false %><!--<![endif]-->
-    <%=
-      render_component_stylesheets
-    %>
-    <%= javascript_include_tag "application", integrity: false, type: "module" %>
-    <meta name="robots" content="noindex">
-  </head>
 
-  <body>
-    <div id="wrapper">
-      <%= yield :body %>
-    </div>
-  </body>
-</html>
+<%= content_for :head do %>
+  <%= csp_meta_tag %>
+  <%= render_component_stylesheets %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      rendering_app: "finder-frontend",
+    }
+  } %>
+  <meta name="robots" content="noindex">
+<% end %>
+
+<%= render "govuk_publishing_components/components/layout_for_public", {
+      title: "#{yield(:title)} - GOV.UK",
+  } do %>
+  <%= yield :body %>
+<% end %>

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -7,30 +7,29 @@
     </div>
   </main>
 <% end %>
-<% @omit_feedback_footer ||= nil %>
-<!DOCTYPE html>
-<html>
-  <head>
-    <title><%= yield :title %> - GOV.UK</title>
-    <%= stylesheet_link_tag "application", media: "all", integrity: false %>
-    <%=
-      render_component_stylesheets
-    %>
-    <%= javascript_include_tag 'test-dependencies.js', type: "module" if Rails.env.test? %>
-    <%= javascript_include_tag 'application', integrity: false, type: "module" %>
-    <%= csrf_meta_tags %>
-    <%= yield :head %>
 
-    <% if params[:page] || params[:keywords] || params[:q] %>
-      <meta name="robots" content="noindex">
-    <% end %>
-    <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
-    <%= yield :meta_tags %>
-  </head>
+<%= content_for :head do %>
+  <%= csp_meta_tag %>
+  <%= csrf_meta_tags %>
+  <%= render_component_stylesheets %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      rendering_app: "finder-frontend",
+    }
+  } %>
+  <% if params[:page] || params[:keywords] || params[:q] %>
+    <meta name="robots" content="noindex">
+  <% end %>
+  <meta name="govuk:base_title" content="<%= yield :meta_title %> - GOV.UK">
+  <%= yield :meta_tags %>
+<% end %>
 
-  <body class="<%= yield :body_classes %>">
-    <div id="wrapper">
-      <%= yield :body %>
-    </div>
-  </body>
-</html>
+<%= render "govuk_publishing_components/components/layout_for_public", {
+      title: "#{yield(:title)} - GOV.UK",
+      full_width: i_am_a_topic_page_finder,
+      omit_feedback_footer: @omit_feedback_footer
+  } do %>
+  <div class="govuk-width-container">
+    <%= yield :body %>
+  </div>
+<% end %>

--- a/app/views/layouts/search_layout.html.erb
+++ b/app/views/layouts/search_layout.html.erb
@@ -1,25 +1,21 @@
 <% content_for :body do %>
-  <%= yield %>
+    <%= yield %>
 <% end %>
-<!DOCTYPE html>
-<html>
-  <head>
-    <title><%= yield :title %> - GOV.UK</title>
-    <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
-    <%= stylesheet_link_tag "application", media: "all", integrity: false %>
-    <%=
-      render_component_stylesheets
-    %>
-    <%= javascript_include_tag 'application', integrity: false, type: "module" %>
-    <% if @content_item %>
-      <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.as_hash %>
-    <% end %>
-    <%= yield :extra_headers %>
-  </head>
 
-  <body class="mainstream <%= yield :body_classes %>">
-    <div id="wrapper" class="govuk-width-container">
-      <%= yield :body %>
-    </div>
-  </body>
-</html>
+<%= content_for :head do %>
+  <%= csp_meta_tag %>
+  <%= csrf_meta_tags %>
+  <%= render_component_stylesheets %>
+  <% if @content_item %>
+    <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item.as_hash %>
+  <% end %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/layout_for_public", {
+      title: "#{yield(:title)} - GOV.UK",
+      omit_feedback_footer: @omit_feedback_footer
+  } do %>
+  <div class="govuk-width-container">
+    <%= yield :body %>
+  </div>
+<% end %>

--- a/app/views/search/no_search_term.html.erb
+++ b/app/views/search/no_search_term.html.erb
@@ -1,6 +1,6 @@
 <% content_for :body_classes, "search" %>
 <% content_for :title, "Search" %>
-<% content_for :extra_headers do %>
+<% content_for :head do %>
   <meta name="description" content="Search GOV.UK." />
 <% end %>
 

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,3 +1,19 @@
 GovukPublishingComponents.configure do |c|
   c.component_guide_title = "Finder Frontend Component Guide"
+  c.application_stylesheet = "application"
+  c.custom_css_exclude_list = %w[
+    button
+    cookie-banner
+    feedback
+    govspeak
+    heading
+    input
+    label
+    layout-footer
+    layout-for-public
+    layout-super-navigation-header
+    search
+    search-with-autocomplete
+    skip-link
+  ]
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,8 +13,6 @@ require "cucumber/rspec/doubles"
 require "webmock/cucumber"
 WebMock.disable_net_connect!(allow_localhost: true)
 
-require "slimmer/test"
-
 GovukTest.configure
 
 # Capybara defaults to CSS3 selectors rather than XPath.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,6 @@
 require "simplecov"
 SimpleCov.start
 
-require "slimmer/test"
-
 ENV["RAILS_ENV"] ||= "test"
 ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.test.gov.uk"
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
https://trello.com/c/RaZbqOP1/389-remove-slimmer-finder-frontend, [Jira issue PNP-5242](https://gov-uk.atlassian.net/browse/PNP-5242)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
