### PR TITLE
Bump components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       rest-client (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.32.0)
+    google-protobuf (4.32.1)
       bigdecimal
       rake (>= 13)
     googleapis-common-protos-types (1.21.0)
@@ -192,7 +192,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (60.2.1)
+    govuk_publishing_components (61.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -278,7 +278,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.9)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     null_logger (0.0.1)
@@ -595,7 +595,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.3)
+    rexml (3.4.4)
     rouge (4.6.0)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)

--- a/app/assets/stylesheets/components/mixins/_chevron.scss
+++ b/app/assets/stylesheets/components/mixins/_chevron.scss
@@ -1,4 +1,4 @@
-@import "govuk_publishing_components/components/mixins/prefixed-transform";
+@import "govuk_publishing_components/components/mixins/css3";
 
 @mixin chevron($open: false) {
   &::before {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Upgrade to the latest version of `govuk_publishing_components` and fix the associated breaking change. This was causing a sass compilation error for the chevron sass file, used by the filter panel component.

## Why
Changes made in https://github.com/alphagov/govuk_publishing_components/pull/4969 have caused this breaking change.