### PR TITLE
Update content item doc with new finder example and sorting validation rules

### DIFF
--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -58,10 +58,12 @@ For example, rejecting all documents which don't have a policy would need a hash
 
 A string. Optional.
 
-You can use a minus (-) in front of the field to order in descending order (see [whitehall/lib/finders/case_studies.json](https://github.com/alphagov/whitehall/blob/master/lib/finders/case_studies.json#L12) for an example).
+You can use a minus (-) in front of the field to order in descending order (see [search-api/config/finders/case_studies_finder.yml](https://github.com/alphagov/search-api/blob/main/config/finders/case_studies_finder.yml#L21) for an example).
 
 Rummager must allow this field to be sorted on. At the time of writing [this
 was restricted to a couple of fields](https://github.com/alphagov/rummager/blob/ff35f2efb17d145f657cb520bc9892e64b713901/lib/parameter_parser/base_parameter_parser.rb#L10-L17).
+
+**Note:** If you include a custom `sort` block in the finder configuration, you must also include `relevance` as one of the available sort options. Finder Frontend requires this option to be present in the DOM, and the page's JavaScript will fail to initialize if it's missing.
 
 ## `default_documents_per_page`
 


### PR DESCRIPTION
## What
This PR updates the doc to highlight important information and changes made to finders on Whitehall.

- Finders on Whitehall have been migrated to Search API
- During migration, we encountered an issue where Javascript was broken on the frontend, more details in the 'Why' section below. We have added a note to highlight the importance of having the required sort field in the sorting config.

## Why
It does look like Finder Frontend requires having `relevance` sort option by default. When sort options are supplied without it, Javascript throws an error in the DOM as it tries to query the option on load. Consequently, a user will be unable to perform other JS interactions such as realtime filtering, sorting, etc.

### Issue Screenshot
In this case, there were other sort options in the Sort Field except the required `relevance` option. As shown below, the JS broke and nothing happens when you try to sort the data.

<img width="2966" height="1272" alt="image" src="https://github.com/user-attachments/assets/ad125131-9107-4c62-a4c1-c3edb70872db" />

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
