### PR TITLE
Fix pagination

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -56,7 +56,7 @@ private
     {
       title: page_label,
       label: "#{number_to_delimited(page)} of #{number_to_delimited(total_pages)}",
-      url: url_builder.url(page:),
+      href: url_builder.url(page:),
     }
   end
 end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -43,7 +43,7 @@ describe PaginationPresenter do
           next_page: {
             label: "2 of 5",
             title: "Next page",
-            url: "/search?page=2",
+            href: "/search?page=2",
           },
         )
       end
@@ -59,7 +59,7 @@ describe PaginationPresenter do
           previous_page: {
             label: "4 of 5",
             title: "Previous page",
-            url: "/search?page=4",
+            href: "/search?page=4",
           },
         )
       end
@@ -75,12 +75,12 @@ describe PaginationPresenter do
           next_page: {
             label: "3 of 5",
             title: "Next page",
-            url: "/search?page=3",
+            href: "/search?page=3",
           },
           previous_page: {
             label: "1 of 5",
             title: "Previous page",
-            url: "/search?page=1",
+            href: "/search?page=1",
           },
         )
       end


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- the previous next component was recently changed to be the pagination component, and in that change the option for `url` was renamed to `href`
- we should probably have some tests in place to click on these links, given that they were broken, but for now let's just get them working again

## Visual changes
Fixes the pagination links at the bottom of search pages, currently look like this and can't be clicked on:

<img width="748" height="331" alt="Screenshot 2025-12-11 at 15 29 54" src="https://github.com/user-attachments/assets/718be328-a5dd-4f41-8290-2d5311373031" />
