### PR TITLE
Make pagination tests more specific

### DIFF
--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -291,14 +291,14 @@ Then(/^I can see pagination$/) do
   visit finder_path("government/policies/benefits-reform")
 
   expect(page).not_to have_content("Previous page")
-  expect(page).to have_content("Next page")
+  expect(page).to have_link("Next page", href: "/government/policies/benefits-reform?page=2")
 end
 
 Then(/^I can browse to the next page$/) do
   stub_search_api_request_with_10_government_results_page_2
   visit finder_path("government/policies/benefits-reform", page: 2)
 
-  expect(page).to have_content("Previous page")
+  expect(page).to have_link("Previous page", href: "/government/policies/benefits-reform?page=1")
   expect(page).not_to have_content("Next page")
 end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- change tests to check for the presence of links with expected href attributes, instead of simply checking the link text content is present
- adding because there was a recent change to the pagination component where the link option changed, causing pagination links to stop working, but the tests still passed as they didn't check the outputted href attribute

## Visual changes
None.

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1355?selectedIssue=PNP-9742