### PR TITLE
Add note about pinned connection_pool version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "8.1.1"
 
 gem "bootsnap", require: false
 gem "chronic"
-gem "connection_pool", "< 3"
+gem "connection_pool", "< 3" # Do not bump via Dependabot - https://github.com/alphagov/finder-frontend/pull/3921
 gem "dalli"
 gem "dartsass-rails"
 gem "gds-api-adapters"


### PR DESCRIPTION
We still get Dependabot PRs to update the gem.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

