### PR TITLE
[PNP-9784] Notify Slack when GitHub Actions fail on 'main'

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -1,0 +1,24 @@
+name: Notify Slack of failure on main
+
+on:
+  workflow_run:
+    workflows: [CI, Deploy]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Notify Slack if failure on main
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-patterns-and-pages-tech
+          message: "Github was unable to complete the CI or Deploy Actions workflow - requires further investigation."


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What 
[Jira Card](https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9784)

Add a slack notification when GitHub Actions workflow fails on `main`.

## Why
Sometimes a new image on `main` fails to build after a PR is merged, blocking deployments without anyone noticing.

Notifying Slack of these failures makes them visible immediately, helping the team spot problems quickly and reducing the risk of delayed or missed deployments. 
