### PR TITLE
Handle nil fields in organisations registry

### DIFF
--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -29,7 +29,7 @@ module Registries
     def organisations_as_hash
       GovukStatsd.time("registries.organisations.request_time") do
         fetch_organisations_from_rummager
-          .reject { |result| result["slug"].empty? || result["title"].empty? }
+          .reject { |result| result["slug"].blank? || result["title"].blank? }
           .sort_by { |result| result["title"].sub("Closed organisation: ", "ZZ").upcase }
           .each_with_object({}) do |result, orgs|
             slug = result["slug"]


### PR DESCRIPTION
### What

Previously, the `organisations_as_hash` method assumed that every result from the `Rummager search` had both a slug and a title. This caused a `NoMethodError` when either was nil:

`undefined method 'empty?' for nil (NoMethodError)
        .reject { |result| result["slug"].empty? || result["title"].empty?`

This change replaces `empty?` with `blank?`, which safely handles `nil` values. As a result, fetching or caching organisations will no longer crash, even when some are missing slugs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
