### PR TITLE
Remove obsolete hardcoded route from ecommerce check

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -243,7 +243,6 @@ private
     %w[
       /government/groups
       /world/organisations
-      /government/organisations/hm-revenue-customs/contact
     ].exclude?(content_item.base_path)
   end
 


### PR DESCRIPTION
`/government/organisations/hm-revenue-customs/contact` now redirects to `/find-hmrc-contacts`, so this page is never rendered.

See https://www.gov.uk/api/content/government/organisations/hm-revenue-customs/contact

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
