### PR TITLE
[SCH-1750] Remove #batch_search queries

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -44,52 +44,8 @@ module Search
 
     attr_reader :ab_params, :is_for_feed, :content_item, :v2_serving_config
 
-    def merge_and_deduplicate(search_response)
-      results = search_response.fetch("results")
-
-      return results[0] if results.count == 1
-
-      # This currently doesn't handle more complex features such as pagination.
-      # The only finder where the facets work as an OR filter
-      # doesn't use pagination and there aren't enough documents it to be
-      # important. The results are sorted here because they are only
-      # sorted by Rummager within the results of each query.
-
-      all_unique_results = results
-        .flat_map { |hash| hash["results"] }
-        .uniq { |hash| hash["_id"] }
-      {
-        "results" => sort_batch_results(all_unique_results),
-        "total" => all_unique_results.count,
-        "start" => 0,
-      }
-    end
-
-    def sort_batch_results(raw_results)
-      case @order
-      when "most-viewed"
-        raw_results.sort_by { |hash| hash["popularity"] }.reverse
-      when "most-recent"
-        raw_results.sort_by { |hash| hash["public_timestamp"] }.reverse
-      when "a-to-z"
-        raw_results.sort_by { |hash| hash["title"] }
-      else
-        sort_by_relevance(raw_results)
-      end
-    end
-
-    def sort_by_relevance(raw_results)
-      return raw_results unless relevance_scores_exist?(raw_results)
-
-      raw_results.sort_by { |hash| hash["combined_score"] || hash["es_score"] }.reverse
-    end
-
-    def relevance_scores_exist?(results)
-      results.all? { |result| (result["combined_score"] || result["es_score"]).present? }
-    end
-
     def fetch_search_response(content_item)
-      queries = QueryBuilder.new(
+      query = QueryBuilder.new(
         finder_content_item: content_item,
         params: filter_params,
         is_for_feed:,
@@ -101,21 +57,13 @@ module Search
         Metrics.increment_counter(:searches, api: "v2", finder: content_item.base_path)
 
         Metrics.observe_duration(:search_request_duration, api: "v2") do
-          Services.search_api_v2.search(queries.first).to_hash
+          Services.search_api_v2.search(query).to_hash
         end
-      elsif queries.one?
+      else
         Metrics.increment_counter(:searches, api: "v1", finder: content_item.base_path)
 
         Metrics.observe_duration(:search_request_duration, api: "v1") do
-          Services.rummager.search(queries.first).to_hash
-        end
-      else
-        Metrics.increment_counter(:searches, api: "v1_bulk", finder: content_item.base_path)
-
-        Metrics.observe_duration(:search_request_duration, api: "v1_bulk") do
-          merge_and_deduplicate(
-            Services.rummager.batch_search(queries).to_hash,
-          )
+          Services.rummager.search(query).to_hash
         end
       end
     end

--- a/spec/lib/search/query_builder_spec.rb
+++ b/spec/lib/search/query_builder_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Search::QueryBuilder do
-  subject(:queries) do
+  subject(:query) do
     described_class.new(
       finder_content_item:,
       use_v2_api:,
@@ -9,8 +9,6 @@ describe Search::QueryBuilder do
       params:,
     ).call
   end
-
-  let(:query) { queries.first }
 
   let(:finder_content_item) do
     ContentItem.new(
@@ -111,38 +109,6 @@ describe Search::QueryBuilder do
       end
     end
 
-    context "facets with or combine_mode" do
-      before do
-        facets.first["filterable"] = true
-        facets.first["type"] = "text"
-
-        facets.second["filterable"] = true
-        facets.second["type"] = "text"
-        facets.second["combine_mode"] = "or"
-      end
-
-      let(:params) do
-        {
-          "alpha" => "test",
-          "beta" => "test",
-        }
-      end
-
-      it "generates two queries" do
-        expect(queries.count).to eq(2)
-      end
-
-      it "filters on just alpha in the first query" do
-        expect(queries.first["filter_alpha"]).to eq(%w[test])
-        expect(queries.first["filter_beta"]).to be_nil
-      end
-
-      it "filters on both alpha and beta in the second query" do
-        expect(queries.second["filter_alpha"]).to be_nil
-        expect(queries.second["filter_beta"]).to eq(%w[test])
-      end
-    end
-
     context "of 'content_id' type" do
       let(:allowed_values) do
         [
@@ -177,21 +143,8 @@ describe Search::QueryBuilder do
         facets.second["allowed_values"] = intellectual_property_allowed_values
       end
 
-      context "with `and` combine_mode" do
-        it "adds a `filter_facet_values` filter with the content_id" do
-          expect(query["filter_any_facet_values"]).to eq(%w[yes-cont-id copyright-cont-id patents-cont-id])
-        end
-      end
-
-      context "with `or` combine_mode" do
-        before do
-          facets.second["combine_mode"] = "or"
-        end
-
-        it "sends the correct `filter_any_facet_values` to each query" do
-          expect(queries.first["filter_any_facet_values"]).to eq(%w[yes-cont-id])
-          expect(queries.second["filter_any_facet_values"]).to eq(%w[copyright-cont-id patents-cont-id])
-        end
+      it "adds a `filter_facet_values` filter with the content_id" do
+        expect(query["filter_any_facet_values"]).to eq(%w[yes-cont-id copyright-cont-id patents-cont-id])
       end
     end
   end
@@ -373,7 +326,7 @@ describe Search::QueryBuilder do
         query = described_class.new(
           finder_content_item:,
           params:,
-        ).call.first
+        ).call
 
         expect(query).to include("q" => "mango")
         expect(query).not_to include("q" => "mango licence")
@@ -387,7 +340,7 @@ describe Search::QueryBuilder do
         query = described_class.new(
           finder_content_item:,
           params:,
-        ).call.first
+        ).call
 
         expect(query).to include("q" => "mango")
         expect(query).not_to include("q" => "certification, mango license?")
@@ -401,7 +354,7 @@ describe Search::QueryBuilder do
         query = described_class.new(
           finder_content_item:,
           params:,
-        ).call.first
+        ).call
 
         expect(query).to include("q" => "mango")
         expect(query).not_to include("q" => "PERMIT mango")
@@ -415,7 +368,7 @@ describe Search::QueryBuilder do
         query = described_class.new(
           finder_content_item:,
           params:,
-        ).call.first
+        ).call
 
         expect(query).to include("q" => "50")
       end
@@ -499,7 +452,7 @@ describe Search::QueryBuilder do
       query = described_class.new(
         finder_content_item:,
         ab_params:,
-      ).call.first
+      ).call
 
       expect(query).to include("ab_tests" => "test_one:a,test_two:b")
     end
@@ -560,7 +513,7 @@ describe Search::QueryBuilder do
       described_class.new(
         finder_content_item:,
         params:,
-      ).call.first
+      ).call
     end
   end
 end


### PR DESCRIPTION
The `#batch_search` endpoint is not being used, and we're in the process of removing as part of tidying up unused code. Removing from finder-frontend first, and there is a [companion PR to remove from gds-api-adapters](https://github.com/alphagov/gds-api-adapters/pull/1381).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://finder-frontend-pr-3981.herokuapp.com/search/all
- https://finder-frontend-pr-3981.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-3981.herokuapp.com/drug-device-alerts
