### PR TITLE
Stop i_am_a_topic_page_finder returning true given a nil topic

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -221,6 +221,8 @@ private
   end
 
   def i_am_a_topic_page_finder
+    return false unless params[:topic]
+
     @i_am_a_topic_page_finder ||= taxonomy_registry.taxonomy.key? params[:topic]
   end
 


### PR DESCRIPTION
## What / Why
- `full_width` rendering is determined in `finder_frontend` by `params[:topic]` existing as a key in the `taxonomy_registry.taxonomy` array
- However in draft environments, `taxonomy_registry.taxonomy` has `nil` as a key in the array
- Therefore pages that have a `nil` `params[:topic]` are rendering as full width in draft, as `nil` is a valid key inside of `taxonomy_registry.taxonomy`
- This PR adds a guard around the code to stop this. I wasn't sure where to add a test for this, and I assume it could also be fixed by ensuring `taxonomy_registry.taxonomy` never contains `nil` instead
- You can see it working on https://draft-origin.integration.publishing.service.gov.uk/search/all?order=updated-newest&topical_events%5B%5D=topical-event-header-and-logo
- You can see it broken on production https://draft-origin.publishing.service.gov.uk/search/all?order=updated-newest&topical_events%5B%5D=topical-event-header-and-logo
