### PR TITLE
[PNP-9914] Pin Dalli to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rails", "8.1.3"
 gem "bootsnap", require: false
 gem "chronic"
 gem "connection_pool", "< 3" # Do not bump via Dependabot - https://github.com/alphagov/finder-frontend/pull/3921
-gem "dalli"
+gem "dalli", "~> 4"
 gem "dartsass-rails"
 gem "gds-api-adapters"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
       cucumber (>= 7, < 11)
       railties (>= 6.1, < 9)
     cucumber-tag-expressions (8.1.0)
-    dalli (5.0.2)
+    dalli (4.3.3)
       logger
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
@@ -691,7 +691,7 @@ DEPENDENCIES
   climate_control
   connection_pool (< 3)
   cucumber-rails
-  dalli
+  dalli (~> 4)
   dartsass-rails
   dotenv-rails
   factory_bot


### PR DESCRIPTION
The 4.3.1 -> 5.0 update silently broke caching on frontend apps. Pin to 4.x (in this case 4.3.3, the latest 4.x version) to fix.

JIRA Card: https://gov-uk.atlassian.net/browse/PNP-9914

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
