### PR TITLE
Log common cache-control header options

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if ENV["GOVUK_RAILS_JSON_LOGGING"].present?
+  GovukJsonLogging.configure do
+    add_custom_fields do |fields|
+      fields[:cache_max_age] = response.cache_control["max-age"]
+      fields[:cache_public] = response.cache_control["public"]
+    end
+  end
+end


### PR DESCRIPTION
It would useful to be able to examine these header responses so that:

- we're efficiently serving content
- we have a means of auditing `private` responses (less required in this app, but more in other frontend apps)

If these values are missing, accessing the hash value results in nil.

It _might_ be better to just log the whole cache-control header, but I value the easier filtering of having separate fields at the moment.

I'm following the [example set in content-store](https://github.com/alphagov/content-store/blob/main/config/initializers/logstasher.rb)

I decided to not add tests for this. As it's configured at boot time, major problems will be spotted then. Trying to test this in code seems to result in stubbing a bunch of stuff and ending up with something performative rather than useful. Happy to discuss if you'd rather a different approach.

## Some search page examples to sense check:
- https://finder-frontend-pr-4053.herokuapp.com/search/all
- https://finder-frontend-pr-4053.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-4053.herokuapp.com/drug-device-alerts
