### PR TITLE
Sch 2050 update documentation for new vertex name

### DIFF
--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -77,17 +77,17 @@ module Search
       return false if ActiveModel::Type::Boolean.new.cast(ENV["FORCE_USE_V1_SEARCH_API"])
 
       # Use v1 in scenarios where v2 is not (yet) able to give us good results
-      # These scenarios should be reviewed as we continue our migration work and Vertex AI Search
-      # evolves.
+      # These scenarios should be reviewed as we continue our migration work and Google Cloud
+      # Discovery Engine evolves.
       ## Whitehall directly indexes slugs for world locations into v1, which we don't have access
       ## to in v2, breaking world location facets.
       return false if filter_params["world_locations"].present?
-      ## Vertex AI Search is not designed to handle non-keyword queries well, and there are cost
+      ## Discovery Engine is not designed to handle non-keyword queries well, and there are cost
       ## implications as well when it comes to bot traffic.
       return false if filter_params["keywords"].blank?
 
-      ## Feeds with keywords are sorted newest to oldest, so the relevance benefits of Vertex are
-      ## not realised.
+      ## Feeds with keywords are sorted newest to oldest, so the relevance benefits of Discovery
+      ## Engine are not realised.
       return false if @is_for_feed
 
       # Use v2 iff the current finder is site search (the only migrated finder so far)

--- a/docs/how-search-works.md
+++ b/docs/how-search-works.md
@@ -73,7 +73,7 @@ Search content items are published by Search API and Specialist Publisher.
 
 As described in [GOV.UK Search: how it works](https://docs.publishing.service.gov.uk/manual/govuk-search.html), there are two search applications with differing responsibilities:
 
-- [Search API v2](https://github.com/alphagov/search-api-v2) which powers site search, refered to as the `all_content_finder` in this application.
+- [Search API v2](https://github.com/alphagov/search-api-v2) which powers site search, referred to as the `all_content_finder` in this application.
 - [Search API](https://github.com/alphagov/search-api) which powers all of the other finders on gov.uk
 
 The query we make for search results is performed by [`Search::Query`](app/lib/search/query.rb). Logic within this class decides which API to contact. The default behaviour is for all requests from the all_content finder to be sent to SearchAPI v2 with the following exceptions when the request will fall back to SearchAPI instead:

--- a/docs/search-apis.md
+++ b/docs/search-apis.md
@@ -11,7 +11,7 @@ precedence over any other logic. These are useful for comparing results and debu
 
 ## Using v1 as a backup in case of v2 issues
 In the event of a major issue with `search-api-v2` or its underlying SaaS search product (Google
-Vertex AI Search), a feature flag `FORCE_USE_V1_SEARCH_API` is available and will force all search
+Cloud Discovery Engine), a feature flag `FORCE_USE_V1_SEARCH_API` is available and will force all search
 traffic to use the v1 API.
 
 The v1 API provides pure keyword search and lacks the "smart" semantic search of v2, leading to


### PR DESCRIPTION
Google have rebranded Vertex AI Search to "Agent Search". Here we are changing our documentation to use "Discovery Engine", which is the more stable API name, to avoid future re-namings and because it should be a more familiar name for developers.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2050