### PR TITLE
Remove phase banner from before content and call in layout for public

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.40.0)
+    opentelemetry-semantic_conventions (1.41.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     parallel (1.28.0)

--- a/app/views/finders/_before_content.html.erb
+++ b/app/views/finders/_before_content.html.erb
@@ -1,13 +1,6 @@
 <% content_for :before_content do %>
   <div class="app-before-content<%= " app-before-content--inverse" if is_inverse? %>">
     <div class="<%= 'govuk-width-container' if is_inverse? %>">
-      <% if content_item.show_phase_banner? %>
-        <%= render 'govuk_publishing_components/components/phase_banner', {
-            phase: content_item.phase,
-            message: sanitize(content_item.phase_message)
-        } %>
-      <% end %>
-
       <% if @breadcrumbs.breadcrumbs %>
         <%= render 'govuk_publishing_components/components/breadcrumbs', {
             breadcrumbs: @breadcrumbs.breadcrumbs,

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -1,4 +1,13 @@
-<% title = yield :title %>
+<%
+  title = yield :title
+
+  if @content_item&.show_phase_banner?
+    phase_banner = {
+      phase: @content_item.phase,
+      message: sanitize(@content_item.phase_message)
+    }
+  end
+%>
 
 <%= content_for :head do %>
   <%= javascript_include_tag 'application', integrity: false, type: "module" %>
@@ -15,6 +24,7 @@
     title: safe_join([title, "GOV.UK"], " - "),
     emergency_banner: render("govuk_web_banners/emergency_banner"),
     global_banner: render("govuk_web_banners/global_banner"),
+    phase_banner:
   } do %>
     <div class="<%= class_names("govuk-width-container" => !@full_width) %>">
       <%= yield :before_content %>


### PR DESCRIPTION
## What
See publishing components PR for further context: https://github.com/alphagov/govuk_publishing_components/pull/5481#issue-4564134511

Removed the rendering of the phase banner from the body view architecture and directly feed it into the layout configuration.

## Why
Accompanies the foundational layout changes introduced in the publishing components gem to transition the phase banner into the header element for accessibility compliance.

Jira card: https://gov-uk.atlassian.net/browse/[NAV-18918]

## Visual Changes
Before: The phase banner rendered visually separated below the main header.

After: The phase banner successfully renders inside the header element.

| Before | After |
|--------|--------|
| <img width="999" height="872" alt="Screenshot 2026-06-02 at 10 35 25" src="https://github.com/user-attachments/assets/2a275908-c139-4a9e-9b99-e0acf3526b4b" /> | <img width="983" height="874" alt="Screenshot 2026-06-02 at 10 35 42" src="https://github.com/user-attachments/assets/08461346-c655-4de9-9125-2126e0a5bac0" /> | 
<img width="518" height="284" alt="Screenshot 2026-06-02 at 10 37 54" src="https://github.com/user-attachments/assets/2192d9a6-00f5-41e5-a2c7-13fb24fa77ee" /> | <img width="512" height="177" alt="Screenshot 2026-06-02 at 10 38 48" src="https://github.com/user-attachments/assets/702b7687-7e37-4379-92a2-e30a24a9b082" /> |

[NAV-18918]: https://gov-uk.atlassian.net/browse/NAV-18918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ