### PR TITLE
Support aggregate cookie

### DIFF
--- a/app/assets/javascripts/live_search.js
+++ b/app/assets/javascripts/live_search.js
@@ -125,7 +125,7 @@
     if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4EcommerceTracker) {
       var consentCookie = GOVUK.getConsentCookie()
 
-      if (consentCookie && consentCookie.usage) {
+      if (consentCookie && (consentCookie.usage || consentCookie.aggregate)) {
         if (this.$resultsWrapper) {
           this.$resultsWrapper.setAttribute('data-ga4-search-query', this.currentKeywords())
           var sortedBy = this.$resultsWrapper.querySelector('.js-order-results')
@@ -547,7 +547,7 @@
         if (GOVUK.analyticsGa4 && GOVUK.analyticsGa4.Ga4FinderTracker) {
           var consentCookie = GOVUK.getConsentCookie()
 
-          if (consentCookie && consentCookie.usage) {
+          if (consentCookie && (consentCookie.usage || consentCookie.aggregate)) {
             GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(event, ga4ChangeCategory)
           }
         }

--- a/app/assets/javascripts/modules/all-content-finder.js
+++ b/app/assets/javascripts/modules/all-content-finder.js
@@ -31,7 +31,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     userHasConsentedToAnalytics () {
-      return GOVUK.getConsentCookie() && GOVUK.getConsentCookie().usage
+      var consentCookie = GOVUK.getConsentCookie()
+
+      return consentCookie && (consentCookie.usage || consentCookie.aggregate)
     }
 
     setupTaxonomySelect () {

--- a/spec/javascripts/live_search_spec.js
+++ b/spec/javascripts/live_search_spec.js
@@ -68,11 +68,11 @@ describe('liveSearch', function () {
   }
 
   function agreeToCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true}')
+    GOVUK.setCookie('cookies_policy', '{"essential":true,"settings":true,"usage":true,"campaigns":true,"aggregate":false}')
   }
 
   function denyCookies () {
-    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false}')
+    GOVUK.setCookie('cookies_policy', '{"essential":false,"settings":false,"usage":false,"campaigns":false,"aggregate":false}')
   }
 
   beforeEach(function () {
@@ -737,6 +737,23 @@ describe('liveSearch', function () {
     })
 
     it('calls GA4 finder tracker on form update when data-ga4-change-category exists on the target', function () {
+      var $input = $form.find('input[name="field"]')
+      $input.attr('data-ga4-change-category', 'update-filter checkbox')
+
+      liveSearch.state = []
+
+      liveSearch.formChange({ target: $input[0] })
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        response: '{"total":81,"display_total":"81 reports","facet_tags":"","search_results":"","display_selected_facets_count":"","sort_options_markup":"","next_and_prev_links":"","suggestions":"","errors":{}}'
+      })
+
+      expect(window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent).toHaveBeenCalled()
+    })
+
+    it('calls GA4 finder tracker on form update when data-ga4-change-category exists on the target and aggregate consent has already been given', function () {
+      window.GOVUK.setDefaultConsentCookie()
+
       var $input = $form.find('input[name="field"]')
       $input.attr('data-ga4-change-category', 'update-filter checkbox')
 

--- a/spec/javascripts/modules/all-content-finder.spec.js
+++ b/spec/javascripts/modules/all-content-finder.spec.js
@@ -169,7 +169,7 @@ describe('AllContentFinder module', () => {
 
     describe('when usage tracking is declined', () => {
       beforeEach(() => {
-        GOVUK.setConsentCookie({ usage: false })
+        GOVUK.setConsentCookie({ usage: false, aggregate: false })
         allContentFinder.init()
       })
 
@@ -186,7 +186,26 @@ describe('AllContentFinder module', () => {
 
     describe('when usage tracking is accepted', () => {
       beforeEach(() => {
-        GOVUK.setConsentCookie({ usage: true })
+        GOVUK.setConsentCookie({ usage: true, aggregate: false })
+        allContentFinder.init()
+      })
+
+      it('fires analytics tracking on form element changes through the GA4 finder tracker', () => {
+        const event = new Event('change', { bubbles: true })
+        const input = fixture.querySelector('#foo')
+        input.dispatchEvent(event)
+
+        expect(GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent).toHaveBeenCalledWith(event, 'FooCategory')
+      })
+
+      it('sets up ecommerce tracking', () => {
+        expect(GOVUK.analyticsGa4.Ga4EcommerceTracker.init).toHaveBeenCalled()
+      })
+    })
+
+    describe('when aggregate tracking is accepted', () => {
+      beforeEach(() => {
+        GOVUK.setConsentCookie({ usage: false, aggregate: true })
         allContentFinder.init()
       })
 


### PR DESCRIPTION
## What

Enable tracking in `LiveSearch`  and `AllContentFinder` when aggregate is true

## Why

To support the new aggregate cookie

Jira card: https://gov-uk.atlassian.net/browse/NAV-18724
Blocked by: https://github.com/alphagov/govuk_publishing_components/pull/5389

## Some search page examples to sense check:

- https://finder-frontend-pr-4084.herokuapp.com/search/all
- https://finder-frontend-pr-4084.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-4084.herokuapp.com/drug-device-alerts
