### PR TITLE
Update colours to Design System v6 

### DIFF
--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -6,7 +6,7 @@
 }
 
 .app-c-filter-panel__content {
-  background-color:  govuk-colour("light-grey");
+  background-color:  govuk-colour("black", $variant: "tint-95");
   padding: 0 govuk-spacing(3);
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(1);

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -25,7 +25,7 @@
   display: flex;
   align-items: center;
   color: $govuk-text-colour;
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   @include govuk-font(19);
 
   &:focus {

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -69,7 +69,7 @@
 @include govuk-media-query($until: tablet) {
   .govuk-frontend-supported {
     .facets__box {
-      border-left: 5px solid #b1b4b6;
+      border-left: 5px solid govuk-colour("black", $variant: "tint-80");
       padding-left: govuk-spacing(2);
       padding-bottom: 2px;
       margin-bottom: govuk-spacing(4);

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -242,7 +242,7 @@ mark {
     border: 1px solid transparent;
 
     &:hover {
-      background: govuk-colour("mid-grey");
+      background: govuk-colour("black", $variant: "tint-80");
     }
 
     &:focus {

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -78,7 +78,7 @@ mark {
 
 .published-by {
   display: block;
-  color: govuk-colour("dark-grey");
+  color: govuk-colour("black", $variant: "tint-25");
   @include govuk-font(14);
 }
 
@@ -192,7 +192,7 @@ mark {
   display: table-cell;
   position: relative;
   padding: govuk-em(5, 16px);
-  border: 1px solid govuk-colour("dark-grey");
+  border: 1px solid govuk-colour("black", $variant: "tint-25");
   border-radius: govuk-em(5, 16px);
   background-color: govuk-colour("light-grey");
 

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -150,7 +150,7 @@ mark {
 
   @include govuk-media-query($from: tablet) {
     &:nth-child(odd) {
-      background-color: govuk-colour("light-grey");
+      background-color: govuk-colour("black", $variant: "tint-95");
     }
   }
 }
@@ -194,7 +194,7 @@ mark {
   padding: govuk-em(5, 16px);
   border: 1px solid govuk-colour("black", $variant: "tint-25");
   border-radius: govuk-em(5, 16px);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   .govuk-frontend-supported & {
     padding: govuk-em(8, 16px) govuk-em(8, 16px) govuk-em(8, 16px) govuk-em(24, 16px);


### PR DESCRIPTION
## What
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.

This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

## Why
Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-1892