### PR TITLE
Remove data-ga4-track-links-only references

### DIFF
--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -79,7 +79,6 @@
             <div
               class="govuk-grid-column-one-half govuk-!-text-align-right subscription-links subscription-links--desktop"
               data-module="ga4-link-tracker"
-              data-ga4-track-links-only
               data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Top" }'>
               <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
             </div>
@@ -107,7 +106,6 @@
           class="subscription-links"
           id="subscription-links-footer"
           data-module="ga4-link-tracker"
-          data-ga4-track-links-only
           data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "section": "Footer" }'>
           <%= render "govuk_publishing_components/components/subscription_links", signup_links %>
         </div>


### PR DESCRIPTION
## What / Why
- This attribute was removed from govuk_publishing_components as it wasn't actually needed, so we can remove it from this app.
- JIRA Card: https://gov-uk.atlassian.net/browse/PNP-10043