### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - govuk_*
+        - rubocop-govuk    
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -21,3 +29,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
To add cooldown period for 
- bundler (3 days) with exclusion for alphagov gems that have their own cooldown
-  npm (3 days) 
- docker (7 days)

Ref. https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-10048)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
