### PR TITLE
Update references to Sass variables to use the govuk-functional-colour function

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -1,7 +1,7 @@
 .app-c-expander {
   padding: 0 0 govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
 }
 
 .app-c-expander__title {
@@ -62,7 +62,7 @@
   text-align: left;
   cursor: pointer;
   padding: 0;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   @include govuk-font(19);
 
   &:hover {
@@ -91,7 +91,7 @@
 
 .app-c-expander__selected-counter {
   display: block;
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   margin-top: 3px;
   margin-left: 44px;
   @include govuk-font($size: 14);

--- a/app/assets/stylesheets/components/_filter-panel.scss
+++ b/app/assets/stylesheets/components/_filter-panel.scss
@@ -31,13 +31,13 @@
 
 .app-c-filter-panel__count {
   margin: 0;
-  color: $govuk-secondary-text-colour;
+  color: govuk-functional-colour(secondary-text);
   @include govuk-font(16, $weight: regular);
 }
 
 .app-c-filter-panel__button {
   background-color: transparent;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   text-decoration: none;
   border-style: none;
   padding-left: 0;
@@ -62,7 +62,7 @@
   &:focus,
   &:focus-visible {
     text-decoration: none;
-    background-color: $govuk-focus-colour;
+    background-color: govuk-functional-colour(focus);
     @include govuk-link-hover-decoration;
     @include govuk-focused-text;
 

--- a/app/assets/stylesheets/components/_filter-section.scss
+++ b/app/assets/stylesheets/components/_filter-section.scss
@@ -1,7 +1,7 @@
 @import "mixins/chevron";
 
 .app-c-filter-section {
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
 
   &:last-child {
     border-bottom: 0;
@@ -23,7 +23,7 @@
   align-items: center;
   width: 100%;
   cursor: pointer;
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   list-style: none;
   padding: govuk-spacing(1) 0;
   @include chevron;
@@ -41,7 +41,7 @@
   }
 
   &:focus .app-c-filter-section__summary-heading {
-    background-color: $govuk-focus-colour;
+    background-color: govuk-functional-colour(focus);
     @include govuk-focused-text;
   }
 

--- a/app/assets/stylesheets/components/_filter-summary.scss
+++ b/app/assets/stylesheets/components/_filter-summary.scss
@@ -1,6 +1,6 @@
 .app-c-filter-summary {
   padding-bottom: govuk-spacing(1);
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
 }
 
 .app-c-filter-summary__heading {
@@ -18,27 +18,27 @@
 }
 
 .app-c-filter-summary__remove-filter {
-  border: 1px solid $govuk-border-colour;
+  border: 1px solid govuk-functional-colour(border);
   border-radius: govuk-em(5, 16px);
   padding: govuk-spacing(1) govuk-spacing(2);
   text-decoration: none;
   display: flex;
   align-items: center;
-  color: $govuk-text-colour;
+  color: govuk-functional-colour(text);
   background-color: govuk-colour("black", $variant: "tint-95");
   @include govuk-font(19);
 
   &:focus {
-    background-color: $govuk-focus-colour;
-    outline: 2px $govuk-text-colour solid;
+    background-color: govuk-functional-colour(focus);
+    outline: 2px govuk-functional-colour(text) solid;
     outline-offset: 0;
-    border-color: $govuk-text-colour;
+    border-color: govuk-functional-colour(text);
   }
 
   &:hover {
-    outline: 1px $govuk-text-colour solid;
+    outline: 1px govuk-functional-colour(text) solid;
     outline-offset: 0;
-    border-color: $govuk-text-colour;
+    border-color: govuk-functional-colour(text);
   }
 
   &::before {

--- a/app/assets/stylesheets/components/_mobile-filters.scss
+++ b/app/assets/stylesheets/components/_mobile-filters.scss
@@ -77,7 +77,7 @@
 
     .facets__header {
       padding: 0 0 govuk-spacing(3) 0;
-      border-bottom: 1px solid $govuk-border-colour;
+      border-bottom: 1px solid govuk-functional-colour(border);
       @supports (display: grid) {
         display: grid;
         grid-auto-flow: column;

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -203,7 +203,7 @@ mark {
   @include govuk-media-query($until: tablet) {
     display: inline-block;
     background: none;
-    border: 2px solid $govuk-input-border-colour;
+    border: 2px solid govuk-functional-colour(input-border);
   }
 }
 
@@ -249,7 +249,7 @@ mark {
       -webkit-box-shadow: inset 0 0 0 2px;
       box-shadow: inset 0 0 0 2px;
       border: solid 1px govuk-colour("black");
-      outline: 3px solid $govuk-focus-colour;
+      outline: 3px solid govuk-functional-colour(focus);
     }
   }
 }
@@ -298,7 +298,7 @@ mark {
 .app-c-button-as-link {
   padding: 0;
   border-width: 0;
-  color: $govuk-link-colour;
+  color: govuk-functional-colour(link);
   background: none;
   cursor: pointer;
   -webkit-appearance: none;


### PR DESCRIPTION
## What

Replace colour variables with govuk-functional-colour function

## Why

The Sass variables for accessing functional colours are deprecated, and will be removed in a future breaking release of govuk-frontend

Jira card: https://gov-uk.atlassian.net/browse/NAV-18923
