### PR TITLE
Stop using size 14 from the type scale

### DIFF
--- a/app/assets/stylesheets/components/_expander.scss
+++ b/app/assets/stylesheets/components/_expander.scss
@@ -94,5 +94,5 @@
   color: $govuk-text-colour;
   margin-top: 3px;
   margin-left: 44px;
-  @include govuk-font($size: 14);
+  @include govuk-font($size: 16);
 }

--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -79,7 +79,7 @@ mark {
 .published-by {
   display: block;
   color: govuk-colour("dark-grey");
-  @include govuk-font(14);
+  @include govuk-font(16);
 }
 
 .debug-results {


### PR DESCRIPTION
## What
We are replacing all instances of 14px typography across GOV.UK Publishing Components and frontend apps. This involves removing or updating Sass mixins passing $size: 14, eliminating utility classes like govuk-body-xs and govuk-!-font-size-14, and clearing out any raw 14px/rem equivalents.

## Why
Size 14 is being officially removed from the type scale. We want to update these references to an approved font size to avoid Sass triggering a compilation error and fail to build.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18915

## Visual Changes

[’First published' in search results](https://www.gov.uk/search/all?keywords=hydrogen+peroxide&order=updated-oldest#:~:text=First%20published%20during%20the%201997%20to%202007%20Blair%20Labour%20government)

**Before**
<img width="685" height="581" alt="Screenshot 2026-06-30 at 16 39 25" src="https://github.com/user-attachments/assets/5d53b05a-7151-42aa-868c-5ed3aa68dfed" />

**After**
<img width="865" height="708" alt="Screenshot 2026-06-30 at 16 41 04" src="https://github.com/user-attachments/assets/b7a60662-0675-4783-aa46-f638bc2f8fd5" />

[X selected in ‘Published’ expander](https://www.gov.uk/government/statistical-data-sets?public_timestamp%5Bfrom%5D=21/11/2014&public_timestamp%5Bto%5D=21/11/2014&organisations%5B%5D=academy-for-justice-commissioning&organisations%5B%5D=academy-for-social-justice&organisations%5B%5D=academy-for-social-justice-commissioning&order=updated-newest)

**Before** 
<img width="2054" height="739" alt="Screenshot 2026-06-30 at 16 35 51" src="https://github.com/user-attachments/assets/abbb0b53-b3aa-4102-9e9a-4bfb1009d39b" />

**After**
<img width="2041" height="853" alt="Screenshot 2026-06-30 at 16 36 17" src="https://github.com/user-attachments/assets/ce7f3f63-40fe-45a0-bc7b-18d480b23dad" />


