### PR TITLE
Fix inverse finders

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -346,7 +346,6 @@ mark {
   background-color: $govuk-blue-tint-80;
   // Stretch background colour over inner margins
   overflow: hidden;
-  padding-top: govuk-spacing(3);
 }
 
 .app-all-content-finder__spelling-suggestions {

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -23,6 +23,7 @@
         <%= render 'spelling_suggestion' %>
       </div>
     <% elsif topic_finder?(filter_params) %>
+      <%= render "govuk_web_banners/recruitment_banner" %>
       <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'govuk-link gem-c-inverse-header__link topic-finder__taxon-link' %>
       <%= render "govuk_publishing_components/components/heading", {
         text: content_item.title,

--- a/app/views/layouts/finder_layout.html.erb
+++ b/app/views/layouts/finder_layout.html.erb
@@ -28,7 +28,7 @@
   } do %>
     <div class="<%= class_names("govuk-width-container" => !@full_width) %>">
       <%= yield :before_content %>
-      <%= render "govuk_web_banners/recruitment_banner" %>
+      <%= render "govuk_web_banners/recruitment_banner" if !@full_width %>
 
       <main id="content" class="<%= class_names('govuk-main-wrapper' => !content_for?(:inverse)) %>">
         <div class="finder-frontend">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the layout of finders with an inverse header that include the recruitment banner, on pages like https://www.gov.uk/search/news-and-communications?topic=2687579f-e20c-43cb-af77-f3d002951747

## Why
It was broken, see commit for details.

## Visual changes
Before

<img width="1632" height="979" alt="Screenshot 2026-07-02 at 09 34 39" src="https://github.com/user-attachments/assets/e58d2776-4304-4287-ad3b-9b1e7a63003b" />

After

<img width="1633" height="833" alt="Screenshot 2026-07-02 at 09 34 48" src="https://github.com/user-attachments/assets/195b1c37-0bf3-4128-bb69-6f7eb0be17a8" />

Regular finder for comparison

<img width="1633" height="783" alt="Screenshot 2026-07-02 at 09 34 57" src="https://github.com/user-attachments/assets/bed2c0fa-a2fa-4ba7-9d67-69c22049fbbb" />
