### PR TITLE
Rename rummager

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -2,7 +2,7 @@ class DevelopmentController < ApplicationController
   layout "development_layout"
 
   def index
-    rendered_pages = Services.rummager.search(filter_rendering_app: "finder-frontend", count: 1000, order: "title")["results"]
+    rendered_pages = Services.search_api_v1.search(filter_rendering_app: "finder-frontend", count: 1000, order: "title")["results"]
     @rendered_pages = (rendered_pages + pages_with_inverted_header).sort_by { |hsh| hsh["title"] }
   end
 

--- a/app/lib/filters/checkbox_filter.rb
+++ b/app/lib/filters/checkbox_filter.rb
@@ -4,7 +4,7 @@ module Filters
 
     def value
       # 'params' for a checkbox should be true or false. the value
-      # we send to rummager can be params or a static value provided in
+      # we send to search-api v1 can be params or a static value provided in
       # the finder content item
       @value ||= params.nil? ? nil : facet["filter_value"] || params
     end

--- a/app/lib/filters/taxon_filter.rb
+++ b/app/lib/filters/taxon_filter.rb
@@ -7,7 +7,7 @@ module Filters
         topic = params["level_one_taxon"]
         subtopic = params["level_two_taxon"]
 
-        # we send a conjunctive query to rummager for part_of_taxonomy_tree
+        # we send a conjunctive query to search-api v1 for part_of_taxonomy_tree
         [topic, subtopic]
       end
     end

--- a/app/lib/registries/manuals_registry.rb
+++ b/app/lib/registries/manuals_registry.rb
@@ -28,7 +28,7 @@ module Registries
 
     def manuals_as_hash
       GovukStatsd.time("registries.manuals.request_time") do
-        fetch_manuals_from_rummager
+        fetch_manuals_from_search_api_v1
           .reject { |manual| manual["_id"].empty? || manual["title"].empty? }
           .each_with_object({}) do |manual, manuals|
             manuals[manual["_id"]] = { "title" => manual["title"], "slug" => manual["_id"] }
@@ -36,13 +36,13 @@ module Registries
       end
     end
 
-    def fetch_manuals_from_rummager
+    def fetch_manuals_from_search_api_v1
       params = {
         filter_document_type: %w[hmrc_manual manual service_manual_homepage service_manual_guide],
         fields: %w[title],
         count: 1500,
       }
-      Services.rummager.search(params)["results"]
+      Services.search_api_v1.search(params)["results"]
     end
   end
 end

--- a/app/lib/registries/organisations_registry.rb
+++ b/app/lib/registries/organisations_registry.rb
@@ -28,7 +28,7 @@ module Registries
 
     def organisations_as_hash
       GovukStatsd.time("registries.organisations.request_time") do
-        fetch_organisations_from_rummager
+        fetch_organisations_from_search_api_v1
           .reject { |result| result["slug"].blank? || result["title"].blank? }
           .sort_by { |result| result["title"].sub("Closed organisation: ", "ZZ").upcase }
           .each_with_object({}) do |result, orgs|
@@ -38,14 +38,14 @@ module Registries
       end
     end
 
-    def fetch_organisations_from_rummager
+    def fetch_organisations_from_search_api_v1
       params = {
         filter_format: "organisation",
         fields: %w[title slug acronym content_id],
         count: 1500,
         order: "title",
       }
-      response = Services.rummager.search(params)
+      response = Services.search_api_v1.search(params)
       response["results"]
     end
   end

--- a/app/lib/registries/people_registry.rb
+++ b/app/lib/registries/people_registry.rb
@@ -28,7 +28,7 @@ module Registries
 
     def people_as_hash
       GovukStatsd.time("registries.people.request_time") do
-        people = fetch_people_from_rummager || {}
+        people = fetch_people_from_search_api_v1 || {}
 
         people.reject { |result| result.dig("value", "slug").blank? || result.dig("value", "title").blank? }
           .each_with_object({}) do |result, orgs|
@@ -38,12 +38,12 @@ module Registries
       end
     end
 
-    def fetch_people_from_rummager
+    def fetch_people_from_search_api_v1
       params = {
         facet_people: "1500,examples:0,order:value.title",
         count: 0,
       }
-      Services.rummager.search(params).dig("facets", "people", "options")
+      Services.search_api_v1.search(params).dig("facets", "people", "options")
     end
   end
 end

--- a/app/lib/registries/roles_registry.rb
+++ b/app/lib/registries/roles_registry.rb
@@ -28,7 +28,7 @@ module Registries
 
     def roles_as_hash
       GovukStatsd.time("registries.roles.request_time") do
-        (fetch_roles_from_rummager || {})
+        (fetch_roles_from_search_api_v1 || {})
           .reject { |result| result.dig("value", "slug").blank? || result.dig("value", "title").blank? }
           .each_with_object({}) do |result, roles|
             slug = result["value"]["slug"]
@@ -37,12 +37,12 @@ module Registries
       end
     end
 
-    def fetch_roles_from_rummager
+    def fetch_roles_from_search_api_v1
       params = {
         facet_roles: "1500,examples:0,order:value.title",
         count: 0,
       }
-      Services.rummager.search(params).dig("facets", "roles", "options")
+      Services.search_api_v1.search(params).dig("facets", "roles", "options")
     end
   end
 end

--- a/app/lib/registries/topical_events_registry.rb
+++ b/app/lib/registries/topical_events_registry.rb
@@ -28,7 +28,7 @@ module Registries
 
     def topical_events_as_hash
       GovukStatsd.time("registries.topical_events.request_time") do
-        fetch_topical_events_from_rummager
+        fetch_topical_events_from_search_api_v1
           .reject { |topical_event| topical_event["slug"].empty? || topical_event["title"].empty? }
           .each_with_object({}) do |topical_event, topical_events|
             topical_events[topical_event["slug"]] = { "title" => topical_event["title"], "slug" => topical_event["slug"] }
@@ -36,14 +36,14 @@ module Registries
       end
     end
 
-    def fetch_topical_events_from_rummager
+    def fetch_topical_events_from_search_api_v1
       params = {
         filter_format: "topical_event",
         fields: %w[title slug],
         count: 1500,
         order: "title",
       }
-      Services.rummager.search(params)["results"]
+      Services.search_api_v1.search(params)["results"]
     end
   end
 end

--- a/app/lib/search/facet_query_builder.rb
+++ b/app/lib/search/facet_query_builder.rb
@@ -1,9 +1,9 @@
-# Used by Search::QueryBuilder to build the `facet` part of the Rummager
-# search query. This will determine the "facets" Rummager returns.
+# Used by Search::QueryBuilder to build the `facet` part of search-api v1
+# search query. This will determine the "facets" search-api v1.
 #
-# For more on facetting, see the Rummager docs:
+# For more on facetting, see the search-api docs:
 #
-#   https://github.com/alphagov/rummager/blob/master/docs/search-api.md
+#   https://github.com/alphagov/search-api/blob/master/docs/using-the-search-api.md
 module Search
   class FacetQueryBuilder
     def initialize(facets:)

--- a/app/lib/search/filter_query_builder.rb
+++ b/app/lib/search/filter_query_builder.rb
@@ -1,5 +1,5 @@
-# Used by by Search::QueryBuilder to build the `filter` part of the Rummager
-# search query. This will determine the documents that are returned from rummager.
+# Used by by Search::QueryBuilder to build the `filter` part of the search-api v1
+# search query. This will determine the documents that are returned from search-api v1.
 module Search
   class FilterQueryBuilder
     def initialize(facets:, user_params:)

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -63,7 +63,7 @@ module Search
         Metrics.increment_counter(:searches, api: "v1", finder: content_item.base_path)
 
         Metrics.observe_duration(:search_request_duration, api: "v1") do
-          Services.rummager.search(query).to_hash
+          Services.search_api_v1.search(query).to_hash
         end
       end
     end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -21,7 +21,7 @@ module Services
     end
   end
 
-  def self.rummager
+  def self.search_api_v1
     GdsApi::Search.new(Plek.find("search-api"))
   end
 

--- a/docs/finder-content-item.md
+++ b/docs/finder-content-item.md
@@ -26,7 +26,7 @@ The lowercase singular version of whatever format the Finder is using. For examp
 
 A hash. Optional.
 
-Used to restrict the base search in Rummager. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in Rummager](https://github.com/alphagov/rummager/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16).
+Used to restrict the base search in search-api v1. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in search-api v1](https://github.com/alphagov/search-api/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16).
 
 For example filtering all documents with a `contact` format from HM Revenue & Customs would need a hash like:
 
@@ -43,7 +43,7 @@ For example filtering all documents with a `contact` format from HM Revenue & Cu
 
 A hash. Optional.
 
-Used to restrict the base search in Rummager. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in Rummager](https://github.com/alphagov/rummager/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16). The `_MISSING` value is
+Used to restrict the base search in search_api_v1. It can contain any key and value pair as long as the key is listed in `ALLOWED_FILTER_FIELDS` [in search-api v1](https://github.com/alphagov/search-api/blob/be2ee6927eeab348c0bfc1e2b553c9c138a3ebc8/lib/search_parameter_parser.rb#L16). The `_MISSING` value is
 useful here if you find yourself chaining too many values in filter and running over the max URL length supported by `Net::HTTP`.
 
 For example, rejecting all documents which don't have a policy would need a hash like:
@@ -60,8 +60,8 @@ A string. Optional.
 
 You can use a minus (-) in front of the field to order in descending order (see [search-api/config/finders/case_studies_finder.yml](https://github.com/alphagov/search-api/blob/main/config/finders/case_studies_finder.yml#L21) for an example).
 
-Rummager must allow this field to be sorted on. At the time of writing [this
-was restricted to a couple of fields](https://github.com/alphagov/rummager/blob/ff35f2efb17d145f657cb520bc9892e64b713901/lib/parameter_parser/base_parameter_parser.rb#L10-L17).
+search-api v1 must allow this field to be sorted on. At the time of writing [this
+was restricted to a couple of fields](https://github.com/alphagov/search-api/blob/ff35f2efb17d145f657cb520bc9892e64b713901/lib/parameter_parser/base_parameter_parser.rb#L10-L17).
 
 **Note:** If you include a custom `sort` block in the finder configuration, you must also include `relevance` as one of the available sort options. Finder Frontend requires this option to be present in the DOM, and the page's JavaScript will fail to initialize if it's missing.
 
@@ -69,7 +69,7 @@ was restricted to a couple of fields](https://github.com/alphagov/rummager/blob/
 
 An integer. Optional.
 
-Used to build pagination when querying Rummager.
+Used to build pagination when querying search-api v1.
 
 ## `signup_link`
 
@@ -180,7 +180,7 @@ If `allowed_values` is missing or empty, the values are dynamically generated ba
 
 This is usually better than providing fixed values, because the user is not given options that filter out every document in their search.
 
-This behaviour is closer to what is meant by "facet" in the underlying  [search API](https://github.com/alphagov/rummager/blob/master/docs/search-api.md).
+This behaviour is closer to what is meant by "facet" in the underlying [search-api v1](https://github.com/alphagov/search-api/blob/main/docs/using-the-search-api.md).
 
 The current implementation of dynamic facets always requests the facet from the search api using a particular ordering: `1000,order:value.title`. This means it won't work for all fields.
 
@@ -245,7 +245,7 @@ longer than this due to page-level caching.
 
 A string. Required.
 
-`snake_case` string which matches to the field being searched in Rummager.
+`snake_case` string which matches to the field being searched in search-api v1.
 
 #### `filterable`
 

--- a/features/step_definitions/filtering_steps.rb
+++ b/features/step_definitions/filtering_steps.rb
@@ -238,13 +238,13 @@ end
 Given(/^a finder tagged to the topic taxonomy$/) do
   stub_taxonomy_api_request
   stub_content_store_with_a_taxon_tagged_finder
-  stub_rummager_with_cma_cases
+  stub_search_api_v1_with_cma_cases
 end
 
 Given(/^a collection of documents that can be filtered by dates$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder
-  stub_rummager_with_cma_cases
+  stub_search_api_v1_with_cma_cases
 end
 
 When(/^I use a date filter$/) do
@@ -339,19 +339,19 @@ end
 Given(/^a finder with description exists$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder_with_description
-  stub_rummager_with_cma_cases
+  stub_search_api_v1_with_cma_cases
 end
 
 Given(/^a finder with a no_index property exists$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder_with_no_index
-  stub_rummager_with_cma_cases
+  stub_search_api_v1_with_cma_cases
 end
 
 Given(/^a finder with metadata exists$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder_with_metadata
-  stub_rummager_with_cma_cases
+  stub_search_api_v1_with_cma_cases
 end
 
 When(/^I can see that the finder metadata is present$/) do
@@ -434,7 +434,7 @@ end
 Given(/^a collection of documents exist that can be filtered by checkbox$/) do
   stub_taxonomy_api_request
   stub_content_store_with_cma_cases_finder_for_supergroup_checkbox_filter
-  stub_rummager_with_cma_cases_for_supergroups_checkbox
+  stub_search_api_v1_with_cma_cases_for_supergroups_checkbox
   visit_cma_cases_finder
 end
 
@@ -592,7 +592,7 @@ end
 When(/^I use a checkbox filter and another disallowed filter$/) do
   find("label", text: "Show open cases").click
   fill_in("closed_date[from]", with: "1st November 2015")
-  stub_rummager_with_cma_cases_for_supergroups_checkbox_and_date
+  stub_search_api_v1_with_cma_cases_for_supergroups_checkbox_and_date
   within ".js-live-search-fallback" do
     click_on "Filter results"
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -28,8 +28,8 @@ module DocumentHelper
   end
 
   def stub_search_api_request
-    stub_response(hash_including(rummager_all_documents_params), all_documents_json, including_v2: true)
-    stub_response(rummager_hopscotch_walks_params, hopscotch_reports_json, including_v2: true)
+    stub_response(hash_including(search_api_v1_all_documents_params), all_documents_json, including_v2: true)
+    stub_response(search_api_v1_hopscotch_walks_params, hopscotch_reports_json, including_v2: true)
   end
 
   def stub_keyword_search_api_request(term)
@@ -45,24 +45,24 @@ module DocumentHelper
   end
 
   def stub_search_api_request_with_10_government_results
-    stub_response(rummager_10_documents_params, government_documents_json)
+    stub_response(search_api_v1_10_documents_params, government_documents_json)
   end
 
   def stub_search_api_request_with_bad_data
-    stub_response(rummager_all_documents_params, documents_with_bad_data_json)
+    stub_response(search_api_v1_all_documents_params, documents_with_bad_data_json)
   end
 
   def stub_search_api_request_with_10_government_results_page_2
-    stub_response(rummager_10_documents_page_2_params, government_documents_page_2_json)
+    stub_response(search_api_v1_10_documents_page_2_params, government_documents_page_2_json)
   end
 
   def stub_search_api_request_with_news_and_communication_results
     stub_response(
-      hash_including(rummager_newest_news_and_communications_params),
+      hash_including(search_api_v1_newest_news_and_communications_params),
       newest_news_and_communication_json,
     )
     stub_response(
-      hash_including(rummager_popular_news_and_communications_params),
+      hash_including(search_api_v1_popular_news_and_communications_params),
       popular_news_and_communication_json,
     )
   end
@@ -212,17 +212,17 @@ module DocumentHelper
   end
 
   def stub_search_api_request_with_services_results
-    stub_response(hash_including(rummager_alphabetical_services_params), alpabetical_services_json)
-    stub_response(hash_including(rummager_popular_services_params), popular_services_json)
+    stub_response(hash_including(search_api_v1_alphabetical_services_params), alpabetical_services_json)
+    stub_response(hash_including(search_api_v1_popular_services_params), popular_services_json)
   end
 
   def stub_search_api_request_with_no_results
-    stub_response(rummager_0_documents_params, %({ "results": [], "total": 0, "start": 0}))
+    stub_response(search_api_v1_0_documents_params, %({ "results": [], "total": 0, "start": 0}))
   end
 
   def stub_search_api_request_with_422_response(page_number)
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: rummager_document_other_page_search_params(page_number))
+      .with(query: search_api_v1_document_other_page_search_params(page_number))
       .to_return(status: 422)
   end
 
@@ -348,13 +348,13 @@ module DocumentHelper
     )
   end
 
-  def stub_rummager_with_cma_cases
+  def stub_search_api_v1_with_cma_cases
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: rummager_all_cma_case_documents_params)
+      .with(query: search_api_v1_all_cma_case_documents_params)
       .to_return(body: all_cma_case_documents_json)
 
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: rummager_filtered_cma_case_documents_params)
+      .with(query: search_api_v1_filtered_cma_case_documents_params)
       .to_return(body: filtered_cma_case_documents_json)
   end
 
@@ -412,9 +412,9 @@ module DocumentHelper
     )
   end
 
-  def stub_rummager_with_cma_cases_for_supergroups_checkbox
+  def stub_search_api_v1_with_cma_cases_for_supergroups_checkbox
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: hash_including(rummager_all_cma_case_documents_params))
+      .with(query: hash_including(search_api_v1_all_cma_case_documents_params))
       .to_return(body: all_cma_case_documents_json)
 
     open_cma_case_documents_params =
@@ -428,9 +428,9 @@ module DocumentHelper
       .to_return(body: filtered_cma_case_documents_json)
   end
 
-  def stub_rummager_with_cma_cases_for_supergroups_checkbox_and_date
+  def stub_search_api_v1_with_cma_cases_for_supergroups_checkbox_and_date
     stub_request(:get, SEARCH_ENDPOINT)
-      .with(query: hash_including(rummager_all_cma_case_documents_params))
+      .with(query: hash_including(search_api_v1_all_cma_case_documents_params))
       .to_return(body: all_cma_case_documents_json)
 
     open_cma_case_documents_params = cma_case_search_params.merge(
@@ -444,25 +444,25 @@ module DocumentHelper
       .to_return(body: filtered_cma_case_documents_json)
   end
 
-  def rummager_all_documents_params
+  def search_api_v1_all_documents_params
     mosw_search_params.merge("order" => "-public_timestamp")
   end
 
-  def rummager_0_documents_params
+  def search_api_v1_0_documents_params
     mosw_search_params_no_facets.merge(
       "order" => "-public_timestamp",
       "count" => 1500,
     )
   end
 
-  def rummager_10_documents_params
+  def search_api_v1_10_documents_params
     mosw_search_params.merge(
       "order" => "-public_timestamp",
       "count" => 10,
     )
   end
 
-  def rummager_10_documents_page_2_params
+  def search_api_v1_10_documents_page_2_params
     mosw_search_params.merge(
       "order" => "-public_timestamp",
       "count" => 10,
@@ -470,42 +470,42 @@ module DocumentHelper
     )
   end
 
-  def rummager_hopscotch_walks_params
+  def search_api_v1_hopscotch_walks_params
     mosw_search_params.merge(
       "filter_walk_type" => %w[hopscotch],
       "order" => "-public_timestamp",
     )
   end
 
-  def rummager_newest_news_and_communications_params
+  def search_api_v1_newest_news_and_communications_params
     news_and_communications_search_params.merge(
       "order" => "-public_timestamp",
       "count" => "20",
     )
   end
 
-  def rummager_popular_news_and_communications_params
+  def search_api_v1_popular_news_and_communications_params
     news_and_communications_search_params.merge(
       "order" => "-popularity",
       "count" => "20",
     )
   end
 
-  def rummager_popular_services_params
+  def search_api_v1_popular_services_params
     services_search_params.merge(
       "order" => "-popularity",
       "count" => "20",
     )
   end
 
-  def rummager_alphabetical_services_params
+  def search_api_v1_alphabetical_services_params
     services_search_params.merge(
       "order" => "title",
       "count" => "20",
     )
   end
 
-  def rummager_document_other_page_search_params(page_number)
+  def search_api_v1_document_other_page_search_params(page_number)
     count_per_page = 10
 
     mosw_search_params.merge(
@@ -515,11 +515,11 @@ module DocumentHelper
     )
   end
 
-  def rummager_all_cma_case_documents_params
+  def search_api_v1_all_cma_case_documents_params
     cma_case_search_params.merge("order" => "-public_timestamp")
   end
 
-  def rummager_filtered_cma_case_documents_params
+  def search_api_v1_filtered_cma_case_documents_params
     cma_case_search_params.merge(
       "filter_closed_date" => "from:2015-11-01",
       "order" => "-public_timestamp",

--- a/features/support/search_api_v1_url_helper.rb
+++ b/features/support/search_api_v1_url_helper.rb
@@ -1,5 +1,5 @@
-module RummagerUrlHelper
-  def rummager_url(params)
+module SearchApiV1UrlHelper
+  def search_api_v1_url(params)
     "#{Plek.find('search-api')}/search.json?#{params.to_query}"
   end
 
@@ -96,4 +96,4 @@ module RummagerUrlHelper
   end
 end
 
-World(RummagerUrlHelper)
+World(SearchApiV1UrlHelper)

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -119,7 +119,7 @@ describe FindersController, type: :controller do
         it "initializes a filterable facet with the param field value" do
           stub_content_store_has_item(lunch_finder["base_path"], lunch_finder)
 
-          rummager_response = %({
+          search_api_v1_response = %({
           "results": [],
           "total": 0,
           "start": 0,
@@ -139,7 +139,7 @@ describe FindersController, type: :controller do
                 suggest: "spelling_with_highlighting",
               },
             )
-            .to_return(status: 200, body: rummager_response, headers: {})
+            .to_return(status: 200, body: search_api_v1_response, headers: {})
 
           expect(OptionSelectFacet).to receive(:new).with(
             {
@@ -184,7 +184,7 @@ describe FindersController, type: :controller do
           lunch_finder.merge("details" => lunch_finder["details"].merge("sort" => sort_options)),
         )
 
-        rummager_response = %({
+        search_api_v1_response = %({
           "results": [],
           "total": 0,
           "start": 0,
@@ -203,7 +203,7 @@ describe FindersController, type: :controller do
               suggest: "spelling_with_highlighting",
             },
           )
-          .to_return(status: 200, body: rummager_response, headers: {})
+          .to_return(status: 200, body: search_api_v1_response, headers: {})
 
         get :show, params: { format: :atom, slug: "lunch-finder" }
         expect(stub).to have_been_requested
@@ -216,7 +216,7 @@ describe FindersController, type: :controller do
         stub_content_store_has_item("/lunch-finder", lunch_finder)
 
         stub_request(:get, /\A#{Plek.find('search-api')}\/search.json/)
-          .to_return(status: 200, body: rummager_response, headers: {})
+          .to_return(status: 200, body: search_api_v1_response, headers: {})
 
         get :show, params: { slug: "lunch-finder", keywords: "<script>alert(0)</script>" }
         expect(response.body).to include("&lt;script&gt;alert(0)&lt;/script&gt;")
@@ -417,14 +417,14 @@ describe FindersController, type: :controller do
 
     before do
       stub_content_store_has_item(breakfast_finder["base_path"], breakfast_finder)
-      rummager_response = %({
+      search_api_v1_response = %({
         "results": [],
         "total": 0,
         "start": 0,
         "facets": {},
         "suggested_queries": [{ "text": "cereal", "highlighted": "<mark>cereal</mark>" }]
       })
-      stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
+      stub_request(:get, /search.json/).to_return(status: 200, body: search_api_v1_response, headers: {})
     end
 
     it "Gives the spelling suggestion and links to it" do
@@ -442,7 +442,7 @@ describe FindersController, type: :controller do
       stub_content_store_has_item("/search/all", all_content_finder)
     end
 
-    rummager_response = %({
+    search_api_v1_response = %({
       "results": [],
       "total": 0,
       "start": 0,
@@ -451,7 +451,7 @@ describe FindersController, type: :controller do
     })
 
     it "detects bad 'from' dates" do
-      stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
+      stub_request(:get, /search.json/).to_return(status: 200, body: search_api_v1_response, headers: {})
 
       get :show, params: { slug: "search/all", format: "json", public_timestamp: { from: "99-99-99", to: "01-01-01" } }
       json_response = JSON.parse(response.body)
@@ -461,7 +461,7 @@ describe FindersController, type: :controller do
     end
 
     it "detects bad 'to' dates" do
-      stub_request(:get, /search.json/).to_return(status: 200, body: rummager_response, headers: {})
+      stub_request(:get, /search.json/).to_return(status: 200, body: search_api_v1_response, headers: {})
 
       get :show, params: { slug: "search/all", format: "json", public_timestamp: { from: "01-01-01", to: "99-99-99" } }
 
@@ -649,15 +649,15 @@ describe FindersController, type: :controller do
   end
 
   def search_response(discovery_engine_attribution_token: nil)
-    return rummager_response if discovery_engine_attribution_token.blank?
+    return search_api_v1_response if discovery_engine_attribution_token.blank?
 
     JSON.generate(
-      JSON.parse(rummager_response)
+      JSON.parse(search_api_v1_response)
           .merge!("discovery_engine_attribution_token" => discovery_engine_attribution_token),
     )
   end
 
-  def rummager_response
+  def search_api_v1_response
     %({
       "results": [],
       "total": 11,

--- a/spec/lib/facets_builder_spec.rb
+++ b/spec/lib/facets_builder_spec.rb
@@ -252,13 +252,13 @@ describe FacetsBuilder do
     let(:search_results) do
       {}
     end
-    let(:rummager_params) do
+    let(:search_api_v1_params) do
       {
         count: 0,
         facet_people: "1500,examples:0,order:value.title",
       }
     end
-    let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
+    let(:search_api_v1_url) { "#{Plek.find('search-api')}/search.json?#{search_api_v1_params.to_query}" }
 
     let(:detail_hash) do
       {
@@ -286,7 +286,7 @@ describe FacetsBuilder do
       end
 
       it "gets values from the registry" do
-        stub_request(:get, rummager_url).to_return(body: people_search_api_results.to_json)
+        stub_request(:get, search_api_v1_url).to_return(body: people_search_api_results.to_json)
         expect(facet.allowed_values).to eq([{ "label" => "Cornelius Fudge", "value" => "cornelius-fudge" }, { "label" => "Rufus Scrimgeour", "value" => "rufus-scrimgeour" }])
       end
     end

--- a/spec/lib/registries/manuals_registry_spec.rb
+++ b/spec/lib/registries/manuals_registry_spec.rb
@@ -2,18 +2,18 @@ require "spec_helper"
 
 RSpec.describe Registries::ManualsRegistry do
   let(:slug) { "/guidance/care-and-use-of-a-nimbus-2000" }
-  let(:rummager_params) do
+  let(:search_api_v1_params) do
     {
       filter_document_type: %w[hmrc_manual manual service_manual_homepage service_manual_guide],
       fields: %w[title],
       count: 1500,
     }
   end
-  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
+  let(:search_api_v1_url) { "#{Plek.find('search-api')}/search.json?#{search_api_v1_params.to_query}" }
 
-  describe "when rummager is available" do
+  describe "when search_api_v1 is available" do
     before do
-      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      stub_request(:get, search_api_v1_url).to_return(body: search_api_v1_results)
       clear_cache
     end
 
@@ -33,13 +33,13 @@ RSpec.describe Registries::ManualsRegistry do
 
     it "fetches the correct types of document" do
       described_class.new[slug]
-      assert_requested :get, rummager_url
+      assert_requested :get, search_api_v1_url
     end
   end
 
   describe "there is no id or title" do
     it "removes those results" do
-      stub_request(:get, rummager_url).to_return(
+      stub_request(:get, search_api_v1_url).to_return(
         body: {
           "results": [
             {
@@ -57,9 +57,9 @@ RSpec.describe Registries::ManualsRegistry do
     end
   end
 
-  describe "when rummager is unavailable" do
+  describe "when search_api_v1 is unavailable" do
     before do
-      rummager_is_unavailable
+      search_api_v1_is_unavailable
       clear_cache
     end
 
@@ -70,15 +70,15 @@ RSpec.describe Registries::ManualsRegistry do
     end
   end
 
-  def rummager_is_unavailable
-    stub_request(:get, rummager_url).to_return(status: 500)
+  def search_api_v1_is_unavailable
+    stub_request(:get, search_api_v1_url).to_return(status: 500)
   end
 
   def clear_cache
     Rails.cache.delete(described_class.new.cache_key)
   end
 
-  def rummager_results
+  def search_api_v1_results
     %({
       "results": [
         {

--- a/spec/lib/registries/organisations_registry_spec.rb
+++ b/spec/lib/registries/organisations_registry_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Registries::OrganisationsRegistry do
   include RegistrySpecHelper
 
   let(:slug) { "ministry-of-magic" }
-  let(:rummager_params) do
+  let(:search_api_v1_params) do
     {
       "count" => 1500,
       "fields" => %w[slug title acronym content_id],
@@ -12,9 +12,9 @@ RSpec.describe Registries::OrganisationsRegistry do
       "order" => "title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
+  let(:search_api_v1_url) { "#{Plek.find('search-api')}/search.json?#{search_api_v1_params.to_query}" }
 
-  describe "when rummager is available" do
+  describe "when search_api_v1 is available" do
     before do
       stub_organisations_registry_request
       clear_cache
@@ -38,9 +38,9 @@ RSpec.describe Registries::OrganisationsRegistry do
     end
   end
 
-  describe "when rummager is unavailable" do
+  describe "when search_api_v1 is unavailable" do
     before do
-      rummager_is_unavailable
+      search_api_v1_is_unavailable
       clear_cache
     end
 
@@ -51,8 +51,8 @@ RSpec.describe Registries::OrganisationsRegistry do
     end
   end
 
-  def rummager_is_unavailable
-    stub_request(:get, rummager_url).to_return(status: 500)
+  def search_api_v1_is_unavailable
+    stub_request(:get, search_api_v1_url).to_return(status: 500)
   end
 
   def clear_cache

--- a/spec/lib/registries/people_registry_spec.rb
+++ b/spec/lib/registries/people_registry_spec.rb
@@ -2,17 +2,17 @@ require "spec_helper"
 
 RSpec.describe Registries::PeopleRegistry do
   let(:slug) { "cornelius-fudge" }
-  let(:rummager_params) do
+  let(:search_api_v1_params) do
     {
       count: 0,
       facet_people: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
+  let(:search_api_v1_url) { "#{Plek.find('search-api')}/search.json?#{search_api_v1_params.to_query}" }
 
-  describe "when rummager is available" do
+  describe "when search_api_v1 is available" do
     before do
-      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      stub_request(:get, search_api_v1_url).to_return(body: search_api_v1_results)
       clear_cache
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Registries::PeopleRegistry do
 
   describe "there is no slug or title" do
     it "removes those results" do
-      stub_request(:get, rummager_url).to_return(
+      stub_request(:get, search_api_v1_url).to_return(
         body: {
           "facets": {
             "people": {
@@ -48,9 +48,9 @@ RSpec.describe Registries::PeopleRegistry do
     end
   end
 
-  describe "when rummager is unavailable" do
+  describe "when search_api_v1 is unavailable" do
     before do
-      rummager_is_unavailable
+      search_api_v1_is_unavailable
       clear_cache
     end
 
@@ -61,15 +61,15 @@ RSpec.describe Registries::PeopleRegistry do
     end
   end
 
-  def rummager_is_unavailable
-    stub_request(:get, rummager_url).to_return(status: 500)
+  def search_api_v1_is_unavailable
+    stub_request(:get, search_api_v1_url).to_return(status: 500)
   end
 
   def clear_cache
     Rails.cache.delete(described_class.new.cache_key)
   end
 
-  def rummager_results
+  def search_api_v1_results
     %({
       "results": [],
       "total": 394075,

--- a/spec/lib/registries/roles_registry_spec.rb
+++ b/spec/lib/registries/roles_registry_spec.rb
@@ -2,17 +2,17 @@ require "spec_helper"
 
 RSpec.describe Registries::RolesRegistry do
   let(:slug) { "prime-minister" }
-  let(:rummager_params) do
+  let(:search_api_v1_params) do
     {
       count: 0,
       facet_roles: "1500,examples:0,order:value.title",
     }
   end
-  let(:rummager_url) { "#{Plek.find('search-api')}/search.json?#{rummager_params.to_query}" }
+  let(:search_api_v1_url) { "#{Plek.find('search-api')}/search.json?#{search_api_v1_params.to_query}" }
 
-  describe "when rummager is available" do
+  describe "when search_api_v1 is available" do
     before do
-      stub_request(:get, rummager_url).to_return(body: rummager_results)
+      stub_request(:get, search_api_v1_url).to_return(body: search_api_v1_results)
       clear_cache
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Registries::RolesRegistry do
 
   describe "there is no slug or title" do
     it "removes those results" do
-      stub_request(:get, rummager_url).to_return(
+      stub_request(:get, search_api_v1_url).to_return(
         body: {
           "facets": {
             "roles": {
@@ -48,9 +48,9 @@ RSpec.describe Registries::RolesRegistry do
     end
   end
 
-  describe "when rummager is unavailable" do
+  describe "when search_api_v1 is unavailable" do
     before do
-      rummager_is_unavailable
+      search_api_v1_is_unavailable
       clear_cache
     end
 
@@ -61,15 +61,15 @@ RSpec.describe Registries::RolesRegistry do
     end
   end
 
-  def rummager_is_unavailable
-    stub_request(:get, rummager_url).to_return(status: 500)
+  def search_api_v1_is_unavailable
+    stub_request(:get, search_api_v1_url).to_return(status: 500)
   end
 
   def clear_cache
     Rails.cache.delete(described_class.new.cache_key)
   end
 
-  def rummager_results
+  def search_api_v1_results
     %({
       "results": [],
       "total": 394075,

--- a/spec/presenters/subscriber_list_params_presenter_spec.rb
+++ b/spec/presenters/subscriber_list_params_presenter_spec.rb
@@ -74,14 +74,14 @@ RSpec.describe SubscriberListParamsPresenter do
           {
             "facet_id" => "some_arbitrary_facet_id",
             "facet_name" => "some_arbitrary_facet_name",
-            "filter_key" => "a_filter_key_rummager_can_filter_by",
+            "filter_key" => "a_filter_key_search_api_v1_can_filter_by",
           },
         ]
       end
 
       params = { "some_arbitrary_facet_id" => "some-taxon" }
       presenter = described_class.new(signup_finder_content_item, params)
-      expect(presenter.subscriber_list_params).to eql("a_filter_key_rummager_can_filter_by" => %w[some-taxon])
+      expect(presenter.subscriber_list_params).to eql("a_filter_key_search_api_v1_can_filter_by" => %w[some-taxon])
     end
 
     it "translates option_lookup values into a filter key if they are present" do


### PR DESCRIPTION
Replace all references to Rummager with references to search-api v1 (we explicitly call out v1 here to distinguish from v2, even though search api v1's official name is search-api. If necessary this can easily be bulk replaced later, but it would be difficult to bulk replace search_api to search_api_v1). Rummager was retired 7 years ago now, we shouldn't still have references to it in code.

If merged, fixes https://github.com/alphagov/finder-frontend/issues/4097

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://finder-frontend-pr-4100.herokuapp.com/search/all
- https://finder-frontend-pr-4100.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-4100.herokuapp.com/drug-device-alerts
