### PR TITLE
Change breadcrumbs on collections finders

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -289,12 +289,6 @@ mark {
   box-sizing: border-box;
 }
 
-.topic-finder__taxon-link,
-.topic-finder__taxon-link:link,
-.topic-finder__taxon-link:visited {
-  @include govuk-font(24, $weight: bold);
-}
-
 .app-c-button-as-link {
   padding: 0;
   border-width: 0;

--- a/app/views/finders/_before_content.html.erb
+++ b/app/views/finders/_before_content.html.erb
@@ -6,6 +6,15 @@
             breadcrumbs: @breadcrumbs.breadcrumbs,
             collapse_on_mobile: true
         } %>
+      <% elsif topic_finder_parent(filter_params) && topic_finder_parent(filter_params)['title'] %>
+        <%
+          crumbs = [{ title: "Home", url: "/" }]
+          crumbs << { title: topic_finder_parent(filter_params)['title'], url: topic_finder_parent(filter_params)['base_path'] }
+        %>
+        <%= render 'govuk_publishing_components/components/breadcrumbs', {
+          breadcrumbs: crumbs,
+          collapse_on_mobile: true
+        } %>
       <% else %>
         <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', {
             content_item: content_item.as_hash

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -24,9 +24,10 @@
       </div>
     <% elsif topic_finder?(filter_params) %>
       <%= render "govuk_web_banners/recruitment_banner" %>
-      <%= link_to topic_finder_parent(filter_params)['title'], topic_finder_parent(filter_params)['base_path'], class: 'govuk-link gem-c-inverse-header__link topic-finder__taxon-link' %>
+
       <%= render "govuk_publishing_components/components/heading", {
         text: content_item.title,
+        context: topic_finder_parent(filter_params)['title'],
         heading_level: 1,
         font_size: "xl",
         margin_bottom: 8,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- change collections finders so that the name and link to the collection is moved into the breadcrumbs, instead of directly above the heading as a link
- add the name of the collection as the context in the heading component, to restore the emphasis on where the user is

## Why
The existing pattern isn't a usual thing across GOV.UK - it seems more consistent with other pages that this link to the 'parent' page is part of the breadcrumbs.

## Visual changes

Before

<img width="1089" height="419" alt="Screenshot 2026-07-02 at 14 59 51" src="https://github.com/user-attachments/assets/cd232f47-978c-450a-aa5d-2e915a7dc85e" />

After

<img width="1079" height="425" alt="Screenshot 2026-07-02 at 14 59 58" src="https://github.com/user-attachments/assets/d50402d0-521d-4b67-a1b9-cb7a94a3447b" />
