### PR TITLE
Add vs debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "debug"
   gem "dotenv-rails"
   gem "govuk_schemas"
   gem "govuk_test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
     date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
     docile (1.4.0)
@@ -699,6 +702,7 @@ DEPENDENCIES
   cucumber-rails
   dalli (~> 4)
   dartsass-rails
+  debug
   dotenv-rails
   factory_bot
   gds-api-adapters

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ bundle exec cucumber
 bundle exec rake jasmine:ci
 ```
 
+### Debugging support
+
+See [Debugging](docs/debugging-in-vs-code.md)
+
 ### Further documentation
 
 See the [`docs/`](docs/) directory for manuals and instructions.

--- a/config/initializers/debug.rb
+++ b/config/initializers/debug.rb
@@ -1,0 +1,6 @@
+if Rails.env.development? && ENV["DEBUGGER"] == "true"
+  require "debug/session"
+  Rails.logger.info "Starting debug session"
+  # the port can be anything
+  DEBUGGER__.open(port: "12345", host: "0.0.0.0")
+end

--- a/docs/debugging-in-vs-code.md
+++ b/docs/debugging-in-vs-code.md
@@ -1,0 +1,25 @@
+# Debugging in VS Code
+
+If you want to debug within VS Code, you'll need the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension, and once that's installed, create a configuration file for it at `.vscode/launch.json` containing the following values
+
+```
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "rdbg",
+      "name": "Attach with rdbg",
+      "request": "attach",
+      "debugPort": "finder-frontend.dev.gov.uk:12347",
+      "localfsMap": "/:${userHome}"
+    }
+  ]
+}
+```
+
+Then run govuk-docker-up, and use the Run and Debug tab and press the play button next to "Attach with rdbg", at which point you'll be able to set breakpoints in your code.
+
+Note: the magic number in the debugPort setting should match the equivalent one in govuk-docker for finder-frontend (by default the debug port creates itself at 12345, but to avoid clashes if running more than one app, we redirect that port to different numbers on the host)

--- a/procfile.dev
+++ b/procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3062
+web: DEBUGGER=true bin/rails server -p 3062 --restart
 css: bin/rails dartsass:watch


### PR DESCRIPTION
Adds vs code debugging support to Finder-Frontend with govuk-docker.

(Note that there will be an equivalent PR for govuk-docker to open the debug port)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
