### PR TITLE
Restyle finders headers layout

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -1,8 +1,15 @@
 $app-colour-true-black: #000000;
 
-.metadata-summary {
+.header-item-row {
   margin-bottom: govuk-spacing(6);
-  @include govuk-font(19);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.header-item-element {
+  margin-bottom: govuk-spacing(6);
 }
 
 .finder-logo {
@@ -11,11 +18,11 @@ $app-colour-true-black: #000000;
 
 .finder-logo__image {
   max-width: 100%;
+  margin-bottom: govuk-spacing(6);
 }
 
 .related-links {
-  margin-top: govuk-spacing(8);
-  margin-bottom: govuk-spacing(8);
+  margin-bottom: govuk-spacing(6);
 }
 
 .related-links__item {

--- a/app/helpers/page_metadata_helper.rb
+++ b/app/helpers/page_metadata_helper.rb
@@ -1,12 +1,11 @@
 module PageMetadataHelper
-  def page_metadata(content_item, filter_params)
+  def page_metadata(content_item)
     organisation_links = content_item.organisations.map do |organisation|
       link_to(organisation["title"], organisation["web_url"])
     end
 
     {}.tap do |metadata|
       metadata[:from] = organisation_links if organisation_links.present?
-      metadata[:inverse] = true if topic_finder?(filter_params)
     end
   end
 end

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -41,38 +41,49 @@
         margin_bottom: 8,
       } %>
     <% end %>
+  </div>
+</div>
 
-    <% if page_metadata.any? %>
-      <% page_metadata.merge!({ inverse: inverse, inverse_compress: true, margin_bottom: 2 }) %>
-      <%= render 'govuk_publishing_components/components/metadata', page_metadata %>
+<% if page_metadata.any? || content_item.summary || content_item.logo_path || content_item.related.any? %>
+  <div class="govuk-grid-row header-item-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if page_metadata.any? %>
+        <div class="header-item-element">
+          <% page_metadata.merge!({ inverse: inverse, inverse_compress: true, margin_bottom: 0 }) %>
+          <%= render 'govuk_publishing_components/components/metadata', page_metadata %>
+        </div>
+      <% end %>
+
+      <% if content_item.summary %>
+        <div class="header-item-element">
+          <%= render 'govuk_publishing_components/components/govspeak', { inverse: inverse, margin_bottom: 0 } do %>
+            <%= sanitize(content_item.summary) %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%
+      classes = %w[govuk-grid-column-one-third]
+      classes << "finder-logo" if content_item.logo_path
+      classes << "related-links" if content_item.related.any?
+    %>
+    <% if content_item.logo_path || content_item.related.any? %>
+      <%= content_tag(:div, class: classes) do %>
+        <% if content_item.logo_path %>
+          <%= image_tag content_item.logo_path, class: "finder-logo__image" %>
+        <% end %>
+
+        <% if content_item.related.any? %>
+          <ul class="govuk-list js-finder-results">
+            <% content_item.related.each do |link| %>
+              <li class="related-links__item">
+                <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      <% end %>
     <% end %>
   </div>
-
-  <% if content_item.summary %>
-    <div class="govuk-grid-column-two-thirds">
-      <div class="metadata-summary ">
-        <%= render 'govuk_publishing_components/components/govspeak', { inverse: inverse } do %>
-          <%= sanitize(content_item.summary) %>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-
-  <% if content_item.logo_path %>
-    <div class="finder-logo govuk-grid-column-one-third">
-      <%= image_tag content_item.logo_path, class: "finder-logo__image" %>
-    </div>
-  <% end %>
-
-  <% if content_item.related.any? %>
-    <div class="related-links govuk-grid-column-one-third">
-      <ul class="govuk-list js-finder-results">
-        <% content_item.related.each do |link| %>
-          <li class="related-links__item">
-            <%= link_to link['title'], link['web_url'], class: "related-links__link" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-</div>
+<% end %>

--- a/app/views/finders/show.html.erb
+++ b/app/views/finders/show.html.erb
@@ -31,14 +31,14 @@
       <div class="govuk-width-container">
         <%= render partial: 'show_header', locals: {
           inverse: is_inverse?,
-          page_metadata: page_metadata(content_item, filter_params)
+          page_metadata: page_metadata(content_item)
         } %>
       </div>
     <% end %>
   <% else %>
     <%= render partial: 'show_header', locals: {
       inverse: is_inverse?,
-      page_metadata: page_metadata(content_item, filter_params)
+      page_metadata: page_metadata(content_item)
     } %>
   <% end %>
 

--- a/spec/helpers/page_metadata_helper_spec.rb
+++ b/spec/helpers/page_metadata_helper_spec.rb
@@ -6,7 +6,7 @@ describe PageMetadataHelper, type: :helper do
   include TopicFinderHelper
 
   subject do
-    page_metadata(content_item, filter_params)
+    page_metadata(content_item)
   end
 
   let(:organisations) do
@@ -16,7 +16,6 @@ describe PageMetadataHelper, type: :helper do
   let(:content_item) do
     FactoryBot.build(:content_item, links: { organisations: })
   end
-  let(:filter_params) { {} }
 
   before do
     topic_taxonomy_has_taxons([FactoryBot.build(:level_one_taxon_hash, content_id: "existing_content_id")])
@@ -32,20 +31,6 @@ describe PageMetadataHelper, type: :helper do
 
       it 'does not contain the "from" key' do
         expect(subject).not_to have_key(:from)
-      end
-    end
-
-    describe "it is a topic page" do
-      let(:filter_params) { { "topic" => "existing_content_id" } }
-
-      it 'does not contain the "inverse" key' do
-        expect(subject[:inverse]).to be true
-      end
-    end
-
-    describe "it is not a topic page" do
-      it 'does not contain the "inverse" key' do
-        expect(subject).not_to have_key(:inverse)
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- improve the layout of finders headers by splitting the multiple grid columns into distinct rows, adding some specific spacing, and adding additional logic
- ensures the title of the page is always on its own row, with the metadata / description / extra links / image all appearing in a separate row beneath

## Why
Fixes https://github.com/alphagov/finder-frontend/issues/4103

## Visual changes

https://www.gov.uk/drug-device-alerts
Note the change of alignment for the links on the right, now aligned with the metadata beneath the heading.

Before | After
------- | ------
<img width="1094" height="503" alt="Screenshot 2026-07-07 at 15 28 38" src="https://github.com/user-attachments/assets/321623a4-03bf-40a0-bc3c-4ca9b3de6efc" /> | <img width="1103" height="590" alt="Screenshot 2026-07-07 at 15 28 48" src="https://github.com/user-attachments/assets/9d277aec-d829-47dd-bb4f-5cdf8a2b7a99" />


https://www.gov.uk/animal-disease-cases-england
Note the change of alignment for the links on the right, now aligned with the metadata beneath the heading.

Before | After
------- | ------
<img width="1087" height="756" alt="Screenshot 2026-07-07 at 15 28 22" src="https://github.com/user-attachments/assets/7e8352f6-59b2-44c0-b110-4d2a425ccf6f" /> | <img width="1107" height="666" alt="Screenshot 2026-07-07 at 15 28 29" src="https://github.com/user-attachments/assets/51bd4926-9543-4b15-88bc-70c409f7142e" />
