### PR TITLE
Update frontend apps to ensure the new functional colour custom prope…

### DIFF
--- a/app/assets/stylesheets/views/_search.scss
+++ b/app/assets/stylesheets/views/_search.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .search-wrapper {


### PR DESCRIPTION
## What

In preparing to upgrade to Design System v6 this PR configures any secondary and standalone stylesheets to exclude duplicate custom properties by utilising the `$govuk-output-custom-properties` setting. 

## Why

In v6, importing the core `base` styles automatically outputs a large block of CSS custom properties. 

This `$govuk-output-custom-properties` setting is not added to `application.scss` as this performs the initial load for the custom properties and functional colours. We've added `$govuk-output-custom-properties: false;` to the top of any other standalone/secondary stylesheets that independently import `govuk_publishing_components/base` preventing an identical second load. 

This follows the implementation pattern outlined in this [GOV.UK Frontend PR](https://github.com/alphagov/govuk-frontend/pull/6606).

Jira card: https://gov-uk.atlassian.net/browse/NAV-18925

## Visual changes

This is an under-the-hood optimisation to the asset pipeline. The custom property definitions are still loaded globally via the primary layout's `application.css`, so components rendered on these pages will inherit their functional colours as expected.

## Testing

This change was tested locally by pointing the application's Gemfile directly to the `v6-upgrade-feature-branch` of the `govuk_publishing_components` gem to simulate the upcoming production environment. Ran local asset compilation to ensure the build completes without errors.