### PR TITLE
Change port to match the port in govuk-docker (which is the only place procfile is used)

### DIFF
--- a/procfile.dev
+++ b/procfile.dev
@@ -1,2 +1,2 @@
-web: DEBUGGER=true bin/rails server -p 3062 --restart
+web: DEBUGGER=true bin/rails server -p 3000 --restart
 css: bin/rails dartsass:watch


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
