### PR TITLE
[PNP-10075] Add maximum page value for search

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -77,6 +77,12 @@ private
     unless filter_params.fetch(:keywords, "").is_a?(String)
       raise ActionController::BadRequest, "Invalid 'keywords' query parameter"
     end
+
+    max_page = Search::Query::MAX_RESULTS_VALUE / content_item.default_documents_per_page
+    page = filter_params.fetch(:page, 0).to_i
+    if page.negative? || page > max_page
+      raise ActionController::BadRequest, "Invalid page value"
+    end
   end
 
   def redirect_to_destination

--- a/app/lib/search/query.rb
+++ b/app/lib/search/query.rb
@@ -3,6 +3,7 @@
 module Search
   class Query
     SITE_SEARCH_FINDER_BASE_PATH = "/search/all".freeze
+    MAX_RESULTS_VALUE = 2_147_483_647
 
     include ActiveModel::Validations
 

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -245,6 +245,20 @@ describe FindersController, type: :controller do
         get :show, params: { slug: "lunch-finder", q: { "invalid" => "hash" } }
         expect(response.status).to eq(400)
       end
+
+      it "renders a BadRequest when the page parameter is negative" do
+        stub_content_store_has_item("/lunch-finder", lunch_finder)
+
+        get :show, params: { slug: "lunch-finder", q: "hash", page: "-1" }
+        expect(response.status).to eq(400)
+      end
+
+      it "renders a BadRequest when the page parameter is larger than the maximum page size" do
+        stub_content_store_has_item("/lunch-finder", lunch_finder)
+
+        get :show, params: { slug: "lunch-finder", q: "hash", page: "214748365" }
+        expect(response.status).to eq(400)
+      end
     end
 
     describe "finder item doesn't exist" do


### PR DESCRIPTION
- Google's search can't handle situations where we've asked it to cap results at more than 2,147,483,647 (max signed int 32). The content item provides details/default_documents_per_page of 10, and we use that to derive a max page size that is safe to ask Google for.
- If the page request is bigger than that, return a BadRequest.
- Also return a BadRequest if the page is negative (Google search will handle this by just rounding up to 1, but we shouldn't be encouraging it).

https://gov-uk.atlassian.net/browse/PNP-10075

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://[HEROKU-APP-ID].herokuapp.com/search/all
- https://[HEROKU-APP-ID].herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://[HEROKU-APP-ID].herokuapp.com/drug-device-alerts
