### PR TITLE
[PNP-10075] Handle BadRequest returned from search apis

### DIFF
--- a/app/controllers/finders_controller.rb
+++ b/app/controllers/finders_controller.rb
@@ -50,6 +50,8 @@ class FindersController < ApplicationController
     end
   rescue ActionController::UnknownFormat, ActionController::UnfilteredParameters
     render plain: "Not acceptable", status: :not_acceptable
+  rescue GdsApi::HTTPBadRequest
+    render plain: "Bad Request", status: :bad_request
   rescue UnsupportedContentItem
     render plain: "Not found", status: :not_found
   end

--- a/spec/controllers/finders_controller_spec.rb
+++ b/spec/controllers/finders_controller_spec.rb
@@ -354,6 +354,32 @@ describe FindersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template("finders/show_all_content_finder")
       end
+
+      context "when search-api-v2 returns bad request" do
+        before do
+          stub_request(:get, "#{Plek.find('search-api-v2')}/search.json")
+            .with(
+              query: {
+                count: 10,
+                fields: "title,link,description_with_highlighting,public_timestamp,popularity,content_purpose_supergroup,content_store_document_type,format,is_historic,government_name,content_id,parts,walk_type,place_of_origin,date_of_introduction,creator",
+                filter_document_type: "mosw_report",
+                start: 99_999_999_980,
+                suggest: "spelling_with_highlighting",
+                q: "hello",
+              },
+            )
+            .to_return(
+              status: 400,
+              body: "Invalid start value",
+              headers: {},
+            )
+        end
+
+        it "returns a bad request" do
+          get :show, params: { slug: "search/all", keywords: "hello", page: "9999999999" }
+          expect(response.status).to eq(400)
+        end
+      end
     end
 
     describe "all content finder SearchFreshnessBoost AB test" do


### PR DESCRIPTION
Following merging of https://github.com/alphagov/search-api-v2/pull/703, search-api-v2 may now return BadRequest if the user specifies a page value that would cause the number of results limited to overflow a signed 32-bit int (approx 2.14 billion). We should respect this, returning the 400 to the user. This will also clear up a large class of unactionable errors in Sentry.

https://gov-uk.atlassian.net/browse/PNP-10075

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Some search page examples to sense check:
- https://finder-frontend-pr-4122.herokuapp.com/search/all
- https://finder-frontend-pr-4122.herokuapp.com/search/news-and-communications?parent=%2Feducation&topic=c58fdadd-7743-46d6-9629-90bb3ccc4ef0
- https://finder-frontend-pr-4122.herokuapp.com/drug-device-alerts
