### PR TITLE
Fix highlighted search results in high contrast

### DIFF
--- a/app/assets/stylesheets/finder_frontend.scss
+++ b/app/assets/stylesheets/finder_frontend.scss
@@ -38,6 +38,22 @@ mark {
   background-color: inherit;
   color: inherit;
   @include govuk-typography-weight-bold;
+
+  // In forced color mode some browsers will keep the background transparent
+  // but set the text colour black, making the highlighted text unreadable.
+  // The following blocks fix this by setting the text colour to be the same as
+  // other text in a way that forced color mode will respect.
+
+  @media screen and (-ms-high-contrast: active) {
+    // IE does not support `CanvasText`,
+    // and `currentColor` does not work with Blink
+    color: currentColor; // stylelint-disable-line value-keyword-case
+  }
+
+  @media screen and (forced-colors: active) {
+    background-color: Canvas;  // needed for Firefox
+    color: CanvasText;
+  }
 }
 
 .related-links__link {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fixes the highlighted text in search results when using high contrast mode in Windows 11.

- mark elements were invisible (black text on a black background) in some browsers when Windows high contrast mode was enabled
- occurred on the words in user search queries, highlighted in search results
- solution copied from the tech docs gem: https://github.com/alphagov/tech-docs-gem/pull/265
- but tested on Windows in various browsers
- Fixes https://github.com/alphagov/finder-frontend/issues/2649

Note for testing: Windows high contrast mode is available in browserstack through the 'Settings' option in the left hand menu.

## Visual changes
Before | After
------ | -----
<img width="729" height="184" alt="Screenshot 2026-08-06 at 10 27 16" src="https://github.com/user-attachments/assets/7527625d-c7a7-48a5-9b58-adce35b7b978" /> | <img width="724" height="182" alt="Screenshot 2026-08-06 at 10 27 25" src="https://github.com/user-attachments/assets/562472df-f73d-4e48-b29f-8e11c31c47ca" />
