### PR TITLE
Replace prefixed-transform usages with standard CSS transform

### DIFF
--- a/app/assets/stylesheets/components/mixins/_chevron.scss
+++ b/app/assets/stylesheets/components/mixins/_chevron.scss
@@ -11,10 +11,10 @@
     width: govuk-spacing(2);
     border-color: initial;
     clip-path: unset;
-    @include prefixed-transform($translateY: -25%, $rotate: 135deg);
+    transform: translateY(-25%) rotate(135deg);
 
     @if $open {
-      @include prefixed-transform($translateY: 30%, $rotate: -45deg);
+      transform: translateY(30%) rotate(-45deg);
     }
   }
 }


### PR DESCRIPTION
## What
- Removes the deprecated use of prefixed-transform.
- Refactors the filter chevron to standard native CSS transform.

https://www.gov.uk/search/all

<img width="673" height="536" alt="Screenshot 2026-09-10 at 14 52 02" src="https://github.com/user-attachments/assets/bf87707f-61d5-47a9-8cc6-6e778ad0bf4c" />

## Why
- Updates finder-frontend to accommodate the removal of prefixed-transform.scss from  publishing components gem.
- Replaces redundant prefixed-transform functions with native CSS transform supported by all Grade C+ browsers.
- Retains the exact transform behaviour while allowing unsupported legacy browsers to still present a usable page.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19071

## Visual changes

There should be no visual differences

Device and browser testing in BrowserStack

Device / browser | Outcome
-- | --
macOS Catalina - Chrome 128 | No change, as expected
macOS Tahoe - Safari 26.4 | No change, as expected
macOS Ventura - Safari 16.5 | No change, as expected
macOS Monterey - Safari 15.6 | No change, as expected
macOS Big Sur - Safari 14.1 | Filter working but sub topic chevrons not level (same as live)
macOS Catalina - Safari 13.1 | Filter working, but sub topic chevrons not level (same as live)
macOS Mojave - Safari 12.1 | Filter working, but sub topic chevrons not level (same as live)
macOS High Sierra - Safari 11.1 | Select not working as dropdown at all. Chevron rotating correctly (same as live)
macOS High Sierra - Firefox 115 | No change, as expected
macOS Sequoia - Firefox 100 | No change, as expected
macOS High Sierra - Firefox 75 | No change, as expected
macOS Monterey - Firefox 70 | No change, as expected
macOS Big Sur - Edge 138 | No change, as expected
macOS Big Sur - Edge 118 | No change, as expected
macOS Big Sur - Edge 85 | Sub section native select triangle appearing in addition to bespoke chevron (same as live)
macOS Big Sur - Edge 80 | Sub section native select triangle appearing in addition to bespoke chevron (same as live)
macOS High Sierra - Edge 116 | No change, as expected
macOS High Sierra - Edge 90 | No change, as expected
macOS High Sierra - Edge 87 | No change, as expected
Android 16 - Samsung Galaxy S23 (Chrome) | No change, as expected
Android 16 - Samsung Galaxy Tab S8 (Chrome) | No change, as expected
Android 10 - Samsung Galaxy S20 (Samsung Internet) | No change, as expected
iOS 12 - Safari | No change, as expected
iOS 13 - Chrome | No change, as expected
iOS SE 2022 - Safari | No change, as expected
Windows 10 - Edge 17 | Select not working as dropdown at all. Chevron rotating correctly (same as live)
Windows 10 - Edge 100 | No change, as expected
Windows 10 - Edge 80 | Sub section native select triangle appearing in addition to bespoke chevron (same as live)

### Comments on the above testing

Safari 11.1 & Edge 17 (Dropdown issue failure): Edge 17 and Safari 11 are nearly a decade old. Under GOV.UK’s progressive enhancement guidelines for Grade C support we should be providing a readable, static page without rich interactive elements on outdated engines as expected fallback behaviour.

Safari 12.1 – 14.1 (Chevrons not level): Seems the misaligned chevrons are caused by older WebKit layout quirks with inline flex or vertical align baselines, unrelated to how transform is declared.

Edge 80 & 85 (Duplicate select arrows): Early Chromium based Edge builds occasionally fail to suppress native UI select indicators alongside custom icons.
